### PR TITLE
fix(readme): 修复 README 破损图片引用

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="Resources/AppIcon.png" alt="OpenLess" width="160" />
+  <img src="openless-all/app/src-tauri/icons/128x128@2x.png" alt="OpenLess" width="160" />
 </p>
 
 <h1 align="center">OpenLess</h1>

--- a/README.zh.md
+++ b/README.zh.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="Resources/AppIcon.png" alt="OpenLess" width="160" />
+  <img src="openless-all/app/src-tauri/icons/128x128@2x.png" alt="OpenLess" width="160" />
 </p>
 
 <h1 align="center">OpenLess</h1>


### PR DESCRIPTION
Resources/AppIcon.png 已删除，README hero 图改指 Tauri icon 128x128@2x.png。

## Summary by Sourcery

Documentation:
- Update the English and Chinese README files to use the new Tauri app icon image instead of the removed Resources/AppIcon asset.