### PR TITLE
fix(mic): dictation 缺麦克风权限时不再抢前台焦点

### DIFF
--- a/openless-all/app/src-tauri/src/coordinator.rs
+++ b/openless-all/app/src-tauri/src/coordinator.rs
@@ -1505,12 +1505,11 @@ fn debug_transcript_override_text() -> Option<String> {
     }
 }
 
-fn ensure_microphone_permission(inner: &Arc<Inner>) -> Result<(), String> {
+fn ensure_microphone_permission(_inner: &Arc<Inner>) -> Result<(), String> {
     use crate::permissions::{self, PermissionStatus};
 
     #[cfg(target_os = "windows")]
     {
-        let _ = inner;
         if permissions::windows_microphone_access_explicitly_denied() {
             return Err("需要麦克风权限，当前状态: Denied".to_string());
         }
@@ -1525,11 +1524,10 @@ fn ensure_microphone_permission(inner: &Arc<Inner>) -> Result<(), String> {
         return Ok(());
     }
 
-    let requested = if let Some(app) = inner.app.lock().clone() {
-        crate::request_microphone_from_foreground(&app)
-    } else {
-        permissions::request_microphone()
-    };
+    // 听写路径不抢前台焦点：缺 mic 权限时直接请求系统授权，不再先 show_main_window。
+    // 用户在设置页手动点“请求权限”仍走 request_microphone_from_foreground，那是显式操作。
+    // 这里若系统不弹框，后续会通过 capsule error 引导用户主动去权限页处理。详见 #166。
+    let requested = permissions::request_microphone();
     if matches!(
         requested,
         PermissionStatus::Granted | PermissionStatus::NotApplicable


### PR DESCRIPTION
## 摘要

Closes #166

把 dictation 路径里的 mic 权限请求改成直接调用系统权限 API，不再先 `show_main_window` / `activateIgnoringOtherApps` 抢到前台。

## 改动

- `coordinator.rs::ensure_microphone_permission` 不再走 `request_microphone_from_foreground`
- 设置页里用户手动点按钮触发权限提示的显式路径保持不变
- 缺权限时仍会走现有 capsule error 提示，不会静默吞掉

## 验证

- `cargo check --manifest-path src-tauri/Cargo.toml` ✅

@codex review
