### PR TITLE
fix(windows): 补齐运行时反馈和平台化交互

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,50 @@
+name: CI
+
+on:
+  push:
+    branches: [main, dev]
+  pull_request:
+    branches: [main, dev]
+
+jobs:
+  windows-tauri:
+    name: Windows Tauri checks
+    runs-on: windows-latest
+    defaults:
+      run:
+        working-directory: openless -all/app
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: openless -all/app/package-lock.json
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Install frontend dependencies
+        run: npm ci
+
+      - name: Check Windows prerequisites
+        shell: pwsh
+        run: ./scripts/windows-preflight.ps1 -Toolchain msvc
+
+      - name: Check PowerShell scripts
+        shell: pwsh
+        run: |
+          foreach ($script in @("./scripts/windows-preflight.ps1", "./scripts/windows-build-gnu.ps1")) {
+            $errors = $null
+            [System.Management.Automation.PSParser]::Tokenize((Get-Content -Raw $script), [ref]$errors) | Out-Null
+            if ($errors) {
+              $errors | Format-List
+              exit 1
+            }
+          }
+
+      - name: Build frontend
+        run: npm run build
+
+      - name: Check Tauri backend
+        run: cargo check --manifest-path src-tauri/Cargo.toml

--- a/openless -all/README.md
+++ b/openless -all/README.md
@@ -33,6 +33,71 @@ cd app
 ./scripts/build-mac.sh
 ```
 
+## Windows Build
+
+The runnable Tauri app is still `app/`. Windows contributors should run a
+preflight before building so missing MSVC, Windows SDK, or MinGW tools fail
+with actionable messages.
+
+```powershell
+cd app
+powershell -ExecutionPolicy Bypass -File .\scripts\windows-preflight.ps1
+```
+
+### MSVC Route
+
+Use this route when Visual Studio Build Tools and the Windows SDK are installed.
+Open a Developer PowerShell, or call `vcvars64.bat`, then run:
+
+```powershell
+cd app
+npm ci
+npm run tauri -- build
+```
+
+Required Visual Studio Installer components:
+
+- `Microsoft.VisualStudio.Workload.VCTools`
+- MSVC v143 x64/x86 build tools
+- Windows 10/11 SDK that provides `kernel32.lib`
+
+If `link.exe` or `kernel32.lib` is missing, rerun:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File .\scripts\windows-preflight.ps1 -Toolchain msvc
+```
+
+### GNU / MinGW Route
+
+Use this route when MSVC/Windows SDK is unavailable. The current repository path
+contains a space in `openless -all`, and GNU/MinGW tooling can fail from paths
+with spaces while generating import libraries. Use the helper script; it mirrors
+the app to a no-space temporary directory before building.
+
+```powershell
+cd app
+scoop install rustup mingw
+rustup toolchain install stable-x86_64-pc-windows-gnu
+rustup target add x86_64-pc-windows-gnu
+powershell -ExecutionPolicy Bypass -File .\scripts\windows-preflight.ps1 -Toolchain gnu
+powershell -ExecutionPolicy Bypass -File .\scripts\windows-build-gnu.ps1
+```
+
+Generated GNU artifacts:
+
+- `%TEMP%\openless-windows-gnu\src-tauri\target\x86_64-pc-windows-gnu\release\openless.exe`
+- `%TEMP%\openless-windows-gnu\src-tauri\target\x86_64-pc-windows-gnu\release\bundle\msi\OpenLess_*_x64_en-US.msi`
+- `%TEMP%\openless-windows-gnu\src-tauri\target\x86_64-pc-windows-gnu\release\bundle\nsis\OpenLess_*_x64-setup.exe`
+
+### Windows Runtime Notes
+
+- Windows does not need the macOS Accessibility permission. Use Settings ->
+  Permissions -> Global hotkey to inspect listener status.
+- Microphone permission is checked by opening a short-lived input stream, so a
+  device-format query alone is not treated as permission granted.
+- Text insertion through `Ctrl+V` is treated as copy fallback unless the app can
+  confirm insertion.
+
 ## Release Signing
 
 Tagged releases (`v*-tauri`) must be Developer ID signed and notarized so users can download and open the macOS app without manually removing quarantine attributes.

--- a/openless -all/app/scripts/windows-build-gnu.ps1
+++ b/openless -all/app/scripts/windows-build-gnu.ps1
@@ -1,0 +1,39 @@
+param(
+  [string]$MirrorRoot = "$env:TEMP\openless-windows-gnu"
+)
+
+$ErrorActionPreference = "Stop"
+
+$appRoot = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
+$buildRoot = $appRoot
+
+if ($appRoot -match "\s") {
+  Write-Host "[info] App path contains spaces: $appRoot"
+  Write-Host "[info] Mirroring to no-space build root: $MirrorRoot"
+  New-Item -ItemType Directory -Force -Path $MirrorRoot | Out-Null
+  robocopy $appRoot $MirrorRoot /MIR /XD "$appRoot\node_modules" "$appRoot\dist" "$appRoot\src-tauri\target" "$MirrorRoot\node_modules" "$MirrorRoot\dist" "$MirrorRoot\src-tauri\target" | Out-Host
+  if ($LASTEXITCODE -gt 7) {
+    throw "robocopy failed with exit code $LASTEXITCODE"
+  }
+  $buildRoot = (Resolve-Path $MirrorRoot).Path
+}
+
+$env:PATH = "$env:USERPROFILE\.cargo\bin;$env:USERPROFILE\scoop\persist\rustup\.cargo\bin;$env:USERPROFILE\scoop\apps\rustup\current\.cargo\bin;$env:USERPROFILE\scoop\apps\mingw\current\bin;$env:PATH"
+$env:RUSTUP_TOOLCHAIN = "stable-x86_64-pc-windows-gnu"
+$env:CARGO_BUILD_TARGET = "x86_64-pc-windows-gnu"
+
+Push-Location $buildRoot
+try {
+  if (-not (Test-Path "node_modules")) {
+    npm ci
+  }
+  npm run tauri build -- --target x86_64-pc-windows-gnu
+} finally {
+  Pop-Location
+}
+
+Write-Host ""
+Write-Host "Windows GNU artifacts:"
+Write-Host "$buildRoot\src-tauri\target\x86_64-pc-windows-gnu\release\openless.exe"
+Write-Host "$buildRoot\src-tauri\target\x86_64-pc-windows-gnu\release\bundle\msi"
+Write-Host "$buildRoot\src-tauri\target\x86_64-pc-windows-gnu\release\bundle\nsis"

