### PR TITLE
fix(windows): 校准麦克风权限探测

### DIFF
--- a/openless-all/app/src-tauri/src/permissions.rs
+++ b/openless-all/app/src-tauri/src/permissions.rs
@@ -264,6 +264,11 @@ mod platform {
     /// Windows 的麦克风权限走系统设置 → 隐私 → 麦克风；
     /// 这里用 cpal 建立一次短生命周期输入流，避免只查设备格式时误报已授权。
     pub fn check_microphone() -> PermissionStatus {
+        if windows_microphone_registry_denied() {
+            log::warn!("[mic] Windows microphone privacy registry is denied");
+            return PermissionStatus::Denied;
+        }
+
         let host = cpal::default_host();
         let Some(device) = host.default_input_device() else {
             log::warn!("[mic] no default input device");
@@ -333,6 +338,51 @@ mod platform {
         std::thread::sleep(Duration::from_millis(120));
         drop(stream);
         Ok(())
+    }
+
+    fn windows_microphone_registry_denied() -> bool {
+        candidate_microphone_registry_paths()
+            .into_iter()
+            .any(|path| registry_value_is_deny(&path))
+    }
+
+    fn candidate_microphone_registry_paths() -> Vec<String> {
+        let mut paths = vec![
+            r"HKCU\Software\Microsoft\Windows\CurrentVersion\CapabilityAccessManager\ConsentStore\microphone".to_string(),
+            r"HKCU\Software\Microsoft\Windows\CurrentVersion\CapabilityAccessManager\ConsentStore\microphone\NonPackaged".to_string(),
+            r"HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\CapabilityAccessManager\ConsentStore\microphone".to_string(),
+        ];
+
+        if let Ok(exe) = std::env::current_exe() {
+            if let Some(encoded) = exe.to_str().map(|path| path.replace('\\', "#")) {
+                paths.push(format!(
+                    r"HKCU\Software\Microsoft\Windows\CurrentVersion\CapabilityAccessManager\ConsentStore\microphone\NonPackaged\{encoded}"
+                ));
+            }
+        }
+
+        paths
+    }
+
+    fn registry_value_is_deny(path: &str) -> bool {
+        let output = match std::process::Command::new("reg")
+            .args(["query", path, "/v", "Value"])
+            .output()
+        {
+            Ok(output) => output,
+            Err(err) => {
+                log::warn!("[mic] reg query failed for {path}: {err}");
+                return false;
+            }
+        };
+
+        if !output.status.success() {
+            return false;
+        }
+
+        String::from_utf8_lossy(&output.stdout)
+            .lines()
+            .any(|line| line.contains("REG_SZ") && line.split_whitespace().any(|part| part == "Deny"))
     }
 }
 

--- a/openless-all/app/src/pages/Settings.tsx
+++ b/openless-all/app/src/pages/Settings.tsx
@@ -502,37 +502,46 @@ function PermissionsSection() {
   const [hotkey, setHotkey] = useState<HotkeyStatus | null>(null);
   const { capability } = useHotkeySettings();
 
-  const refresh = async () => {
+  const refreshPermissions = async () => {
     const [a, m] = await Promise.all([
       checkAccessibilityPermission(),
       checkMicrophonePermission(),
     ]);
     setAccessibility(a);
     setMicrophone(m);
+  };
+
+  const refreshHotkey = async () => {
     setHotkey(await getHotkeyStatus());
   };
 
   useEffect(() => {
-    refresh();
-    const id = window.setInterval(refresh, 1000);
-    // 用户从系统设置切回来时立刻刷新（不等下一个 1s tick）
-    const onFocus = () => refresh();
+    refreshPermissions();
+    refreshHotkey();
+    const hotkeyId = window.setInterval(refreshHotkey, 1000);
+    // 麦克风检查会短暂打开输入流，避免每秒探测导致隐私指示器频繁闪烁。
+    const permissionId = window.setInterval(refreshPermissions, 10000);
+    const onFocus = () => {
+      refreshPermissions();
+      refreshHotkey();
+    };
     window.addEventListener('focus', onFocus);
     return () => {
-      window.clearInterval(id);
+      window.clearInterval(hotkeyId);
+      window.clearInterval(permissionId);
       window.removeEventListener('focus', onFocus);
     };
   }, []);
 
   const reRequestAccessibility = async () => {
     await requestAccessibilityPermission();
-    refresh();
+    refreshPermissions();
   };
 
   const reRequestMicrophone = async () => {
     if (microphone === 'denied' || microphone === 'restricted') {
       await openSystemSettings('microphone');
-      refresh();
+      refreshPermissions();
       return;
     }
     const status = await requestMicrophonePermission();
@@ -540,7 +549,7 @@ function PermissionsSection() {
     if (status === 'denied' || status === 'restricted') {
       await openSystemSettings('microphone');
     }
-    refresh();
+    refreshPermissions();
   };
 
   const desc = capability?.requiresAccessibilityPermission


### PR DESCRIPTION
﻿## 摘要

关联 fork 验证：Cooper-X-Oak/openless#12。

本 PR 是从 fork/dev 已验证批次拆出的第四个最小 upstream 维护项：校准 Windows 麦克风隐私权限探测，并避免设置页每秒打开输入流导致隐私指示器频繁闪烁。

## fork/dev 先行验证

- fork PR：Cooper-X-Oak/openless#12 https://github.com/Cooper-X-Oak/openless/pull/12
- fork PR 状态：已 merge，merge commit `b9ee8b8`。
- fork CI：Windows Tauri checks SUCCESS，Sourcery review SUCCESS。
- fork 自审评论：https://github.com/Cooper-X-Oak/openless/pull/12#issuecomment-4349705702

## 修复 / 新增 / 改进

- Windows `check_microphone()` 先读取 CapabilityAccessManager 麦克风隐私注册表 Deny 状态。
- 覆盖全局 microphone、NonPackaged、当前 exe 对应 NonPackaged 路径。
- 保留现有短生命周期 input stream probe，用于设备/权限真实可用性探测。
- 设置页权限刷新拆成两路：hotkey 每 1 秒刷新，麦克风/辅助功能每 10 秒刷新。
- 用户从系统设置切回窗口时仍立即刷新权限和 hotkey 状态。

## 兼容

- 不包含：启动路径、热键 core、ASR、插入 fallback、凭据字段保存。
- 对现有用户 / 本地环境 / 构建流程的影响：Windows 设置页不再每秒触发麦克风输入流探测；麦克风隐私被关闭时更早返回 Denied。

## 测试计划

- [x] 命令：`npm run build`
- [x] 结果：TypeScript + Vite build 通过。
- [x] 命令：`openless-all/app/scripts/windows-build-gnu.ps1`
- [x] 结果：Windows GNU build/msi/nsis 通过，仅既有 warning。
- [x] 命令：`git diff --check`
- [x] 结果：通过。
- [x] fork PR CI：Cooper-X-Oak/openless#12 Windows Tauri checks / Sourcery review 均通过。

## Summary by Sourcery

Calibrate Windows microphone permission detection and reduce intrusive probing in the settings page.

Bug Fixes:
- Return microphone permission as denied when Windows CapabilityAccessManager registry indicates microphone access is blocked, covering global, NonPackaged, and current executable-specific keys.

Enhancements:
- Add registry-based precheck for Windows microphone privacy status before opening an input stream to avoid unnecessary device probing.
- Adjust settings page refresh behavior to poll hotkey status every second while checking microphone and accessibility permissions less frequently and on window focus to reduce privacy indicator flicker.