### PR TITLE
[谨慎发布，需要测试]fix(recorder): 上报录音流运行期错误

### DIFF
--- a/openless-all/app/src-tauri/src/coordinator.rs
+++ b/openless-all/app/src-tauri/src/coordinator.rs
@@ -26,7 +26,7 @@ use crate::persistence::{
 };
 
 use crate::polish::{OpenAICompatibleConfig, OpenAICompatibleLLMProvider};
-use crate::recorder::Recorder;
+use crate::recorder::{Recorder, RecorderError};
 use crate::types::{
     CapsulePayload, CapsuleState, DictationSession, HotkeyCapability, HotkeyMode, HotkeyStatus,
     HotkeyStatusState, InsertStatus, PolishMode,
@@ -583,8 +583,9 @@ fn start_recorder_for_starting(
     });
 
     match Recorder::start(consumer, level_handler) {
-        Ok(rec) => {
+        Ok((rec, runtime_errors)) => {
             *inner.recorder.lock() = Some(rec);
+            spawn_recorder_error_monitor(inner, runtime_errors);
             stop_recorder_if_pending_start_stop(inner);
             log::info!("[coord] recorder started (asr={active_asr}, phase=Starting)");
         }
@@ -611,6 +612,56 @@ fn start_recorder_for_starting(
     }
 
     Ok(())
+}
+
+fn spawn_recorder_error_monitor(inner: &Arc<Inner>, rx: mpsc::Receiver<RecorderError>) {
+    let inner = Arc::clone(inner);
+    std::thread::Builder::new()
+        .name("openless-recorder-error-monitor".into())
+        .spawn(move || {
+            if let Ok(err) = rx.recv() {
+                log::error!("[coord] recorder runtime error: {err}");
+                abort_recording_with_error(&inner, format!("录音中断: {err}"));
+            }
+        })
+        .ok();
+}
+
+fn abort_recording_with_error(inner: &Arc<Inner>, message: String) {
+    let elapsed = {
+        let mut state = inner.state.lock();
+        if state.cancelled
+            || !matches!(
+                state.phase,
+                SessionPhase::Starting | SessionPhase::Listening
+            )
+        {
+            return;
+        }
+        state.cancelled = true;
+        state.phase = SessionPhase::Idle;
+        state.started_at.elapsed().as_millis() as u64
+    };
+
+    if let Some(rec) = inner.recorder.lock().take() {
+        rec.stop();
+    }
+    if let Some(asr) = inner.asr.lock().take() {
+        match asr {
+            ActiveAsr::Volcengine(v) => v.cancel(),
+            ActiveAsr::Whisper(w) => w.cancel(),
+        }
+    }
+
+    emit_capsule(
+        inner,
+        CapsuleState::Error,
+        0.0,
+        elapsed,
+        Some(message),
+        None,
+    );
+    schedule_capsule_idle(inner, CAPSULE_AUTO_HIDE_DELAY_MS);
 }
 
 async fn start_recorder_and_enter_listening(
@@ -1155,6 +1206,24 @@ mod tests {
         let state = coordinator.inner.state.lock();
         assert_eq!(state.phase, SessionPhase::Starting);
         assert!(state.pending_stop);
+    }
+
+    #[test]
+    fn recorder_runtime_error_aborts_active_session() {
+        let coordinator = Coordinator::new();
+        {
+            let mut state = coordinator.inner.state.lock();
+            state.phase = SessionPhase::Listening;
+            state.cancelled = false;
+        }
+
+        abort_recording_with_error(&coordinator.inner, "录音中断: stream failed".to_string());
+
+        let state = coordinator.inner.state.lock();
+        assert_eq!(state.phase, SessionPhase::Idle);
+        assert!(state.cancelled);
+        assert!(coordinator.inner.recorder.lock().is_none());
+        assert!(coordinator.inner.asr.lock().is_none());
     }
 
     #[tokio::test]

--- a/openless-all/app/src-tauri/src/recorder.rs
+++ b/openless-all/app/src-tauri/src/recorder.rs
@@ -11,7 +11,7 @@
 //! - 主线程通过 `AtomicBool` 通知"该停了"，并 `join` 线程；线程内 `drop` Stream。
 
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
-use std::sync::mpsc::{channel, Sender};
+use std::sync::mpsc::{channel, Receiver, Sender};
 use std::sync::Arc;
 use std::thread::{self, JoinHandle};
 
@@ -57,16 +57,24 @@ impl Recorder {
     pub fn start(
         consumer: Arc<dyn AudioConsumer>,
         level_handler: Arc<dyn Fn(f32) + Send + Sync>,
-    ) -> Result<Self, RecorderError> {
+    ) -> Result<(Self, Receiver<RecorderError>), RecorderError> {
         // 启动信号：子线程构造 Stream 完成后通过 startup_tx 报告结果。
         let (startup_tx, startup_rx) = channel::<Result<(), RecorderError>>();
+        // 运行期错误：Stream 已成功启动后，cpal 通过 err_cb 异步上报。
+        let (runtime_error_tx, runtime_error_rx) = channel::<RecorderError>();
         let stop_flag = Arc::new(AtomicBool::new(false));
         let stop_for_thread = Arc::clone(&stop_flag);
 
         let join_handle = thread::Builder::new()
             .name("openless-recorder".into())
             .spawn(move || {
-                run_audio_thread(consumer, level_handler, stop_for_thread, startup_tx);
+                run_audio_thread(
+                    consumer,
+                    level_handler,
+                    stop_for_thread,
+                    startup_tx,
+                    runtime_error_tx,
+                );
             })
             .map_err(|e| RecorderError::EngineFailed(format!("spawn audio thread: {e}")))?;
 
@@ -77,10 +85,13 @@ impl Recorder {
             .map_err(|e| RecorderError::EngineFailed(format!("audio thread vanished: {e}")))?;
         startup_result?;
 
-        Ok(Self {
-            stop_flag,
-            join_handle: Mutex::new(Some(join_handle)),
-        })
+        Ok((
+            Self {
+                stop_flag,
+                join_handle: Mutex::new(Some(join_handle)),
+            },
+            runtime_error_rx,
+        ))
     }
 
     /// 停止采集并等待音频线程退出。
@@ -102,8 +113,9 @@ fn run_audio_thread(
     level_handler: Arc<dyn Fn(f32) + Send + Sync>,
     stop_flag: Arc<AtomicBool>,
     startup_tx: Sender<Result<(), RecorderError>>,
+    runtime_error_tx: Sender<RecorderError>,
 ) {
-    let stream = match build_input_stream(consumer, level_handler) {
+    let stream = match build_input_stream(consumer, level_handler, runtime_error_tx) {
         Ok(s) => s,
         Err(err) => {
             // 启动失败：通知主线程后即退出。
@@ -133,6 +145,7 @@ fn run_audio_thread(
 fn build_input_stream(
     consumer: Arc<dyn AudioConsumer>,
     level_handler: Arc<dyn Fn(f32) + Send + Sync>,
+    runtime_error_tx: Sender<RecorderError>,
 ) -> Result<cpal::Stream, RecorderError> {
     let host = cpal::default_host();
     let device = host
@@ -165,6 +178,7 @@ fn build_input_stream(
         state,
         input_sr,
         channels,
+        runtime_error_tx,
     )
 }
 
@@ -202,14 +216,19 @@ fn build_stream_for_format(
     state: Arc<StreamState>,
     input_sr: u32,
     channels: usize,
+    runtime_error_tx: Sender<RecorderError>,
 ) -> Result<cpal::Stream, RecorderError> {
-    let err_cb = |err| log::error!("[recorder] stream error: {err}");
-
     macro_rules! make_stream {
         ($t:ty, $to_f32:expr) => {{
             let consumer = Arc::clone(&consumer);
             let level_handler = Arc::clone(&level_handler);
             let state = Arc::clone(&state);
+            let runtime_error_tx = runtime_error_tx.clone();
+            let err_cb = move |err| {
+                log::error!("[recorder] stream error: {err}");
+                let _ =
+                    runtime_error_tx.send(RecorderError::EngineFailed(format!("stream: {err}")));
+            };
             device
                 .build_input_stream::<$t, _, _>(
                     config,


### PR DESCRIPTION
## 摘要

Fixes #59。

本 PR 修复录音流运行期错误只写日志、不通知 coordinator 的问题。

此前录音流启动成功后，如果运行期发生错误，例如麦克风断开、音频设备异常，`recorder.rs` 只会记录错误日志。coordinator 不知道录音已经失败，UI 胶囊仍可能停留在录音状态，最终流程继续处理空音频，用户只能看到“没有识别出来”，但无法明确知道是录音流中断。

本次改动增加一条从 Recorder 到 coordinator 的运行期错误通道。录音流启动后，如果 cpal stream 在运行期上报错误，会通过 channel 通知 coordinator；coordinator 收到后只中止 Starting / Listening 阶段的活动会话，停止 recorder / ASR，并显示错误胶囊。

## 修复 / 新增 / 改进

- Recorder 启动结果新增运行期错误接收端：
  - 原来返回 `Recorder`
  - 现在返回 `Recorder` 与 `Receiver<RecorderError>`

- 在录音流启动成功后，保留 cpal 运行期错误通道。

- coordinator 启动 recorder 后新增错误监听线程：
  - 监听 recorder runtime error
  - 收到错误后记录 coordinator 日志
  - 将错误转为用户可见的错误胶囊

- 新增 `abort_recording_with_error`：
  - 仅处理中止 `Starting` / `Listening` 中的活动会话
  - 将状态切回 `Idle`
  - 标记当前会话为 cancelled
  - 停止 recorder
  - cancel 当前 ASR
  - 发出 `CapsuleState::Error`
  - 安排胶囊自动回到 idle

- 避免录音流已经失败后继续走空音频识别流程。

- 新增测试覆盖：
  - `recorder_runtime_error_aborts_active_session`

## 兼容

- 不包含：
  - 不重构 recorder / coordinator 所有权模型。
  - 不改变录音启动失败的既有处理路径。
  - 不改变正常录音、停止、转写流程。
  - 不新增 UI 页面。
  - 不引入新依赖。
  - 不调整 ASR provider 行为。

- 对现有用户 / 本地环境 / 构建流程的影响：
  - 正常录音流程无变化。
  - 录音流运行期失败时，UI 不会继续假装处于录音中。
  - 麦克风断开或音频流异常时，会中止当前录音并显示错误胶囊。
  - 不再把运行期录音失败误处理成空音频识别。
  - 构建流程无变化。

## 测试计划

- [x] 命令：`cargo check --manifest-path openless-all/app/src-tauri/Cargo.toml`
- [x] 结果：通过
- [x] 证据路径：本地检查输出

- [x] 命令：`cargo test --manifest-path openless-all/app/src-tauri/Cargo.toml recorder_runtime_error_aborts_active_session`
- [x] 结果：通过
- [x] 证据路径：本地测试输出

- [x] 命令：`git diff --check`
- [x] 结果：通过
- [x] 证据路径：本地命令输出

## 主要改动文件

- `openless-all/app/src-tauri/src/coordinator.rs`
- `openless-all/app/src-tauri/src/recorder.rs`

## 备注

本 PR 采用 issue #59 要求的最小处理方式：只把 recorder 运行期错误抛回 coordinator，并让活动录音会话进入错误胶囊。没有扩大到 recorder / coordinator 所有权模型重构。