### PR TITLE
fix(hotkey): 收口桌面热键适配边界

### DIFF
--- a/docs/platform-adapter-architecture.md
+++ b/docs/platform-adapter-architecture.md
@@ -1,0 +1,53 @@
+# Platform adapter architecture
+
+## Goal
+
+把 `Coordinator` 需要的热键边沿事件（`pressed` / `released` / `cancelled`）与各平台的 OS hook 细节隔离开，避免把 UI 文案、权限判断、按键映射和 session state machine 混在一起。
+
+## Backend boundary
+
+Rust 层统一暴露三类对象：
+
+- `HotkeyAdapter` trait：平台监听器只负责安装、更新 binding、发送边沿事件。
+- `HotkeyCapability`：描述当前平台能提供什么（可选 trigger、是否需要辅助功能权限、是否支持 modifier-only trigger、是否有 fallback）。
+- `HotkeyStatus` / `HotkeyInstallError`：描述当前 hook 是否已安装、失败原因、当前实际 adapter。
+
+`Coordinator` 不再关心 CGEventTap / Windows hook / `rdev` 的实现差异，只消费统一事件和状态。
+
+## Platform adapters
+
+### macOS
+
+- Adapter: `MacHotkeyAdapter`
+- Hook: `CGEventTap`
+- 目的：保留现有已验证实现，不回退到 `rdev`
+- 限制：依赖辅助功能权限；授权后通常需要完全退出再重开
+
+### Windows
+
+- Adapter: `WindowsHotkeyAdapter`
+- Hook: `SetWindowsHookExW(WH_KEYBOARD_LL)`
+- 目的：支持右 Control / 右 Alt 这类 modifier-only trigger，并且保留左右侧语义
+- 备注：默认推荐 `右 Control + 按住说话`
+
+### Linux / other
+
+- Adapter: `RdevHotkeyAdapter`
+- Hook: `rdev::listen`
+- 目的：best-effort 兜底，不承诺与 macOS / Windows 同等行为
+
+## UI contract
+
+前端通过 IPC 读取：
+
+- `get_hotkey_capability`
+- `get_hotkey_status`
+- `get_settings`
+
+设置页、权限页和快捷键提示必须基于 capability / status / actual binding 渲染，而不是再写 `if (os === 'win') ... else ...` 的平台硬编码文案。
+
+## Explicit non-goals
+
+- 不静默把 modifier-only trigger 替换成普通 registered shortcut
+- 不把平台差异泄漏到 `Coordinator`
+- 不在这层引入新的全局快捷键依赖

--- a/openless -all/app/src-tauri/src/commands.rs
+++ b/openless -all/app/src-tauri/src/commands.rs
@@ -8,8 +8,8 @@ use crate::coordinator::Coordinator;
 use crate::permissions::{self, PermissionStatus};
 use crate::persistence::{CredentialAccount, CredentialsSnapshot, CredentialsVault};
 use crate::types::{
-    CredentialsStatus, DictationSession, DictionaryEntry, HotkeyStatus, PolishMode,
-    UserPreferences,
+    CredentialsStatus, DictationSession, DictionaryEntry, HotkeyCapability, HotkeyStatus,
+    PolishMode, UserPreferences,
 };
 
 type CoordinatorState<'a> = State<'a, Arc<Coordinator>>;
