### PR TITLE
fix(windows): 收敛 clipboard restore 并发恢复竞态

### DIFF
--- a/openless-all/app/src-tauri/src/insertion.rs
+++ b/openless-all/app/src-tauri/src/insertion.rs
@@ -11,7 +11,14 @@
 //! 3. 其他平台 (Windows/Linux) 仍用 enigo。
 
 #[cfg(not(target_os = "macos"))]
+use std::sync::atomic::{AtomicU64, Ordering};
+#[cfg(not(target_os = "macos"))]
 use std::time::Duration;
+
+#[cfg(not(target_os = "macos"))]
+use once_cell::sync::Lazy;
+#[cfg(not(target_os = "macos"))]
+use parking_lot::Mutex;
 
 use crate::types::InsertStatus;
 
@@ -82,6 +89,20 @@ struct ClipboardRestorePlan {
     previous_text: Option<String>,
 }
 
+#[cfg(not(target_os = "macos"))]
+#[derive(Debug, Clone)]
+struct PendingClipboardRestore {
+    latest_restore_id: u64,
+    original_text: Option<String>,
+}
+
+#[cfg(not(target_os = "macos"))]
+static NEXT_CLIPBOARD_RESTORE_ID: AtomicU64 = AtomicU64::new(1);
+
+#[cfg(not(target_os = "macos"))]
+static PENDING_CLIPBOARD_RESTORE: Lazy<Mutex<Option<PendingClipboardRestore>>> =
+    Lazy::new(|| Mutex::new(None));
+
 fn copy_to_clipboard(text: &str) -> bool {
     let mut clipboard = match arboard::Clipboard::new() {
         Ok(c) => c,
@@ -143,16 +164,41 @@ fn insert_with_clipboard_restore(text: &str, restore_clipboard_after_paste: bool
 
 #[cfg(not(target_os = "macos"))]
 fn schedule_clipboard_restore(plan: ClipboardRestorePlan) {
-    std::thread::spawn(move || restore_clipboard_after_delay(plan, CLIPBOARD_RESTORE_DELAY));
+    let restore_id = NEXT_CLIPBOARD_RESTORE_ID.fetch_add(1, Ordering::SeqCst);
+    let original_text = {
+        let mut pending = PENDING_CLIPBOARD_RESTORE.lock();
+        let original = pending
+            .as_ref()
+            .map(|batch| batch.original_text.clone())
+            .unwrap_or_else(|| plan.previous_text.clone());
+        *pending = Some(PendingClipboardRestore {
+            latest_restore_id: restore_id,
+            original_text: original.clone(),
+        });
+        original
+    };
+    std::thread::spawn(move || {
+        restore_clipboard_after_delay(
+            plan,
+            original_text,
+            restore_id,
+            CLIPBOARD_RESTORE_DELAY,
+        )
+    });
 }
 
 #[cfg(not(target_os = "macos"))]
-fn restore_clipboard_after_delay(plan: ClipboardRestorePlan, delay: Duration) {
-    if plan.previous_text.is_none() {
+fn restore_clipboard_after_delay(
+    plan: ClipboardRestorePlan,
+    original_text: Option<String>,
+    restore_id: u64,
+    delay: Duration,
+) {
+    std::thread::sleep(delay);
+
+    if !is_latest_clipboard_restore(restore_id) {
         return;
     }
-
-    std::thread::sleep(delay);
 
     let mut clipboard = match arboard::Clipboard::new() {
         Ok(clipboard) => clipboard,
@@ -161,6 +207,7 @@ fn restore_clipboard_after_delay(plan: ClipboardRestorePlan, delay: Duration) {
                 "[insertion] clipboard re-open failed during restore: {}",
                 err
             );
+            clear_pending_clipboard_restore(restore_id);
             return;
         }
     };
@@ -176,14 +223,34 @@ fn restore_clipboard_after_delay(plan: ClipboardRestorePlan, delay: Duration) {
         }
     };
 
-    if !should_restore_clipboard(current_text.as_deref(), &plan.inserted_text) {
-        return;
+    if should_restore_clipboard(current_text.as_deref(), &plan.inserted_text) {
+        if let Some(previous_text) = original_text {
+            if let Err(err) = clipboard.set_text(previous_text) {
+                log::warn!("[insertion] clipboard restore failed: {}", err);
+            }
+        }
+    } else {
+        log::info!(
+            "[insertion] skip clipboard restore: latest clipboard no longer matches inserted text"
+        );
     }
 
-    if let Some(previous_text) = plan.previous_text {
-        if let Err(err) = clipboard.set_text(previous_text) {
-            log::warn!("[insertion] clipboard restore failed: {}", err);
-        }
+    clear_pending_clipboard_restore(restore_id);
+}
+
+#[cfg(not(target_os = "macos"))]
+fn is_latest_clipboard_restore(restore_id: u64) -> bool {
+    matches!(
+        PENDING_CLIPBOARD_RESTORE.lock().as_ref(),
+        Some(batch) if batch.latest_restore_id == restore_id
+    )
+}
+
+#[cfg(not(target_os = "macos"))]
+fn clear_pending_clipboard_restore(restore_id: u64) {
+    let mut pending = PENDING_CLIPBOARD_RESTORE.lock();
+    if matches!(pending.as_ref(), Some(batch) if batch.latest_restore_id == restore_id) {
+        pending.take();
     }
 }
 


### PR DESCRIPTION
## 摘要

Closes #167

把 Windows/Linux 路径里的“恢复用户原剪贴板”从无界多线程改成单条最新恢复链：连续多次听写时，只允许最新一轮 restore 真正落地，但保留最早那份原始剪贴板快照。

## 改动

- `schedule_clipboard_restore` 改为分配递增 `restore_id`
- 用进程级 `PENDING_CLIPBOARD_RESTORE` 记录“当前批次的最早原始剪贴板 + 最新 restore id”
- 旧 restore 线程睡醒后若发现自己不是最新批次，直接退出，不再写系统剪贴板
- 最新批次仍保留现有保护：只有剪贴板内容还等于最后一次插入文本时才恢复

## 验证

- `cargo check --manifest-path src-tauri/Cargo.toml` ✅
- 最终 Windows 时序由 CI / 实机验证

@codex review
