### PR TITLE
fix(ui): 本会话内延后提供商配置提示

### DIFF
--- a/openless-all/app/src/components/FloatingShell.tsx
+++ b/openless-all/app/src/components/FloatingShell.tsx
@@ -18,7 +18,7 @@ import { getHotkeyTriggerLabel } from '../lib/hotkey';
 import { getCredentials, openExternal } from '../lib/ipc';
 import { OL_DATA } from '../lib/mockData';
 import {
-  PROVIDER_SETUP_PROMPT_SEEN_KEY,
+  PROVIDER_SETUP_PROMPT_DEFERRED_KEY,
   shouldShowProviderSetupPrompt,
 } from '../lib/providerSetup';
 import type { SettingsSectionId } from '../pages/Settings';
@@ -70,8 +70,8 @@ function FloatingShellBody({ os, initialTab, initialSettings }: { os: OS; initia
     let cancelled = false;
     (async () => {
       const credentials = await getCredentials();
-      const promptSeenValue = window.localStorage.getItem(PROVIDER_SETUP_PROMPT_SEEN_KEY);
-      if (!cancelled && shouldShowProviderSetupPrompt(credentials, promptSeenValue)) {
+      const promptDeferredValue = window.sessionStorage.getItem(PROVIDER_SETUP_PROMPT_DEFERRED_KEY);
+      if (!cancelled && shouldShowProviderSetupPrompt(credentials, promptDeferredValue)) {
         setProviderPromptOpen(true);
       }
     })();
@@ -81,7 +81,7 @@ function FloatingShellBody({ os, initialTab, initialSettings }: { os: OS; initia
   }, []);
 
   const rememberProviderPrompt = () => {
-    window.localStorage.setItem(PROVIDER_SETUP_PROMPT_SEEN_KEY, '1');
+    window.sessionStorage.setItem(PROVIDER_SETUP_PROMPT_DEFERRED_KEY, '1');
     setProviderPromptOpen(false);
   };
 

--- a/openless-all/app/src/lib/providerSetup.test.ts
+++ b/openless-all/app/src/lib/providerSetup.test.ts
@@ -42,7 +42,7 @@ assertEqual(
     '1',
   ),
   false,
-  'do not repeat first-run prompt after the user has seen it',
+  'do not repeat first-run prompt after the user has deferred it in this session',
 );
 
 assertEqual(

--- a/openless-all/app/src/lib/providerSetup.ts
+++ b/openless-all/app/src/lib/providerSetup.ts
@@ -1,6 +1,6 @@
 import type { CredentialsStatus } from './types';
 
-export const PROVIDER_SETUP_PROMPT_SEEN_KEY = 'ol.providerSetupPromptSeen';
+export const PROVIDER_SETUP_PROMPT_DEFERRED_KEY = 'ol.providerSetupPromptDeferredThisSession';
 
 export function areProvidersConfigured(credentials: CredentialsStatus): boolean {
   return credentials.volcengineConfigured && credentials.arkConfigured;
@@ -8,7 +8,7 @@ export function areProvidersConfigured(credentials: CredentialsStatus): boolean 
 
 export function shouldShowProviderSetupPrompt(
   credentials: CredentialsStatus,
-  promptSeenValue: string | null,
+  promptDeferredValue: string | null,
 ): boolean {
-  return !areProvidersConfigured(credentials) && promptSeenValue !== '1';
+  return !areProvidersConfigured(credentials) && promptDeferredValue !== '1';
 }


### PR DESCRIPTION
﻿## 摘要

关联 fork 验证：Cooper-X-Oak/openless#12。

本 PR 是从 fork/dev 已验证批次拆出的 UI 状态修复：提供商配置提示不再用 localStorage 永久记住“已看过”，而是只在本 session 内延后，避免用户未完成配置后后续启动再也不提示。

## fork/dev 先行验证

- fork PR：Cooper-X-Oak/openless#12 https://github.com/Cooper-X-Oak/openless/pull/12
- fork PR 状态：已 merge，merge commit `b9ee8b8`。
- fork CI：Windows Tauri checks SUCCESS，Sourcery review SUCCESS。
- fork 自审评论：https://github.com/Cooper-X-Oak/openless/pull/12#issuecomment-4349705702

## 修复 / 新增 / 改进

- `PROVIDER_SETUP_PROMPT_SEEN_KEY` 改为 `PROVIDER_SETUP_PROMPT_DEFERRED_KEY`。
- provider prompt 状态从 `localStorage` 改为 `sessionStorage`。
- “稍后”只在当前会话内延后提示，下次启动若凭据仍未配置会再次提示。
- 更新 providerSetup 测试文案，明确 deferred 语义。

## 兼容

- 不包含：启动路径、热键 core、ASR、插入 fallback、权限状态、凭据字段保存。
- 对现有用户 / 本地环境 / 构建流程的影响：只影响未配置 provider 时的提示频率；不会读写真实凭据。

## 测试计划

- [x] 命令：`npm run build`
- [x] 结果：TypeScript + Vite build 通过。
- [x] 命令：`git diff --check`
- [x] 结果：通过。
- [ ] 命令：`node --loader ts-node/esm src/lib/providerSetup.test.ts`
- [ ] 结果：未运行，当前项目未安装 `ts-node`。
- [x] fork PR CI：Cooper-X-Oak/openless#12 Windows Tauri checks / Sourcery review 均通过。

## Summary by Sourcery

Limit provider setup prompts to be deferred only within the current session instead of being permanently suppressed.

Enhancements:
- Switch provider setup prompt state from localStorage to sessionStorage using a new deferred-key name and semantics.
- Clarify provider setup test description to reflect session-scoped deferral of the prompt.