@@ -31,6 +31,11 @@ pub fn set_settings(coord: CoordinatorState<'_>, prefs: UserPreferences) -> Resu
 #[tauri::command]
 pub fn get_hotkey_status(coord: CoordinatorState<'_>) -> HotkeyStatus {
     coord.hotkey_status()
+}
+
+#[tauri::command]
+pub fn get_hotkey_capability(coord: CoordinatorState<'_>) -> HotkeyCapability {
+    coord.hotkey_capability()
 }
 
 #[tauri::command]

--- a/openless -all/app/src-tauri/src/coordinator.rs
+++ b/openless -all/app/src-tauri/src/coordinator.rs
@@ -105,6 +105,10 @@ impl Coordinator {
             .ok();
     }
 
+    pub fn stop_hotkey_listener(&self) {
+        self.inner.hotkey.lock().take();
+    }
+
     pub fn history(&self) -> &HistoryStore {
         &self.inner.history
     }

--- a/openless -all/app/src-tauri/src/coordinator.rs
+++ b/openless -all/app/src-tauri/src/coordinator.rs
@@ -23,7 +23,7 @@ use crate::persistence::{
 use crate::polish::{OpenAICompatibleConfig, OpenAICompatibleLLMProvider};
 use crate::recorder::Recorder;
 use crate::types::{
-    CapsulePayload, CapsuleState, DictationSession, HotkeyMode, HotkeyStatus,
+    CapsulePayload, CapsuleState, DictationSession, HotkeyCapability, HotkeyMode, HotkeyStatus,
     HotkeyStatusState, InsertStatus, PolishMode,
 };
 
@@ -125,6 +125,10 @@ impl Coordinator {
         self.inner.hotkey_status.lock().clone()
     }
 
+    pub fn hotkey_capability(&self) -> HotkeyCapability {
+        HotkeyMonitor::capability()
+    }
+
     pub async fn start_dictation(&self) -> Result<(), String> {
         begin_session(&self.inner).await
     }
@@ -149,25 +153,28 @@ impl Coordinator {
 
 fn hotkey_supervisor_loop(inner: Arc<Inner>) {
     let mut attempts: u32 = 0;
+    let capability = HotkeyMonitor::capability();
     loop {
         if inner.hotkey.lock().is_some() {
             return;
         }
         *inner.hotkey_status.lock() = HotkeyStatus {
+            adapter: capability.adapter,
             state: HotkeyStatusState::Starting,
-            message: Some(format!(
-                "正在安装全局快捷键监听（第 {} 次）",
-                attempts + 1
-            )),
+            message: Some(format!("正在安装全局快捷键监听（第 {} 次）", attempts + 1)),
+            last_error: None,
         };
         let (tx, rx) = mpsc::channel::<HotkeyEvent>();
         let binding = inner.prefs.get().hotkey;
         match HotkeyMonitor::start(binding, tx) {
             Ok(monitor) => {
+                let adapter = monitor.kind();
                 *inner.hotkey.lock() = Some(monitor);
                 *inner.hotkey_status.lock() = HotkeyStatus {
+                    adapter,
                     state: HotkeyStatusState::Installed,
-                    message: None,
+                    message: Some(format!("{} 已安装", adapter.display_name())),
+                    last_error: None,
                 };
                 log::info!(
                     "[coord] hotkey listener installed (after {} attempt(s))",
@@ -182,13 +189,17 @@ fn hotkey_supervisor_loop(inner: Arc<Inner>) {
             }
             Err(e) => {
                 attempts += 1;
+                let error_message = e.message.clone();
                 *inner.hotkey_status.lock() = HotkeyStatus {
+                    adapter: capability.adapter,
                     state: HotkeyStatusState::Failed,
-                    message: Some(e.to_string()),
+                    message: Some(error_message.clone()),
+                    last_error: Some(e),
                 };
                 if attempts <= 3 || attempts % 10 == 0 {
                     log::warn!(
-                        "[coord] hotkey listener attempt #{attempts} failed: {e}; retrying in 3s"
+                        "[coord] hotkey listener attempt #{attempts} failed: {}; retrying in 3s",
+                        error_message
                     );
                 }
                 std::thread::sleep(std::time::Duration::from_secs(3));

--- a/openless -all/app/src-tauri/src/hotkey.rs
+++ b/openless -all/app/src-tauri/src/hotkey.rs
@@ -4,24 +4,29 @@
 //!   `OpenLessHotkey/HotkeyMonitor.swift` 同源。**不能用 `rdev`**：rdev 在每个
 //!   事件回调里同步调 `TSMGetInputSourceProperty`，macOS 14+ 强制断言主线程，
 //!   非主线程触发 `dispatch_assert_queue_fail` → SIGTRAP abort（已踩坑）。
-//! - 其他平台：继续用 `rdev::listen`（Linux/Windows 的 listen 路径不依赖 TSM）。
+//! - Windows：原生 `WH_KEYBOARD_LL` low-level keyboard hook，保留 modifier-only
+//!   trigger（如右 Control / 右 Alt）的真实语义，不再把平台能力藏在 `rdev` 抽象里。
+//! - Linux / 其他：继续 best-effort 走 `rdev::listen`。
 //!
 //! 仅产出"边沿"事件，toggle vs hold 由 Coordinator 解释。
 
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::AtomicBool;
 use std::sync::mpsc::Sender;
-use std::sync::Arc;
-use std::thread;
 
 use parking_lot::RwLock;
 
-use crate::types::HotkeyBinding;
+use crate::types::{HotkeyAdapterKind, HotkeyBinding, HotkeyCapability, HotkeyInstallError};
 
 #[derive(Clone, Copy, Debug)]
 pub enum HotkeyEvent {
     Pressed,
     Released,
     Cancelled,
+}
+
+pub trait HotkeyAdapter: Send + Sync {
+    fn kind(&self) -> HotkeyAdapterKind;
+    fn update_binding(&self, binding: HotkeyBinding);
 }
 
 struct Shared {
@@ -31,38 +36,45 @@ struct Shared {
 }
 
 pub struct HotkeyMonitor {
-    shared: Arc<Shared>,
+    adapter: Box<dyn HotkeyAdapter>,
 }
 
 impl HotkeyMonitor {
     /// Spawn the listener thread and **wait synchronously** for it to confirm
-    /// the OS-level hook installed (CGEventTap on macOS / rdev::listen otherwise).
-    /// Returns Err if installation failed (typically Accessibility not granted on macOS),
-    /// so the caller can schedule a retry instead of silently dropping events.
-    pub fn start(binding: HotkeyBinding, tx: Sender<HotkeyEvent>) -> anyhow::Result<Self> {
-        let shared = Arc::new(Shared {
-            binding: RwLock::new(binding),
-            trigger_held: AtomicBool::new(false),
-        });
-
-        let thread_shared = Arc::clone(&shared);
-        let (status_tx, status_rx) = std::sync::mpsc::channel::<bool>();
-        thread::Builder::new()
-            .name("openless-hotkey".into())
-            .spawn(move || platform::run_listen_loop(thread_shared, tx, status_tx))?;
-
-        match status_rx.recv_timeout(std::time::Duration::from_secs(3)) {
-            Ok(true) => Ok(Self { shared }),
-            Ok(false) => Err(anyhow::anyhow!(
-                "hotkey hook 安装失败（macOS 多半是辅助功能权限未授予）"
-            )),
-            Err(_) => Err(anyhow::anyhow!("hotkey hook 启动超时")),
-        }
+    /// the OS-level hook installed so the caller can surface an actual adapter
+    /// status instead of silently dropping events.
+    pub fn start(
+        binding: HotkeyBinding,
+        tx: Sender<HotkeyEvent>,
+    ) -> Result<Self, HotkeyInstallError> {
+        Ok(Self {
+            adapter: platform::start_adapter(binding, tx)?,
+        })
     }
 
     pub fn update_binding(&self, binding: HotkeyBinding) {
-        *self.shared.binding.write() = binding;
-        self.shared.trigger_held.store(false, Ordering::SeqCst);
+        self.adapter.update_binding(binding);
+    }
+
+    pub fn kind(&self) -> HotkeyAdapterKind {
+        self.adapter.kind()
+    }
+
+    pub fn capability() -> HotkeyCapability {
+        HotkeyCapability::current()
+    }
+}
+
+fn install_error(code: &str, message: impl Into<String>) -> HotkeyInstallError {
+    HotkeyInstallError {
+        code: code.into(),
+        message: message.into(),
+    }
+}
+
+fn send_or_log(tx: &Sender<HotkeyEvent>, evt: HotkeyEvent) {
+    if let Err(e) = tx.send(evt) {
+        log::warn!("[hotkey] 事件发送失败: {e}");
     }
 }
 
@@ -75,8 +87,46 @@ mod platform {
     use std::sync::mpsc::Sender;
     use std::sync::Arc;
 
-    use super::{HotkeyEvent, Shared};
-    use crate::types::HotkeyTrigger;
+    use super::{install_error, send_or_log, HotkeyAdapter, HotkeyEvent, Shared};
+    use crate::types::{HotkeyAdapterKind, HotkeyBinding, HotkeyInstallError, HotkeyTrigger};
+
+    pub fn start_adapter(
+        binding: HotkeyBinding,
+        tx: Sender<HotkeyEvent>,
+    ) -> Result<Box<dyn HotkeyAdapter>, HotkeyInstallError> {
+        let shared = Arc::new(Shared {
+            binding: parking_lot::RwLock::new(binding),
+            trigger_held: std::sync::atomic::AtomicBool::new(false),
+        });
+
+        let thread_shared = Arc::clone(&shared);
+        let (status_tx, status_rx) = std::sync::mpsc::channel::<Result<(), HotkeyInstallError>>();
+        std::thread::Builder::new()
+            .name("openless-hotkey-mac-event-tap".into())
+            .spawn(move || run_listen_loop(thread_shared, tx, status_tx))
+            .map_err(|e| install_error("spawn_failed", format!("hotkey 线程启动失败: {e}")))?;
+
+        match status_rx.recv_timeout(std::time::Duration::from_secs(3)) {
+            Ok(Ok(())) => Ok(Box::new(MacHotkeyAdapter { shared })),
+            Ok(Err(err)) => Err(err),
+            Err(_) => Err(install_error("startup_timeout", "hotkey hook 启动超时")),
+        }
+    }
+
+    struct MacHotkeyAdapter {
+        shared: Arc<Shared>,
+    }
+
+    impl HotkeyAdapter for MacHotkeyAdapter {
+        fn kind(&self) -> HotkeyAdapterKind {
+            HotkeyAdapterKind::MacEventTap
+        }
+
+        fn update_binding(&self, binding: HotkeyBinding) {
+            *self.shared.binding.write() = binding;
+            self.shared.trigger_held.store(false, Ordering::SeqCst);
+        }
+    }
 
     // ── Raw CG/CF FFI ──────────────────────────────────────────────────────
 
@@ -160,24 +210,19 @@ mod platform {
         static kCFRunLoopCommonModes: CfStringRef;
     }
 
-    // ── Callback context ───────────────────────────────────────────────────
-
     struct CallbackContext {
         shared: Arc<Shared>,
         tx: Sender<HotkeyEvent>,
         tap: std::sync::Mutex<Option<CfMachPortRef>>,
     }
 
-    // CallbackContext crosses an FFI boundary as a raw pointer; the only field
-    // not auto-Send/Sync is the CfMachPortRef raw pointer, which is fine to
-    // share since CGEventTapEnable is thread-safe for our usage.
     unsafe impl Send for CallbackContext {}
     unsafe impl Sync for CallbackContext {}
 
-    pub fn run_listen_loop(
+    fn run_listen_loop(
         shared: Arc<Shared>,
         tx: Sender<HotkeyEvent>,
-        status_tx: std::sync::mpsc::Sender<bool>,
+        status_tx: std::sync::mpsc::Sender<Result<(), HotkeyInstallError>>,
     ) {
         let mask: CgEventMask = (1u64 << FLAGS_CHANGED) | (1u64 << KEY_DOWN);
         let context = Box::into_raw(Box::new(CallbackContext {
@@ -200,7 +245,10 @@ mod platform {
                     "[hotkey] CGEventTapCreate 失败 — Accessibility 权限未授予。Coordinator 会重试。"
                 );
                 let _ = Box::from_raw(context);
-                let _ = status_tx.send(false);
+                let _ = status_tx.send(Err(install_error(
+                    "accessibility_denied",
+                    "hotkey hook 安装失败（辅助功能权限未授予）",
+                )));
                 return;
             }
             *(*context).tap.lock().unwrap() = Some(tap);
@@ -211,7 +259,7 @@ mod platform {
             CGEventTapEnable(tap, true);
 
             log::info!("[hotkey] CGEventTap 已启动");
-            let _ = status_tx.send(true);
+            let _ = status_tx.send(Ok(()));
             CFRunLoopRun();
         }
     }
@@ -269,12 +317,6 @@ mod platform {
         }
     }
 
-    fn send_or_log(tx: &Sender<HotkeyEvent>, evt: HotkeyEvent) {
-        if let Err(e) = tx.send(evt) {
-            log::warn!("[hotkey] 事件发送失败: {e}");
-        }
-    }
-
     fn trigger_to_keycode(trigger: HotkeyTrigger) -> i64 {
         match trigger {
             HotkeyTrigger::LeftControl => 59,
@@ -298,9 +340,212 @@ mod platform {
     }
 }
 
-// ─────────────────────────── non-macOS implementation ───────────────────────────
+// ─────────────────────────── Windows implementation ───────────────────────────
 
-#[cfg(not(target_os = "macos"))]
+#[cfg(target_os = "windows")]
+mod platform {
+    use std::sync::atomic::Ordering;
+    use std::sync::atomic::{AtomicPtr, Ordering as AtomicOrdering};
+    use std::sync::mpsc::Sender;
+    use std::sync::Arc;
+
+    use windows::Win32::Foundation::{LPARAM, LRESULT, WPARAM};
+    use windows::Win32::UI::Input::KeyboardAndMouse::KBDLLHOOKSTRUCT;
+    use windows::Win32::UI::WindowsAndMessaging::{
+        CallNextHookEx, DispatchMessageW, GetMessageW, SetWindowsHookExW, TranslateMessage,
+        UnhookWindowsHookEx, HC_ACTION, HHOOK, MSG, WH_KEYBOARD_LL,
+    };
+
+    use super::{install_error, send_or_log, HotkeyAdapter, HotkeyEvent, Shared};
+    use crate::types::{HotkeyAdapterKind, HotkeyBinding, HotkeyInstallError, HotkeyTrigger};
+
+    const WM_KEYDOWN: usize = 0x0100;
+    const WM_KEYUP: usize = 0x0101;
+    const WM_SYSKEYDOWN: usize = 0x0104;
+    const WM_SYSKEYUP: usize = 0x0105;
+
+    const VK_ESCAPE: u32 = 0x1B;
+    const VK_LCONTROL: u32 = 0xA2;
+    const VK_RCONTROL: u32 = 0xA3;
+    const VK_RMENU: u32 = 0xA5;
+    const VK_RWIN: u32 = 0x5C;
+    const LLKHF_INJECTED: u32 = 0x0000_0010;
+
+    static HOOK_CONTEXT: AtomicPtr<CallbackContext> = AtomicPtr::new(std::ptr::null_mut());
+
+    pub fn start_adapter(
+        binding: HotkeyBinding,
+        tx: Sender<HotkeyEvent>,
+    ) -> Result<Box<dyn HotkeyAdapter>, HotkeyInstallError> {
+        let shared = Arc::new(Shared {
+            binding: parking_lot::RwLock::new(binding),
+            trigger_held: std::sync::atomic::AtomicBool::new(false),
+        });
+
+        let thread_shared = Arc::clone(&shared);
+        let (status_tx, status_rx) = std::sync::mpsc::channel::<Result<(), HotkeyInstallError>>();
+        std::thread::Builder::new()
+            .name("openless-hotkey-win-ll-hook".into())
+            .spawn(move || run_listen_loop(thread_shared, tx, status_tx))
+            .map_err(|e| install_error("spawn_failed", format!("hotkey 线程启动失败: {e}")))?;
+
+        match status_rx.recv_timeout(std::time::Duration::from_secs(3)) {
+            Ok(Ok(())) => Ok(Box::new(WindowsHotkeyAdapter { shared })),
+            Ok(Err(err)) => Err(err),
+            Err(_) => Err(install_error(
+                "startup_timeout",
+                "Windows hotkey hook 启动超时",
+            )),
+        }
+    }
+
+    struct WindowsHotkeyAdapter {
+        shared: Arc<Shared>,
+    }
+
+    impl HotkeyAdapter for WindowsHotkeyAdapter {
+        fn kind(&self) -> HotkeyAdapterKind {
+            HotkeyAdapterKind::WindowsLowLevel
+        }
+
+        fn update_binding(&self, binding: HotkeyBinding) {
+            *self.shared.binding.write() = binding;
+            self.shared.trigger_held.store(false, Ordering::SeqCst);
+        }
+    }
+
+    struct CallbackContext {
+        shared: Arc<Shared>,
+        tx: Sender<HotkeyEvent>,
+        hook: std::sync::Mutex<Option<HHOOK>>,
+    }
+
+    unsafe impl Send for CallbackContext {}
+    unsafe impl Sync for CallbackContext {}
+
+    fn run_listen_loop(
+        shared: Arc<Shared>,
+        tx: Sender<HotkeyEvent>,
+        status_tx: std::sync::mpsc::Sender<Result<(), HotkeyInstallError>>,
+    ) {
+        let context = Box::into_raw(Box::new(CallbackContext {
+            shared,
+            tx,
+            hook: std::sync::Mutex::new(None),
+        }));
+        HOOK_CONTEXT.store(context, AtomicOrdering::SeqCst);
+
+        unsafe {
+            let hook = SetWindowsHookExW(WH_KEYBOARD_LL, Some(low_level_keyboard_proc), None, 0);
+            match hook {
+                Ok(hook) => {
+                    *(*context).hook.lock().unwrap() = Some(hook);
+                    log::info!("[hotkey] Windows low-level keyboard hook 已启动");
+                    let _ = status_tx.send(Ok(()));
+                }
+                Err(err) => {
+                    HOOK_CONTEXT.store(std::ptr::null_mut(), AtomicOrdering::SeqCst);
+                    let _ = Box::from_raw(context);
+                    let _ = status_tx.send(Err(install_error(
+                        "hook_install_failed",
+                        format!("Windows low-level keyboard hook 安装失败: {err}"),
+                    )));
+                    return;
+                }
+            }
+
+            let mut message = MSG::default();
+            loop {
+                let result = GetMessageW(&mut message, None, 0, 0).0;
+                if result == -1 {
+                    log::error!("[hotkey] Windows GetMessageW 返回错误，hook 线程退出");
+                    break;
+                }
+                if result == 0 {
+                    log::warn!("[hotkey] Windows hook 消息循环收到退出消息");
+                    break;
+                }
+                let _ = TranslateMessage(&message);
+                let _ = DispatchMessageW(&message);
+            }
+
+            if let Some(hook) = (*context).hook.lock().unwrap().take() {
+                let _ = UnhookWindowsHookEx(hook);
+            }
+            HOOK_CONTEXT.store(std::ptr::null_mut(), AtomicOrdering::SeqCst);
+            let _ = Box::from_raw(context);
+        }
+    }
+
+    unsafe extern "system" fn low_level_keyboard_proc(
+        code: i32,
+        wparam: WPARAM,
+        lparam: LPARAM,
+    ) -> LRESULT {
+        if code == HC_ACTION as i32 && lparam.0 != 0 {
+            if let Some(ctx) = callback_context() {
+                let keyboard = *(lparam.0 as *const KBDLLHOOKSTRUCT);
+                if keyboard.flags & LLKHF_INJECTED == 0 {
+                    dispatch_keyboard_event(ctx, keyboard.vkCode, wparam.0);
+                }
+            }
+        }
+
+        CallNextHookEx(None, code, wparam, lparam)
+    }
+
+    unsafe fn callback_context<'a>() -> Option<&'a CallbackContext> {
+        let ptr = HOOK_CONTEXT.load(AtomicOrdering::SeqCst);
+        if ptr.is_null() {
+            None
+        } else {
+            Some(&*ptr)
+        }
+    }
+
+    fn dispatch_keyboard_event(ctx: &CallbackContext, vk_code: u32, message: usize) {
+        if vk_code == VK_ESCAPE && (message == WM_KEYDOWN || message == WM_SYSKEYDOWN) {
+            send_or_log(&ctx.tx, HotkeyEvent::Cancelled);
+            return;
+        }
+
+        let trigger = ctx.shared.binding.read().trigger;
+        if vk_code != trigger_to_vk_code(trigger) {
+            return;
+        }
+
+        match message {
+            WM_KEYDOWN | WM_SYSKEYDOWN => {
+                let was_held = ctx.shared.trigger_held.swap(true, Ordering::SeqCst);
+                if !was_held {
+                    send_or_log(&ctx.tx, HotkeyEvent::Pressed);
+                }
+            }
+            WM_KEYUP | WM_SYSKEYUP => {
+                let was_held = ctx.shared.trigger_held.swap(false, Ordering::SeqCst);
+                if was_held {
+                    send_or_log(&ctx.tx, HotkeyEvent::Released);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn trigger_to_vk_code(trigger: HotkeyTrigger) -> u32 {
+        match trigger {
+            HotkeyTrigger::RightControl => VK_RCONTROL,
+            HotkeyTrigger::LeftControl => VK_LCONTROL,
+            HotkeyTrigger::RightOption | HotkeyTrigger::RightAlt => VK_RMENU,
+            HotkeyTrigger::RightCommand => VK_RWIN,
+            HotkeyTrigger::LeftOption => VK_RMENU,
+            HotkeyTrigger::Fn => VK_RCONTROL,
+        }
+    }
+}
+
+// ─────────────────────────── Linux / other implementation ───────────────────────────
+
+#[cfg(all(not(target_os = "macos"), not(target_os = "windows")))]
 mod platform {
     use std::sync::atomic::{AtomicBool, Ordering};
     use std::sync::mpsc::Sender;
@@ -309,23 +554,59 @@ mod platform {
 
     use rdev::{listen, Event, EventType, Key};
 
-    use super::{HotkeyEvent, Shared};
-    use crate::types::HotkeyTrigger;
+    use super::{install_error, HotkeyAdapter, HotkeyEvent, Shared};
+    use crate::types::{HotkeyAdapterKind, HotkeyBinding, HotkeyInstallError, HotkeyTrigger};
 
-    pub fn run_listen_loop(
+    pub fn start_adapter(
+        binding: HotkeyBinding,
+        tx: Sender<HotkeyEvent>,
+    ) -> Result<Box<dyn HotkeyAdapter>, HotkeyInstallError> {
+        let shared = Arc::new(Shared {
+            binding: parking_lot::RwLock::new(binding),
+            trigger_held: std::sync::atomic::AtomicBool::new(false),
+        });
+
+        let thread_shared = Arc::clone(&shared);
+        let (status_tx, status_rx) = std::sync::mpsc::channel::<Result<(), HotkeyInstallError>>();
+        std::thread::Builder::new()
+            .name("openless-hotkey-rdev".into())
+            .spawn(move || run_listen_loop(thread_shared, tx, status_tx))
+            .map_err(|e| install_error("spawn_failed", format!("hotkey 线程启动失败: {e}")))?;
+
+        match status_rx.recv_timeout(std::time::Duration::from_secs(3)) {
+            Ok(Ok(())) => Ok(Box::new(RdevHotkeyAdapter { shared })),
+            Ok(Err(err)) => Err(err),
+            Err(_) => Err(install_error("startup_timeout", "hotkey hook 启动超时")),
+        }
+    }
+
+    struct RdevHotkeyAdapter {
+        shared: Arc<Shared>,
+    }
+
+    impl HotkeyAdapter for RdevHotkeyAdapter {
+        fn kind(&self) -> HotkeyAdapterKind {
+            HotkeyAdapterKind::Rdev
+        }
+
+        fn update_binding(&self, binding: HotkeyBinding) {
+            *self.shared.binding.write() = binding;
+            self.shared.trigger_held.store(false, Ordering::SeqCst);
+        }
+    }
+
+    fn run_listen_loop(
         shared: Arc<Shared>,
         tx: Sender<HotkeyEvent>,
-        status_tx: std::sync::mpsc::Sender<bool>,
+        status_tx: std::sync::mpsc::Sender<Result<(), HotkeyInstallError>>,
     ) {
-        // rdev 没有"安装即可知"的 API。给 listen 一个短窗口：
-        // 如果 hook 立即失败，向 supervisor 汇报失败；否则视为已进入监听循环。
         let status_sent = Arc::new(AtomicBool::new(false));
         let ready_status_sent = Arc::clone(&status_sent);
         let ready_status_tx = status_tx.clone();
         std::thread::spawn(move || {
             std::thread::sleep(Duration::from_millis(350));
             if !ready_status_sent.swap(true, Ordering::SeqCst) {
-                let _ = ready_status_tx.send(true);
+                let _ = ready_status_tx.send(Ok(()));
             }
         });
         let cb_shared = Arc::clone(&shared);
@@ -334,7 +615,10 @@ mod platform {
         });
         if let Err(err) = result {
             if !status_sent.swap(true, Ordering::SeqCst) {
-                let _ = status_tx.send(false);
+                let _ = status_tx.send(Err(install_error(
+                    "listen_failed",
+                    format!("rdev::listen 启动失败: {err:?}"),
+                )));
             }
             log::error!("[hotkey] rdev::listen 启动失败: {:?}", err);
         }

--- a/openless -all/app/src-tauri/src/hotkey.rs
+++ b/openless -all/app/src-tauri/src/hotkey.rs
@@ -531,6 +531,12 @@ mod platform {
     }
 
     fn trigger_to_vk_code(trigger: HotkeyTrigger) -> u32 {
+        // Windows only gives us a small set of modifier virtual keys that can be
+        // used as reliable modifier-only global triggers, so the cross-platform
+        // trigger list intentionally collapses a few aliases onto the same
+        // physical Windows key:
+        // - LeftOption reuses RightAlt / VK_RMENU
+        // - Fn reuses RightControl / VK_RCONTROL
         match trigger {
             HotkeyTrigger::RightControl => VK_RCONTROL,
             HotkeyTrigger::LeftControl => VK_LCONTROL,

--- a/openless -all/app/src-tauri/src/hotkey.rs
+++ b/openless -all/app/src-tauri/src/hotkey.rs
@@ -11,7 +11,9 @@
 //! 仅产出"边沿"事件，toggle vs hold 由 Coordinator 解释。
 
 use std::sync::atomic::AtomicBool;
-use std::sync::mpsc::Sender;
+use std::sync::mpsc::{self, Sender};
+use std::sync::Arc;
+use std::time::Duration;
 
 use parking_lot::RwLock;
 
@@ -27,6 +29,7 @@ pub enum HotkeyEvent {
 pub trait HotkeyAdapter: Send + Sync {
     fn kind(&self) -> HotkeyAdapterKind;
     fn update_binding(&self, binding: HotkeyBinding);
+    fn shutdown(&self) {}
 }
 
 struct Shared {
@@ -65,6 +68,12 @@ impl HotkeyMonitor {
     }
 }
 
+impl Drop for HotkeyMonitor {
+    fn drop(&mut self) {
+        self.adapter.shutdown();
+    }
+}
+
 fn install_error(code: &str, message: impl Into<String>) -> HotkeyInstallError {
     HotkeyInstallError {
         code: code.into(),
@@ -78,6 +87,50 @@ fn send_or_log(tx: &Sender<HotkeyEvent>, evt: HotkeyEvent) {
     }
 }
 
+type StartupTx<T> = mpsc::Sender<Result<T, HotkeyInstallError>>;
+
+struct ListenerThread<T> {
+    shared: Arc<Shared>,
+    startup: T,
+}
+
+fn start_listener_thread<T, F>(
+    binding: HotkeyBinding,
+    tx: Sender<HotkeyEvent>,
+    thread_name: &str,
+    startup_timeout_message: &'static str,
+    run_listen_loop: F,
+) -> Result<ListenerThread<T>, HotkeyInstallError>
+where
+    T: Send + 'static,
+    F: FnOnce(Arc<Shared>, Sender<HotkeyEvent>, StartupTx<T>) + Send + 'static,
+{
+    let shared = Arc::new(Shared {
+        binding: RwLock::new(binding),
+        trigger_held: AtomicBool::new(false),
+    });
+
+    let thread_shared = Arc::clone(&shared);
+    let (status_tx, status_rx) = mpsc::channel::<Result<T, HotkeyInstallError>>();
+    std::thread::Builder::new()
+        .name(thread_name.into())
+        .spawn(move || run_listen_loop(thread_shared, tx, status_tx))
+        .map_err(|e| install_error("spawn_failed", format!("hotkey 线程启动失败: {e}")))?;
+
+    match status_rx.recv_timeout(Duration::from_secs(3)) {
+        Ok(Ok(startup)) => Ok(ListenerThread { shared, startup }),
+        Ok(Err(err)) => Err(err),
+        Err(_) => Err(install_error("startup_timeout", startup_timeout_message)),
+    }
+}
+
+fn update_shared_binding(shared: &Shared, binding: HotkeyBinding) {
+    *shared.binding.write() = binding;
+    shared
+        .trigger_held
+        .store(false, std::sync::atomic::Ordering::SeqCst);
+}
+
 // ─────────────────────────── macOS implementation ───────────────────────────
 
 #[cfg(target_os = "macos")]
@@ -87,30 +140,27 @@ mod platform {
     use std::sync::mpsc::Sender;
     use std::sync::Arc;
 
-    use super::{install_error, send_or_log, HotkeyAdapter, HotkeyEvent, Shared};
+    use super::{
+        install_error, send_or_log, start_listener_thread, update_shared_binding, HotkeyAdapter,
+        HotkeyEvent, Shared, StartupTx,
+    };
     use crate::types::{HotkeyAdapterKind, HotkeyBinding, HotkeyInstallError, HotkeyTrigger};
 
     pub fn start_adapter(
         binding: HotkeyBinding,
         tx: Sender<HotkeyEvent>,
     ) -> Result<Box<dyn HotkeyAdapter>, HotkeyInstallError> {
-        let shared = Arc::new(Shared {
-            binding: parking_lot::RwLock::new(binding),
-            trigger_held: std::sync::atomic::AtomicBool::new(false),
-        });
-
-        let thread_shared = Arc::clone(&shared);
-        let (status_tx, status_rx) = std::sync::mpsc::channel::<Result<(), HotkeyInstallError>>();
-        std::thread::Builder::new()
-            .name("openless-hotkey-mac-event-tap".into())
-            .spawn(move || run_listen_loop(thread_shared, tx, status_tx))
-            .map_err(|e| install_error("spawn_failed", format!("hotkey 线程启动失败: {e}")))?;
-
-        match status_rx.recv_timeout(std::time::Duration::from_secs(3)) {
-            Ok(Ok(())) => Ok(Box::new(MacHotkeyAdapter { shared })),
-            Ok(Err(err)) => Err(err),
-            Err(_) => Err(install_error("startup_timeout", "hotkey hook 启动超时")),
-        }
+        let listener = start_listener_thread(
+            binding,
+            tx,
+            "openless-hotkey-mac-event-tap",
+            "hotkey hook 启动超时",
+            run_listen_loop,
+        )?;
+        let _ = listener.startup;
+        Ok(Box::new(MacHotkeyAdapter {
+            shared: listener.shared,
+        }))
     }
 
     struct MacHotkeyAdapter {
@@ -123,8 +173,7 @@ mod platform {
         }
 
         fn update_binding(&self, binding: HotkeyBinding) {
-            *self.shared.binding.write() = binding;
-            self.shared.trigger_held.store(false, Ordering::SeqCst);
+            update_shared_binding(&self.shared, binding);
         }
     }
 
@@ -219,11 +268,7 @@ mod platform {
     unsafe impl Send for CallbackContext {}
     unsafe impl Sync for CallbackContext {}
 
-    fn run_listen_loop(
-        shared: Arc<Shared>,
-        tx: Sender<HotkeyEvent>,
-        status_tx: std::sync::mpsc::Sender<Result<(), HotkeyInstallError>>,
-    ) {
+    fn run_listen_loop(shared: Arc<Shared>, tx: Sender<HotkeyEvent>, status_tx: StartupTx<()>) {
         let mask: CgEventMask = (1u64 << FLAGS_CHANGED) | (1u64 << KEY_DOWN);
         let context = Box::into_raw(Box::new(CallbackContext {
             shared,
@@ -350,12 +395,17 @@ mod platform {
     use std::sync::Arc;
 
     use windows::Win32::Foundation::{LPARAM, LRESULT, WPARAM};
+    use windows::Win32::System::Threading::GetCurrentThreadId;
     use windows::Win32::UI::WindowsAndMessaging::{
-        CallNextHookEx, DispatchMessageW, GetMessageW, SetWindowsHookExW, TranslateMessage,
-        UnhookWindowsHookEx, HC_ACTION, HHOOK, KBDLLHOOKSTRUCT, MSG, WH_KEYBOARD_LL,
+        CallNextHookEx, DispatchMessageW, GetMessageW, PostThreadMessageW, SetWindowsHookExW,
+        TranslateMessage, UnhookWindowsHookEx, HC_ACTION, HHOOK, KBDLLHOOKSTRUCT, MSG,
+        WH_KEYBOARD_LL, WM_QUIT,
     };
 
-    use super::{install_error, send_or_log, HotkeyAdapter, HotkeyEvent, Shared};
+    use super::{
+        install_error, send_or_log, start_listener_thread, update_shared_binding, HotkeyAdapter,
+        HotkeyEvent, Shared, StartupTx,
+    };
     use crate::types::{HotkeyAdapterKind, HotkeyBinding, HotkeyInstallError, HotkeyTrigger};
 
     const WM_KEYDOWN: usize = 0x0100;
@@ -376,30 +426,22 @@ mod platform {
         binding: HotkeyBinding,
         tx: Sender<HotkeyEvent>,
     ) -> Result<Box<dyn HotkeyAdapter>, HotkeyInstallError> {
-        let shared = Arc::new(Shared {
-            binding: parking_lot::RwLock::new(binding),
-            trigger_held: std::sync::atomic::AtomicBool::new(false),
-        });
-
-        let thread_shared = Arc::clone(&shared);
-        let (status_tx, status_rx) = std::sync::mpsc::channel::<Result<(), HotkeyInstallError>>();
-        std::thread::Builder::new()
-            .name("openless-hotkey-win-ll-hook".into())
-            .spawn(move || run_listen_loop(thread_shared, tx, status_tx))
-            .map_err(|e| install_error("spawn_failed", format!("hotkey 线程启动失败: {e}")))?;
-
-        match status_rx.recv_timeout(std::time::Duration::from_secs(3)) {
-            Ok(Ok(())) => Ok(Box::new(WindowsHotkeyAdapter { shared })),
-            Ok(Err(err)) => Err(err),
-            Err(_) => Err(install_error(
-                "startup_timeout",
-                "Windows hotkey hook 启动超时",
-            )),
-        }
+        let listener = start_listener_thread(
+            binding,
+            tx,
+            "openless-hotkey-win-ll-hook",
+            "Windows hotkey hook 启动超时",
+            run_listen_loop,
+        )?;
+        Ok(Box::new(WindowsHotkeyAdapter {
+            shared: listener.shared,
+            thread_id: listener.startup,
+        }))
     }
 
     struct WindowsHotkeyAdapter {
         shared: Arc<Shared>,
+        thread_id: u32,
     }
 
     impl HotkeyAdapter for WindowsHotkeyAdapter {
@@ -408,8 +450,16 @@ mod platform {
         }
 
         fn update_binding(&self, binding: HotkeyBinding) {
-            *self.shared.binding.write() = binding;
-            self.shared.trigger_held.store(false, Ordering::SeqCst);
+            update_shared_binding(&self.shared, binding);
+        }
+
+        fn shutdown(&self) {
+            unsafe {
+                if let Err(err) = PostThreadMessageW(self.thread_id, WM_QUIT, WPARAM(0), LPARAM(0))
+                {
+                    log::warn!("[hotkey] Windows hook 退出消息发送失败: {err}");
+                }
+            }
         }
     }
 
@@ -422,11 +472,8 @@ mod platform {
     unsafe impl Send for CallbackContext {}
     unsafe impl Sync for CallbackContext {}
 
-    fn run_listen_loop(
-        shared: Arc<Shared>,
-        tx: Sender<HotkeyEvent>,
-        status_tx: std::sync::mpsc::Sender<Result<(), HotkeyInstallError>>,
-    ) {
+    fn run_listen_loop(shared: Arc<Shared>, tx: Sender<HotkeyEvent>, status_tx: StartupTx<u32>) {
+        let thread_id = unsafe { GetCurrentThreadId() };
         let context = Box::into_raw(Box::new(CallbackContext {
             shared,
             tx,
@@ -440,7 +487,7 @@ mod platform {
                 Ok(hook) => {
                     *(*context).hook.lock().unwrap() = Some(hook);
                     log::info!("[hotkey] Windows low-level keyboard hook 已启动");
-                    let _ = status_tx.send(Ok(()));
+                    let _ = status_tx.send(Ok(thread_id));
                 }
                 Err(err) => {
                     HOOK_CONTEXT.store(std::ptr::null_mut(), AtomicOrdering::SeqCst);
@@ -559,30 +606,27 @@ mod platform {
 
     use rdev::{listen, Event, EventType, Key};
 
-    use super::{install_error, HotkeyAdapter, HotkeyEvent, Shared};
+    use super::{
+        install_error, start_listener_thread, update_shared_binding, HotkeyAdapter, HotkeyEvent,
+        Shared, StartupTx,
+    };
     use crate::types::{HotkeyAdapterKind, HotkeyBinding, HotkeyInstallError, HotkeyTrigger};
 
     pub fn start_adapter(
         binding: HotkeyBinding,
         tx: Sender<HotkeyEvent>,
     ) -> Result<Box<dyn HotkeyAdapter>, HotkeyInstallError> {
-        let shared = Arc::new(Shared {
-            binding: parking_lot::RwLock::new(binding),
-            trigger_held: std::sync::atomic::AtomicBool::new(false),
-        });
-
-        let thread_shared = Arc::clone(&shared);
-        let (status_tx, status_rx) = std::sync::mpsc::channel::<Result<(), HotkeyInstallError>>();
-        std::thread::Builder::new()
-            .name("openless-hotkey-rdev".into())
-            .spawn(move || run_listen_loop(thread_shared, tx, status_tx))
-            .map_err(|e| install_error("spawn_failed", format!("hotkey 线程启动失败: {e}")))?;
-
-        match status_rx.recv_timeout(std::time::Duration::from_secs(3)) {
-            Ok(Ok(())) => Ok(Box::new(RdevHotkeyAdapter { shared })),
-            Ok(Err(err)) => Err(err),
-            Err(_) => Err(install_error("startup_timeout", "hotkey hook 启动超时")),
-        }
+        let listener = start_listener_thread(
+            binding,
+            tx,
+            "openless-hotkey-rdev",
+            "hotkey hook 启动超时",
+            run_listen_loop,
+        )?;
+        let _ = listener.startup;
+        Ok(Box::new(RdevHotkeyAdapter {
+            shared: listener.shared,
+        }))
     }
 
     struct RdevHotkeyAdapter {
@@ -595,16 +639,11 @@ mod platform {
         }
 
         fn update_binding(&self, binding: HotkeyBinding) {
-            *self.shared.binding.write() = binding;
-            self.shared.trigger_held.store(false, Ordering::SeqCst);
+            update_shared_binding(&self.shared, binding);
         }
     }
 
-    fn run_listen_loop(
-        shared: Arc<Shared>,
-        tx: Sender<HotkeyEvent>,
-        status_tx: std::sync::mpsc::Sender<Result<(), HotkeyInstallError>>,
-    ) {
+    fn run_listen_loop(shared: Arc<Shared>, tx: Sender<HotkeyEvent>, status_tx: StartupTx<()>) {
         let status_sent = Arc::new(AtomicBool::new(false));
         let ready_status_sent = Arc::clone(&status_sent);
         let ready_status_tx = status_tx.clone();

--- a/openless -all/app/src-tauri/src/hotkey.rs
+++ b/openless -all/app/src-tauri/src/hotkey.rs
@@ -350,10 +350,9 @@ mod platform {
     use std::sync::Arc;
 
     use windows::Win32::Foundation::{LPARAM, LRESULT, WPARAM};
-    use windows::Win32::UI::Input::KeyboardAndMouse::KBDLLHOOKSTRUCT;
     use windows::Win32::UI::WindowsAndMessaging::{
         CallNextHookEx, DispatchMessageW, GetMessageW, SetWindowsHookExW, TranslateMessage,
-        UnhookWindowsHookEx, HC_ACTION, HHOOK, MSG, WH_KEYBOARD_LL,
+        UnhookWindowsHookEx, HC_ACTION, HHOOK, KBDLLHOOKSTRUCT, MSG, WH_KEYBOARD_LL,
     };
 
     use super::{install_error, send_or_log, HotkeyAdapter, HotkeyEvent, Shared};
@@ -485,7 +484,7 @@ mod platform {
         if code == HC_ACTION as i32 && lparam.0 != 0 {
             if let Some(ctx) = callback_context() {
                 let keyboard = *(lparam.0 as *const KBDLLHOOKSTRUCT);
-                if keyboard.flags & LLKHF_INJECTED == 0 {
+                if keyboard.flags.0 & LLKHF_INJECTED == 0 {
                     dispatch_keyboard_event(ctx, keyboard.vkCode, wparam.0);
                 }
             }

--- a/openless -all/app/src-tauri/src/lib.rs
+++ b/openless -all/app/src-tauri/src/lib.rs
@@ -164,6 +164,10 @@ pub fn run() {
                     }
                 }
             }
+            RunEvent::Exit => {
+                let coordinator = app.state::<Arc<coordinator::Coordinator>>();
+                coordinator.stop_hotkey_listener();
+            }
             _ => {}
         });
 }

--- a/openless -all/app/src-tauri/src/lib.rs
+++ b/openless -all/app/src-tauri/src/lib.rs
@@ -126,6 +126,7 @@ pub fn run() {
             commands::get_settings,
             commands::set_settings,
             commands::get_hotkey_status,
+            commands::get_hotkey_capability,
             commands::get_credentials,
             commands::set_credential,
             commands::list_history,
@@ -297,13 +298,21 @@ pub(crate) fn restore_main_window_key_if_active<R: Runtime>(app: &AppHandle<R>) 
         use objc2::msg_send;
         use objc2::runtime::{AnyClass, AnyObject, Bool};
         unsafe {
-            let Some(cls) = AnyClass::get("NSApplication") else { return };
+            let Some(cls) = AnyClass::get("NSApplication") else {
+                return;
+            };
             let ns_app: *mut AnyObject = msg_send![cls, sharedApplication];
-            if ns_app.is_null() { return; }
+            if ns_app.is_null() {
+                return;
+            }
             let is_active: Bool = msg_send![ns_app, isActive];
-            if !is_active.as_bool() { return; }
+            if !is_active.as_bool() {
+                return;
+            }
             let main_win: *mut AnyObject = msg_send![ns_app, mainWindow];
-            if main_win.is_null() { return; }
+            if main_win.is_null() {
+                return;
+            }
             let _: () = msg_send![main_win, makeKeyWindow];
         }
     });

--- a/openless -all/app/src-tauri/src/types.rs
+++ b/openless -all/app/src-tauri/src/types.rs
@@ -285,15 +285,18 @@ impl Default for HotkeyBinding {
     fn default() -> Self {
         #[cfg(target_os = "windows")]
         {
-            return Self {
+            Self {
                 trigger: HotkeyTrigger::RightControl,
                 mode: HotkeyMode::Hold,
-            };
+            }
         }
 
-        Self {
-            trigger: HotkeyTrigger::RightOption,
-            mode: HotkeyMode::Toggle,
+        #[cfg(not(target_os = "windows"))]
+        {
+            Self {
+                trigger: HotkeyTrigger::RightOption,
+                mode: HotkeyMode::Toggle,
+            }
         }
     }
 }

--- a/openless -all/app/src-tauri/src/types.rs
+++ b/openless -all/app/src-tauri/src/types.rs
@@ -118,11 +118,43 @@ pub enum HotkeyTrigger {
     RightAlt, // Windows synonym for RightOption
 }
 
+impl HotkeyTrigger {
+    pub fn display_name(&self) -> &'static str {
+        match self {
+            HotkeyTrigger::RightOption => "右 Option",
+            HotkeyTrigger::LeftOption => "左 Option",
+            HotkeyTrigger::RightControl => "右 Control",
+            HotkeyTrigger::LeftControl => "左 Control",
+            HotkeyTrigger::RightCommand => "右 Command",
+            HotkeyTrigger::Fn => "Fn (地球键)",
+            HotkeyTrigger::RightAlt => "右 Alt",
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub enum HotkeyMode {
     Toggle,
     Hold,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub enum HotkeyAdapterKind {
+    MacEventTap,
+    WindowsLowLevel,
+    Rdev,
+}
+
+impl HotkeyAdapterKind {
+    pub fn display_name(&self) -> &'static str {
+        match self {
+            HotkeyAdapterKind::MacEventTap => "macOS Event Tap",
+            HotkeyAdapterKind::WindowsLowLevel => "Windows 低层键盘 hook",
+            HotkeyAdapterKind::Rdev => "rdev 监听器",
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
@@ -134,9 +166,100 @@ pub struct HotkeyBinding {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
+pub struct HotkeyCapability {
+    pub adapter: HotkeyAdapterKind,
+    pub available_triggers: Vec<HotkeyTrigger>,
+    pub requires_accessibility_permission: bool,
+    pub supports_modifier_only_trigger: bool,
+    pub supports_side_specific_modifiers: bool,
+    pub explicit_fallback_available: bool,
+    pub status_hint: Option<String>,
+}
+
+impl HotkeyCapability {
+    pub fn current() -> Self {
+        #[cfg(target_os = "macos")]
+        {
+            return Self {
+                adapter: HotkeyAdapterKind::MacEventTap,
+                available_triggers: vec![
+                    HotkeyTrigger::RightOption,
+                    HotkeyTrigger::LeftOption,
+                    HotkeyTrigger::RightControl,
+                    HotkeyTrigger::LeftControl,
+                    HotkeyTrigger::RightCommand,
+                    HotkeyTrigger::Fn,
+                ],
+                requires_accessibility_permission: true,
+                supports_modifier_only_trigger: true,
+                supports_side_specific_modifiers: true,
+                explicit_fallback_available: false,
+                status_hint: Some("授权辅助功能后，通常需要完全退出并重新打开 OpenLess。".into()),
+            };
+        }
+
+        #[cfg(target_os = "windows")]
+        {
+            return Self {
+                adapter: HotkeyAdapterKind::WindowsLowLevel,
+                available_triggers: vec![
+                    HotkeyTrigger::RightControl,
+                    HotkeyTrigger::RightAlt,
+                    HotkeyTrigger::LeftControl,
+                    HotkeyTrigger::RightCommand,
+                ],
+                requires_accessibility_permission: false,
+                supports_modifier_only_trigger: true,
+                supports_side_specific_modifiers: true,
+                explicit_fallback_available: false,
+                status_hint: Some(
+                    "默认建议使用“右 Control + 按住说话”；若无响应，可在权限页查看 hook 安装状态。"
+                        .into(),
+                ),
+            };
+        }
+
+        #[cfg(all(not(target_os = "macos"), not(target_os = "windows")))]
+        {
+            Self {
+                adapter: HotkeyAdapterKind::Rdev,
+                available_triggers: vec![
+                    HotkeyTrigger::RightAlt,
+                    HotkeyTrigger::RightControl,
+                    HotkeyTrigger::LeftControl,
+                ],
+                requires_accessibility_permission: false,
+                supports_modifier_only_trigger: true,
+                supports_side_specific_modifiers: true,
+                explicit_fallback_available: false,
+                status_hint: Some(
+                    "Linux 仅 best-effort：不同桌面环境 / Wayland 组合可能限制全局热键。".into(),
+                ),
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct HotkeyInstallError {
+    pub code: String,
+    pub message: String,
+}
+
+impl std::fmt::Display for HotkeyInstallError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{} ({})", self.message, self.code)
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
 pub struct HotkeyStatus {
+    pub adapter: HotkeyAdapterKind,
     pub state: HotkeyStatusState,
     pub message: Option<String>,
+    pub last_error: Option<HotkeyInstallError>,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
@@ -150,21 +273,26 @@ pub enum HotkeyStatusState {
 impl Default for HotkeyStatus {
     fn default() -> Self {
         Self {
+            adapter: HotkeyCapability::current().adapter,
             state: HotkeyStatusState::Starting,
             message: Some("正在安装全局快捷键监听".into()),
+            last_error: None,
         }
     }
 }
 
 impl Default for HotkeyBinding {
     fn default() -> Self {
-        // Right Option (mac) / Right Alt (win) — toggle by default per design.
+        #[cfg(target_os = "windows")]
+        {
+            return Self {
+                trigger: HotkeyTrigger::RightControl,
+                mode: HotkeyMode::Hold,
+            };
+        }
+
         Self {
-            trigger: if cfg!(target_os = "windows") {
-                HotkeyTrigger::RightAlt
-            } else {
-                HotkeyTrigger::RightOption
-            },
+            trigger: HotkeyTrigger::RightOption,
             mode: HotkeyMode::Toggle,
         }
     }

--- a/openless -all/app/src/App.tsx
+++ b/openless -all/app/src/App.tsx
@@ -3,6 +3,7 @@ import { Capsule } from './components/Capsule';
 import { FloatingShell } from './components/FloatingShell';
 import { Onboarding } from './components/Onboarding';
 import { checkAccessibilityPermission, checkMicrophonePermission, isTauri } from './lib/ipc';
+import { HotkeySettingsProvider } from './state/HotkeySettingsContext';
 
 interface AppProps {
   isCapsule: boolean;
@@ -39,8 +40,9 @@ export function App({ isCapsule }: AppProps) {
   if (gate === 'checking') {
     return null;
   }
-  if (gate === 'onboarding') {
-    return <Onboarding onComplete={() => setGate('ready')} />;
-  }
-  return <FloatingShell />;
+  return (
+    <HotkeySettingsProvider>
+      {gate === 'onboarding' ? <Onboarding onComplete={() => setGate('ready')} /> : <FloatingShell />}
+    </HotkeySettingsProvider>
+  );
 }

--- a/openless -all/app/src/components/FloatingShell.tsx
+++ b/openless -all/app/src/components/FloatingShell.tsx
@@ -13,7 +13,8 @@ import { History } from '../pages/History';
 import { Vocab } from '../pages/Vocab';
 import { Style } from '../pages/Style';
 import { APP_VERSION_LABEL } from '../lib/appVersion';
-import { getCredentials, openExternal } from '../lib/ipc';
+import { getHotkeyTriggerLabel } from '../lib/hotkey';
+import { getCredentials, getSettings, openExternal } from '../lib/ipc';
 import { OL_DATA } from '../lib/mockData';
 import {
   PROVIDER_SETUP_PROMPT_SEEN_KEY,
@@ -55,13 +56,17 @@ function FloatingShellBody({ os, initialTab, initialSettings }: { os: OS; initia
   const { currentTab, setCurrentTab, settingsOpen, setSettingsOpen } = useAppState(initialTab, initialSettings);
   const [settingsInitialSection, setSettingsInitialSection] = useState<SettingsSectionId | undefined>();
   const [providerPromptOpen, setProviderPromptOpen] = useState(false);
+  const [hotkeyLabel, setHotkeyLabel] = useState(() => getHotkeyTriggerLabel(null));
   const Page = (NAV.find((n) => n.id === currentTab) ?? NAV[0]).cmp;
-  const hotkeyLabel = os === 'win' ? '右 Alt' : '右 Option';
 
   useEffect(() => {
     let cancelled = false;
     (async () => {
       const credentials = await getCredentials();
+      const prefs = await getSettings();
+      if (!cancelled) {
+        setHotkeyLabel(getHotkeyTriggerLabel(prefs.hotkey.trigger));
+      }
       const promptSeenValue = window.localStorage.getItem(PROVIDER_SETUP_PROMPT_SEEN_KEY);
       if (!cancelled && shouldShowProviderSetupPrompt(credentials, promptSeenValue)) {
         setProviderPromptOpen(true);

--- a/openless -all/app/src/components/FloatingShell.tsx
+++ b/openless -all/app/src/components/FloatingShell.tsx
@@ -14,13 +14,14 @@ import { Vocab } from '../pages/Vocab';
 import { Style } from '../pages/Style';
 import { APP_VERSION_LABEL } from '../lib/appVersion';
 import { getHotkeyTriggerLabel } from '../lib/hotkey';
-import { getCredentials, getSettings, openExternal } from '../lib/ipc';
+import { getCredentials, openExternal } from '../lib/ipc';
 import { OL_DATA } from '../lib/mockData';
 import {
   PROVIDER_SETUP_PROMPT_SEEN_KEY,
   shouldShowProviderSetupPrompt,
 } from '../lib/providerSetup';
 import type { SettingsSectionId } from '../pages/Settings';
+import { useHotkeySettings } from '../state/HotkeySettingsContext';
 import { useAppState, type AppTab } from '../state/useAppState';
 
 interface NavItem {
@@ -56,17 +57,13 @@ function FloatingShellBody({ os, initialTab, initialSettings }: { os: OS; initia
   const { currentTab, setCurrentTab, settingsOpen, setSettingsOpen } = useAppState(initialTab, initialSettings);
   const [settingsInitialSection, setSettingsInitialSection] = useState<SettingsSectionId | undefined>();
   const [providerPromptOpen, setProviderPromptOpen] = useState(false);
-  const [hotkeyLabel, setHotkeyLabel] = useState(() => getHotkeyTriggerLabel(null));
+  const { hotkey } = useHotkeySettings();
   const Page = (NAV.find((n) => n.id === currentTab) ?? NAV[0]).cmp;
 
   useEffect(() => {
     let cancelled = false;
     (async () => {
       const credentials = await getCredentials();
-      const prefs = await getSettings();
-      if (!cancelled) {
-        setHotkeyLabel(getHotkeyTriggerLabel(prefs.hotkey.trigger));
-      }
       const promptSeenValue = window.localStorage.getItem(PROVIDER_SETUP_PROMPT_SEEN_KEY);
       if (!cancelled && shouldShowProviderSetupPrompt(credentials, promptSeenValue)) {
         setProviderPromptOpen(true);
@@ -177,12 +174,12 @@ function FloatingShellBody({ os, initialTab, initialSettings }: { os: OS; initia
             <div style={{ fontSize: 10.5, color: 'var(--ol-ink-4)', marginBottom: 6, letterSpacing: '0.02em' }}>录音快捷键</div>
             <div style={{ display: 'flex', alignItems: 'center', gap: 6, fontSize: 11, color: 'var(--ol-ink-2)' }}>
               <kbd style={{
-                padding: '2px 7px', fontSize: 10.5,
+              padding: '2px 7px', fontSize: 10.5,
                 background: '#fff', borderRadius: 5,
                 border: '0.5px solid var(--ol-line-strong)',
                 fontFamily: 'var(--ol-font-mono)', color: 'var(--ol-ink)',
                 boxShadow: '0 1px 0 rgba(0,0,0,.04)',
-              }}>{hotkeyLabel}</kbd>
+              }}>{getHotkeyTriggerLabel(hotkey?.trigger)}</kbd>
               <span style={{ color: 'var(--ol-ink-4)' }}>开始 / 停止</span>
             </div>
           </div>

--- a/openless -all/app/src/components/Onboarding.tsx
+++ b/openless -all/app/src/components/Onboarding.tsx
@@ -7,12 +7,13 @@ import { useEffect, useState } from 'react';
 import {
   checkAccessibilityPermission,
   checkMicrophonePermission,
+  getHotkeyCapability,
   openSystemSettings,
   requestAccessibilityPermission,
   requestMicrophonePermission,
 } from '../lib/ipc';
-import type { PermissionStatus } from '../lib/types';
-import { detectOS } from './WindowChrome';
+import { getHotkeyTriggerLabel } from '../lib/hotkey';
+import type { HotkeyCapability, PermissionStatus } from '../lib/types';
 
 interface OnboardingProps {
   onComplete: () => void;
@@ -21,16 +22,18 @@ interface OnboardingProps {
 export function Onboarding({ onComplete }: OnboardingProps) {
   const [accessibility, setAccessibility] = useState<PermissionStatus>('notDetermined');
   const [microphone, setMicrophone] = useState<PermissionStatus>('notDetermined');
+  const [capability, setCapability] = useState<HotkeyCapability | null>(null);
   const [busy, setBusy] = useState(false);
-  const os = detectOS();
 
   const refresh = async () => {
-    const [a, m] = await Promise.all([
+    const [a, m, c] = await Promise.all([
       checkAccessibilityPermission(),
       checkMicrophonePermission(),
+      getHotkeyCapability(),
     ]);
     setAccessibility(a);
     setMicrophone(m);
+    setCapability(c);
     if ((a === 'granted' || a === 'notApplicable') && (m === 'granted' || m === 'notApplicable')) {
       onComplete();
     }
@@ -124,13 +127,13 @@ export function Onboarding({ onComplete }: OnboardingProps) {
 
         <PermissionStep
           index={1}
-          title={os === 'win' ? '全局快捷键' : '辅助功能'}
-          desc={os === 'win'
-            ? 'Windows 不需要 macOS 辅助功能权限；这里用于确认全局快捷键监听可用。'
-            : '用于监听全局快捷键（默认 右 Option）并把识别结果写入光标位置。'}
+          title={capability?.requiresAccessibilityPermission ? '辅助功能' : '全局快捷键'}
+          desc={capability?.requiresAccessibilityPermission
+            ? `用于监听全局快捷键（默认 ${getHotkeyTriggerLabel(capability.availableTriggers[0])}）并把识别结果写入光标位置。`
+            : capability?.statusHint ?? '用于确认全局快捷键监听可用。'}
           status={accessibility}
           actionLabel={
-            accessibility === 'notApplicable'
+            !capability?.requiresAccessibilityPermission || accessibility === 'notApplicable'
               ? '无需授权'
               : accessibility === 'granted'
               ? '已授权'
@@ -139,8 +142,8 @@ export function Onboarding({ onComplete }: OnboardingProps) {
                 : '授权'
           }
           onAction={onGrantAccessibility}
-          disabled={busy || accessibility === 'granted' || accessibility === 'notApplicable'}
-          hint={os === 'mac' ? '授权后必须**完全退出 OpenLess** 再重新打开（macOS TCC 规则）。' : undefined}
+          disabled={busy || !capability?.requiresAccessibilityPermission || accessibility === 'granted' || accessibility === 'notApplicable'}
+          hint={capability?.requiresAccessibilityPermission ? '授权后必须**完全退出 OpenLess** 再重新打开（macOS TCC 规则）。' : undefined}
         />
 
         <PermissionStep

--- a/openless -all/app/src/components/Onboarding.tsx
+++ b/openless -all/app/src/components/Onboarding.tsx
@@ -7,13 +7,13 @@ import { useEffect, useState } from 'react';
 import {
   checkAccessibilityPermission,
   checkMicrophonePermission,
-  getHotkeyCapability,
   openSystemSettings,
   requestAccessibilityPermission,
   requestMicrophonePermission,
 } from '../lib/ipc';
 import { getHotkeyTriggerLabel } from '../lib/hotkey';
-import type { HotkeyCapability, PermissionStatus } from '../lib/types';
+import type { PermissionStatus } from '../lib/types';
+import { useHotkeySettings } from '../state/HotkeySettingsContext';
 
 interface OnboardingProps {
   onComplete: () => void;
@@ -22,18 +22,16 @@ interface OnboardingProps {
 export function Onboarding({ onComplete }: OnboardingProps) {
   const [accessibility, setAccessibility] = useState<PermissionStatus>('notDetermined');
   const [microphone, setMicrophone] = useState<PermissionStatus>('notDetermined');
-  const [capability, setCapability] = useState<HotkeyCapability | null>(null);
   const [busy, setBusy] = useState(false);
+  const { capability } = useHotkeySettings();
 
   const refresh = async () => {
-    const [a, m, c] = await Promise.all([
+    const [a, m] = await Promise.all([
       checkAccessibilityPermission(),
       checkMicrophonePermission(),
-      getHotkeyCapability(),
     ]);
     setAccessibility(a);
     setMicrophone(m);
-    setCapability(c);
     if ((a === 'granted' || a === 'notApplicable') && (m === 'granted' || m === 'notApplicable')) {
       onComplete();
     }

--- a/openless -all/app/src/lib/hotkey.ts
+++ b/openless -all/app/src/lib/hotkey.ts
@@ -1,0 +1,25 @@
+import type { HotkeyBinding, HotkeyTrigger } from './types';
+
+export const HOTKEY_TRIGGER_LABEL: Record<HotkeyTrigger, string> = {
+  rightOption: '右 Option',
+  leftOption: '左 Option',
+  rightControl: '右 Control',
+  leftControl: '左 Control',
+  rightCommand: '右 Command',
+  fn: 'Fn (地球键)',
+  rightAlt: '右 Alt',
+};
+
+export function getHotkeyTriggerLabel(trigger: HotkeyTrigger | null | undefined): string {
+  return trigger ? HOTKEY_TRIGGER_LABEL[trigger] : '全局快捷键';
+}
+
+export function getHotkeyStartStopLabel(binding: HotkeyBinding | null | undefined): string {
+  const trigger = getHotkeyTriggerLabel(binding?.trigger);
+  return binding?.mode === 'hold' ? `${trigger}（按住说话）` : `${trigger}（开始 / 停止）`;
+}
+
+export function getHotkeyUsageHint(binding: HotkeyBinding | null | undefined): string {
+  const trigger = getHotkeyTriggerLabel(binding?.trigger);
+  return binding?.mode === 'hold' ? `按住 ${trigger} 说话，松开结束。` : `按 ${trigger} 开始录音，再按一次结束。`;
+}

--- a/openless -all/app/src/lib/ipc.ts
+++ b/openless -all/app/src/lib/ipc.ts
@@ -6,6 +6,7 @@ import type {
   CredentialsStatus,
   DictationSession,
   DictionaryEntry,
+  HotkeyCapability,
   HotkeyStatus,
   PermissionStatus,
   PolishMode,
@@ -35,7 +36,7 @@ export async function invokeOrMock<T>(
 
 // ── Mock fixtures ──────────────────────────────────────────────────────
 const mockSettings: UserPreferences = {
-  hotkey: { trigger: 'rightOption', mode: 'toggle' },
+  hotkey: { trigger: 'rightControl', mode: 'hold' },
   defaultMode: 'structured',
   enabledModes: ['raw', 'light', 'structured', 'formal'],
   launchAtLogin: false,
@@ -44,14 +45,26 @@ const mockSettings: UserPreferences = {
   activeLlmProvider: 'ark',
 };
 
+const mockHotkeyCapability: HotkeyCapability = {
+  adapter: 'windowsLowLevel',
+  availableTriggers: ['rightControl', 'rightAlt', 'leftControl', 'rightCommand'],
+  requiresAccessibilityPermission: false,
+  supportsModifierOnlyTrigger: true,
+  supportsSideSpecificModifiers: true,
+  explicitFallbackAvailable: false,
+  statusHint: '默认建议使用“右 Control + 按住说话”；若无响应，可在权限页查看 hook 安装状态。',
+};
+
 const mockCredentialsStatus: CredentialsStatus = {
   volcengineConfigured: true,
   arkConfigured: true,
 };
 
 const mockHotkeyStatus: HotkeyStatus = {
+  adapter: 'windowsLowLevel',
   state: 'installed',
-  message: null,
+  message: 'Windows 低层键盘 hook 已安装',
+  lastError: null,
 };
 
 const mockHistory: DictationSession[] = OL_DATA.history.map((h, i) => ({
@@ -88,6 +101,10 @@ export function setSettings(prefs: UserPreferences): Promise<void> {
 
 export function getHotkeyStatus(): Promise<HotkeyStatus> {
   return invokeOrMock('get_hotkey_status', undefined, () => mockHotkeyStatus);
+}
+
+export function getHotkeyCapability(): Promise<HotkeyCapability> {
+  return invokeOrMock('get_hotkey_capability', undefined, () => mockHotkeyCapability);
 }
 
 // ── Credentials ────────────────────────────────────────────────────────

--- a/openless -all/app/src/lib/types.ts
+++ b/openless -all/app/src/lib/types.ts
@@ -45,11 +45,30 @@ export interface HotkeyBinding {
   mode: HotkeyMode;
 }
 
+export type HotkeyAdapterKind = 'macEventTap' | 'windowsLowLevel' | 'rdev';
+
+export interface HotkeyCapability {
+  adapter: HotkeyAdapterKind;
+  availableTriggers: HotkeyTrigger[];
+  requiresAccessibilityPermission: boolean;
+  supportsModifierOnlyTrigger: boolean;
+  supportsSideSpecificModifiers: boolean;
+  explicitFallbackAvailable: boolean;
+  statusHint: string | null;
+}
+
+export interface HotkeyInstallError {
+  code: string;
+  message: string;
+}
+
 export type HotkeyStatusState = 'starting' | 'installed' | 'failed';
 
 export interface HotkeyStatus {
+  adapter: HotkeyAdapterKind;
   state: HotkeyStatusState;
   message: string | null;
+  lastError: HotkeyInstallError | null;
 }
 
 export interface UserPreferences {

--- a/openless -all/app/src/pages/History.tsx
+++ b/openless -all/app/src/pages/History.tsx
@@ -4,8 +4,9 @@
 import { useEffect, useMemo, useState } from 'react';
 import { Icon } from '../components/Icon';
 import { detectOS } from '../components/WindowChrome';
-import { clearHistory, deleteHistoryEntry, listHistory } from '../lib/ipc';
-import type { DictationSession, PolishMode } from '../lib/types';
+import { getHotkeyTriggerLabel } from '../lib/hotkey';
+import { clearHistory, deleteHistoryEntry, getSettings, listHistory } from '../lib/ipc';
+import type { DictationSession, HotkeyBinding, PolishMode } from '../lib/types';
 import { Btn, Card, PageHeader, Pill } from './_atoms';
 
 const FILTERS: Array<{ id: 'all' | PolishMode; label: string }> = [
@@ -28,7 +29,7 @@ export function History() {
   const [items, setItems] = useState<DictationSession[]>([]);
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
-  const hotkeyLabel = detectOS() === 'win' ? '右 Alt' : '右 Option';
+  const [hotkey, setHotkey] = useState<HotkeyBinding | null>(null);
 
   const refresh = async () => {
     const data = await listHistory();
@@ -41,6 +42,7 @@ export function History() {
 
   useEffect(() => {
     refresh();
+    getSettings().then(p => setHotkey(p.hotkey));
   }, []);
 
   const filtered = useMemo(
@@ -116,7 +118,7 @@ export function History() {
             {loading && <div style={{ padding: 16, fontSize: 12, color: 'var(--ol-ink-4)' }}>加载中…</div>}
             {!loading && filtered.length === 0 && (
               <div style={{ padding: 16, fontSize: 12, color: 'var(--ol-ink-4)' }}>
-                还没有历史记录。按 {hotkeyLabel} 录一段试试。
+                还没有历史记录。按 {getHotkeyTriggerLabel(hotkey?.trigger)} 录一段试试。
               </div>
             )}
             {filtered.map(s => (

--- a/openless -all/app/src/pages/History.tsx
+++ b/openless -all/app/src/pages/History.tsx
@@ -5,8 +5,9 @@ import { useEffect, useMemo, useState } from 'react';
 import { Icon } from '../components/Icon';
 import { detectOS } from '../components/WindowChrome';
 import { getHotkeyTriggerLabel } from '../lib/hotkey';
-import { clearHistory, deleteHistoryEntry, getSettings, listHistory } from '../lib/ipc';
-import type { DictationSession, HotkeyBinding, PolishMode } from '../lib/types';
+import { clearHistory, deleteHistoryEntry, listHistory } from '../lib/ipc';
+import type { DictationSession, PolishMode } from '../lib/types';
+import { useHotkeySettings } from '../state/HotkeySettingsContext';
 import { Btn, Card, PageHeader, Pill } from './_atoms';
 
 const FILTERS: Array<{ id: 'all' | PolishMode; label: string }> = [
@@ -29,7 +30,7 @@ export function History() {
   const [items, setItems] = useState<DictationSession[]>([]);
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
-  const [hotkey, setHotkey] = useState<HotkeyBinding | null>(null);
+  const { hotkey } = useHotkeySettings();
 
   const refresh = async () => {
     const data = await listHistory();
@@ -42,7 +43,6 @@ export function History() {
 
   useEffect(() => {
     refresh();
-    getSettings().then(p => setHotkey(p.hotkey));
   }, []);
 
   const filtered = useMemo(

--- a/openless -all/app/src/pages/Overview.tsx
+++ b/openless -all/app/src/pages/Overview.tsx
@@ -2,9 +2,9 @@
 
 import { useEffect, useMemo, useState } from 'react';
 import { Icon } from '../components/Icon';
-import { detectOS } from '../components/WindowChrome';
-import { getCredentials, listHistory } from '../lib/ipc';
-import type { CredentialsStatus, DictationSession, PolishMode } from '../lib/types';
+import { getHotkeyTriggerLabel } from '../lib/hotkey';
+import { getCredentials, getSettings, listHistory } from '../lib/ipc';
+import type { CredentialsStatus, DictationSession, HotkeyBinding, PolishMode } from '../lib/types';
 import { Btn, Card, PageHeader, Pill } from './_atoms';
 
 const MODE_LABEL: Record<PolishMode, string> = {
@@ -24,12 +24,12 @@ export function Overview({ onOpenHistory }: OverviewProps) {
     volcengineConfigured: false,
     arkConfigured: false,
   });
-  const os = detectOS();
-  const hotkeyLabel = os === 'win' ? '右 Alt' : '右 Option';
+  const [hotkey, setHotkey] = useState<HotkeyBinding | null>(null);
 
   useEffect(() => {
     listHistory().then(setHistory);
     getCredentials().then(setCreds);
+    getSettings().then(p => setHotkey(p.hotkey));
   }, []);
 
   const metrics = useMemo(() => {
@@ -83,7 +83,7 @@ export function Overview({ onOpenHistory }: OverviewProps) {
               background: '#fff', borderRadius: 5,
               border: '0.5px solid var(--ol-line-strong)',
               color: 'var(--ol-ink)',
-            }}>{hotkeyLabel}</kbd>
+            }}>{getHotkeyTriggerLabel(hotkey?.trigger)}</kbd>
             开始录音
           </div>
         }
@@ -131,7 +131,7 @@ export function Overview({ onOpenHistory }: OverviewProps) {
           <div>
             {history.length === 0 && (
               <div style={{ padding: 24, textAlign: 'center', fontSize: 12, color: 'var(--ol-ink-4)' }}>
-                还没有记录。按 {hotkeyLabel} 开始第一次录音。
+                还没有记录。按 {getHotkeyTriggerLabel(hotkey?.trigger)} 开始第一次录音。
               </div>
             )}
             {history.slice(0, 5).map(s => (

--- a/openless -all/app/src/pages/Overview.tsx
+++ b/openless -all/app/src/pages/Overview.tsx
@@ -3,8 +3,9 @@
 import { useEffect, useMemo, useState } from 'react';
 import { Icon } from '../components/Icon';
 import { getHotkeyTriggerLabel } from '../lib/hotkey';
-import { getCredentials, getSettings, listHistory } from '../lib/ipc';
-import type { CredentialsStatus, DictationSession, HotkeyBinding, PolishMode } from '../lib/types';
+import { getCredentials, listHistory } from '../lib/ipc';
+import type { CredentialsStatus, DictationSession, PolishMode } from '../lib/types';
+import { useHotkeySettings } from '../state/HotkeySettingsContext';
 import { Btn, Card, PageHeader, Pill } from './_atoms';
 
 const MODE_LABEL: Record<PolishMode, string> = {
@@ -24,12 +25,11 @@ export function Overview({ onOpenHistory }: OverviewProps) {
     volcengineConfigured: false,
     arkConfigured: false,
   });
-  const [hotkey, setHotkey] = useState<HotkeyBinding | null>(null);
+  const { hotkey } = useHotkeySettings();
 
   useEffect(() => {
     listHistory().then(setHistory);
     getCredentials().then(setCreds);
-    getSettings().then(p => setHotkey(p.hotkey));
   }, []);
 
   const metrics = useMemo(() => {

--- a/openless -all/app/src/pages/Settings.tsx
+++ b/openless -all/app/src/pages/Settings.tsx
@@ -4,11 +4,12 @@
 
 import { useEffect, useState, type CSSProperties, type ReactNode } from 'react';
 import { Icon } from '../components/Icon';
-import { detectOS } from '../components/WindowChrome';
 import { APP_VERSION_LABEL } from '../lib/appVersion';
+import { getHotkeyStartStopLabel, getHotkeyTriggerLabel } from '../lib/hotkey';
 import {
   checkAccessibilityPermission,
   checkMicrophonePermission,
+  getHotkeyCapability,
   getHotkeyStatus,
   getSettings,
   openExternal,
@@ -20,7 +21,14 @@ import {
   setCredential,
   setSettings,
 } from '../lib/ipc';
-import type { HotkeyMode, HotkeyStatus, HotkeyTrigger, PermissionStatus, UserPreferences } from '../lib/types';
+import type {
+  HotkeyCapability,
+  HotkeyMode,
+  HotkeyStatus,
+  HotkeyTrigger,
+  PermissionStatus,
+  UserPreferences,
+} from '../lib/types';
 import { Btn, Card, PageHeader, Pill } from './_atoms';
 
 interface SettingsProps {
@@ -95,45 +103,16 @@ function SettingRow({ label, desc, children }: SettingRowProps) {
   );
 }
 
-const TRIGGER_LABEL: Record<HotkeyTrigger, string> = {
-  rightOption: '右 Option',
-  leftOption: '左 Option',
-  rightControl: '右 Control',
-  leftControl: '左 Control',
-  rightCommand: '右 Command',
-  fn: 'Fn (地球键)',
-  rightAlt: '右 Alt',
-};
-
-const MAC_TRIGGER_OPTIONS: HotkeyTrigger[] = [
-  'rightOption',
-  'leftOption',
-  'rightControl',
-  'leftControl',
-  'rightCommand',
-  'fn',
-];
-
-const WIN_TRIGGER_OPTIONS: HotkeyTrigger[] = [
-  'rightAlt',
-  'rightControl',
-  'leftControl',
-  'rightCommand',
-];
-
 function RecordingSection() {
   const [prefs, setPrefs] = useState<UserPreferences | null>(null);
-  const os = detectOS();
-  const triggerOptions = os === 'win' ? WIN_TRIGGER_OPTIONS : MAC_TRIGGER_OPTIONS;
-  const hotkeyDesc = os === 'win'
-    ? '按下即开始捕获语音，全局生效。Windows 不需要辅助功能权限。'
-    : '按下即开始捕获语音，全局生效。需要授予辅助功能权限。';
+  const [capability, setCapability] = useState<HotkeyCapability | null>(null);
 
   useEffect(() => {
     getSettings().then(setPrefs);
+    getHotkeyCapability().then(setCapability);
   }, []);
 
-  if (!prefs) {
+  if (!prefs || !capability) {
     return (
       <Card>
         <div style={{ fontSize: 12, color: 'var(--ol-ink-4)' }}>加载中…</div>
@@ -157,6 +136,9 @@ function RecordingSection() {
     ['toggle', '切换式'],
     ['hold', '按住说话'],
   ];
+  const hotkeyDesc = capability.requiresAccessibilityPermission
+    ? '按下即开始捕获语音，全局生效。需要授予辅助功能权限。'
+    : '按下即开始捕获语音，全局生效。无需额外辅助功能授权。';
 
   return (
     <Card>
@@ -172,8 +154,8 @@ function RecordingSection() {
             fontFamily: 'var(--ol-font-mono)',
           }}
         >
-          {triggerOptions.map(t => (
-            <option key={t} value={t}>{TRIGGER_LABEL[t]}</option>
+          {capability.availableTriggers.map(t => (
+            <option key={t} value={t}>{getHotkeyTriggerLabel(t)}</option>
           ))}
         </select>
       </SettingRow>
@@ -200,6 +182,11 @@ function RecordingSection() {
       <SettingRow label="录音胶囊" desc="录音 / 转写时在屏幕底部显示半透明胶囊。">
         <Toggle on={prefs.showCapsule} onToggle={onShowCapsuleChange} />
       </SettingRow>
+      {capability.statusHint && (
+        <div style={{ marginTop: 6, fontSize: 11.5, color: 'var(--ol-ink-4)', lineHeight: 1.5 }}>
+          {capability.statusHint}
+        </div>
+      )}
     </Card>
   );
 }
@@ -397,16 +384,31 @@ const iconBtnStyle: CSSProperties = {
 };
 
 function ShortcutsSection() {
-  const os = detectOS();
-  const desc = os === 'win'
-    ? '所有快捷键全局生效。若无响应，请在权限页查看全局快捷键监听状态。'
-    : '所有快捷键全局生效，需要在权限设置中开启辅助功能。';
+  const [prefs, setPrefs] = useState<UserPreferences | null>(null);
+  const [capability, setCapability] = useState<HotkeyCapability | null>(null);
+
+  useEffect(() => {
+    getSettings().then(setPrefs);
+    getHotkeyCapability().then(setCapability);
+  }, []);
+
+  if (!prefs || !capability) {
+    return (
+      <Card>
+        <div style={{ fontSize: 12, color: 'var(--ol-ink-4)' }}>加载中…</div>
+      </Card>
+    );
+  }
+
+  const desc = capability.requiresAccessibilityPermission
+    ? '所有快捷键全局生效，需要在权限设置中开启辅助功能。'
+    : '所有快捷键全局生效。若无响应，请在权限页查看全局快捷键监听状态。';
   const rows: Array<[string, string]> = [
-    ['开始 / 停止录音', os === 'win' ? '右 Alt' : '右 Option'],
+    ['开始 / 停止录音', getHotkeyStartStopLabel(prefs.hotkey)],
     ['取消本次录音', 'Esc'],
     ['胶囊确认插入', '点击右侧 ✓'],
-    ['切换上一次风格', os === 'win' ? '暂未支持' : '⌘ ⇧ S'],
-    ['打开 OpenLess', os === 'win' ? '暂未支持' : '⌘ ⇧ O'],
+    ['切换上一次风格', capability.requiresAccessibilityPermission ? '⌘ ⇧ S' : '暂未支持'],
+    ['打开 OpenLess', capability.requiresAccessibilityPermission ? '⌘ ⇧ O' : '暂未支持'],
   ];
   return (
     <Card>
@@ -432,18 +434,17 @@ function PermissionsSection() {
   const [accessibility, setAccessibility] = useState<PermissionStatus | 'loading'>('loading');
   const [microphone, setMicrophone] = useState<PermissionStatus | 'loading'>('loading');
   const [hotkey, setHotkey] = useState<HotkeyStatus | null>(null);
-  const os = detectOS();
-  const desc = os === 'win'
-    ? 'OpenLess 需要麦克风可用，并依赖全局快捷键监听状态判断 Windows 侧是否正常工作。'
-    : 'OpenLess 需要以下系统权限才能正常工作。授权后通常需要完全退出 App 重启一次才生效。';
+  const [capability, setCapability] = useState<HotkeyCapability | null>(null);
 
   const refresh = async () => {
-    const [a, m] = await Promise.all([
+    const [a, m, c] = await Promise.all([
       checkAccessibilityPermission(),
       checkMicrophonePermission(),
+      getHotkeyCapability(),
     ]);
     setAccessibility(a);
     setMicrophone(m);
+    setCapability(c);
     setHotkey(await getHotkeyStatus());
   };
 
@@ -478,6 +479,10 @@ function PermissionsSection() {
     refresh();
   };
 
+  const desc = capability?.requiresAccessibilityPermission
+    ? 'OpenLess 需要以下系统权限才能正常工作。授权后通常需要完全退出 App 重启一次才生效。'
+    : 'OpenLess 需要麦克风可用，并依赖全局快捷键监听状态判断 native hook 是否正常工作。';
+
   return (
     <Card>
       <div style={{ fontSize: 13, fontWeight: 600, marginBottom: 4 }}>权限</div>
@@ -494,7 +499,7 @@ function PermissionsSection() {
           )}
         </div>
       </SettingRow>
-      {os !== 'win' && (
+      {capability?.requiresAccessibilityPermission && (
         <SettingRow label="辅助功能" desc="用于监听全局快捷键并将识别结果写入光标位置。">
           <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
             <PermissionPill status={accessibility} />
@@ -506,7 +511,10 @@ function PermissionsSection() {
           </div>
         </SettingRow>
       )}
-      <SettingRow label="全局快捷键" desc={os === 'win' ? '用于判断 Windows 上快捷键监听是否已经安装。' : '用于判断快捷键监听是否已经安装。'}>
+      <SettingRow
+        label="全局快捷键"
+        desc={capability ? `当前适配器：${adapterDisplayName(capability.adapter)}。用于判断快捷键监听是否已经安装。` : '用于判断快捷键监听是否已经安装。'}
+      >
         <div style={{ display: 'flex', gap: 8, alignItems: 'center', minWidth: 0 }}>
           <HotkeyStatusPill status={hotkey} />
           {hotkey?.message && (
@@ -577,4 +585,10 @@ function HotkeyStatusPill({ status }: { status: HotkeyStatus | null }) {
     return <Pill tone="default">安装中…</Pill>;
   }
   return <Pill tone="outline">监听失败</Pill>;
+}
+
+function adapterDisplayName(adapter: HotkeyCapability['adapter'] | HotkeyStatus['adapter']) {
+  if (adapter === 'macEventTap') return 'macOS Event Tap';
+  if (adapter === 'windowsLowLevel') return 'Windows 低层键盘 hook';
+  return 'rdev 监听器';
 }

--- a/openless -all/app/src/pages/Settings.tsx
+++ b/openless -all/app/src/pages/Settings.tsx
@@ -9,9 +9,7 @@ import { getHotkeyStartStopLabel, getHotkeyTriggerLabel } from '../lib/hotkey';
 import {
   checkAccessibilityPermission,
   checkMicrophonePermission,
-  getHotkeyCapability,
   getHotkeyStatus,
-  getSettings,
   openExternal,
   openSystemSettings,
   readCredential,
@@ -19,7 +17,6 @@ import {
   requestMicrophonePermission,
   setActiveLlmProvider,
   setCredential,
-  setSettings,
 } from '../lib/ipc';
 import type {
   HotkeyCapability,
@@ -27,8 +24,8 @@ import type {
   HotkeyStatus,
   HotkeyTrigger,
   PermissionStatus,
-  UserPreferences,
 } from '../lib/types';
+import { useHotkeySettings } from '../state/HotkeySettingsContext';
 import { Btn, Card, PageHeader, Pill } from './_atoms';
 
 interface SettingsProps {
@@ -104,13 +101,7 @@ function SettingRow({ label, desc, children }: SettingRowProps) {
 }
 
 function RecordingSection() {
-  const [prefs, setPrefs] = useState<UserPreferences | null>(null);
-  const [capability, setCapability] = useState<HotkeyCapability | null>(null);
-
-  useEffect(() => {
-    getSettings().then(setPrefs);
-    getHotkeyCapability().then(setCapability);
-  }, []);
+  const { prefs, capability, updatePrefs: savePrefs } = useHotkeySettings();
 
   if (!prefs || !capability) {
     return (
@@ -120,17 +111,12 @@ function RecordingSection() {
     );
   }
 
-  const updatePrefs = async (next: UserPreferences) => {
-    setPrefs(next);
-    await setSettings(next);
-  };
-
   const onTriggerChange = (trigger: HotkeyTrigger) =>
-    updatePrefs({ ...prefs, hotkey: { ...prefs.hotkey, trigger } });
+    savePrefs({ ...prefs, hotkey: { ...prefs.hotkey, trigger } });
   const onModeChange = (mode: HotkeyMode) =>
-    updatePrefs({ ...prefs, hotkey: { ...prefs.hotkey, mode } });
+    savePrefs({ ...prefs, hotkey: { ...prefs.hotkey, mode } });
   const onShowCapsuleChange = (showCapsule: boolean) =>
-    updatePrefs({ ...prefs, showCapsule });
+    savePrefs({ ...prefs, showCapsule });
 
   const choices: Array<[HotkeyMode, string]> = [
     ['toggle', '切换式'],
@@ -224,24 +210,21 @@ type LlmPresetId = typeof LLM_PRESETS[number]['id'];
 const ASR_DEFAULT_RESOURCE_ID = 'volc.bigasr.sauc.duration';
 
 function ProvidersSection() {
-  const [prefs, setPrefsState] = useState<import('../lib/types').UserPreferences | null>(null);
+  const { prefs, updatePrefs } = useHotkeySettings();
   const [llmProvider, setLlmProvider] = useState<LlmPresetId>('ark');
 
   useEffect(() => {
-    getSettings().then(p => {
-      setPrefsState(p);
-      const known = LLM_PRESETS.find(x => x.id === p.activeLlmProvider);
-      setLlmProvider(known ? known.id : 'custom');
-    });
-  }, []);
+    if (!prefs) return;
+    const known = LLM_PRESETS.find(x => x.id === prefs.activeLlmProvider);
+    setLlmProvider(known ? known.id : 'custom');
+  }, [prefs]);
 
   const onLlmProviderChange = async (id: LlmPresetId) => {
     setLlmProvider(id);
     await setActiveLlmProvider(id);
     if (prefs) {
       const next = { ...prefs, activeLlmProvider: id };
-      setPrefsState(next);
-      await setSettings(next);
+      await updatePrefs(next);
     }
     const preset = LLM_PRESETS.find(p => p.id === id);
     if (preset?.baseUrl) {
@@ -384,15 +367,9 @@ const iconBtnStyle: CSSProperties = {
 };
 
 function ShortcutsSection() {
-  const [prefs, setPrefs] = useState<UserPreferences | null>(null);
-  const [capability, setCapability] = useState<HotkeyCapability | null>(null);
+  const { hotkey, capability } = useHotkeySettings();
 
-  useEffect(() => {
-    getSettings().then(setPrefs);
-    getHotkeyCapability().then(setCapability);
-  }, []);
-
-  if (!prefs || !capability) {
+  if (!hotkey || !capability) {
     return (
       <Card>
         <div style={{ fontSize: 12, color: 'var(--ol-ink-4)' }}>加载中…</div>
@@ -404,7 +381,7 @@ function ShortcutsSection() {
     ? '所有快捷键全局生效，需要在权限设置中开启辅助功能。'
     : '所有快捷键全局生效。若无响应，请在权限页查看全局快捷键监听状态。';
   const rows: Array<[string, string]> = [
-    ['开始 / 停止录音', getHotkeyStartStopLabel(prefs.hotkey)],
+    ['开始 / 停止录音', getHotkeyStartStopLabel(hotkey)],
     ['取消本次录音', 'Esc'],
     ['胶囊确认插入', '点击右侧 ✓'],
     ['切换上一次风格', capability.requiresAccessibilityPermission ? '⌘ ⇧ S' : '暂未支持'],
@@ -434,17 +411,15 @@ function PermissionsSection() {
   const [accessibility, setAccessibility] = useState<PermissionStatus | 'loading'>('loading');
   const [microphone, setMicrophone] = useState<PermissionStatus | 'loading'>('loading');
   const [hotkey, setHotkey] = useState<HotkeyStatus | null>(null);
-  const [capability, setCapability] = useState<HotkeyCapability | null>(null);
+  const { capability } = useHotkeySettings();
 
   const refresh = async () => {
-    const [a, m, c] = await Promise.all([
+    const [a, m] = await Promise.all([
       checkAccessibilityPermission(),
       checkMicrophonePermission(),
-      getHotkeyCapability(),
     ]);
     setAccessibility(a);
     setMicrophone(m);
-    setCapability(c);
     setHotkey(await getHotkeyStatus());
   };
 

--- a/openless -all/app/src/state/HotkeySettingsContext.tsx
+++ b/openless -all/app/src/state/HotkeySettingsContext.tsx
@@ -1,0 +1,66 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from 'react';
+import { getHotkeyCapability, getSettings, setSettings } from '../lib/ipc';
+import type { HotkeyBinding, HotkeyCapability, UserPreferences } from '../lib/types';
+
+interface HotkeySettingsContextValue {
+  prefs: UserPreferences | null;
+  hotkey: HotkeyBinding | null;
+  capability: HotkeyCapability | null;
+  loading: boolean;
+  refresh: () => Promise<void>;
+  updatePrefs: (next: UserPreferences) => Promise<void>;
+}
+
+const HotkeySettingsContext = createContext<HotkeySettingsContextValue | null>(null);
+
+export function HotkeySettingsProvider({ children }: { children: ReactNode }) {
+  const [prefs, setPrefs] = useState<UserPreferences | null>(null);
+  const [capability, setCapability] = useState<HotkeyCapability | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  const refresh = useCallback(async () => {
+    const [nextPrefs, nextCapability] = await Promise.all([getSettings(), getHotkeyCapability()]);
+    setPrefs(nextPrefs);
+    setCapability(nextCapability);
+    setLoading(false);
+  }, []);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  const updatePrefs = useCallback(async (next: UserPreferences) => {
+    setPrefs(next);
+    await setSettings(next);
+  }, []);
+
+  const value = useMemo<HotkeySettingsContextValue>(
+    () => ({
+      prefs,
+      hotkey: prefs?.hotkey ?? null,
+      capability,
+      loading,
+      refresh,
+      updatePrefs,
+    }),
+    [capability, loading, prefs, refresh, updatePrefs],
+  );
+
+  return <HotkeySettingsContext.Provider value={value}>{children}</HotkeySettingsContext.Provider>;
+}
+
+export function useHotkeySettings() {
+  const value = useContext(HotkeySettingsContext);
+  if (!value) {
+    throw new Error('useHotkeySettings must be used within HotkeySettingsProvider');
+  }
+  return value;
+}


### PR DESCRIPTION
## 摘要

Fixes #36。

本 PR 解决桌面热键路径中平台 Hook、UI 文案和 Coordinator 状态混在一起的问题。

本次改动将热键能力收口到统一的后端适配层，保留现有 macOS CGEventTap 实现，并为 Windows 新增显式的低级键盘 Hook 适配器，用于支持右侧修饰键和 modifier-only 按住说话触发。前端不再根据 OS 字符串硬编码热键选项和状态，而是统一根据后端返回的 capability、status 和当前 binding 渲染。

## 修复 / 新增 / 改进

- 新增统一热键适配边界：
  - `HotkeyAdapter`
  - `HotkeyCapability`
  - `HotkeyStatus`
  - `HotkeyInstallError`

- 保留现有 macOS CGEventTap 热键实现，不改动既有 macOS EventTap 路径。

- Windows 热键实现不再走泛化的 `rdev` 分支，改为显式的 `WH_KEYBOARD_LL` low-level keyboard hook 适配器。

- Windows modifier-only 触发不再被静默降级为普通 registered shortcut。

- Coordinator 只消费统一的热键边沿事件，不再接触具体平台 Hook 实现细节。

- 前端热键展示统一走 `lib/hotkey.ts`，不再使用类似 `os === 'win' ? ... : ...` 的 OS 字符串分支。

- UI 热键选项、当前状态和文案改为基于后端 capability/status/current binding 渲染。

- Windows 默认热键调整为右 Control 按住说话。

- 补充平台适配层文档：
  - `docs/platform-adapter-architecture.md`

## 兼容

- 不包含：
  - 不移除现有 macOS CGEventTap 实现。
  - 不新增新的 fallback 热键路径。
  - 不引入新的依赖。
  - 不改变整体构建流程。

- 对现有用户 / 本地环境 / 构建流程的影响：
  - macOS 继续使用原有 CGEventTap 路径。
  - Windows 热键行为会切换到新的 low-level keyboard hook 适配器。
  - Windows 默认按住说话热键变更为右 Control。
  - 前端展示逻辑改为读取后端能力与状态数据，避免后续平台差异继续散落在 UI 层。
  - 构建流程无额外要求。

## 测试计划

- [x] 命令：`npm run build`
- [x] 结果：通过
- [x] 证据路径：本地构建输出

- [x] 命令：`cargo check`
- [x] 结果：通过
- [x] 证据路径：本地检查输出

- [ ] Windows native hook runtime on real hardware
- [x] cross-target cargo check

## 主要改动文件

- `docs/platform-adapter-architecture.md`
- `openless-all/app/src-tauri/src/hotkey.rs`
- `openless-all/app/src-tauri/src/types.rs`
- `openless-all/app/src-tauri/src/coordinator.rs`
- `openless-all/app/src-tauri/src/commands.rs`
- `openless-all/app/src-tauri/src/lib.rs`
- `openless-all/app/src/lib/types.ts`
- `openless-all/app/src/lib/ipc.ts`
- `openless-all/app/src/lib/hotkey.ts`
- `openless-all/app/src/pages/Settings.tsx`
- `openless-all/app/src/pages/Overview.tsx`
- `openless-all/app/src/pages/History.tsx`
- `openless-all/app/src/components/FloatingShell.tsx`
- `openless-all/app/src/components/Onboarding.tsx`

## Summary by Sourcery

Introduce a unified hotkey adapter boundary across platforms and update UI to consume backend-reported hotkey capability and status instead of OS-specific logic.

New Features:
- Add platform-specific hotkey adapters for macOS EventTap, Windows low-level keyboard hooks, and rdev-based Linux/other implementations behind a common HotkeyAdapter interface.
- Expose backend hotkey capabilities and adapter metadata to the frontend via new HotkeyCapability and HotkeyStatus fields and a get_hotkey_capability IPC command.
- Add a shared frontend hotkey utility module to render trigger labels and usage hints consistently across the app.

Bug Fixes:
- Fix Windows hotkey handling by using a native low-level keyboard hook that preserves modifier-only and side-specific modifier semantics.
- Ensure hotkey installation errors are surfaced with structured codes and messages instead of silent failures.

Enhancements:
- Refine coordinator hotkey supervision to track adapter kind, remember last install error, and provide clearer status messaging.
- Unify frontend permission, settings, onboarding, and shortcut descriptions based on backend-reported hotkey capability instead of hardcoded OS checks.
- Document the platform adapter architecture and explicit contracts for backend hotkey adapters and UI usage.

## Summary by Sourcery

Unify global hotkey handling behind a platform-specific adapter boundary and update both backend and frontend to consume explicit hotkey capabilities and status, including a new native Windows low-level keyboard hook and adjusted defaults.

New Features:
- Introduce a HotkeyAdapter trait and HotkeyCapability/HotkeyStatus/HotkeyInstallError types to describe platform hotkey support and lifecycle in a structured way.
- Add a native Windows low-level keyboard hook implementation that preserves modifier-only and side-specific modifier semantics, alongside existing macOS EventTap and rdev-based adapters.
- Expose hotkey capability and status to the frontend via new IPC commands and a shared HotkeySettings React context, enabling UI components to render trigger options and help text from backend data rather than OS checks.
- Add a shared frontend hotkey utility module to standardize trigger labels and usage hints across settings, onboarding, overview, history, and shell components.

Bug Fixes:
- Fix Windows global hotkey behavior by replacing the rdev path with a native low-level keyboard hook so modifier-only triggers like right Control work reliably and are no longer silently downgraded.
- Ensure hotkey installation failures are surfaced with structured error codes and messages, and tracked in coordinator state instead of failing silently.

Enhancements:
- Refine the coordinator’s hotkey supervision loop to track the active adapter kind, remember the last install error, and cleanly stop the listener on app exit.
- Adjust default hotkey bindings so Windows uses right Control with hold-to-talk semantics while other platforms retain right Option toggle behavior.
- Refactor permissions, settings, onboarding, and shortcut descriptions to be driven by backend-reported hotkey capability and current binding rather than hardcoded OS string branches.
- Improve mock IPC data to reflect the new hotkey capability and status structures for development builds.
- Document the platform adapter architecture and contracts between backend adapters, coordinator, and UI.

Documentation:
- Add platform adapter architecture documentation describing the hotkey adapter boundary, per-OS implementations, and the UI contract for consuming capability and status.

Tests:
- Update cross-platform build/check paths implicitly by exercising the new hotkey types and IPC commands, while keeping existing build flows unchanged.