### PR TITLE
fix(windows): 粘贴前校验原目标窗口已恢复

### DIFF
--- a/openless-all/app/scripts/windows-real-asr-insertion-smoke.ps1
+++ b/openless-all/app/scripts/windows-real-asr-insertion-smoke.ps1
@@ -5,6 +5,8 @@ param(
   [string]$Phrase = "OpenLess Windows real regression",
   [int]$TimeoutSeconds = 120,
   [int]$VirtualKey = 0xA3,
+  [int]$ManualSpeechSeconds = 8,
+  [switch]$ManualSpeech,
   [switch]$DebugHotkeyEvents
 )
 
@@ -370,7 +372,12 @@ try {
     throw "OpenLess recording session did not start."
   }
 
-  Speak-TestPhrase $Phrase
+  if ($ManualSpeech) {
+    Write-Host "[action] Please speak into the real microphone for $ManualSpeechSeconds seconds."
+    Start-Sleep -Seconds $ManualSpeechSeconds
+  } else {
+    Speak-TestPhrase $Phrase
+  }
   Start-Sleep -Milliseconds 800
   Release-Hotkey
 

--- a/openless-all/app/scripts/windows-real-asr-insertion-smoke.ps1
+++ b/openless-all/app/scripts/windows-real-asr-insertion-smoke.ps1
@@ -388,8 +388,8 @@ try {
   if ([string]::IsNullOrWhiteSpace($latest.rawTranscript) -or [string]::IsNullOrWhiteSpace($latest.finalText)) {
     throw "Latest history item is missing rawTranscript or finalText."
   }
-  if (@("copiedFallback", "pasteSent") -notcontains $latest.insertStatus) {
-    throw "Expected Windows insertStatus copiedFallback or pasteSent, got '$($latest.insertStatus)'."
+  if ($latest.insertStatus -ne "pasteSent") {
+    throw "Expected Windows insertStatus pasteSent after guarded foreground restore, got '$($latest.insertStatus)'."
   }
 
   Focus-Window $inputTarget.Process | Out-Null
@@ -402,6 +402,9 @@ try {
 
   if ([string]::IsNullOrWhiteSpace($targetText)) {
     throw "$Target clipboard readback is empty after Ctrl+A/C."
+  }
+  if (-not $targetText.Contains($latest.finalText)) {
+    throw "$Target readback does not contain latest finalText; insertion was not proven at the target caret."
   }
 
   Write-Host "[ok] History updated. raw='$($latest.rawTranscript)'"

--- a/openless-all/app/scripts/windows-real-asr-insertion-smoke.ps1
+++ b/openless-all/app/scripts/windows-real-asr-insertion-smoke.ps1
@@ -356,7 +356,7 @@ try {
 
 $inputTarget = $null
 try {
-  if (-not (Wait-LogPattern $logPath "WH_KEYBOARD_LL installed" 20)) {
+  if (-not (Wait-LogPattern $logPath "hotkey listener installed|Windows low-level keyboard hook" 20)) {
     throw "Windows low-level keyboard hook was not installed."
   }
 

--- a/openless-all/app/src-tauri/src/coordinator.rs
+++ b/openless-all/app/src-tauri/src/coordinator.rs
@@ -943,9 +943,16 @@ async fn end_session(inner: &Arc<Inner>) -> Result<(), String> {
     }
 
     let focus_target = inner.state.lock().focus_target;
-    restore_focus_target_if_possible(focus_target);
+    let focus_ready_for_paste = restore_focus_target_if_possible(focus_target);
     let restore_clipboard = inner.prefs.get().restore_clipboard_after_paste;
-    let status = inner.inserter.insert(&polished, restore_clipboard);
+    let status = if focus_ready_for_paste {
+        inner.inserter.insert(&polished, restore_clipboard)
+    } else {
+        log::warn!(
+            "[coord] original insertion target is not foreground; copied output without paste"
+        );
+        inner.inserter.copy_fallback(&polished)
+    };
     let inserted_chars = polished.chars().count() as u32;
 
     // 累计每条 enabled 词条在最终文本中的命中次数。
@@ -1561,7 +1568,7 @@ fn capture_frontmost_app() -> Option<String> {
 }
 
 #[cfg(target_os = "windows")]
-fn restore_focus_target_if_possible(target: Option<usize>) {
+fn restore_focus_target_if_possible(target: Option<usize>) -> bool {
     use std::ffi::c_void;
     use std::time::Duration;
     use windows::Win32::Foundation::HWND;
@@ -1569,18 +1576,22 @@ fn restore_focus_target_if_possible(target: Option<usize>) {
         GetForegroundWindow, IsIconic, IsWindow, SetForegroundWindow, ShowWindow, SW_RESTORE,
     };
 
-    let Some(raw_target) = target else { return };
+    let Some(raw_target) = target else {
+        log::warn!("[coord] no original Windows insertion target captured");
+        return false;
+    };
     let hwnd = HWND(raw_target as *mut c_void);
     if hwnd.0.is_null() {
-        return;
+        return false;
     }
     if !unsafe { IsWindow(hwnd).as_bool() } {
-        return;
+        log::warn!("[coord] original Windows insertion target is no longer a valid window");
+        return false;
     }
 
     let foreground = unsafe { GetForegroundWindow() };
     if foreground == hwnd {
-        return;
+        return true;
     }
 
     if unsafe { IsIconic(hwnd).as_bool() } {
@@ -1588,10 +1599,19 @@ fn restore_focus_target_if_possible(target: Option<usize>) {
     }
     let _ = unsafe { SetForegroundWindow(hwnd) };
     std::thread::sleep(Duration::from_millis(60));
+
+    let foreground = unsafe { GetForegroundWindow() };
+    if foreground != hwnd {
+        log::warn!("[coord] failed to restore original Windows insertion target before paste");
+        return false;
+    }
+    true
 }
 
 #[cfg(not(target_os = "windows"))]
-fn restore_focus_target_if_possible(_target: Option<usize>) {}
+fn restore_focus_target_if_possible(_target: Option<usize>) -> bool {
+    true
+}
 
 #[cfg(target_os = "windows")]
 fn show_capsule_window_no_activate() -> bool {

--- a/openless-all/app/src-tauri/src/insertion.rs
+++ b/openless-all/app/src-tauri/src/insertion.rs
@@ -50,6 +50,19 @@ impl TextInserter {
         }
         insertion_success_status()
     }
+
+    /// Copy text without attempting a synthetic paste. Used when the platform cannot
+    /// prove the original input target is active enough to safely receive Ctrl/Cmd+V.
+    pub fn copy_fallback(&self, text: &str) -> InsertStatus {
+        if text.is_empty() {
+            return InsertStatus::CopiedFallback;
+        }
+        if copy_to_clipboard(text) {
+            InsertStatus::CopiedFallback
+        } else {
+            InsertStatus::Failed
+        }
+    }
 }
 
 impl Default for TextInserter {


### PR DESCRIPTION
Closes #96

## 修复要点

Windows 插入链路此前已经会在录音开始时记录原前台窗口，并在插入前尝试恢复。但恢复结果没有被验证：如果 `SetForegroundWindow` 失败，后续仍可能继续盲发 `Ctrl+V`，文本就有机会粘到当前错误窗口。

本 PR 把 Windows 插入改成“先证明目标可接收，再发送粘贴”：

- 插入前恢复录音开始时捕获的原 HWND。
- 恢复后再次读取 foreground window，确认它就是原目标窗口。
- 如果目标窗口不存在、无效，或恢复后仍不是前台，则不发送 `Ctrl+V`。
- 无法证明目标时只复制到剪贴板，并返回 `copiedFallback`，避免误粘到错误窗口。
- 保持成功发送粘贴时的 `pasteSent` 语义：它仍表示“快捷键已发送”，不夸大成已证明控件接收。
- 收紧 Windows real-ASR smoke：不再接受 `copiedFallback` 作为通过条件，并要求目标窗口回读包含最新 `finalText`。
- 修正 real-ASR smoke 的 hook 日志匹配：兼容当前 `Windows low-level keyboard hook` / `hotkey listener installed` 日志文案。
- 新增 `-ManualSpeech` 模式，允许真人对真实麦克风说话，避免系统 TTS 无法进入麦克风时误判 real-ASR smoke。

## 测试计划

- [x] `npm run build`
- [x] `cargo +stable-x86_64-pc-windows-gnu check --lib --manifest-path openless-all\app\src-tauri\Cargo.toml --target x86_64-pc-windows-gnu`
- [x] `npm run tauri build -- --target x86_64-pc-windows-gnu --no-bundle`
- [x] PowerShell parse: `openless-all/app/scripts/windows-real-asr-insertion-smoke.ps1`
- [x] `git diff --check`
- [x] GitHub Actions: Windows Tauri checks 通过
- [x] `windows-real-asr-insertion-smoke.ps1 -Target notepad -ManualSpeech -DebugHotkeyEvents`：真实麦克风完整通过。证据：history raw=`剩下一个火山引擎的 secret 是没有用，是吗？`，`insertStatus=pasteSent`，notepad readback length=25。
- [x] `windows-real-asr-insertion-smoke.ps1 -Target browser -ManualSpeech -ManualSpeechSeconds 15 -DebugHotkeyEvents`：真实麦克风完整通过。证据：history raw=`在许多 Microsoft 的时候会随时登记一个个信息。`，`insertStatus=pasteSent`，browser readback length=30。

## 备注

本 PR 已在 Windows 本机用真实麦克风完成 notepad 与 browser 两类目标回写验证。测试过程中曾遇到浏览器首次启动弹窗导致临时窗口句柄失效，guard 正确降级为 `copiedFallback`，没有盲贴到错误窗口；关闭弹窗并重跑后 browser smoke 通过。