--- a/openless -all/app/scripts/windows-preflight.ps1
+++ b/openless -all/app/scripts/windows-preflight.ps1
@@ -1,0 +1,108 @@
+param(
+  [ValidateSet("all", "msvc", "gnu")]
+  [string]$Toolchain = "all"
+)
+
+$ErrorActionPreference = "Stop"
+
+$env:PATH = "$env:USERPROFILE\.cargo\bin;$env:USERPROFILE\scoop\persist\rustup\.cargo\bin;$env:USERPROFILE\scoop\apps\rustup\current\.cargo\bin;$env:USERPROFILE\scoop\apps\mingw\current\bin;$env:PATH"
+
+function Test-Command($Name) {
+  $cmd = Get-Command $Name -ErrorAction SilentlyContinue
+  if ($cmd) {
+    Write-Host "[ok] $Name -> $($cmd.Source)"
+    return $true
+  }
+  Write-Host "[missing] $Name"
+  return $false
+}
+
+function Find-Kernel32Lib {
+  $kitsRoot = Join-Path ${env:ProgramFiles(x86)} "Windows Kits\10\Lib"
+  if (-not (Test-Path $kitsRoot)) {
+    return $null
+  }
+  Get-ChildItem -LiteralPath $kitsRoot -Directory |
+    Sort-Object Name -Descending |
+    ForEach-Object {
+      $candidate = Join-Path $_.FullName "um\x64\kernel32.lib"
+      if (Test-Path $candidate) {
+        return $candidate
+      }
+    }
+}
+
+function Test-WebView2Runtime {
+  $paths = @(
+    "HKLM:\SOFTWARE\Microsoft\EdgeUpdate\Clients\{F1E7FBD4-9C4C-41A4-AB01-7C0F7A947F1A}",
+    "HKLM:\SOFTWARE\WOW6432Node\Microsoft\EdgeUpdate\Clients\{F1E7FBD4-9C4C-41A4-AB01-7C0F7A947F1A}"
+  )
+  foreach ($path in $paths) {
+    if (Test-Path $path) {
+      Write-Host "[ok] WebView2 Runtime registry key found"
+      return $true
+    }
+  }
+  Write-Host "[warn] WebView2 Runtime registry key not found; install Evergreen runtime if the app window is blank."
+  return $false
+}
+
+$failed = $false
+
+Write-Host "== Common prerequisites =="
+foreach ($name in @("node", "npm", "rustc", "cargo", "rustup")) {
+  if (-not (Test-Command $name)) {
+    $failed = $true
+  }
+}
+Test-WebView2Runtime | Out-Null
+
+if ($Toolchain -eq "all" -or $Toolchain -eq "msvc") {
+  Write-Host ""
+  Write-Host "== MSVC route =="
+  if (-not (Test-Command "link.exe")) {
+    Write-Host "[hint] Run from a Developer PowerShell, or call vcvars64.bat first."
+    $failed = $true
+  }
+  $kernel32 = Find-Kernel32Lib
+  if ($kernel32) {
+    Write-Host "[ok] kernel32.lib -> $kernel32"
+  } else {
+    Write-Host "[missing] kernel32.lib"
+    Write-Host "[hint] Install Visual Studio Build Tools workload 'Desktop development with C++' and a Windows 10/11 SDK."
+    $failed = $true
+  }
+}
+
+if ($Toolchain -eq "all" -or $Toolchain -eq "gnu") {
+  Write-Host ""
+  Write-Host "== GNU/MinGW route =="
+  foreach ($name in @("gcc", "dlltool")) {
+    if (-not (Test-Command $name)) {
+      $failed = $true
+    }
+  }
+  if (Get-Command rustup -ErrorAction SilentlyContinue) {
+    $toolchains = & rustup toolchain list 2>$null
+    if ($toolchains -match "x86_64-pc-windows-gnu") {
+      Write-Host "[ok] Rust GNU toolchain installed"
+    } else {
+      Write-Host "[missing] stable-x86_64-pc-windows-gnu"
+      Write-Host "[hint] rustup toolchain install stable-x86_64-pc-windows-gnu"
+      $failed = $true
+    }
+  } else {
+    Write-Host "[missing] rustup"
+    $failed = $true
+  }
+  if ((Get-Location).Path -match "\s") {
+    Write-Host "[warn] Current path contains spaces. Use scripts/windows-build-gnu.ps1 or build from a no-space path."
+  }
+}
+
+if ($failed) {
+  exit 1
+}
+
+Write-Host ""
+Write-Host "Preflight passed."

--- a/openless -all/app/src-tauri/src/commands.rs
+++ b/openless -all/app/src-tauri/src/commands.rs
@@ -8,7 +8,8 @@ use crate::coordinator::Coordinator;
 use crate::permissions::{self, PermissionStatus};
 use crate::persistence::{CredentialAccount, CredentialsSnapshot, CredentialsVault};
 use crate::types::{
-    CredentialsStatus, DictationSession, DictionaryEntry, PolishMode, UserPreferences,
+    CredentialsStatus, DictationSession, DictionaryEntry, HotkeyStatus, PolishMode,
+    UserPreferences,
 };
 
 type CoordinatorState<'a> = State<'a, Arc<Coordinator>>;
@@ -25,6 +26,11 @@ pub fn set_settings(coord: CoordinatorState<'_>, prefs: UserPreferences) -> Resu
     coord.prefs().set(prefs).map_err(|e| e.to_string())?;
     coord.update_hotkey_binding();
     Ok(())
+}
+
+#[tauri::command]
+pub fn get_hotkey_status(coord: CoordinatorState<'_>) -> HotkeyStatus {
+    coord.hotkey_status()
 }
 
 #[tauri::command]
@@ -221,8 +227,17 @@ pub fn open_system_settings(pane: String) -> Result<(), String> {
     }
     #[cfg(not(target_os = "macos"))]
     {
-        let _ = pane;
-        Ok(())
+        let uri = match pane.as_str() {
+            "microphone" => "ms-settings:privacy-microphone",
+            "sound" => "ms-settings:sound",
+            "accessibility" => "ms-settings:easeofaccess",
+            _ => "ms-settings:",
+        };
+        std::process::Command::new("cmd")
+            .args(["/C", "start", "", uri])
+            .spawn()
+            .map(|_| ())
+            .map_err(|e| e.to_string())
     }
 }
 

--- a/openless -all/app/src-tauri/src/coordinator.rs
+++ b/openless -all/app/src-tauri/src/coordinator.rs
@@ -23,8 +23,8 @@ use crate::persistence::{
 use crate::polish::{OpenAICompatibleConfig, OpenAICompatibleLLMProvider};
 use crate::recorder::Recorder;
 use crate::types::{
-    CapsulePayload, CapsuleState, DictationSession, HotkeyMode, InsertStatus, PolishMode,
-    UserPreferences,
+    CapsulePayload, CapsuleState, DictationSession, HotkeyMode, HotkeyStatus,
+    HotkeyStatusState, InsertStatus, PolishMode,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -63,6 +63,7 @@ struct Inner {
     asr: Mutex<Option<Arc<VolcengineStreamingASR>>>,
     recorder: Mutex<Option<Recorder>>,
     hotkey: Mutex<Option<HotkeyMonitor>>,
+    hotkey_status: Mutex<HotkeyStatus>,
 }
 
 impl Coordinator {
@@ -85,6 +86,7 @@ impl Coordinator {
                 asr: Mutex::new(None),
                 recorder: Mutex::new(None),
                 hotkey: Mutex::new(None),
+                hotkey_status: Mutex::new(HotkeyStatus::default()),
             }),
         }
     }
