### PR TITLE
fix(windows): QA 浮窗显示时不再抢前台焦点

### DIFF
--- a/openless-all/app/src-tauri/Cargo.lock
+++ b/openless-all/app/src-tauri/Cargo.lock
@@ -3270,6 +3270,7 @@ dependencies = [
  "objc2-foundation 0.2.2",
  "once_cell",
  "parking_lot",
+ "raw-window-handle",
  "rdev",
  "reqwest 0.12.28",
  "serde",

--- a/openless-all/app/src-tauri/Cargo.toml
+++ b/openless-all/app/src-tauri/Cargo.toml
@@ -35,6 +35,7 @@ uuid = { version = "1", features = ["v4", "serde"] }
 chrono = { version = "0.4", features = ["serde"] }
 bytes = "1"
 url = "2"
+raw-window-handle = "0.6"
 
 # Hotkey + audio + insertion
 global-hotkey = "0.6"

--- a/openless-all/app/src-tauri/src/lib.rs
+++ b/openless-all/app/src-tauri/src/lib.rs
@@ -514,7 +514,16 @@ pub(crate) fn show_qa_window<R: tauri::Runtime>(app: &AppHandle<R>, content_kind
             }
         });
     }
-    #[cfg(not(target_os = "macos"))]
+    #[cfg(target_os = "windows")]
+    {
+        if !show_qa_window_no_activate(&window) {
+            log::warn!("[qa] show_no_activate failed; falling back to window.show()");
+            if let Err(e) = window.show() {
+                log::warn!("[qa] show fallback failed: {e}");
+            }
+        }
+    }
+    #[cfg(all(not(target_os = "macos"), not(target_os = "windows")))]
     if let Err(e) = window.show() {
         log::warn!("[qa] show failed: {e}");
     }
@@ -558,6 +567,41 @@ pub(crate) fn hide_qa_window<R: tauri::Runtime>(app: &AppHandle<R>) {
     if let Some(window) = app.get_webview_window("qa") {
         let _ = window.hide();
     }
+}
+
+#[cfg(target_os = "windows")]
+fn show_qa_window_no_activate<R: tauri::Runtime>(window: &tauri::WebviewWindow<R>) -> bool {
+    use raw_window_handle::{HasWindowHandle, RawWindowHandle};
+    use windows::Win32::Foundation::HWND;
+    use windows::Win32::UI::WindowsAndMessaging::{
+        SetWindowPos, ShowWindow, HWND_TOPMOST, SWP_NOACTIVATE, SWP_NOMOVE, SWP_NOSIZE,
+        SWP_SHOWWINDOW, SW_SHOWNOACTIVATE,
+    };
+
+    let Ok(handle) = window.window_handle() else {
+        return false;
+    };
+    let RawWindowHandle::Win32(raw) = handle.as_raw() else {
+        return false;
+    };
+    let hwnd = HWND(raw.hwnd.get() as *mut _);
+    if hwnd.0.is_null() {
+        return false;
+    }
+
+    let _ = unsafe { ShowWindow(hwnd, SW_SHOWNOACTIVATE) };
+    let _ = unsafe {
+        SetWindowPos(
+            hwnd,
+            HWND_TOPMOST,
+            0,
+            0,
+            0,
+            0,
+            SWP_NOMOVE | SWP_NOSIZE | SWP_SHOWWINDOW | SWP_NOACTIVATE,
+        )
+    };
+    true
 }
 
 /// 把 capsule 窗口移到屏幕底部居中，与 Swift `CapsuleWindowController.repositionToBottomCenter` 同效。


### PR DESCRIPTION
## 摘要

Closes #164

把 Windows 上 QA 浮窗的显示路径从普通 `window.show()` 改成 `SW_SHOWNOACTIVATE + SWP_NOACTIVATE`，避免多轮追问时 QA 浮窗抢成前台，后续抓选区读到自家 webview。

## 改动

- `show_qa_window` 新增 Windows 专用 `show_qa_window_no_activate`
- 直接从 `WebviewWindow` 读取 `HWND`，不靠窗口标题猜句柄
- 失败时保留 `window.show()` fallback，避免把窗口彻底显示不出来

## 验证

- `cargo check --manifest-path src-tauri/Cargo.toml` ✅
- Windows 语义依赖 CI / 实机验证

@codex review
