### PR TITLE
chore: release 1.2.8 + zh-CN Access Key label 精简

### DIFF
--- a/openless-all/app/package.json
+++ b/openless-all/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openless-app",
   "private": true,
-  "version": "1.2.7",
+  "version": "1.2.8",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/openless-all/app/src-tauri/Cargo.lock
+++ b/openless-all/app/src-tauri/Cargo.lock
@@ -3250,7 +3250,7 @@ dependencies = [
 
 [[package]]
 name = "openless"
-version = "1.2.7"
+version = "1.2.8"
 dependencies = [
  "anyhow",
  "arboard",

--- a/openless-all/app/src-tauri/Cargo.toml
+++ b/openless-all/app/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openless"
-version = "1.2.7"
+version = "1.2.8"
 description = "OpenLess — local voice input that types where your cursor is"
 authors = ["OpenLess"]
 edition = "2021"

--- a/openless-all/app/src-tauri/tauri.conf.json
+++ b/openless-all/app/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "OpenLess",
-  "version": "1.2.7",
+  "version": "1.2.8",
   "identifier": "com.openless.app",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/openless-all/app/src/i18n/zh-CN.ts
+++ b/openless-all/app/src/i18n/zh-CN.ts
@@ -242,7 +242,7 @@ export const zhCN = {
       baseUrlLabel: '接口地址',
       modelLabel: '模型',
       appIdLabel: 'App ID（应用 ID）',
-      accessKeyLabel: 'Access Key（访问密钥）',
+      accessKeyLabel: 'Access Key',
       resourceIdLabel: '资源 ID',
     },
     shortcuts: {


### PR DESCRIPTION
## 改动
- 火山引擎 ASR `Access Key（访问密钥）` → `Access Key`（zh-CN），跟英文版一致
- bump 1.2.7 → 1.2.8

## Test plan
- [x] cargo check 干净
- [x] npm run build 干净
- [x] 本地 build-mac.sh 通过

## 备注
单行 i18n 改动 + 版本号同步，体量小，不重新跑 Codex 后审。
