### PR TITLE
fix(windows): 归一 QA hotkey 的跨平台修饰键语义

### DIFF
--- a/openless-all/app/src-tauri/src/qa_hotkey.rs
+++ b/openless-all/app/src-tauri/src/qa_hotkey.rs
@@ -173,7 +173,7 @@ fn forward_loop(
 fn parse_binding(binding: &QaHotkeyBinding) -> Result<HotKey, QaHotkeyError> {
     let mut mods = Modifiers::empty();
     for raw in &binding.modifiers {
-        let tag = raw.trim().to_ascii_lowercase();
+        let tag = normalize_modifier_tag(raw);
         let bit = match tag.as_str() {
             "cmd" | "command" | "super" | "meta" | "win" => Modifiers::SUPER,
             "ctrl" | "control" => Modifiers::CONTROL,
@@ -185,6 +185,17 @@ fn parse_binding(binding: &QaHotkeyBinding) -> Result<HotKey, QaHotkeyError> {
     }
     let code = parse_primary(&binding.primary)?;
     Ok(HotKey::new(Some(mods), code))
+}
+
+fn normalize_modifier_tag(raw: &str) -> String {
+    let tag = raw.trim().to_ascii_lowercase();
+    #[cfg(target_os = "windows")]
+    {
+        if matches!(tag.as_str(), "cmd" | "command") {
+            return "ctrl".to_string();
+        }
+    }
+    tag
 }
 
 /// 把用户配置的主键字符串解析成 keyboard_types::Code。
@@ -338,5 +349,25 @@ mod tests {
             parse_binding(&binding),
             Err(QaHotkeyError::UnsupportedKey(_))
         ));
+    }
+
+    #[test]
+    fn cmd_modifier_normalizes_per_platform() {
+        let binding = QaHotkeyBinding {
+            primary: ";".into(),
+            modifiers: vec!["cmd".into(), "shift".into()],
+        };
+        let parsed = parse_binding(&binding).expect("binding parses");
+
+        #[cfg(target_os = "windows")]
+        {
+            assert!(parsed.mods.contains(Modifiers::CONTROL));
+            assert!(!parsed.mods.contains(Modifiers::SUPER));
+        }
+
+        #[cfg(not(target_os = "windows"))]
+        {
+            assert!(parsed.mods.contains(Modifiers::SUPER));
+        }
     }
 }


### PR DESCRIPTION
﻿## 摘要

Fixes #148

说明这个 PR 解决的单一目标：归一 QA hotkey 的跨平台 modifier 语义，避免 macOS `cmd` 偏好在 Windows runtime 中字面漂移成 `Win` 键。

## 问题层面 / Problem layer

- 这是 **跨平台配置语义层 / config normalization + migration** 的修复。
- 当前运行态错误主要在 Windows 暴露，但 PR 目标是修正共享配置模型，而不是只补一个 Windows 临时映射。

## 修复 / 新增 / 改进

- 占位 draft PR：后续只承接 issue #148 的配置迁移 / normalization 修复
- 预期改动范围：`qa_hotkey.rs` / preference load or migration path / cross-platform validation

## 兼容

- 不包含：QA panel UI、ASR/LLM 请求链路、Windows 主窗口视觉问题
- 对现有用户 / 本地环境 / 构建流程的影响：可能涉及历史 `qaHotkey` 配置迁移与默认值回显

## 测试计划

- [ ] 命令：最小配置迁移验证 + Windows runtime hotkey 验证
- [ ] 结果：Windows 不再把历史 `cmd` 语义静默注册为 `Win` hotkey
- [ ] 证据路径：issue #148 / preferences.json before-after / `openless.log`
