### PR TITLE
fix(settings): 防止凭据字段清空已有密钥

### DIFF
--- a/openless-all/app/src/pages/Settings.tsx
+++ b/openless-all/app/src/pages/Settings.tsx
@@ -353,11 +353,35 @@ function CredentialField({ label, account, placeholder, mono, mask, defaultValue
   const { t } = useTranslation();
   const [value, setValue] = useState('');
   const [revealed, setRevealed] = useState(false);
-  const [saved, setSaved] = useState(false);
+  const [loaded, setLoaded] = useState(false);
+  const [dirty, setDirty] = useState(false);
+  const [status, setStatus] = useState<'idle' | 'saving' | 'saved' | 'saveError' | 'copied' | 'copyError'>('idle');
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
-    readCredential(account).then(v => setValue(v ?? ''));
+    let cancelled = false;
+    setLoaded(false);
+    setDirty(false);
+    setStatus('idle');
+    if (debounceRef.current) {
+      clearTimeout(debounceRef.current);
+      debounceRef.current = null;
+    }
+    readCredential(account)
+      .then(v => {
+        if (cancelled) return;
+        setValue(v ?? '');
+        setLoaded(true);
+      })
+      .catch(error => {
+        if (cancelled) return;
+        console.error('[settings] failed to read credential', account, error);
+        setLoaded(true);
+        setStatus('saveError');
+      });
+    return () => {
+      cancelled = true;
+    };
   }, [account]);
 
   useEffect(() => {
@@ -367,19 +391,29 @@ function CredentialField({ label, account, placeholder, mono, mask, defaultValue
   }, []);
 
   const save = async (v: string) => {
-    await setCredential(account, v);
-    setSaved(true);
-    setTimeout(() => setSaved(false), 1200);
+    if (!loaded) return;
+    setStatus('saving');
+    try {
+      await setCredential(account, v);
+      setDirty(false);
+      setStatus('saved');
+    } catch (error) {
+      console.error('[settings] failed to save credential', account, error);
+      setStatus('saveError');
+    }
+    window.setTimeout(() => setStatus('idle'), 1600);
   };
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const v = e.target.value;
     setValue(v);
+    setDirty(true);
     if (debounceRef.current) clearTimeout(debounceRef.current);
     debounceRef.current = setTimeout(() => save(v), 300);
   };
 
   const onBlur = () => {
+    if (!loaded || !dirty) return;
     if (debounceRef.current) {
       clearTimeout(debounceRef.current);
       debounceRef.current = null;
@@ -388,9 +422,25 @@ function CredentialField({ label, account, placeholder, mono, mask, defaultValue
   };
 
   const fillDefault = async () => {
-    if (!defaultValue) return;
+    if (!loaded || !defaultValue) return;
     setValue(defaultValue);
+    setDirty(true);
     await save(defaultValue);
+  };
+
+  const onCopy = async () => {
+    if (!value) return;
+    try {
+      if (!navigator.clipboard?.writeText) {
+        throw new Error('Clipboard API unavailable');
+      }
+      await navigator.clipboard.writeText(value);
+      setStatus('copied');
+    } catch (error) {
+      console.error('[settings] failed to copy credential', account, error);
+      setStatus('copyError');
+    }
+    window.setTimeout(() => setStatus('idle'), 1600);
   };
 
   const inputType = mask && !revealed ? 'password' : 'text';
@@ -404,10 +454,11 @@ function CredentialField({ label, account, placeholder, mono, mask, defaultValue
           placeholder={placeholder}
           onChange={handleChange}
           onBlur={onBlur}
+          disabled={!loaded}
           style={{ ...inputStyle, fontFamily: mono ? 'var(--ol-font-mono)' : 'inherit' }}
         />
         {defaultValue && !value && (
-          <button onClick={fillDefault} title={t('settings.providers.fillDefault')} style={iconBtnStyle}>
+          <button onClick={fillDefault} title={t('settings.providers.fillDefault')} style={iconBtnStyle} disabled={!loaded}>
             <Icon name="check" size={13} />
           </button>
         )}
@@ -421,15 +472,29 @@ function CredentialField({ label, account, placeholder, mono, mask, defaultValue
           </button>
         )}
         <button
-          onClick={() => navigator.clipboard?.writeText(value)}
+          onClick={onCopy}
           title={t('common.copy')}
           style={iconBtnStyle}
           disabled={!value}
         >
           <Icon name="copy" size={14} />
         </button>
-        {saved && (
-          <span style={{ fontSize: 11, color: 'var(--ol-ok)', whiteSpace: 'nowrap' }}>{t('common.saved')}</span>
+        {status !== 'idle' && (
+          <span
+            style={{
+              fontSize: 11,
+              color: status.endsWith('Error') ? 'var(--ol-warn)' : 'var(--ol-ok)',
+              whiteSpace: 'nowrap',
+            }}
+          >
+            {status === 'saving'
+              ? '保存中'
+              : status === 'saved'
+                ? t('common.saved')
+                : status === 'copied'
+                  ? '已复制'
+                  : '操作失败'}
+          </span>
         )}
       </div>
     </SettingRow>


### PR DESCRIPTION
﻿## 摘要

关联 fork 验证：Cooper-X-Oak/openless#12。

本 PR 是从 fork/dev 已验证批次拆出的第三个最小 upstream 维护项：修复设置页凭据字段在读取完成前可能把已有密钥保存为空值的问题。

## fork/dev 先行验证

- fork PR：Cooper-X-Oak/openless#12 https://github.com/Cooper-X-Oak/openless/pull/12
- fork PR 状态：已 merge，merge commit `b9ee8b8`。
- fork CI：Windows Tauri checks SUCCESS，Sourcery review SUCCESS。
- fork 自审评论：https://github.com/Cooper-X-Oak/openless/pull/12#issuecomment-4349705702

## 修复 / 新增 / 改进

- 凭据字段读取期间禁用输入和默认填充按钮，避免加载完成前 blur 写入空值。
- 增加 `loaded` / `dirty` 状态：只有用户实际修改后的字段才会保存。
- 保留现有 debounce 保存行为，但 account 切换时会清理 pending debounce。
- 读取、保存、复制失败时输出 console error，并在 UI 中显示失败状态。
- 复制按钮改为显式 `onCopy`，剪贴板 API 不可用时不再静默失败。

## 兼容

- 不包含：启动路径、热键 core、ASR、插入 fallback、权限状态。
- 对现有用户 / 本地环境 / 构建流程的影响：只影响设置页凭据字段交互；不会迁移或改写已有凭据格式。

## 测试计划

- [x] 命令：`npm run build`
- [x] 结果：TypeScript + Vite build 通过。
- [x] 命令：`git diff --check`
- [x] 结果：通过。
- [x] fork PR CI：Cooper-X-Oak/openless#12 Windows Tauri checks / Sourcery review 均通过。

## Summary by Sourcery

Prevent settings credential fields from overwriting existing secrets with empty values and improve user feedback for credential operations.

Bug Fixes:
- Ensure credential fields only save after credentials have finished loading and the user has actually modified the value.
- Avoid pending debounced saves from a previous account when switching accounts in the settings page.
- Stop attempting to copy credentials silently when the Clipboard API is unavailable, surfacing the failure instead.

Enhancements:
- Introduce loaded/dirty/status state tracking for credential fields to control when saves occur and to show operation status badges for saving, saved, copied, and error states.