### PR TITLE
fix(llm): 更新 DeepSeek 模型引用名

### DIFF
--- a/openless-all/app/src/lib/ipc.ts
+++ b/openless-all/app/src/lib/ipc.ts
@@ -148,7 +148,7 @@ export function validateProviderCredentials(kind: 'llm' | 'asr'): Promise<Provid
 }
 
 export function listProviderModels(kind: 'llm' | 'asr'): Promise<ProviderModelsResult> {
-  return invokeOrMock('list_provider_models', { kind }, () => ({ models: kind === 'llm' ? ['gpt-4o', 'deepseek-chat'] : ['whisper-1'] }));
+  return invokeOrMock('list_provider_models', { kind }, () => ({ models: kind === 'llm' ? ['gpt-4o', 'deepseek-v4-flash', 'deepseek-v4-pro'] : ['whisper-1'] }));
 }
 
 // ── History ────────────────────────────────────────────────────────────

--- a/openless-all/app/src/pages/Settings.tsx
+++ b/openless-all/app/src/pages/Settings.tsx
@@ -264,7 +264,7 @@ function Toggle({ on, onToggle }: { on: boolean; onToggle?: (next: boolean) => v
 
 const LLM_PRESETS = [
   { id: 'ark',          nameKey: 'ark',         baseUrl: 'https://ark.cn-beijing.volces.com/api/v3', modelPlaceholder: 'deepseek-v3-2' },
-  { id: 'deepseek',     nameKey: 'deepseek',    baseUrl: 'https://api.deepseek.com/v1',             modelPlaceholder: 'deepseek-chat' },
+  { id: 'deepseek',     nameKey: 'deepseek',    baseUrl: 'https://api.deepseek.com/v1',             modelPlaceholder: 'deepseek-v4-flash' },
   { id: 'siliconflow',  nameKey: 'siliconflow', baseUrl: 'https://api.siliconflow.cn/v1',           modelPlaceholder: 'Qwen/Qwen2.5-7B-Instruct' },
   { id: 'openai',       nameKey: 'openai',      baseUrl: 'https://api.openai.com/v1',               modelPlaceholder: 'gpt-4o' },
   { id: 'custom',       nameKey: 'custom',      baseUrl: '',                                        modelPlaceholder: '' },


### PR DESCRIPTION
## 摘要

Fixes #132

只修 DeepSeek 模型引用名：把设置页 DeepSeek 预设和本地 mock 模型列表从 `deepseek-chat` 更新到官方当前 V4 模型名。

## 修复 / 新增 / 改进

- DeepSeek 预设 Model placeholder 改为 `deepseek-v4-flash`。
- 本地 mock LLM 模型列表改为 `gpt-4o`、`deepseek-v4-flash`、`deepseek-v4-pro`。

## 兼容

- 不包含：移除 `ARK（火山方舟）` 预设。
- 不包含：修改默认 LLM provider。
- 对现有用户 / 本地环境 / 构建流程的影响：只影响 DeepSeek 预设提示和本地 mock 模型列表，不改后端凭据读取和方舟配置路径。

## 测试计划

- [x] 命令：`npm run build`
- [x] 命令：`git diff --check` / `git diff --cached --check`
- [x] 命令：确认源码中不再出现 `deepseek-chat`
- [x] 结果：以上均通过。