### PR TITLE
fix(ui): 清理卸载后的延迟状态更新

### DIFF
--- a/openless-all/app/src/components/Onboarding.tsx
+++ b/openless-all/app/src/components/Onboarding.tsx
@@ -3,7 +3,7 @@
 // 触发条件：App.tsx 启动检查 accessibility + microphone，任一未授权则渲染本组件而非主 Shell。
 // 与 Swift `Sources/OpenLessApp/Onboarding/` 同语义，但简化为单页三步。
 
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
   checkAccessibilityPermission,
@@ -25,6 +25,7 @@ export function Onboarding({ onComplete }: OnboardingProps) {
   const [accessibility, setAccessibility] = useState<PermissionStatus>('notDetermined');
   const [microphone, setMicrophone] = useState<PermissionStatus>('notDetermined');
   const [busy, setBusy] = useState(false);
+  const refreshTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const { capability } = useHotkeySettings();
 
   const refresh = async () => {
@@ -48,6 +49,7 @@ export function Onboarding({ onComplete }: OnboardingProps) {
     return () => {
       window.clearInterval(id);
       window.removeEventListener('focus', onFocus);
+      if (refreshTimeoutRef.current) clearTimeout(refreshTimeoutRef.current);
     };
   }, []);
 
@@ -76,7 +78,8 @@ export function Onboarding({ onComplete }: OnboardingProps) {
     } finally {
       setBusy(false);
     }
-    setTimeout(refresh, 800);
+    if (refreshTimeoutRef.current) clearTimeout(refreshTimeoutRef.current);
+    refreshTimeoutRef.current = window.setTimeout(refresh, 800);
   };
 
   return (

--- a/openless-all/app/src/pages/Settings.tsx
+++ b/openless-all/app/src/pages/Settings.tsx
@@ -735,11 +735,19 @@ function LanguageSection() {
 function AboutSection() {
   const { t } = useTranslation();
   const [qqCopied, setQqCopied] = useState(false);
+  const qqCopiedRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (qqCopiedRef.current) clearTimeout(qqCopiedRef.current);
+    };
+  }, []);
 
   const copyQq = () => {
     navigator.clipboard?.writeText('1078960553');
     setQqCopied(true);
-    setTimeout(() => setQqCopied(false), 1500);
+    if (qqCopiedRef.current) clearTimeout(qqCopiedRef.current);
+    qqCopiedRef.current = window.setTimeout(() => setQqCopied(false), 1500);
   };
 
   return (


### PR DESCRIPTION
## 摘要

Fixes #64。

本 PR 按最小改动修复前端部分 `setTimeout` 未保存 handle，导致组件卸载后仍可能执行状态更新的问题。

此前 `AboutSection` 的 `qqCopied` 闪烁 timeout，以及 `Onboarding` 中 refresh 延后 timeout，未统一保存并在组件卸载时清理。React 18 strict mode 下可能出现组件卸载后 `setState` 的控制台警告，长时间使用也存在轻微泄漏风险。

本次改动将相关 timeout handle 改为通过 `useRef` 保存，并在组件卸载时执行 `clearTimeout`。重复触发时也会先清理旧 timeout，避免多个延迟回调叠加。

## 修复 / 新增 / 改进

- 修复 `Settings.tsx` 中 `AboutSection` 的 `qqCopied` 闪烁 timeout：
  - 使用 `useRef` 保存 timeout handle
  - 组件卸载时 `clearTimeout`
  - 重复点击复制时先清理旧 timeout

- 修复 `Onboarding.tsx` 中 refresh 延后 timeout：
  - 使用 `useRef` 保存 timeout handle
  - 组件卸载时 `clearTimeout`

- 保持现有 UI 行为不变：
  - 复制成功提示仍会短暂闪烁
  - Onboarding refresh 延后逻辑仍保留

- `CredentialField` 相关 timeout 远端已有 ref / cleanup 处理，本 PR 未重复修改。

## 兼容

- 不包含：
  - 不改变设置页业务逻辑。
  - 不改变 Onboarding 流程。
  - 不调整复制提示时长。
  - 不新增依赖。
  - 不做大范围 hooks 重构。

- 对现有用户 / 本地环境 / 构建流程的影响：
  - 用户可见交互基本不变。
  - 组件卸载后不再保留相关延迟状态更新回调。
  - 可减少 React strict mode 下的卸载后状态更新警告。
  - 构建流程无变化。

## 测试计划

- [x] 命令：`npm run build`
- [x] 结果：通过
- [x] 证据路径：本地构建输出

- [x] 命令：`git diff --check`
- [x] 结果：通过
- [x] 证据路径：本地命令输出

## 主要改动文件

- `openless-all/app/src/pages/Settings.tsx`
- `openless-all/app/src/components/Onboarding.tsx`

## 备注

本 PR 仅处理当前仍缺少 timeout cleanup 的位置。`CredentialField` 相关 timeout 远端已有 ref / cleanup 处理，因此未在本次最小修复中重复改动。