### PR TITLE
fix(asr): 适配火山 2.0 资源 ID 并稳定保存凭据

### DIFF
--- a/openless-all/app/src-tauri/src/asr/volcengine.rs
+++ b/openless-all/app/src-tauri/src/asr/volcengine.rs
@@ -39,7 +39,7 @@ pub struct VolcengineCredentials {
 
 impl VolcengineCredentials {
     pub fn default_resource_id() -> &'static str {
-        "volc.bigasr.sauc.duration"
+        "volc.seedasr.sauc.duration"
     }
 }
 
@@ -700,7 +700,7 @@ mod tests {
     fn default_resource_id_is_sauc_duration() {
         assert_eq!(
             VolcengineCredentials::default_resource_id(),
-            "volc.bigasr.sauc.duration"
+            "volc.seedasr.sauc.duration"
         );
     }
 }

--- a/openless-all/app/src/pages/Settings.tsx
+++ b/openless-all/app/src/pages/Settings.tsx
@@ -272,7 +272,7 @@ const LLM_PRESETS = [
 
 type LlmPresetId = typeof LLM_PRESETS[number]['id'];
 
-const ASR_DEFAULT_RESOURCE_ID = 'volc.bigasr.sauc.duration';
+const ASR_DEFAULT_RESOURCE_ID = 'volc.seedasr.sauc.duration';
 
 // SiliconFlow ASR 暂未在后端实现（coordinator.rs 只路由 whisper / volcengine）。
 // 在后端接入前不暴露给用户，避免选了之后必然失败。重新启用见 issue #58 的 follow-up。
@@ -550,8 +550,8 @@ function CredentialField({ label, account, placeholder, mono, mask, defaultValue
     statusRef.current = window.setTimeout(() => setStatus('idle'), 1600);
   };
 
-  const save = async (v: string) => {
-    if (!loaded || !dirty) return;
+  const save = async (v: string, force = false) => {
+    if (!loaded || (!dirty && !force)) return;
     setStatus('saving');
     try {
       await setCredential(account, v);
@@ -569,7 +569,7 @@ function CredentialField({ label, account, placeholder, mono, mask, defaultValue
     if (!loaded) return;
     setDirty(true);
     if (debounceRef.current) clearTimeout(debounceRef.current);
-    debounceRef.current = setTimeout(() => save(v), 300);
+    debounceRef.current = setTimeout(() => save(v, true), 300);
   };
 
   const onBlur = () => {
@@ -578,14 +578,14 @@ function CredentialField({ label, account, placeholder, mono, mask, defaultValue
       clearTimeout(debounceRef.current);
       debounceRef.current = null;
     }
-    save(value);
+    save(value, true);
   };
 
   const fillDefault = async () => {
     if (!loaded || !defaultValue) return;
     setValue(defaultValue);
     setDirty(true);
-    await save(defaultValue);
+    await save(defaultValue, true);
   };
 
   const onCopy = async () => {


### PR DESCRIPTION
﻿## 摘要

Fixes #128。

修复火山引擎新建 2.0 ASR 应用在 v1.2.8 默认配置下鉴权失败的问题，并让设置页凭据输入稳定写入本地配置。

## 修复 / 新增 / 改进

- 将 Volcengine ASR 默认 Resource ID 从旧的 `volc.bigasr.sauc.duration` 改为 2.0 小时版 `volc.seedasr.sauc.duration`。
- 同步更新设置页 ASR Resource ID 默认值，避免新用户沿用旧资源名导致 403。
- 修复 `CredentialField` 自动保存闭包可能读到旧 `dirty=false` 而跳过保存的问题；输入后 debounce、失焦保存、填默认值都会强制写入。

## 兼容

- 不包含：真实 ASR 音频识别链路改动、火山协议帧格式改动、用户已有凭据迁移脚本。
- 对现有用户 / 本地环境 / 构建流程的影响：已保存 Resource ID 的用户继续使用本地配置；未配置 Resource ID 或点击默认值的新用户会使用 2.0 小时版资源名。

## 测试计划

- [x] 命令：`npm run build`
- [x] 结果：通过，Vite 生产构建完成。
- [x] 证据路径：终端输出
- [x] 命令：`cargo +stable-x86_64-pc-windows-gnu test --manifest-path src-tauri\Cargo.toml --no-run`
- [x] 结果：通过，测试二进制完成编译；仅保留既有 warning。
- [x] 证据路径：终端输出
- [x] 命令：`git diff --check`
- [x] 结果：通过，无 whitespace error。
- [x] 证据路径：终端输出
