### PR TITLE
fix(windows): 启动 gate pollHotkeyStatus 加 10s 超时 (closes #163)

### DIFF
--- a/openless-all/app/src/App.tsx
+++ b/openless-all/app/src/App.tsx
@@ -57,15 +57,28 @@ export function App({ isCapsule, isQa }: AppProps) {
     let cancelled = false;
 
     if (os === 'win') {
+      // 超时保护：50 次 × 200ms = 10s。hotkey hook 永远 starting（被反作弊 / EDR
+      // / UAC 拦）时不让 UI 死锁灰屏，过 10s 强 setGate('ready') 让用户进
+      // Permissions 页看 hotkey_status.lastError 处理。详见 issue #163。
+      const POLL_INTERVAL_MS = 200;
+      const POLL_MAX_ATTEMPTS = 50;
       const pollHotkeyStatus = async () => {
-        while (!cancelled) {
+        let attempts = 0;
+        while (!cancelled && attempts < POLL_MAX_ATTEMPTS) {
+          attempts += 1;
           const status = await getHotkeyStatus();
           if (cancelled) return;
           if (status.state !== 'starting') {
             setGate('ready');
             return;
           }
-          await new Promise(resolve => window.setTimeout(resolve, 200));
+          await new Promise(resolve => window.setTimeout(resolve, POLL_INTERVAL_MS));
+        }
+        if (!cancelled) {
+          console.warn(
+            `[startup] hotkey gate timed out after ${POLL_MAX_ATTEMPTS * POLL_INTERVAL_MS}ms; forcing ready so user can reach Permissions page`
+          );
+          setGate('ready');
         }
       };
       void pollHotkeyStatus().catch(error => {


### PR DESCRIPTION
## 摘要

Closes #163

Windows 上 hotkey hook 永远 starting（反作弊/EDR/UAC 拦）→ 前端 \`while(!cancelled)\` 死循环 → UI 卡 \"正在启动\" 灰屏。

## 修复

\`App.tsx:60\` 加 50 × 200ms = 10s 上限：超时强 \`setGate('ready')\`，让用户能进 Permissions 页看 hotkey_status.lastError。

## 测试

- npm run build ✅
- 非 Windows 路径不动

@codex review。