### PR TITLE
fix(qa): QA recorder error monitor (closes #168)

### DIFF
--- a/openless-all/app/src-tauri/src/coordinator.rs
+++ b/openless-all/app/src-tauri/src/coordinator.rs
@@ -1039,6 +1039,33 @@ fn spawn_recorder_error_monitor(inner: &Arc<Inner>, rx: mpsc::Receiver<RecorderE
         .ok();
 }
 
+/// QA 录音 runtime error 监听器。镜像 `spawn_recorder_error_monitor` 的语义但走 QA
+/// 收尾路径（`finish_qa_with_error` 替代 `abort_recording_with_error`）。
+/// 用 qa_state.session_id 守卫 stale 事件。详见 issue #168。
+fn spawn_qa_recorder_error_monitor(inner: &Arc<Inner>, rx: mpsc::Receiver<RecorderError>) {
+    let captured_session_id = inner.qa_state.lock().session_id;
+    let inner = Arc::clone(inner);
+    std::thread::Builder::new()
+        .name("openless-qa-recorder-error-monitor".into())
+        .spawn(move || {
+            if let Ok(err) = rx.recv() {
+                let current_session_id = inner.qa_state.lock().session_id;
+                if captured_session_id != current_session_id {
+                    log::warn!(
+                        "[coord] QA recorder error from stale session {} dropped (current={}, err={})",
+                        captured_session_id,
+                        current_session_id,
+                        err
+                    );
+                    return;
+                }
+                log::error!("[coord] QA recorder runtime error: {err}");
+                finish_qa_with_error(&inner, format!("录音设备异常: {err}"));
+            }
+        })
+        .ok();
+}
+
 fn abort_recording_with_error(inner: &Arc<Inner>, message: String) {
     let elapsed = {
         let mut state = inner.state.lock();
@@ -1754,8 +1781,11 @@ async fn begin_qa_session(inner: &Arc<Inner>) -> Result<(), String> {
     });
 
     match Recorder::start(consumer, level_handler) {
-        Ok((rec, _runtime_errors)) => {
+        Ok((rec, runtime_errors)) => {
             *inner.qa_recorder.lock() = Some(rec);
+            // QA 也跟主听写一样监听 cpal runtime error。设备中途消失 / panic 时
+            // 不能让 QA 永远卡在 Recording 没反馈。详见 issue #168。
+            spawn_qa_recorder_error_monitor(inner, runtime_errors);
         }
         Err(e) => {
             log::error!("[coord] QA recorder start failed: {e}");


### PR DESCRIPTION
## 摘要

Closes #168

QA 录音设备失败时之前永远卡 Recording 无错误反馈（runtime_errors 用 \`_\` 弃用）。镜像主听写的 \`spawn_recorder_error_monitor\` 加 QA 版本。

## 修复

- \`spawn_qa_recorder_error_monitor\`：用 qa_state.session_id 守 stale，收到 err 后 \`finish_qa_with_error(\"录音设备异常: ..\")\`
- \`begin_qa_session\` Recorder::start 成功后启动监听器
- 之前的 \`_runtime_errors\` 改成 \`runtime_errors\`

## 测试

- \`cargo check\` ✅

@codex review。