### PR TITLE
fix(insertion): 修正 macOS 无权限时插入状态

### DIFF
--- a/openless-all/app/src-tauri/src/insertion.rs
+++ b/openless-all/app/src-tauri/src/insertion.rs
@@ -58,6 +58,12 @@ fn copy_to_clipboard(text: &str) -> bool {
 
 #[cfg(target_os = "macos")]
 fn simulate_paste() -> Result<(), String> {
+    if !matches!(
+        crate::permissions::check_accessibility(),
+        crate::permissions::PermissionStatus::Granted
+    ) {
+        return Err("accessibility permission is not granted".into());
+    }
     macos::post_cmd_v()
 }
 


### PR DESCRIPTION
## 摘要

Fixes #62。

本 PR 按最小改动修复 macOS 在无辅助功能权限时，历史记录仍被标记为已插入的问题。

此前 `simulate_paste()` 在调用 `CGEventPost` 模拟 Cmd+V 后，没有先检查 Accessibility 权限，也没有验证粘贴是否真的成功。当辅助功能权限被撤销时，实际文本不会进入用户输入框，但历史详情仍可能显示为 `Inserted`。

本次改动在 macOS `simulate_paste()` 执行 `CGEventPost` 前增加 Accessibility 权限检查。未授权时直接返回错误，并沿用现有 `TextInserter::insert()` 逻辑回退到 `InsertStatus::CopiedFallback`，避免历史记录虚假标记为已插入。

## 修复 / 新增 / 改进

- macOS `simulate_paste()` 在 `CGEventPost` 前检查 Accessibility 权限。

- 当辅助功能权限未授权时：
  - 不继续发送模拟粘贴事件
  - 返回错误给现有插入流程
  - 沿用 `TextInserter::insert()` 现有 fallback 逻辑
  - 最终状态落到 `InsertStatus::CopiedFallback`

- 修复无辅助功能权限时历史记录错误显示 `Inserted` 的问题。

- 保持剪贴板 fallback 行为不变。

- 只修改 `insertion.rs`，不扩大改动范围。

## 兼容

- 不包含：
  - 不重构插入流程。
  - 不新增 timeout 检测。
  - 不新增 pasteboard read-back 检测。
  - 不改变非 macOS 平台插入逻辑。
  - 不改变已有 `TextInserter::insert()` fallback 语义。
  - 不引入新依赖。

- 对现有用户 / 本地环境 / 构建流程的影响：
  - macOS 用户在未授予辅助功能权限时，不会再看到虚假的“已插入”历史状态。
  - 未授权时文本仍会保留在剪贴板，状态会走 `CopiedFallback`。
  - 已授权情况下仍按原有模拟粘贴路径执行。
  - 其他平台不受影响。
  - 构建流程无变化。

## 测试计划

- [x] 命令：`cargo check --manifest-path openless-all/app/src-tauri/Cargo.toml`
- [x] 结果：通过，仅有既有 warnings
- [x] 证据路径：本地检查输出

- [x] 命令：`git diff --check`
- [x] 结果：通过
- [x] 证据路径：本地命令输出

## 主要改动文件

- `openless-all/app/src-tauri/src/insertion.rs`

## 备注

本 PR 选择最小修复路径：在 macOS 发送模拟粘贴事件前先检查 Accessibility 权限。暂未加入 timeout 检测或 pasteboard read-back，因为本次目标是先避免历史记录在无权限场景下显示虚假的 `Inserted`。