### PR TITLE
fix(windows): 对齐 QA hotkey 设置写回与运行态监听器

### DIFF
--- a/openless-all/app/src-tauri/src/commands.rs
+++ b/openless-all/app/src-tauri/src/commands.rs
@@ -24,11 +24,50 @@ pub fn get_settings(coord: CoordinatorState<'_>) -> UserPreferences {
     coord.prefs().get()
 }
 
+trait SettingsWriter {
+    fn write_settings(&self, prefs: UserPreferences) -> Result<(), String>;
+    fn refresh_dictation_hotkey(&self);
+    fn refresh_qa_hotkey(&self);
+}
+
+impl SettingsWriter for Coordinator {
+    fn write_settings(&self, prefs: UserPreferences) -> Result<(), String> {
+        self.prefs().set(prefs).map_err(|e| e.to_string())
+    }
+
+    fn refresh_dictation_hotkey(&self) {
+        self.update_hotkey_binding();
+    }
+
+    fn refresh_qa_hotkey(&self) {
+        self.update_qa_hotkey_binding();
+    }
+}
+
+impl SettingsWriter for Arc<Coordinator> {
+    fn write_settings(&self, prefs: UserPreferences) -> Result<(), String> {
+        self.prefs().set(prefs).map_err(|e| e.to_string())
+    }
+
+    fn refresh_dictation_hotkey(&self) {
+        self.update_hotkey_binding();
+    }
+
+    fn refresh_qa_hotkey(&self) {
+        self.update_qa_hotkey_binding();
+    }
+}
+
+fn persist_settings<T: SettingsWriter>(coord: &T, prefs: UserPreferences) -> Result<(), String> {
+    coord.write_settings(prefs)?;
+    coord.refresh_dictation_hotkey();
+    coord.refresh_qa_hotkey();
+    Ok(())
+}
+
 #[tauri::command]
 pub fn set_settings(coord: CoordinatorState<'_>, prefs: UserPreferences) -> Result<(), String> {
-    coord.prefs().set(prefs).map_err(|e| e.to_string())?;
-    coord.update_hotkey_binding();
-    Ok(())
+    persist_settings(&*coord, prefs)
 }
 
 #[tauri::command]
@@ -484,7 +523,33 @@ fn _ensure_snapshot_used(_: CredentialsSnapshot) {}
 
 #[cfg(test)]
 mod tests {
-    use super::{models_url, parse_model_ids};
+    use super::{models_url, parse_model_ids, persist_settings, SettingsWriter};
+    use crate::types::{
+        HotkeyBinding, HotkeyMode, HotkeyTrigger, QaHotkeyBinding, UserPreferences,
+    };
+    use std::sync::Mutex;
+
+    #[derive(Default)]
+    struct FakeSettingsWriter {
+        saved: Mutex<Option<UserPreferences>>,
+        dictation_refreshes: Mutex<u32>,
+        qa_refreshes: Mutex<u32>,
+    }
+
+    impl SettingsWriter for FakeSettingsWriter {
+        fn write_settings(&self, prefs: UserPreferences) -> Result<(), String> {
+            *self.saved.lock().unwrap() = Some(prefs);
+            Ok(())
+        }
+
+        fn refresh_dictation_hotkey(&self) {
+            *self.dictation_refreshes.lock().unwrap() += 1;
+        }
+
+        fn refresh_qa_hotkey(&self) {
+            *self.qa_refreshes.lock().unwrap() += 1;
+        }
+    }
 
     #[test]
     fn models_url_accepts_base_or_chat_endpoint() {
@@ -504,5 +569,38 @@ mod tests {
             parse_model_ids(r#"{ "data": [{ "id": "b" }, { "id": "a" }, { "id": "b" }] }"#)
                 .unwrap();
         assert_eq!(models, vec!["a".to_string(), "b".to_string()]);
+    }
+
+    #[test]
+    fn persist_settings_refreshes_both_hotkey_pipelines() {
+        let writer = FakeSettingsWriter::default();
+        let prefs = UserPreferences {
+            hotkey: HotkeyBinding {
+                trigger: HotkeyTrigger::RightControl,
+                mode: HotkeyMode::Toggle,
+            },
+            qa_hotkey: Some(QaHotkeyBinding {
+                primary: ";".to_string(),
+                modifiers: vec!["ctrl".to_string(), "shift".to_string()],
+            }),
+            ..Default::default()
+        };
+
+        persist_settings(&writer, prefs.clone()).unwrap();
+
+        let saved = writer
+            .saved
+            .lock()
+            .unwrap()
+            .clone()
+            .expect("settings saved");
+        assert_eq!(saved.hotkey.trigger, prefs.hotkey.trigger);
+        assert_eq!(saved.hotkey.mode, prefs.hotkey.mode);
+        assert_eq!(
+            saved.qa_hotkey.unwrap().primary,
+            prefs.qa_hotkey.unwrap().primary
+        );
+        assert_eq!(*writer.dictation_refreshes.lock().unwrap(), 1);
+        assert_eq!(*writer.qa_refreshes.lock().unwrap(), 1);
     }
 }


### PR DESCRIPTION
﻿## 摘要

Fixes #147

说明这个 PR 解决的单一目标：对齐 `set_settings` 与 QA hotkey runtime monitor 的生命周期，让 `qaHotkey` 的设置写回能立即反映到运行中的监听器。

## 问题层面 / Problem layer

- 这是 **应用逻辑层 / cross-platform settings-to-runtime contract** 的修复。
- 当前证据来自 Windows，但 PR 目标不是做 Windows-only workaround，而是修正通用设置写回链路。

## 修复 / 新增 / 改进

- 占位 draft PR：后续只承接 issue #147 的修复，不混入 Windows UI 或 capsule 相关改动
- 预期改动范围：`commands.rs` / QA settings write path / 最小回归验证

## 兼容

- 不包含：Windows UI 适配、capsule 几何、主窗口视觉问题
- 对现有用户 / 本地环境 / 构建流程的影响：预期仅影响 QA hotkey 设置变更后的 runtime 行为

## 测试计划

- [ ] 命令：`cargo test`、替代最小验证脚本，或 documented manual check
- [ ] 结果：设置改键 / 禁用后，旧 QA hotkey 立即失效，新 hotkey 立即生效
- [ ] 证据路径：issue #147 / `openless.log` / 对应运行态复现记录
