### PR TITLE
release(v1.2.1): 累积外部 PR + 终审 HIGH 修复

### DIFF
--- a/openless-all/app/package.json
+++ b/openless-all/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openless-app",
   "private": true,
-  "version": "1.2.0",
+  "version": "1.2.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/openless-all/app/src-tauri/Cargo.lock
+++ b/openless-all/app/src-tauri/Cargo.lock
@@ -3167,7 +3167,7 @@ dependencies = [
 
 [[package]]
 name = "openless"
-version = "1.1.4"
+version = "1.2.1"
 dependencies = [
  "anyhow",
  "arboard",

--- a/openless-all/app/src-tauri/Cargo.toml
+++ b/openless-all/app/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openless"
-version = "1.1.4"
+version = "1.2.1"
 description = "OpenLess — local voice input that types where your cursor is"
 authors = ["OpenLess"]
 edition = "2021"

--- a/openless-all/app/src-tauri/tauri.conf.json
+++ b/openless-all/app/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "OpenLess",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "identifier": "com.openless.app",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
develop 同步所有外部贡献 + 修复 + 版本号 1.2.1。直接合。

## Summary by Sourcery

Bump application and Tauri package versions to 1.2.1 for the new release.

Build:
- Update JavaScript package.json version to 1.2.1.
- Align Rust Tauri package version to 1.2.1 in Cargo.toml (and lockfile).