### PR TITLE
fix(credentials): 串行化凭证文件写入

### DIFF
--- a/openless-all/app/src-tauri/src/persistence.rs
+++ b/openless-all/app/src-tauri/src/persistence.rs
@@ -14,6 +14,7 @@
 
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
 
 use anyhow::{anyhow, Context, Result};
 use chrono::Utc;
@@ -35,6 +36,12 @@ const VOCAB_FILE: &str = "dictionary.json";
 /// 让用户在 Swift 版填过的凭据无需重输。
 const LEGACY_CREDS_DIR: &str = ".openless";
 const LEGACY_CREDS_FILE: &str = "credentials.json";
+
+static CREDENTIALS_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+
+fn credentials_lock() -> &'static Mutex<()> {
+    CREDENTIALS_LOCK.get_or_init(|| Mutex::new(()))
+}
 
 // ───────────────────────── path helpers ─────────────────────────
 
@@ -657,10 +664,12 @@ impl CredentialsVault {
     pub const SERVICE_NAME: &'static str = "com.openless.app";
 
     pub fn get(account: CredentialAccount) -> Result<Option<String>> {
+        let _guard = credentials_lock().lock();
         Ok(lookup_account(&load_credentials(), account))
     }
 
     pub fn set(account: CredentialAccount, value: &str) -> Result<()> {
+        let _guard = credentials_lock().lock();
         let mut root = load_credentials();
         let v = if value.is_empty() {
             None
@@ -672,28 +681,33 @@ impl CredentialsVault {
     }
 
     pub fn remove(account: CredentialAccount) -> Result<()> {
+        let _guard = credentials_lock().lock();
         let mut root = load_credentials();
         write_account(&mut root, account, None);
         save_credentials(&root)
     }
 
     pub fn get_active_asr() -> String {
+        let _guard = credentials_lock().lock();
         load_credentials().active.asr
     }
 
     pub fn set_active_asr_provider(id: &str) -> Result<()> {
+        let _guard = credentials_lock().lock();
         let mut root = load_credentials();
         root.active.asr = id.to_string();
         save_credentials(&root)
     }
 
     pub fn set_active_llm_provider(id: &str) -> Result<()> {
+        let _guard = credentials_lock().lock();
         let mut root = load_credentials();
         root.active.llm = id.to_string();
         save_credentials(&root)
     }
 
     pub fn snapshot() -> CredentialsSnapshot {
+        let _guard = credentials_lock().lock();
         let root = load_credentials();
         CredentialsSnapshot {
             volcengine_app_key: lookup_account(&root, CredentialAccount::VolcengineAppKey),


### PR DESCRIPTION
## 摘要

Fixes #61。

本 PR 按最小改动修复凭证 JSON 文件并发写入时可能互相覆盖的问题。

此前 `CredentialsVault` 的凭证更新路径采用 load-modify-save：先读取整个 JSON，再修改其中一个账号或 active provider，最后写回文件。当前端 Settings 页多个凭据字段通过 debounce 近似同时保存时，不同写入可能读到同一个旧 root，后完成的写入会把先完成的修改覆盖掉，导致用户刚保存的 API key 或 provider 选择丢失。

本次改动在 `CredentialsVault` 文件访问层增加进程内全局 `Mutex`，让凭证读取、修改、写回相关入口串行执行，避免同一进程内的并发 Settings 保存互相覆盖。

## 修复 / 新增 / 改进

- 为凭证文件访问增加全局锁：
  - 使用 `OnceLock<Mutex<()>>`
  - 通过 `credentials_lock()` 统一获取锁

- 对 `CredentialsVault` 相关访问入口加锁：
  - `get`
  - `set`
  - `remove`
  - `get_active_asr`
  - `set_active_asr_provider`
  - `set_active_llm_provider`
  - `snapshot`

- 保证现有 JSON vault 的 read-modify-write 顺序执行。

- 避免 Settings 页多个 debounce 保存同时发生时互相覆盖凭证文件内容。

- 只修改现有凭证持久化路径，不重写存储结构。

## 兼容

- 不包含：
  - 不改变凭证 JSON 文件格式。
  - 不迁移凭证存储位置。
  - 不引入 atomic compare-and-swap 重写。
  - 不改动 Settings 页 debounce 行为。
  - 不改变 provider 配置结构。
  - 不引入新依赖。

- 对现有用户 / 本地环境 / 构建流程的影响：
  - 用户同时修改多个凭证字段时，后保存的字段不应再覆盖先保存的字段。
  - 已有凭证文件格式保持不变。
  - 单进程 Tauri 内的凭证读写会串行化。
  - 构建流程无变化。

## 测试计划

- [x] 命令：`cargo check --manifest-path openless-all/app/src-tauri/Cargo.toml`
- [x] 结果：通过
- [x] 证据路径：本地检查输出

- [x] 命令：`git diff --check`
- [x] 结果：通过
- [x] 证据路径：本地命令输出

## 主要改动文件

- `openless-all/app/src-tauri/src/persistence.rs`

## 备注

本 PR 采用 issue #61 要求的最小保护方式：在现有 JSON vault 路径外层增加进程内全局锁。没有选择 atomic compare-and-swap 或更大范围的凭证存储重构，因为当前问题主要来自单进程 Tauri 内多个 Settings debounce 写入并发覆盖。