### PR TITLE
fix(windows): ASR final result 等待加超时保护

### DIFF
--- a/openless-all/app/src-tauri/src/asr/volcengine.rs
+++ b/openless-all/app/src-tauri/src/asr/volcengine.rs
@@ -6,7 +6,7 @@
 
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use futures_util::{SinkExt, StreamExt};
 use parking_lot::Mutex as ParkingMutex;
@@ -29,6 +29,7 @@ const TARGET_AUDIO_CHUNK_BYTES: usize = 6_400;
 /// 16 kHz · 16-bit · mono = 32 000 bytes/sec → 32 bytes/ms.
 const BYTES_PER_MS: f64 = 32.0;
 const HOTWORD_CAP: usize = 80;
+const FINAL_RESULT_TIMEOUT: Duration = Duration::from_secs(12);
 
 #[derive(Clone, Debug)]
 pub struct VolcengineCredentials {
@@ -53,6 +54,8 @@ pub enum VolcengineASRError {
     AuthenticationFailed,
     #[error("no final result")]
     NoFinalResult,
+    #[error("final result timed out")]
+    FinalResultTimeout,
     #[error("decode failed: {0}")]
     DecodeFailed(String),
 }
@@ -334,13 +337,29 @@ impl VolcengineStreamingASR {
     }
 
     pub async fn await_final_result(&self) -> Result<RawTranscript, VolcengineASRError> {
+        self.await_final_result_with_timeout(FINAL_RESULT_TIMEOUT)
+            .await
+    }
+
+    pub async fn await_final_result_with_timeout(
+        &self,
+        timeout: Duration,
+    ) -> Result<RawTranscript, VolcengineASRError> {
         let rx = self.final_rx.lock().take();
         let Some(rx) = rx else {
             return Err(VolcengineASRError::NoFinalResult);
         };
-        match rx.await {
-            Ok(result) => result,
-            Err(_) => Err(VolcengineASRError::NoFinalResult),
+        match tokio::time::timeout(timeout, rx).await {
+            Ok(Ok(result)) => result,
+            Ok(Err(_)) => Err(VolcengineASRError::NoFinalResult),
+            Err(_) => {
+                log::error!(
+                    "[asr] final result timed out after {} ms",
+                    timeout.as_millis()
+                );
+                self.cancel();
+                Err(VolcengineASRError::FinalResultTimeout)
+            }
         }
     }
 
@@ -702,5 +721,29 @@ mod tests {
             VolcengineCredentials::default_resource_id(),
             "volc.bigasr.sauc.duration"
         );
+    }
+
+    #[tokio::test]
+    async fn await_final_result_returns_error_when_final_frame_never_arrives() {
+        let asr = VolcengineStreamingASR::new(
+            VolcengineCredentials {
+                app_id: "app".into(),
+                access_token: "token".into(),
+                resource_id: VolcengineCredentials::default_resource_id().into(),
+            },
+            Vec::new(),
+        );
+        let (tx, rx) = oneshot::channel();
+        asr.state.lock().final_tx = Some(tx);
+        *asr.final_rx.lock() = Some(rx);
+
+        let result = asr
+            .await_final_result_with_timeout(std::time::Duration::from_millis(10))
+            .await;
+
+        assert!(matches!(
+            result,
+            Err(VolcengineASRError::FinalResultTimeout)
+        ));
     }
 }


### PR DESCRIPTION
Closes #97

## 修复要点

Windows 端结束录音后，Volcengine ASR 发送 last frame 之后会等待服务端 final result。此前这一步没有 deadline：如果服务端没有返回 final frame、但连接也没有立即断开，coordinator 会一直卡在 `Transcribing`。

本 PR 给 final result 等待增加明确超时保护：

- 默认最多等待 12 秒 final result。
- 超时后记录错误日志并 cancel 当前 streaming ASR。
- 返回明确的 `FinalResultTimeout` 错误，而不是无限 await。
- coordinator 继续走既有错误胶囊和回到 Idle 的收尾路径。
- 新增单测覆盖“final frame 永远不来”的路径。

## 测试计划

- [x] `npm run build`
- [x] `cargo +stable-x86_64-pc-windows-gnu test --manifest-path openless-all\app\src-tauri\Cargo.toml --target x86_64-pc-windows-gnu asr::volcengine::tests::await_final_result_returns_error_when_final_frame_never_arrives --no-run`
- [x] `git diff --check`
- [x] GitHub Actions: Windows Tauri checks 通过

## 备注

本机 GNU 测试二进制在运行阶段遇到 `STATUS_ENTRYPOINT_NOT_FOUND`，但测试目标已完成编译；因此本地使用 `--no-run` 作为 Rust 编译门禁，并由 GitHub Windows CI 补足平台检查。