### PR TITLE
docs(windows): 跟踪 startup visible-ready 生命周期

### DIFF
--- a/docs/windows-lifecycle-tracking/issue-98-startup-visible-ready.md
+++ b/docs/windows-lifecycle-tracking/issue-98-startup-visible-ready.md
@@ -1,0 +1,27 @@
+# Issue #98 Tracking
+
+Scope: Windows startup `visible` / `ready` lifecycle contract
+
+Current stage:
+
+- This branch is a draft PR placeholder.
+- No runtime fix is included yet.
+- The goal is to freeze the problem boundary before implementation.
+
+Problem statement:
+
+- The main window can become visible before hotkey/runtime readiness is truly established.
+- Backend and frontend both participate in first-show ownership.
+- Windows is the currently observed symptom surface, but the ownership split is architectural.
+
+Implementation target to converge before coding:
+
+- Decide a single owner for initial main-window visibility.
+- Define the relation between `created`, `shown`, `startup`, `ready`, and `first usable state`.
+- Decide whether startup shell and ready shell remain separate concepts.
+
+Non-goals in this draft:
+
+- No Tauri window behavior change yet
+- No frontend gate refactor yet
+- No smoke implementation yet


### PR DESCRIPTION
## 摘要

Closes #98

这个 draft PR 用来承接 Windows startup `visible` / `ready` 生命周期契约问题。目标不是立刻改代码，而是先把“谁拥有 first show”“什么时候可以称为 ready”这两个最容易被混淆的问题锁定下来。

## 修复 / 新增 / 改进

- 新增 tracking doc，冻结 `issue #98` 的问题边界
- 预留后续 startup visibility owner 收敛所需的 PR 入口
- 避免把 hotkey readiness、startup shell、first paint 问题一次性搅在一起

## 兼容

- 不包含：Tauri `main` window 行为变更
- 对现有用户 / 本地环境 / 构建流程的影响：仅新增 tracking 文档，no runtime impact

## 测试计划

- [ ] 命令：待修复方案收敛后补
- [ ] 结果：待修复方案收敛后补
- [ ] 证据路径：`docs/windows-lifecycle-tracking/issue-98-startup-visible-ready.md`
