### PR TITLE
test(hotkey): 补齐热键自动注入门禁

### DIFF
--- a/openless-all/README.md
+++ b/openless-all/README.md
@@ -89,6 +89,18 @@ Generated GNU artifacts:
 - `%TEMP%\openless-windows-gnu\src-tauri\target\x86_64-pc-windows-gnu\release\bundle\msi\OpenLess_*_x64_en-US.msi`
 - `%TEMP%\openless-windows-gnu\src-tauri\target\x86_64-pc-windows-gnu\release\bundle\nsis\OpenLess_*_x64-setup.exe`
 
+### Hotkey Injection Gate
+
+Use this gate before/after Windows hotkey changes when a physical keyboard
+regression is unavailable. It injects a dev/test-only hotkey click through the
+coordinator `handle_pressed` / `handle_released` path, asserts the log contains
+`[coord] hotkey pressed`, and cancels the dry-run session automatically.
+
+```powershell
+cd app
+npm run check:hotkey-injection
+```
+
 ### Windows Runtime Notes
 
 - Windows does not need the macOS Accessibility permission. Use Settings ->

--- a/openless-all/app/package.json
+++ b/openless-all/app/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "preview": "vite preview",
-    "tauri": "tauri"
+    "tauri": "tauri",
+    "check:hotkey-injection": "node scripts/check-hotkey-injection.mjs"
   },
   "dependencies": {
     "@tauri-apps/api": "^2.1.1",

--- a/openless-all/app/scripts/check-hotkey-injection.mjs
+++ b/openless-all/app/scripts/check-hotkey-injection.mjs
@@ -1,0 +1,25 @@
+import { spawnSync } from 'node:child_process';
+
+const result = spawnSync(
+  'cargo',
+  ['test', '--manifest-path', 'src-tauri/Cargo.toml', 'hotkey_injection_gate_logs_pressed_and_cancels', '--', '--nocapture'],
+  {
+    env: { ...process.env, OPENLESS_HOTKEY_INJECTION_DRY_RUN: '1' },
+    encoding: 'utf8',
+  },
+);
+
+const output = `${result.stdout ?? ''}${result.stderr ?? ''}`;
+process.stdout.write(result.stdout ?? '');
+process.stderr.write(result.stderr ?? '');
+
+if (result.status !== 0) {
+  process.exit(result.status ?? 1);
+}
+
+if (!output.includes('[coord] hotkey pressed')) {
+  console.error("Hotkey injection gate did not emit '[coord] hotkey pressed'.");
+  process.exit(1);
+}
+
+console.log('Hotkey injection gate passed.');

--- a/openless-all/app/src-tauri/src/commands.rs
+++ b/openless-all/app/src-tauri/src/commands.rs
@@ -163,6 +163,12 @@ pub fn cancel_dictation(coord: CoordinatorState<'_>) {
     coord.cancel_dictation();
 }
 
+#[cfg(debug_assertions)]
+#[tauri::command]
+pub async fn inject_hotkey_click_for_dev(coord: CoordinatorState<'_>) -> Result<(), String> {
+    coord.inject_hotkey_click_for_dev().await
+}
+
 #[tauri::command]
 pub async fn repolish(
     coord: CoordinatorState<'_>,

--- a/openless-all/app/src-tauri/src/coordinator.rs
+++ b/openless-all/app/src-tauri/src/coordinator.rs
@@ -154,6 +154,15 @@ impl Coordinator {
         cancel_session(&self.inner);
     }
 
+    #[cfg(any(debug_assertions, test))]
+    pub async fn inject_hotkey_click_for_dev(&self) -> Result<(), String> {
+        log::info!("[coord] dev hotkey injection started");
+        handle_pressed(&self.inner).await;
+        handle_released(&self.inner).await;
+        cancel_session(&self.inner);
+        Ok(())
+    }
+
     pub async fn repolish(&self, raw_text: String, mode: PolishMode) -> Result<String, String> {
         let hotwords = enabled_phrases(&self.inner);
         polish_text(&raw_text, mode, &hotwords)
@@ -241,6 +250,7 @@ fn hotkey_bridge_loop(inner: Arc<Inner>, rx: mpsc::Receiver<HotkeyEvent>) {
 async fn handle_pressed(inner: &Arc<Inner>) {
     let mode = inner.prefs.get().hotkey.mode;
     let phase = inner.state.lock().phase;
+    log::info!("[coord] hotkey pressed (mode={mode:?}, phase={phase:?})");
     match (mode, phase) {
         (HotkeyMode::Toggle, SessionPhase::Idle) => {
             let _ = begin_session(inner).await;
@@ -257,8 +267,9 @@ async fn handle_pressed(inner: &Arc<Inner>) {
 
 async fn handle_released(inner: &Arc<Inner>) {
     let mode = inner.prefs.get().hotkey.mode;
+    let phase = inner.state.lock().phase;
+    log::info!("[coord] hotkey released (mode={mode:?}, phase={phase:?})");
     if mode == HotkeyMode::Hold {
-        let phase = inner.state.lock().phase;
         if phase == SessionPhase::Listening {
             let _ = end_session(inner).await;
         }
@@ -277,9 +288,24 @@ async fn begin_session(inner: &Arc<Inner>) -> Result<(), String> {
         state.started_at = Instant::now();
     }
 
+    #[cfg(any(debug_assertions, test))]
+    if hotkey_injection_dry_run_enabled() {
+        emit_capsule(inner, CapsuleState::Recording, 0.0, 0, None, None);
+        inner.state.lock().phase = SessionPhase::Listening;
+        log::info!("[coord] session started (hotkey-injection dry-run)");
+        return Ok(());
+    }
+
     if let Err(message) = ensure_microphone_permission(inner) {
         log::warn!("[coord] microphone permission gate failed: {message}");
-        emit_capsule(inner, CapsuleState::Error, 0.0, 0, Some(message.clone()), None);
+        emit_capsule(
+            inner,
+            CapsuleState::Error,
+            0.0,
+            0,
+            Some(message.clone()),
+            None,
+        );
         inner.state.lock().phase = SessionPhase::Idle;
         return Err(message);
     }
@@ -311,8 +337,9 @@ async fn begin_session(inner: &Arc<Inner>) -> Result<(), String> {
             inner.state.lock().phase = SessionPhase::Idle;
             return Err(e.to_string());
         }
-        let c: Arc<dyn crate::recorder::AudioConsumer> =
-            Arc::new(AsrBridge { asr: Arc::clone(&asr) });
+        let c: Arc<dyn crate::recorder::AudioConsumer> = Arc::new(AsrBridge {
+            asr: Arc::clone(&asr),
+        });
         *inner.asr.lock() = Some(ActiveAsr::Volcengine(asr));
         c
     };
@@ -511,6 +538,11 @@ fn cancel_session(inner: &Arc<Inner>) {
 
 // ─────────────────────────── helpers ───────────────────────────
 
+#[cfg(any(debug_assertions, test))]
+fn hotkey_injection_dry_run_enabled() -> bool {
+    std::env::var_os("OPENLESS_HOTKEY_INJECTION_DRY_RUN").is_some()
+}
+
 fn ensure_microphone_permission(inner: &Arc<Inner>) -> Result<(), String> {
     use crate::permissions::{self, PermissionStatus};
 
@@ -624,6 +656,26 @@ fn enabled_hotwords(inner: &Arc<Inner>) -> Vec<DictionaryHotword> {
             enabled: e.enabled,
         })
         .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn hotkey_injection_gate_logs_pressed_and_cancels() {
+        let _ = env_logger::builder()
+            .filter_level(log::LevelFilter::Info)
+            .is_test(false)
+            .try_init();
+        std::env::set_var("OPENLESS_HOTKEY_INJECTION_DRY_RUN", "1");
+
+        let coordinator = Coordinator::new();
+        coordinator.inject_hotkey_click_for_dev().await.unwrap();
+
+        assert_eq!(coordinator.inner.state.lock().phase, SessionPhase::Idle);
+        std::env::remove_var("OPENLESS_HOTKEY_INJECTION_DRY_RUN");
+    }
 }
 
 fn enabled_phrases(inner: &Arc<Inner>) -> Vec<String> {

--- a/openless-all/app/src-tauri/src/lib.rs
+++ b/openless-all/app/src-tauri/src/lib.rs
@@ -139,6 +139,8 @@ pub fn run() {
             commands::start_dictation,
             commands::stop_dictation,
             commands::cancel_dictation,
+            #[cfg(debug_assertions)]
+            commands::inject_hotkey_click_for_dev,
             commands::repolish,
             commands::set_default_polish_mode,
             commands::set_style_enabled,


### PR DESCRIPTION
## 摘要

Fixes #35。

本 PR 按最小改动补齐 dev/test 专用热键注入门禁，用于验证热键事件是否能进入 coordinator 状态机。

当前 Windows 真机回归中，物理全局热键仍需要人工按键验证，CI 很难稳定证明热键事件是否进入业务链路。本 PR 新增测试注入入口，让自动化脚本可以直接走 `handle_pressed` / `handle_released` 路径，并通过 coordinator 日志断言热键按下事件已进入状态机。

本 PR 不尝试替代真实 OS hook / 物理热键测试，只补齐非人工的 coordinator 热键链路门禁。

## 修复 / 新增 / 改进

- 新增 dev/test 专用热键注入入口。

- 注入路径走真实 coordinator 处理函数：
  - `handle_pressed`
  - `handle_released`

- 为 `handle_pressed` / `handle_released` 增加 coordinator 日志：
  - `[coord] hotkey pressed`

- dry-run 注入后会自动 cancel，避免测试流程触发长时间录音。

- 新增检查脚本：
  - `npm run check:hotkey-injection`

- 检查脚本会断言日志中包含：
  - `[coord] hotkey pressed`

- README 补充 Hotkey Injection Gate 用法说明。

## 兼容

- 不包含：
  - 不改变真实用户的物理热键行为。
  - 不替代 Windows 真机物理热键测试。
  - 不调整 OS hook / rdev / 平台适配实现。
  - 不引入新的运行时依赖。
  - 不改变默认热键配置。

- 对现有用户 / 本地环境 / 构建流程的影响：
  - 对普通用户无行为影响。
  - dev/test 环境新增一个可自动化验证的热键注入门禁。
  - 物理热键测试仍作为额外真机门禁保留，用于覆盖 OS hook 层。
  - CI 或本地 push 前可以通过 `npm run check:hotkey-injection` 验证 coordinator 热键链路。

## 测试计划

- [x] 命令：`npm run check:hotkey-injection`
- [x] 结果：通过
- [x] 证据路径：本地脚本输出，日志包含 `[coord] hotkey pressed`

- [x] 命令：`npm run build`
- [x] 结果：通过
- [x] 证据路径：本地构建输出

- [x] 命令：`cargo check`
- [x] 结果：通过
- [x] 证据路径：本地检查输出

- [x] 命令：`cargo check --release`
- [x] 结果：通过
- [x] 证据路径：本地 release 检查输出

- [x] 命令：`git diff --check`
- [x] 结果：通过
- [x] 证据路径：本地命令输出

## 备注

本 PR 是针对 issue #35 的最小闭环修复：只补齐热键事件进入 coordinator 状态机的自动化门禁，不扩大到真实 Windows OS hook 行为验证。真实物理热键链路仍需要 Windows 真机测试覆盖。

## Summary by Sourcery

Add a dev/test-only hotkey injection gate to validate that hotkey events reach the coordinator state machine without requiring physical hotkey input.

New Features:
- Introduce a coordinator API and Tauri command to inject a synthetic hotkey click in dev/test builds, exercising the real hotkey handling path and automatically cancelling the session.
- Add a Node-based `npm run check:hotkey-injection` script that runs a Rust test and asserts coordinator logs contain the hotkey pressed marker.

Enhancements:
- Log coordinator hotkey press and release events with mode and phase context, and add a dry-run path that skips microphone permission and recording when an environment flag is set.

Documentation:
- Document the Hotkey Injection Gate and its usage in the README.

Tests:
- Add a Rust async test to cover the hotkey injection gate, ensuring it leaves the coordinator session phase idle after a dry-run.