### PR TITLE
fix(windows): 收口录音会话失败态

### DIFF
--- a/openless-all/app/src-tauri/src/coordinator.rs
+++ b/openless-all/app/src-tauri/src/coordinator.rs
@@ -326,6 +326,20 @@ async fn begin_session(inner: &Arc<Inner>) -> Result<(), String> {
         return Ok(());
     }
 
+    if let Err(message) = ensure_asr_credentials() {
+        log::warn!("[coord] ASR credential gate failed: {message}");
+        emit_capsule(
+            inner,
+            CapsuleState::Error,
+            0.0,
+            0,
+            Some(message.clone()),
+            None,
+        );
+        inner.state.lock().phase = SessionPhase::Idle;
+        return Err(message);
+    }
+
     if let Err(message) = ensure_microphone_permission(inner) {
         log::warn!("[coord] microphone permission gate failed: {message}");
         emit_capsule(
@@ -556,10 +570,43 @@ async fn end_session(inner: &Arc<Inner>) -> Result<(), String> {
     };
 
     // ASR 完成后 cancel 检查：用户在 transcribe 进行中按 Esc 时，这里就会命中。
+    // 优先级高于 empty 检查 — 用户取消 → 静默丢弃，不写失败历史也不弹错误胶囊。
     if inner.state.lock().cancelled {
         log::info!("[coord] cancel detected after ASR — discarding transcript");
         inner.state.lock().phase = SessionPhase::Idle;
         return Ok(());
+    }
+
+    // ASR 返回空转写护栏（来自 PR #66）：写一条 emptyTranscript 失败历史 + 错误胶囊，
+    // 与 main 上其它 error 路径保持一致（带 schedule_capsule_idle 让胶囊自动消失）。
+    if raw.text.trim().is_empty() {
+        let session = DictationSession {
+            id: Uuid::new_v4().to_string(),
+            created_at: Utc::now().to_rfc3339(),
+            raw_transcript: raw.text.clone(),
+            final_text: String::new(),
+            mode: inner.prefs.get().default_mode,
+            app_bundle_id: None,
+            app_name: None,
+            insert_status: InsertStatus::Failed,
+            error_code: Some("emptyTranscript".to_string()),
+            duration_ms: Some(raw.duration_ms),
+            dictionary_entry_count: Some(enabled_phrases(inner).len() as u32),
+        };
+        if let Err(e) = inner.history.append(session) {
+            log::error!("[coord] history append failed: {e}");
+        }
+        emit_capsule(
+            inner,
+            CapsuleState::Error,
+            0.0,
+            elapsed,
+            Some("ASR returned empty transcript".to_string()),
+            None,
+        );
+        inner.state.lock().phase = SessionPhase::Idle;
+        schedule_capsule_idle(inner, CAPSULE_AUTO_HIDE_DELAY_MS);
+        return Err("ASR returned empty transcript".to_string());
     }
 
     emit_capsule(inner, CapsuleState::Polishing, 0.0, elapsed, None, None);
@@ -717,6 +764,27 @@ fn ensure_microphone_permission(inner: &Arc<Inner>) -> Result<(), String> {
         Ok(())
     } else {
         Err(format!("需要麦克风权限，当前状态: {requested:?}"))
+    }
+}
+
+fn ensure_asr_credentials() -> Result<(), String> {
+    let active_asr = CredentialsVault::get_active_asr();
+    if active_asr == "whisper" {
+        let api_key = CredentialsVault::get(CredentialAccount::AsrApiKey)
+            .ok()
+            .flatten()
+            .unwrap_or_default();
+        if api_key.trim().is_empty() {
+            return Err("请先在设置中填写 Whisper ASR API Key".to_string());
+        }
+        return Ok(());
+    }
+
+    let creds = read_volc_credentials();
+    if creds.app_id.trim().is_empty() || creds.access_token.trim().is_empty() {
+        Err("请先在设置中填写火山引擎 ASR App Key 和 Access Key".to_string())
+    } else {
+        Ok(())
     }
 }
 


### PR DESCRIPTION
﻿## 摘要

关联 fork 验证：Cooper-X-Oak/openless#12。

本 PR 是从 fork/dev 已验证批次拆出的第五个最小 upstream 维护项：收口 Windows 录音会话失败态，避免缺 ASR 凭据或空转写继续走成功/插入链路。

## fork/dev 先行验证

- fork PR：Cooper-X-Oak/openless#12 https://github.com/Cooper-X-Oak/openless/pull/12
- fork PR 状态：已 merge，merge commit `b9ee8b8`。
- fork CI：Windows Tauri checks SUCCESS，Sourcery review SUCCESS。
- fork 自审评论：https://github.com/Cooper-X-Oak/openless/pull/12#issuecomment-4349705702

## 修复 / 新增 / 改进

- 录音开始前检查当前 ASR provider 凭据。
- Volcengine 缺 App Key / Access Key 时直接返回 Error，不启动录音。
- Whisper 缺 API Key 时直接返回 Error，不启动录音。
- ASR 返回空 transcript 时写入 history 失败记录：`insertStatus=failed`、`errorCode=emptyTranscript`。
- 空转写不再进入 polishing / insertion / Done capsule，避免误报成功。

## 兼容

- 不包含：启动路径、热键 core、麦克风权限、设置页凭据保存、真实 ASR smoke 脚本。
- 对现有用户 / 本地环境 / 构建流程的影响：缺 ASR 凭据和空转写会更早以错误态呈现，不再进入后续插入链路。

## 测试计划

- [x] 命令：`npm run build`
- [x] 结果：TypeScript + Vite build 通过。
- [x] 命令：`openless-all/app/scripts/windows-build-gnu.ps1`
- [x] 结果：Windows GNU build/msi/nsis 通过，仅既有 warning。
- [x] 命令：`git diff --check`
- [x] 结果：通过。
- [x] fork PR CI：Cooper-X-Oak/openless#12 Windows Tauri checks / Sourcery review 均通过。

## Summary by Sourcery

Enforce ASR credential validation and empty-transcript handling in the Windows recording session lifecycle to prevent failed dictations from proceeding as successful sessions.

Bug Fixes:
- Block session start when Whisper or Volcengine ASR credentials are missing, surfacing an explicit error instead of proceeding with recording.
- Record dictation sessions with empty ASR transcripts as failed history entries and stop further processing instead of treating them as successful insertable results.