### PR TITLE
fix(windows): 缺失托盘图标时继续启动

### DIFF
--- a/openless-all/app/src-tauri/src/lib.rs
+++ b/openless-all/app/src-tauri/src/lib.rs
@@ -94,26 +94,30 @@ pub fn run() {
 
             // 与 Swift `StatusBarIcon.swift` 行为一致：用全彩 AppIcon，**不**走 template 模式
             // （走 template 会被 macOS 染成单色 → 看起来像个黑方块）。
-            let _tray = TrayIconBuilder::with_id("main-tray")
-                .icon(app.default_window_icon().unwrap().clone())
-                .icon_as_template(false)
-                .menu(&menu)
-                .show_menu_on_left_click(false)
-                .on_menu_event(|app, event| match event.id.as_ref() {
-                    "toggle" => show_main_window(app),
-                    "quit" => app.exit(0),
-                    _ => {}
-                })
-                .on_tray_icon_event(|tray, event| {
-                    if let TrayIconEvent::Click {
-                        button: MouseButton::Left,
-                        ..
-                    } = event
-                    {
-                        show_main_window(tray.app_handle());
-                    }
-                })
-                .build(app)?;
+            if let Some(icon) = app.default_window_icon() {
+                let _tray = TrayIconBuilder::with_id("main-tray")
+                    .icon(icon.clone())
+                    .icon_as_template(false)
+                    .menu(&menu)
+                    .show_menu_on_left_click(false)
+                    .on_menu_event(|app, event| match event.id.as_ref() {
+                        "toggle" => show_main_window(app),
+                        "quit" => app.exit(0),
+                        _ => {}
+                    })
+                    .on_tray_icon_event(|tray, event| {
+                        if let TrayIconEvent::Click {
+                            button: MouseButton::Left,
+                            ..
+                        } = event
+                        {
+                            show_main_window(tray.app_handle());
+                        }
+                    })
+                    .build(app)?;
+            } else {
+                log::warn!("[startup] default window icon missing; tray icon disabled");
+            }
 
             // Spin up hotkey listener; coordinator owns the lifecycle.
             let app_handle = app.handle().clone();


### PR DESCRIPTION
## 摘要

Fixes #无（不再新增 upstream issue）。

关联 fork 验证：Cooper-X-Oak/openless#12。

本 PR 是从 fork/dev 已验证批次拆出的启动稳定性维护项：当 Tauri 默认窗口图标缺失时，不再 `unwrap()` 直接让应用启动失败，而是记录 warning 并跳过托盘图标创建。

## 修复 / 新增 / 改进

- 将 `app.default_window_icon().unwrap()` 改为 `if let Some(icon)` 分支。
- 图标缺失时输出 `[startup] default window icon missing; tray icon disabled`。
- 主窗口、coordinator 和热键监听继续初始化，避免资源缺失放大成 Windows “无法启动”。

## 兼容

- 不包含：功能逻辑重构、托盘菜单行为变更、图标资产变更。
- 对现有用户 / 本地环境 / 构建流程的影响：只有图标资源异常缺失时改变行为；正常有图标时托盘行为不变。

## 测试计划

- [x] 命令：`git diff --check -- openless-all/app/src-tauri/src/lib.rs`
- [x] 结果：通过。
- [x] 命令：`cargo check --manifest-path openless-all/app/src-tauri/Cargo.toml`
- [x] 结果：本机 MSVC/Windows SDK 环境失败，原因是 `kernel32.lib` 缺失；不是本次代码改动触发。完整编译以 GitHub Windows Tauri checks 为准。
- [ ] 证据路径：等待 GitHub Actions。

## Summary by Sourcery

Bug Fixes:
- Prevent application startup from failing when the default window icon is missing by skipping tray icon creation and continuing initialization.