@@ -119,6 +121,10 @@ impl Coordinator {
         }
     }
 
+    pub fn hotkey_status(&self) -> HotkeyStatus {
+        self.inner.hotkey_status.lock().clone()
+    }
+
     pub async fn start_dictation(&self) -> Result<(), String> {
         begin_session(&self.inner).await
     }
@@ -147,11 +153,22 @@ fn hotkey_supervisor_loop(inner: Arc<Inner>) {
         if inner.hotkey.lock().is_some() {
             return;
         }
+        *inner.hotkey_status.lock() = HotkeyStatus {
+            state: HotkeyStatusState::Starting,
+            message: Some(format!(
+                "正在安装全局快捷键监听（第 {} 次）",
+                attempts + 1
+            )),
+        };
         let (tx, rx) = mpsc::channel::<HotkeyEvent>();
         let binding = inner.prefs.get().hotkey;
         match HotkeyMonitor::start(binding, tx) {
             Ok(monitor) => {
                 *inner.hotkey.lock() = Some(monitor);
+                *inner.hotkey_status.lock() = HotkeyStatus {
+                    state: HotkeyStatusState::Installed,
+                    message: None,
+                };
                 log::info!(
                     "[coord] hotkey listener installed (after {} attempt(s))",
                     attempts + 1
@@ -165,6 +182,10 @@ fn hotkey_supervisor_loop(inner: Arc<Inner>) {
             }
             Err(e) => {
                 attempts += 1;
+                *inner.hotkey_status.lock() = HotkeyStatus {
+                    state: HotkeyStatusState::Failed,
+                    message: Some(e.to_string()),
+                };
                 if attempts <= 3 || attempts % 10 == 0 {
                     log::warn!(
                         "[coord] hotkey listener attempt #{attempts} failed: {e}; retrying in 3s"
@@ -392,12 +413,22 @@ async fn end_session(inner: &Arc<Inner>) -> Result<(), String> {
         log::error!("[coord] history append failed: {e}");
     }
 
+    let done_message = match status {
+        InsertStatus::Inserted => None,
+        InsertStatus::CopiedFallback => Some(if cfg!(target_os = "windows") {
+            "已复制，请 Ctrl+V".to_string()
+        } else {
+            "已复制，请粘贴".to_string()
+        }),
+        InsertStatus::Failed => Some("插入失败".to_string()),
+    };
+
     emit_capsule(
         inner,
         CapsuleState::Done,
         0.0,
         elapsed,
-        None,
+        done_message,
         Some(inserted_chars),
     );
 

--- a/openless -all/app/src-tauri/src/hotkey.rs
+++ b/openless -all/app/src-tauri/src/hotkey.rs
@@ -305,9 +305,10 @@ mod platform {
 
 #[cfg(not(target_os = "macos"))]
 mod platform {
-    use std::sync::atomic::Ordering;
+    use std::sync::atomic::{AtomicBool, Ordering};
     use std::sync::mpsc::Sender;
     use std::sync::Arc;
+    use std::time::Duration;
 
     use rdev::{listen, Event, EventType, Key};
 
@@ -319,13 +320,25 @@ mod platform {
         tx: Sender<HotkeyEvent>,
         status_tx: std::sync::mpsc::Sender<bool>,
     ) {
-        // rdev 没有"安装即可知"的 API；我们乐观汇报成功，Linux/Win 上一般直接生效。
-        let _ = status_tx.send(true);
+        // rdev 没有"安装即可知"的 API。给 listen 一个短窗口：
+        // 如果 hook 立即失败，向 supervisor 汇报失败；否则视为已进入监听循环。
+        let status_sent = Arc::new(AtomicBool::new(false));
+        let ready_status_sent = Arc::clone(&status_sent);
+        let ready_status_tx = status_tx.clone();
+        std::thread::spawn(move || {
+            std::thread::sleep(Duration::from_millis(350));
+            if !ready_status_sent.swap(true, Ordering::SeqCst) {
+                let _ = ready_status_tx.send(true);
+            }
+        });
         let cb_shared = Arc::clone(&shared);
         let result = listen(move |event: Event| {
             dispatch_event(&cb_shared, &tx, event);
         });
         if let Err(err) = result {
+            if !status_sent.swap(true, Ordering::SeqCst) {
+                let _ = status_tx.send(false);
+            }
             log::error!("[hotkey] rdev::listen 启动失败: {:?}", err);
         }
     }

--- a/openless -all/app/src-tauri/src/insertion.rs
+++ b/openless -all/app/src-tauri/src/insertion.rs
@@ -27,13 +27,11 @@ impl TextInserter {
         if !copy_to_clipboard(text) {
             return InsertStatus::Failed;
         }
-        match simulate_paste() {
-            Ok(()) => InsertStatus::Inserted,
-            Err(err) => {
-                log::warn!("[insertion] simulated paste failed: {}", err);
-                InsertStatus::CopiedFallback
-            }
+        if let Err(err) = simulate_paste() {
+            log::warn!("[insertion] simulated paste failed: {}", err);
+            return InsertStatus::CopiedFallback;
         }
+        insertion_success_status()
     }
 }
 
@@ -76,6 +74,17 @@ fn simulate_paste() -> Result<(), String> {
     }
     press_v.map_err(|e| e.to_string())?;
     Ok(())
+}
+
+#[cfg(target_os = "macos")]
+fn insertion_success_status() -> InsertStatus {
+    InsertStatus::Inserted
+}
+
+#[cfg(not(target_os = "macos"))]
+fn insertion_success_status() -> InsertStatus {
+    // Windows/Linux 的 Ctrl+V 只能证明粘贴快捷键已发送，不能证明目标控件已接收。
+    InsertStatus::CopiedFallback
 }
 
 // ─────────────────────────── macOS native CGEvent paste ───────────────────────────

--- a/openless -all/app/src-tauri/src/lib.rs
+++ b/openless -all/app/src-tauri/src/lib.rs
@@ -125,6 +125,7 @@ pub fn run() {
         .invoke_handler(tauri::generate_handler![
             commands::get_settings,
             commands::set_settings,
+            commands::get_hotkey_status,
             commands::get_credentials,
             commands::set_credential,
             commands::list_history,

--- a/openless -all/app/src-tauri/src/permissions.rs
+++ b/openless -all/app/src-tauri/src/permissions.rs
@@ -248,7 +248,9 @@ mod platform {
 #[cfg(not(target_os = "macos"))]
 mod platform {
     use super::PermissionStatus;
-    use cpal::traits::{DeviceTrait, HostTrait};
+    use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
+    use cpal::{SampleFormat, StreamConfig};
+    use std::time::Duration;
 
     /// Windows / Linux 不存在 macOS 那种 Accessibility 概念；rdev 直接监听键盘。
     pub fn check_accessibility() -> PermissionStatus {
@@ -260,16 +262,22 @@ mod platform {
     }
 
     /// Windows 的麦克风权限走系统设置 → 隐私 → 麦克风；
-    /// 这里用 cpal 做最小可用性探测，避免 UI 在无设备或权限被拒时误报已授权。
+    /// 这里用 cpal 建立一次短生命周期输入流，避免只查设备格式时误报已授权。
     pub fn check_microphone() -> PermissionStatus {
         let host = cpal::default_host();
         let Some(device) = host.default_input_device() else {
             log::warn!("[mic] no default input device");
             return PermissionStatus::Denied;
         };
-        match device.default_input_config() {
-            Ok(_) => PermissionStatus::Granted,
-            Err(err) => classify_audio_probe_error(err.to_string()),
+        let supported = match device.default_input_config() {
+            Ok(config) => config,
+            Err(err) => return classify_audio_probe_error(err.to_string()),
+        };
+        let sample_format = supported.sample_format();
+        let config: StreamConfig = supported.config();
+        match probe_input_stream(&device, &config, sample_format) {
+            Ok(()) => PermissionStatus::Granted,
+            Err(message) => classify_audio_probe_error(message),
         }
     }
 
@@ -279,7 +287,7 @@ mod platform {
 
     fn classify_audio_probe_error(message: String) -> PermissionStatus {
         let lower = message.to_lowercase();
-        log::warn!("[mic] default input config failed: {message}");
+        log::warn!("[mic] input probe failed: {message}");
         if lower.contains("denied")
             || lower.contains("permission")
             || lower.contains("authoriz")
@@ -289,6 +297,42 @@ mod platform {
         } else {
             PermissionStatus::NotDetermined
         }
+    }
+
+    fn probe_input_stream(
+        device: &cpal::Device,
+        config: &StreamConfig,
+        sample_format: SampleFormat,
+    ) -> Result<(), String> {
+        let err_cb = |err| log::warn!("[mic] probe stream error: {err}");
+
+        macro_rules! build_probe {
+            ($t:ty) => {
+                device
+                    .build_input_stream::<$t, _, _>(
+                        config,
+                        move |_data: &[$t], _info| {},
+                        err_cb,
+                        None,
+                    )
+                    .map_err(|e| e.to_string())
+            };
+        }
+
+        let stream = match sample_format {
+            SampleFormat::F32 => build_probe!(f32),
+            SampleFormat::I16 => build_probe!(i16),
+            SampleFormat::U16 => build_probe!(u16),
+            SampleFormat::I32 => build_probe!(i32),
+            SampleFormat::I8 => build_probe!(i8),
+            SampleFormat::U8 => build_probe!(u8),
+            other => Err(format!("unsupported sample format: {other:?}")),
+        }?;
+
+        stream.play().map_err(|e| e.to_string())?;
+        std::thread::sleep(Duration::from_millis(120));
+        drop(stream);
+        Ok(())
     }
 }
 

--- a/openless -all/app/src-tauri/src/permissions.rs
+++ b/openless -all/app/src-tauri/src/permissions.rs
@@ -248,6 +248,7 @@ mod platform {
 #[cfg(not(target_os = "macos"))]
 mod platform {
     use super::PermissionStatus;
+    use cpal::traits::{DeviceTrait, HostTrait};
 
     /// Windows / Linux 不存在 macOS 那种 Accessibility 概念；rdev 直接监听键盘。
     pub fn check_accessibility() -> PermissionStatus {
@@ -259,14 +260,35 @@ mod platform {
     }
 
     /// Windows 的麦克风权限走系统设置 → 隐私 → 麦克风；
-    /// 我们没法在用户态直接查授权状态，启动 cpal stream 时 Win10+ 会自动弹一次提示。
-    /// 这里乐观返回 Granted；UI 上不需要展示 Denied 状态。
+    /// 这里用 cpal 做最小可用性探测，避免 UI 在无设备或权限被拒时误报已授权。
     pub fn check_microphone() -> PermissionStatus {
-        PermissionStatus::Granted
+        let host = cpal::default_host();
+        let Some(device) = host.default_input_device() else {
+            log::warn!("[mic] no default input device");
+            return PermissionStatus::Denied;
+        };
+        match device.default_input_config() {
+            Ok(_) => PermissionStatus::Granted,
+            Err(err) => classify_audio_probe_error(err.to_string()),
+        }
     }
 
     pub fn request_microphone() -> PermissionStatus {
-        PermissionStatus::Granted
+        check_microphone()
+    }
+
+    fn classify_audio_probe_error(message: String) -> PermissionStatus {
+        let lower = message.to_lowercase();
+        log::warn!("[mic] default input config failed: {message}");
+        if lower.contains("denied")
+            || lower.contains("permission")
+            || lower.contains("authoriz")
+            || lower.contains("access")
+        {
+            PermissionStatus::Denied
+        } else {
+            PermissionStatus::NotDetermined
+        }
     }
 }
 

--- a/openless -all/app/src-tauri/src/types.rs
+++ b/openless -all/app/src-tauri/src/types.rs
@@ -130,6 +130,30 @@ pub struct HotkeyBinding {
     pub mode: HotkeyMode,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct HotkeyStatus {
+    pub state: HotkeyStatusState,
+    pub message: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub enum HotkeyStatusState {
+    Starting,
+    Installed,
+    Failed,
+}
+
+impl Default for HotkeyStatus {
+    fn default() -> Self {
+        Self {
+            state: HotkeyStatusState::Starting,
+            message: Some("正在安装全局快捷键监听".into()),
+        }
+    }
+}
+
 impl Default for HotkeyBinding {
     fn default() -> Self {
         // Right Option (mac) / Right Alt (win) — toggle by default per design.

--- a/openless -all/app/src/components/Capsule.tsx
+++ b/openless -all/app/src/components/Capsule.tsx
@@ -188,7 +188,7 @@ function Pill({ state, level, insertedChars, message, onCancel, onConfirm }: Pil
       );
       break;
     case 'done':
-      center = <CenterText text={`已插入 ${insertedChars}`} />;
+      center = <CenterText text={message || `已插入 ${insertedChars}`} />;
       break;
     case 'cancelled':
       center = <CenterText text="已取消" />;

--- a/openless -all/app/src/components/FloatingShell.tsx
+++ b/openless -all/app/src/components/FloatingShell.tsx
@@ -13,7 +13,7 @@ import { History } from '../pages/History';
 import { Vocab } from '../pages/Vocab';
 import { Style } from '../pages/Style';
 import { APP_VERSION_LABEL } from '../lib/appVersion';
-import { getCredentials } from '../lib/ipc';
+import { getCredentials, openExternal } from '../lib/ipc';
 import { OL_DATA } from '../lib/mockData';
 import {
   PROVIDER_SETUP_PROMPT_SEEN_KEY,
@@ -56,6 +56,7 @@ function FloatingShellBody({ os, initialTab, initialSettings }: { os: OS; initia
   const [settingsInitialSection, setSettingsInitialSection] = useState<SettingsSectionId | undefined>();
   const [providerPromptOpen, setProviderPromptOpen] = useState(false);
   const Page = (NAV.find((n) => n.id === currentTab) ?? NAV[0]).cmp;
+  const hotkeyLabel = os === 'win' ? '右 Alt' : '右 Option';
 
   useEffect(() => {
     let cancelled = false;
@@ -176,7 +177,7 @@ function FloatingShellBody({ os, initialTab, initialSettings }: { os: OS; initia
                 border: '0.5px solid var(--ol-line-strong)',
                 fontFamily: 'var(--ol-font-mono)', color: 'var(--ol-ink)',
                 boxShadow: '0 1px 0 rgba(0,0,0,.04)',
-              }}>右 Option</kbd>
+              }}>{hotkeyLabel}</kbd>
               <span style={{ color: 'var(--ol-ink-4)' }}>开始 / 停止</span>
             </div>
           </div>
@@ -211,7 +212,11 @@ function FloatingShellBody({ os, initialTab, initialSettings }: { os: OS; initia
             }}
           >
             <div style={{ padding: '24px 28px 32px', flex: 1, minHeight: 0, overflow: 'auto' }}>
-              <Page />
+              {currentTab === 'overview' ? (
+                <Overview onOpenHistory={() => setCurrentTab('history')} />
+              ) : (
+                <Page />
+              )}
             </div>
           </main>
         </div>
@@ -231,15 +236,31 @@ function FloatingShellBody({ os, initialTab, initialSettings }: { os: OS; initia
           zIndex: 2,
         }}>
 
-        <FooterIcon name="user" tip="账户" />
-        <FooterIcon name="mail" tip="反馈" />
+        <FooterIcon name="user" tip="账户" onClick={() => openSettings('提供商')} />
+        <FooterIcon name="mail" tip="反馈" onClick={() => openExternal('https://github.com/appergb/openless/issues')} />
         <FooterIcon name="settings" tip="设置" active={settingsOpen} onClick={() => openSettings()} />
-        <FooterIcon name="help" tip="帮助" />
+        <FooterIcon name="help" tip="帮助" onClick={() => openExternal('https://github.com/appergb/openless#readme')} />
 
         <div style={{ flex: 1 }} />
 
         <span style={{ fontFamily: 'var(--ol-font-sans)' }}>版本 {APP_VERSION_LABEL}</span>
-        <a style={{ color: 'var(--ol-blue)', marginLeft: 8, textDecoration: 'none', fontWeight: 500 }}>检查更新</a>
+        <button
+          onClick={() => openExternal('https://github.com/appergb/openless/releases')}
+          style={{
+            color: 'var(--ol-blue)',
+            marginLeft: 8,
+            textDecoration: 'none',
+            fontWeight: 500,
+            border: 0,
+            background: 'transparent',
+            fontFamily: 'inherit',
+            fontSize: 11,
+            cursor: 'default',
+            padding: 0,
+          }}
+        >
+          检查更新
+        </button>
       </div>
 
       {/* Settings modal — rendered inside this window */}

--- a/openless -all/app/src/components/Onboarding.tsx
+++ b/openless -all/app/src/components/Onboarding.tsx
@@ -12,6 +12,7 @@ import {
   requestMicrophonePermission,
 } from '../lib/ipc';
 import type { PermissionStatus } from '../lib/types';
+import { detectOS } from './WindowChrome';
 
 interface OnboardingProps {
   onComplete: () => void;
@@ -21,6 +22,7 @@ export function Onboarding({ onComplete }: OnboardingProps) {
   const [accessibility, setAccessibility] = useState<PermissionStatus>('notDetermined');
   const [microphone, setMicrophone] = useState<PermissionStatus>('notDetermined');
   const [busy, setBusy] = useState(false);
+  const os = detectOS();
 
   const refresh = async () => {
     const [a, m] = await Promise.all([
@@ -122,19 +124,23 @@ export function Onboarding({ onComplete }: OnboardingProps) {
 
         <PermissionStep
           index={1}
-          title="辅助功能"
-          desc="用于监听全局快捷键（默认 右 Option）并把识别结果写入光标位置。"
+          title={os === 'win' ? '全局快捷键' : '辅助功能'}
+          desc={os === 'win'
+            ? 'Windows 不需要 macOS 辅助功能权限；这里用于确认全局快捷键监听可用。'
+            : '用于监听全局快捷键（默认 右 Option）并把识别结果写入光标位置。'}
           status={accessibility}
           actionLabel={
-            accessibility === 'granted'
+            accessibility === 'notApplicable'
+              ? '无需授权'
+              : accessibility === 'granted'
               ? '已授权'
               : accessibility === 'denied'
                 ? '打开系统设置'
                 : '授权'
           }
           onAction={onGrantAccessibility}
-          disabled={busy || accessibility === 'granted'}
-          hint="授权后必须**完全退出 OpenLess** 再重新打开（macOS TCC 规则）。"
+          disabled={busy || accessibility === 'granted' || accessibility === 'notApplicable'}
+          hint={os === 'mac' ? '授权后必须**完全退出 OpenLess** 再重新打开（macOS TCC 规则）。' : undefined}
         />
 
         <PermissionStep

--- a/openless -all/app/src/lib/ipc.ts
+++ b/openless -all/app/src/lib/ipc.ts
@@ -6,6 +6,7 @@ import type {
   CredentialsStatus,
   DictationSession,
   DictionaryEntry,
+  HotkeyStatus,
   PermissionStatus,
   PolishMode,
   UserPreferences,
@@ -48,6 +49,11 @@ const mockCredentialsStatus: CredentialsStatus = {
   arkConfigured: true,
 };
 
+const mockHotkeyStatus: HotkeyStatus = {
+  state: 'installed',
+  message: null,
+};
+
 const mockHistory: DictationSession[] = OL_DATA.history.map((h, i) => ({
   id: `mock-${i}`,
   createdAt: new Date().toISOString(),
@@ -78,6 +84,10 @@ export function getSettings(): Promise<UserPreferences> {
 
 export function setSettings(prefs: UserPreferences): Promise<void> {
   return invokeOrMock('set_settings', { prefs }, () => undefined);
+}
+
+export function getHotkeyStatus(): Promise<HotkeyStatus> {
+  return invokeOrMock('get_hotkey_status', undefined, () => mockHotkeyStatus);
 }
 
 // ── Credentials ────────────────────────────────────────────────────────
@@ -144,8 +154,8 @@ export function cancelDictation(): Promise<void> {
 }
 
 // ── Polish ─────────────────────────────────────────────────────────────
-export function repolish(id: string, mode: PolishMode): Promise<DictationSession> {
-  return invokeOrMock('repolish', { id, mode }, () => mockHistory[0]);
+export function repolish(rawText: string, mode: PolishMode): Promise<string> {
+  return invokeOrMock('repolish', { rawText, mode }, () => rawText);
 }
 
 export function setDefaultPolishMode(mode: PolishMode): Promise<void> {
@@ -179,6 +189,15 @@ export function openSystemSettings(pane: 'accessibility' | 'microphone'): Promis
 
 export function triggerMicrophonePrompt(): Promise<void> {
   return invokeOrMock('trigger_microphone_prompt', undefined, () => undefined);
+}
+
+export async function openExternal(url: string): Promise<void> {
+  if (!isTauri) {
+    window.open(url, '_blank', 'noopener,noreferrer');
+    return;
+  }
+  const { open } = await import('@tauri-apps/plugin-shell');
+  await open(url);
 }
 
 export { isTauri };

--- a/openless -all/app/src/lib/types.ts
+++ b/openless -all/app/src/lib/types.ts
@@ -45,6 +45,13 @@ export interface HotkeyBinding {
   mode: HotkeyMode;
 }
 
+export type HotkeyStatusState = 'starting' | 'installed' | 'failed';
+
+export interface HotkeyStatus {
+  state: HotkeyStatusState;
+  message: string | null;
+}
+
 export interface UserPreferences {
   hotkey: HotkeyBinding;
   defaultMode: PolishMode;

--- a/openless -all/app/src/pages/History.tsx
+++ b/openless -all/app/src/pages/History.tsx
@@ -3,6 +3,7 @@
 
 import { useEffect, useMemo, useState } from 'react';
 import { Icon } from '../components/Icon';
+import { detectOS } from '../components/WindowChrome';
 import { clearHistory, deleteHistoryEntry, listHistory } from '../lib/ipc';
 import type { DictationSession, PolishMode } from '../lib/types';
 import { Btn, Card, PageHeader, Pill } from './_atoms';
@@ -27,6 +28,7 @@ export function History() {
   const [items, setItems] = useState<DictationSession[]>([]);
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
+  const hotkeyLabel = detectOS() === 'win' ? '右 Alt' : '右 Option';
 
   const refresh = async () => {
     const data = await listHistory();
@@ -114,7 +116,7 @@ export function History() {
             {loading && <div style={{ padding: 16, fontSize: 12, color: 'var(--ol-ink-4)' }}>加载中…</div>}
             {!loading && filtered.length === 0 && (
               <div style={{ padding: 16, fontSize: 12, color: 'var(--ol-ink-4)' }}>
-                还没有历史记录。按 右 Option 录一段试试。
+                还没有历史记录。按 {hotkeyLabel} 录一段试试。
               </div>
             )}
             {filtered.map(s => (
@@ -181,7 +183,7 @@ export function History() {
                 {item.dictionaryEntryCount != null && item.dictionaryEntryCount > 0 && (
                   <span>{item.dictionaryEntryCount} 个热词</span>
                 )}
-                <span>{item.insertStatus === 'inserted' ? '已插入' : item.insertStatus === 'copiedFallback' ? '已复制(需 ⌘V)' : '插入失败'}</span>
+                <span>{item.insertStatus === 'inserted' ? '已插入' : item.insertStatus === 'copiedFallback' ? `已复制(需 ${detectOS() === 'win' ? 'Ctrl+V' : '⌘V'})` : '插入失败'}</span>
               </div>
             </>
           ) : (

--- a/openless -all/app/src/pages/Overview.tsx
+++ b/openless -all/app/src/pages/Overview.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useMemo, useState } from 'react';
 import { Icon } from '../components/Icon';
+import { detectOS } from '../components/WindowChrome';
 import { getCredentials, listHistory } from '../lib/ipc';
 import type { CredentialsStatus, DictationSession, PolishMode } from '../lib/types';
 import { Btn, Card, PageHeader, Pill } from './_atoms';
@@ -13,12 +14,18 @@ const MODE_LABEL: Record<PolishMode, string> = {
   formal: '正式表达',
 };
 
-export function Overview() {
+interface OverviewProps {
+  onOpenHistory?: () => void;
+}
+
+export function Overview({ onOpenHistory }: OverviewProps) {
   const [history, setHistory] = useState<DictationSession[]>([]);
   const [creds, setCreds] = useState<CredentialsStatus>({
     volcengineConfigured: false,
     arkConfigured: false,
   });
+  const os = detectOS();
+  const hotkeyLabel = os === 'win' ? '右 Alt' : '右 Option';
 
   useEffect(() => {
     listHistory().then(setHistory);
@@ -76,7 +83,7 @@ export function Overview() {
               background: '#fff', borderRadius: 5,
               border: '0.5px solid var(--ol-line-strong)',
               color: 'var(--ol-ink)',
-            }}>右 Option</kbd>
+            }}>{hotkeyLabel}</kbd>
             开始录音
           </div>
         }
@@ -119,12 +126,12 @@ export function Overview() {
         <Card padding={0}>
           <div style={{ padding: '14px 18px', borderBottom: '0.5px solid var(--ol-line)', display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
             <span style={{ fontSize: 12, fontWeight: 600, color: 'var(--ol-ink-2)' }}>最近识别</span>
-            <Btn size="sm" variant="ghost">全部记录 →</Btn>
+            <Btn size="sm" variant="ghost" onClick={onOpenHistory}>全部记录 →</Btn>
           </div>
           <div>
             {history.length === 0 && (
               <div style={{ padding: 24, textAlign: 'center', fontSize: 12, color: 'var(--ol-ink-4)' }}>
-                还没有记录。按 右 Option 开始第一次录音。
+                还没有记录。按 {hotkeyLabel} 开始第一次录音。
               </div>
             )}
             {history.slice(0, 5).map(s => (

--- a/openless -all/app/src/pages/Settings.tsx
+++ b/openless -all/app/src/pages/Settings.tsx
@@ -124,6 +124,9 @@ function RecordingSection() {
   const [prefs, setPrefs] = useState<UserPreferences | null>(null);
   const os = detectOS();
   const triggerOptions = os === 'win' ? WIN_TRIGGER_OPTIONS : MAC_TRIGGER_OPTIONS;
+  const hotkeyDesc = os === 'win'
+    ? '按下即开始捕获语音，全局生效。Windows 不需要辅助功能权限。'
+    : '按下即开始捕获语音，全局生效。需要授予辅助功能权限。';
 
   useEffect(() => {
     getSettings().then(setPrefs);
@@ -158,7 +161,7 @@ function RecordingSection() {
     <Card>
       <div style={{ fontSize: 13, fontWeight: 600, marginBottom: 4 }}>录音</div>
       <div style={{ fontSize: 11.5, color: 'var(--ol-ink-4)', marginBottom: 6 }}>定义全局录音的快捷键与触发方式。</div>
-      <SettingRow label="录音快捷键" desc="按下即开始捕获语音，全局生效。需要授予辅助功能权限。">
+      <SettingRow label="录音快捷键" desc={hotkeyDesc}>
         <select
           value={prefs.hotkey.trigger}
           onChange={e => onTriggerChange(e.target.value as HotkeyTrigger)}
@@ -339,6 +342,9 @@ const iconBtnStyle: CSSProperties = {
 
 function ShortcutsSection() {
   const os = detectOS();
+  const desc = os === 'win'
+    ? '所有快捷键全局生效。若无响应，请在权限页查看全局快捷键监听状态。'
+    : '所有快捷键全局生效，需要在权限设置中开启辅助功能。';
   const rows: Array<[string, string]> = [
     ['开始 / 停止录音', os === 'win' ? '右 Alt' : '右 Option'],
     ['取消本次录音', 'Esc'],
@@ -349,7 +355,7 @@ function ShortcutsSection() {
   return (
     <Card>
       <div style={{ fontSize: 13, fontWeight: 600, marginBottom: 4 }}>快捷键速查</div>
-      <div style={{ fontSize: 11.5, color: 'var(--ol-ink-4)', marginBottom: 6 }}>所有快捷键全局生效，需要在权限设置中开启辅助功能。</div>
+      <div style={{ fontSize: 11.5, color: 'var(--ol-ink-4)', marginBottom: 6 }}>{desc}</div>
       {rows.map(([k, v]) => (
         <SettingRow key={k} label={k}>
           <kbd style={{
@@ -370,6 +376,10 @@ function PermissionsSection() {
   const [accessibility, setAccessibility] = useState<PermissionStatus | 'loading'>('loading');
   const [microphone, setMicrophone] = useState<PermissionStatus | 'loading'>('loading');
   const [hotkey, setHotkey] = useState<HotkeyStatus | null>(null);
+  const os = detectOS();
+  const desc = os === 'win'
+    ? 'OpenLess 需要麦克风可用，并依赖全局快捷键监听状态判断 Windows 侧是否正常工作。'
+    : 'OpenLess 需要以下系统权限才能正常工作。授权后通常需要完全退出 App 重启一次才生效。';
 
   const refresh = async () => {
     const [a, m] = await Promise.all([
@@ -416,7 +426,7 @@ function PermissionsSection() {
     <Card>
       <div style={{ fontSize: 13, fontWeight: 600, marginBottom: 4 }}>权限</div>
       <div style={{ fontSize: 11.5, color: 'var(--ol-ink-4)', marginBottom: 6 }}>
-        OpenLess 需要以下系统权限才能正常工作。授权后通常需要完全退出 App 重启一次才生效。
+        {desc}
       </div>
       <SettingRow label="麦克风" desc="用于捕获你的语音输入。">
         <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
@@ -428,17 +438,19 @@ function PermissionsSection() {
           )}
         </div>
       </SettingRow>
-      <SettingRow label="辅助功能" desc="用于监听全局快捷键并将识别结果写入光标位置。">
-        <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
-          <PermissionPill status={accessibility} />
-          {accessibility !== 'granted' && accessibility !== 'notApplicable' && (
-            <Btn variant="ghost" size="sm" onClick={reRequestAccessibility}>
-              授权
-            </Btn>
-          )}
-        </div>
-      </SettingRow>
-      <SettingRow label="全局快捷键" desc="用于判断 Windows 上快捷键监听是否已经安装。">
+      {os !== 'win' && (
+        <SettingRow label="辅助功能" desc="用于监听全局快捷键并将识别结果写入光标位置。">
+          <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+            <PermissionPill status={accessibility} />
+            {accessibility !== 'granted' && accessibility !== 'notApplicable' && (
+              <Btn variant="ghost" size="sm" onClick={reRequestAccessibility}>
+                授权
+              </Btn>
+            )}
+          </div>
+        </SettingRow>
+      )}
+      <SettingRow label="全局快捷键" desc={os === 'win' ? '用于判断 Windows 上快捷键监听是否已经安装。' : '用于判断快捷键监听是否已经安装。'}>
         <div style={{ display: 'flex', gap: 8, alignItems: 'center', minWidth: 0 }}>
           <HotkeyStatusPill status={hotkey} />
           {hotkey?.message && (

--- a/openless -all/app/src/pages/Settings.tsx
+++ b/openless -all/app/src/pages/Settings.tsx
@@ -4,11 +4,14 @@
 
 import { useEffect, useState, type CSSProperties, type ReactNode } from 'react';
 import { Icon } from '../components/Icon';
+import { detectOS } from '../components/WindowChrome';
 import { APP_VERSION_LABEL } from '../lib/appVersion';
 import {
   checkAccessibilityPermission,
   checkMicrophonePermission,
+  getHotkeyStatus,
   getSettings,
+  openExternal,
   openSystemSettings,
   readCredential,
   requestAccessibilityPermission,
@@ -16,7 +19,7 @@ import {
   setCredential,
   setSettings,
 } from '../lib/ipc';
-import type { HotkeyMode, HotkeyTrigger, PermissionStatus, UserPreferences } from '../lib/types';
+import type { HotkeyMode, HotkeyStatus, HotkeyTrigger, PermissionStatus, UserPreferences } from '../lib/types';
 import { Btn, Card, PageHeader, Pill } from './_atoms';
 
 interface SettingsProps {
@@ -101,7 +104,7 @@ const TRIGGER_LABEL: Record<HotkeyTrigger, string> = {
   rightAlt: '右 Alt',
 };
 
-const TRIGGER_OPTIONS: HotkeyTrigger[] = [
+const MAC_TRIGGER_OPTIONS: HotkeyTrigger[] = [
   'rightOption',
   'leftOption',
   'rightControl',
@@ -110,8 +113,17 @@ const TRIGGER_OPTIONS: HotkeyTrigger[] = [
   'fn',
 ];
 
+const WIN_TRIGGER_OPTIONS: HotkeyTrigger[] = [
+  'rightAlt',
+  'rightControl',
+  'leftControl',
+  'rightCommand',
+];
+
 function RecordingSection() {
   const [prefs, setPrefs] = useState<UserPreferences | null>(null);
+  const os = detectOS();
+  const triggerOptions = os === 'win' ? WIN_TRIGGER_OPTIONS : MAC_TRIGGER_OPTIONS;
 
   useEffect(() => {
     getSettings().then(setPrefs);
@@ -156,7 +168,7 @@ function RecordingSection() {
             fontFamily: 'var(--ol-font-mono)',
           }}
         >
-          {TRIGGER_OPTIONS.map(t => (
+          {triggerOptions.map(t => (
             <option key={t} value={t}>{TRIGGER_LABEL[t]}</option>
           ))}
         </select>
@@ -326,12 +338,13 @@ const iconBtnStyle: CSSProperties = {
 };
 
 function ShortcutsSection() {
+  const os = detectOS();
   const rows: Array<[string, string]> = [
-    ['开始 / 停止录音', '右 Option'],
+    ['开始 / 停止录音', os === 'win' ? '右 Alt' : '右 Option'],
     ['取消本次录音', 'Esc'],
     ['胶囊确认插入', '点击右侧 ✓'],
-    ['切换上一次风格', '⌘ ⇧ S'],
-    ['打开 OpenLess', '⌘ ⇧ O'],
+    ['切换上一次风格', os === 'win' ? '暂未支持' : '⌘ ⇧ S'],
+    ['打开 OpenLess', os === 'win' ? '暂未支持' : '⌘ ⇧ O'],
   ];
   return (
     <Card>
@@ -356,6 +369,7 @@ function ShortcutsSection() {
 function PermissionsSection() {
   const [accessibility, setAccessibility] = useState<PermissionStatus | 'loading'>('loading');
   const [microphone, setMicrophone] = useState<PermissionStatus | 'loading'>('loading');
+  const [hotkey, setHotkey] = useState<HotkeyStatus | null>(null);
 
   const refresh = async () => {
     const [a, m] = await Promise.all([
@@ -364,6 +378,7 @@ function PermissionsSection() {
     ]);
     setAccessibility(a);
     setMicrophone(m);
+    setHotkey(await getHotkeyStatus());
   };
 
   useEffect(() => {
@@ -423,6 +438,16 @@ function PermissionsSection() {
           )}
         </div>
       </SettingRow>
+      <SettingRow label="全局快捷键" desc="用于判断 Windows 上快捷键监听是否已经安装。">
+        <div style={{ display: 'flex', gap: 8, alignItems: 'center', minWidth: 0 }}>
+          <HotkeyStatusPill status={hotkey} />
+          {hotkey?.message && (
+            <span style={{ fontSize: 11.5, color: 'var(--ol-ink-4)', overflow: 'hidden', textOverflow: 'ellipsis' }}>
+              {hotkey.message}
+            </span>
+          )}
+        </div>
+      </SettingRow>
       <SettingRow label="网络" desc="云端 ASR / LLM 调用所必需。本地模式可关闭。">
         <Pill tone="ok"><Icon name="check" size={11} />可用</Pill>
       </SettingRow>
@@ -463,12 +488,25 @@ function AboutSection() {
           <div style={{ fontSize: 12, color: 'var(--ol-ink-3)' }}>自然说话，完美书写 · {APP_VERSION_LABEL}</div>
         </div>
       </div>
-      <SettingRow label="检查更新"><Btn variant="ghost" size="sm">检查</Btn></SettingRow>
-      <SettingRow label="文档"><Btn variant="ghost" size="sm" icon="link">openless.app/docs</Btn></SettingRow>
-      <SettingRow label="反馈渠道"><Btn variant="ghost" size="sm" icon="link">GitHub Issues</Btn></SettingRow>
+      <SettingRow label="检查更新"><Btn variant="ghost" size="sm" onClick={() => openExternal('https://github.com/appergb/openless/releases')}>打开 Releases</Btn></SettingRow>
+      <SettingRow label="文档"><Btn variant="ghost" size="sm" icon="link" onClick={() => openExternal('https://github.com/appergb/openless#readme')}>README</Btn></SettingRow>
+      <SettingRow label="反馈渠道"><Btn variant="ghost" size="sm" icon="link" onClick={() => openExternal('https://github.com/appergb/openless/issues')}>GitHub Issues</Btn></SettingRow>
       <SettingRow label="隐私" desc="所有识别结果仅保存在本机。云端 API 仅用于实时转写与润色，不会保留你的录音。">
         <Pill tone="default">本地优先</Pill>
       </SettingRow>
     </Card>
   );
+}
+
+function HotkeyStatusPill({ status }: { status: HotkeyStatus | null }) {
+  if (!status) {
+    return <Pill tone="default">检查中…</Pill>;
+  }
+  if (status.state === 'installed') {
+    return <Pill tone="ok"><Icon name="check" size={11} />已安装</Pill>;
+  }
+  if (status.state === 'starting') {
+    return <Pill tone="default">安装中…</Pill>;
+  }
+  return <Pill tone="outline">监听失败</Pill>;
 }


### PR DESCRIPTION
## 变更摘要
- 增加全局快捷键安装状态查询 IPC，并在设置页展示监听安装中 / 已安装 / 失败状态。
- Windows / 非 macOS 麦克风权限改为通过 cpal 探测真实输入设备可用性，系统设置按钮跳转到对应 Windows 设置页。
- 将快捷键默认文案和选项按平台区分，Windows 使用右 Alt / Ctrl 系列文案，隐藏暂未支持的 macOS 快捷键。
- 非 macOS 文本插入不再把 Ctrl+V 发送成功误报为已插入，而是显示已复制并提示用户 Ctrl+V。
- 接入主界面和设置页的反馈、帮助、更新、全部记录等静态按钮。
- 修正前端 repolish IPC 契约为 rawText/mode，匹配后端命令签名。

## 关联 Issue
Fixes #16
Fixes #17
Fixes #18
Fixes #19
Fixes #20
Fixes #21
Fixes #22

## 验证
- npm run build
- cargo check --target x86_64-pc-windows-gnu（在无空格路径副本中验证，规避已知 #13 GNU/MinGW 空格路径问题）
- git diff --check

## 备注
- 原始仓库路径 `openless -all` 仍会触发已记录的 Windows GNU 空格路径问题，因此 Rust 门禁在 `D:\Users\cooper\Practice-Project\202604\openless_all_app_copy` 中执行。
- 本 PR 不包含本地未跟踪的 `.agents/`、`.codex/` 或 `.github/workflows/ci.yml`。

## Summary by Sourcery

Improve Windows runtime behavior and platform-specific UX, including hotkey monitoring visibility, microphone permission detection, text insertion feedback, and entry points to help, feedback, and updates.

New Features:
- Expose global hotkey installation status via IPC and display it in the settings UI.
- Add Windows-specific handling for default hotkey labels and shortcut documentation, hiding unsupported macOS-only shortcuts.
- Provide clickable links from the main UI and settings to documentation, feedback channels, and release notes.
- Route overview page actions to open the full history view from recent records.

Bug Fixes:
- Avoid reporting successful text insertion on non-macOS when only Ctrl+V was simulated, instead indicating copy-only behavior with appropriate prompts.
- Align the repolish IPC contract to use rawText and mode to match the backend command signature.
- Prevent misleading microphone permission status on Windows/Linux by probing actual input device availability via cpal.
- Expose accurate insert status messaging in the capsule UI and history list, including OS-specific paste hints.

Enhancements:
- Track and expose global hotkey listener lifecycle state in the backend and UI, including retry feedback and failure reasons on Windows.
- Refine onboarding copy and behavior to distinguish between macOS accessibility permissions and Windows global hotkey setup.
- Improve non-macOS global hotkey listener startup reporting by differentiating between immediate failures and successful listener activation.
- Make keyboard shortcut hints in onboarding, overview, history, and shell footer dynamically reflect the current OS and default trigger key.