### PR TITLE
fix(settings): 移除 SiliconFlow ASR 选项 — 后端未实现 (closes #58)

### DIFF
--- a/openless-all/app/src/pages/Settings.tsx
+++ b/openless-all/app/src/pages/Settings.tsx
@@ -225,9 +225,10 @@ type LlmPresetId = typeof LLM_PRESETS[number]['id'];
 
 const ASR_DEFAULT_RESOURCE_ID = 'volc.bigasr.sauc.duration';
 
+// SiliconFlow ASR 暂未在后端实现（coordinator.rs 只路由 whisper / volcengine）。
+// 在后端接入前不暴露给用户，避免选了之后必然失败。重新启用见 issue #58 的 follow-up。
 const ASR_PRESETS = [
   { id: 'volcengine',  nameKey: 'asrVolcengine'  },
-  { id: 'siliconflow', nameKey: 'asrSiliconflow' },
   { id: 'whisper',     nameKey: 'asrWhisper'     },
 ] as const;
 
@@ -320,14 +321,6 @@ function ProvidersSection() {
             <CredentialField key={`${asrProvider}:access_key`} label="Access Key" account="volcengine.access_key" mono mask />
             <CredentialField key={`${asrProvider}:resource_id`} label="Resource ID" account="volcengine.resource_id" mono
               placeholder={ASR_DEFAULT_RESOURCE_ID} defaultValue={ASR_DEFAULT_RESOURCE_ID} />
-          </>
-        ) : asrProvider === 'siliconflow' ? (
-          <>
-            <CredentialField key={`${asrProvider}:api_key`} label="API Key" account="asr.api_key" mono mask />
-            <CredentialField key={`${asrProvider}:endpoint`} label="Base URL" account="asr.endpoint"
-              placeholder="https://api.siliconflow.cn/v1" defaultValue="https://api.siliconflow.cn/v1" />
-            <CredentialField key={`${asrProvider}:model`} label="Model" account="asr.model"
-              placeholder="FunAudioLLM/SenseVoiceSmall" defaultValue="FunAudioLLM/SenseVoiceSmall" />
           </>
         ) : (
           <>


### PR DESCRIPTION
## 背景

\`coordinator.rs\` 只把 \`active_asr == 'whisper'\` 路由到 \`WhisperBatchASR\`，其他都走 Volcengine。设置页之前给用户暴露 SiliconFlow ASR 选项，选了之后 ASR 必然失败。

## 改动

- \`Settings.tsx\` ASR_PRESETS 移除 \`siliconflow\` 条目
- 移除 \`asrProvider === 'siliconflow'\` 的凭证字段分支

## 测试

- [x] \`npm run build\` 通过
- [ ] 手动：ASR 下拉只剩「火山引擎 bigasr / OpenAI Whisper」两项

## 关联

closes #58

## Summary by Sourcery

Remove unsupported SiliconFlow ASR option from settings to prevent users from selecting a non-functional backend.

Bug Fixes:
- Hide the SiliconFlow ASR preset from the ASR provider list since the backend does not implement it, avoiding guaranteed ASR failures when selected.

Enhancements:
- Add an inline comment documenting that SiliconFlow ASR is temporarily disabled until backend support is implemented and referencing follow-up work in issue #58.