### PR TITLE
fix(windows): 收紧主窗口 shell 外观契约

### DIFF
--- a/openless-all/app/scripts/windows-ui-config.test.mjs
+++ b/openless-all/app/scripts/windows-ui-config.test.mjs
@@ -15,18 +15,39 @@ function assertMatch(source, pattern, name) {
 const raw = await readFile(new URL('../src-tauri/tauri.conf.json', import.meta.url), 'utf-8');
 const config = JSON.parse(raw);
 const capsuleWindow = config.app.windows.find((window) => window.label === 'capsule');
+const mainWindow = config.app.windows.find((window) => window.label === 'main');
 const libRs = await readFile(new URL('../src-tauri/src/lib.rs', import.meta.url), 'utf-8');
 const coordinatorRs = await readFile(new URL('../src-tauri/src/coordinator.rs', import.meta.url), 'utf-8');
 const capsuleTsx = await readFile(new URL('../src/components/Capsule.tsx', import.meta.url), 'utf-8');
 const capsuleLayoutTs = await readFile(new URL('../src/lib/capsuleLayout.ts', import.meta.url), 'utf-8');
+const windowChromeTsx = await readFile(new URL('../src/components/WindowChrome.tsx', import.meta.url), 'utf-8');
+const floatingShellTsx = await readFile(new URL('../src/components/FloatingShell.tsx', import.meta.url), 'utf-8');
 
 if (!capsuleWindow) {
   throw new Error('capsule window config missing');
+}
+if (!mainWindow) {
+  throw new Error('main window config missing');
 }
 assertEqual(capsuleWindow.width, 220, 'windows capsule config keeps translation-capable width baseline');
 assertEqual(capsuleWindow.height, 110, 'windows capsule config keeps translation-capable height baseline');
 assertEqual(capsuleWindow.transparent, true, 'capsule window should keep transparent visuals');
 assertEqual(capsuleWindow.alwaysOnTop, true, 'capsule window should stay above the focused app while recording');
+assertEqual(mainWindow.decorations, false, 'windows main window should use only custom titlebar');
+assertEqual(mainWindow.visible, false, 'windows main window should stay hidden until the intended first show point');
+
+if (!/function WindowsResizeHandles\(\)/.test(windowChromeTsx)) {
+  throw new Error('windows frameless shell should expose explicit resize handles');
+}
+
+if (!/startResizeDragging\(direction\)/.test(windowChromeTsx)) {
+  throw new Error('windows resize handles should delegate edge dragging to Tauri');
+}
+
+if (!/borderRadius:\s*'var\(--ol-window-console-radius\)'/.test(floatingShellTsx)) {
+  throw new Error('floating shell should consume the shared window-console radius');
+}
+
 assertMatch(
   coordinatorRs,
   /let visible = !matches!\(state,\s*CapsuleState::Idle\);/,

--- a/openless-all/app/src-tauri/Cargo.toml
+++ b/openless-all/app/src-tauri/Cargo.toml
@@ -53,8 +53,11 @@ objc2-foundation = "0.2"
 objc2-app-kit = "0.2"
 
 [target.'cfg(target_os = "windows")'.dependencies]
+raw-window-handle = "0.6"
 windows = { version = "0.58", features = [
   "Win32_Foundation",
+  "Win32_Graphics_Dwm",
+  "Win32_Graphics_Gdi",
   "Win32_UI_Shell",
   "Win32_UI_Input_KeyboardAndMouse",
   "Win32_UI_WindowsAndMessaging",

--- a/openless-all/app/src-tauri/src/lib.rs
+++ b/openless-all/app/src-tauri/src/lib.rs
@@ -269,9 +269,9 @@ fn apply_windows_rounded_frame<R: Runtime>(window: &tauri::WebviewWindow<R>) {
 
     unsafe {
         let style = GetWindowLongW(hwnd, GWL_STYLE);
-        let native_frame_bits = (WS_CAPTION.0 | WS_THICKFRAME.0) as i32;
-        if style & native_frame_bits != 0 {
-            SetWindowLongW(hwnd, GWL_STYLE, style & !native_frame_bits);
+        let desired_style = (style | WS_THICKFRAME.0 as i32) & !(WS_CAPTION.0 as i32);
+        if style != desired_style {
+            SetWindowLongW(hwnd, GWL_STYLE, desired_style);
             if let Err(e) = SetWindowPos(
                 hwnd,
                 HWND::default(),

--- a/openless-all/app/src-tauri/src/lib.rs
+++ b/openless-all/app/src-tauri/src/lib.rs
@@ -105,12 +105,17 @@ pub fn run() {
                 #[cfg(target_os = "windows")]
                 {
                     use window_vibrancy::apply_mica;
-                    if let Err(e) = apply_mica(&main, None) {
-                        log::warn!("[main] mica failed: {e}");
-                    }
+                    // The window starts hidden so Windows native chrome can be disabled before
+                    // the first show; doing this after the native frame is visible is unreliable.
                     if let Err(e) = main.set_decorations(false) {
                         log::warn!("[main] disable native decorations failed: {e}");
                     }
+                    if let Err(e) = apply_mica(&main, None) {
+                        log::warn!("[main] mica failed: {e}");
+                    }
+                }
+                if let Err(e) = main.show() {
+                    log::warn!("[main] initial show failed: {e}");
                 }
             }
 

--- a/openless-all/app/src-tauri/src/lib.rs
+++ b/openless-all/app/src-tauri/src/lib.rs
@@ -113,6 +113,7 @@ pub fn run() {
                     if let Err(e) = apply_mica(&main, None) {
                         log::warn!("[main] mica failed: {e}");
                     }
+                    apply_windows_rounded_frame(&main);
                 }
                 if let Err(e) = main.show() {
                     log::warn!("[main] initial show failed: {e}");
@@ -219,9 +220,15 @@ pub fn run() {
             RunEvent::Reopen { .. } => show_main_window(app),
             RunEvent::WindowEvent { label, event, .. } => {
                 if label == "main" {
-                    if let tauri::WindowEvent::CloseRequested { api, .. } = event {
+                    if let tauri::WindowEvent::CloseRequested { ref api, .. } = event {
                         api.prevent_close();
                         hide_main_window(app);
+                    }
+                    #[cfg(target_os = "windows")]
+                    if matches!(event, tauri::WindowEvent::Resized(_) | tauri::WindowEvent::ScaleFactorChanged { .. }) {
+                        if let Some(main) = app.get_webview_window("main") {
+                            apply_windows_rounded_frame(&main);
+                        }
                     }
                 }
             }
@@ -232,6 +239,97 @@ pub fn run() {
             }
             _ => {}
         });
+}
+
+#[cfg(target_os = "windows")]
+fn apply_windows_rounded_frame<R: Runtime>(window: &tauri::WebviewWindow<R>) {
+    use raw_window_handle::{HasWindowHandle, RawWindowHandle};
+    use windows::Win32::Foundation::{BOOL, HWND, RECT};
+    use windows::Win32::Graphics::Dwm::{
+        DwmSetWindowAttribute, DWMWA_BORDER_COLOR, DWMWA_WINDOW_CORNER_PREFERENCE, DWMWCP_ROUND,
+    };
+    use windows::Win32::Graphics::Gdi::{CreateRoundRectRgn, SetWindowRgn, HRGN};
+    use windows::Win32::UI::WindowsAndMessaging::{
+        GetWindowLongW, GetWindowRect, SetWindowLongW, SetWindowPos, GWL_STYLE, SWP_FRAMECHANGED,
+        SWP_NOMOVE, SWP_NOSIZE, SWP_NOZORDER, WS_CAPTION, WS_THICKFRAME,
+    };
+
+    let handle = match window.window_handle().map(|h| h.as_raw()) {
+        Ok(RawWindowHandle::Win32(handle)) => handle,
+        Ok(other) => {
+            log::warn!("[main] unexpected raw window handle for DWM frame: {other:?}");
+            return;
+        }
+        Err(e) => {
+            log::warn!("[main] read raw window handle failed: {e}");
+            return;
+        }
+    };
+    let hwnd = HWND(handle.hwnd.get() as *mut core::ffi::c_void);
+
+    unsafe {
+        let style = GetWindowLongW(hwnd, GWL_STYLE);
+        let native_frame_bits = (WS_CAPTION.0 | WS_THICKFRAME.0) as i32;
+        if style & native_frame_bits != 0 {
+            SetWindowLongW(hwnd, GWL_STYLE, style & !native_frame_bits);
+            if let Err(e) = SetWindowPos(
+                hwnd,
+                HWND::default(),
+                0,
+                0,
+                0,
+                0,
+                SWP_NOMOVE | SWP_NOSIZE | SWP_NOZORDER | SWP_FRAMECHANGED,
+            ) {
+                log::warn!("[main] refresh native frame after style update failed: {e}");
+            }
+        }
+
+        if window.is_maximized().unwrap_or(false) {
+            let _ = SetWindowRgn(hwnd, HRGN::default(), BOOL(1));
+            return;
+        }
+
+        let corner_preference = DWMWCP_ROUND;
+        if let Err(e) = DwmSetWindowAttribute(
+            hwnd,
+            DWMWA_WINDOW_CORNER_PREFERENCE,
+            &corner_preference as *const _ as *const core::ffi::c_void,
+            std::mem::size_of_val(&corner_preference) as u32,
+        ) {
+            log::warn!("[main] set DWM rounded corners failed: {e}");
+        }
+
+        // Remove DWM's fallback 1px light border; the React shell draws the visual stroke.
+        let border_color_none: u32 = 0xFFFFFFFE;
+        if let Err(e) = DwmSetWindowAttribute(
+            hwnd,
+            DWMWA_BORDER_COLOR,
+            &border_color_none as *const _ as *const core::ffi::c_void,
+            std::mem::size_of_val(&border_color_none) as u32,
+        ) {
+            log::warn!("[main] remove DWM border color failed: {e}");
+        }
+
+        let mut rect = RECT::default();
+        if let Err(e) = GetWindowRect(hwnd, &mut rect) {
+            log::warn!("[main] read window rect for rounded region failed: {e}");
+            return;
+        }
+        let width = rect.right - rect.left;
+        let height = rect.bottom - rect.top;
+        if width <= 0 || height <= 0 {
+            return;
+        }
+        let region = CreateRoundRectRgn(0, 0, width + 1, height + 1, 18, 18);
+        if region.is_invalid() {
+            log::warn!("[main] create rounded window region failed");
+            return;
+        }
+        if SetWindowRgn(hwnd, region, BOOL(1)) == 0 {
+            log::warn!("[main] apply rounded window region failed");
+        }
+    }
 }
 
 #[tauri::command]

--- a/openless-all/app/src-tauri/tauri.conf.json
+++ b/openless-all/app/src-tauri/tauri.conf.json
@@ -21,7 +21,7 @@
         "minWidth": 980,
         "minHeight": 640,
         "resizable": true,
-        "decorations": true,
+        "decorations": false,
         "transparent": true,
         "shadow": true,
         "hiddenTitle": true,

--- a/openless-all/app/src/components/FloatingShell.tsx
+++ b/openless-all/app/src/components/FloatingShell.tsx
@@ -255,7 +255,7 @@ function FloatingShellBody({ os, initialTab, initialSettings }: { os: OS; initia
               flex: 1, minWidth: 0,
               overflow: 'hidden',
               background: 'var(--ol-surface)',
-              borderRadius: os === 'mac' ? 20 : 10,
+              borderRadius: 'var(--ol-window-console-radius)',
               border: '0.5px solid rgba(0,0,0,0.06)',
               boxShadow: '0 1px 0 rgba(255,255,255,0.8) inset, 0 8px 24px -12px rgba(15,17,22,0.10), 0 2px 6px -2px rgba(15,17,22,0.06)',
               display: 'flex',

--- a/openless-all/app/src/components/FloatingShell.tsx
+++ b/openless-all/app/src/components/FloatingShell.tsx
@@ -255,7 +255,7 @@ function FloatingShellBody({ os, initialTab, initialSettings }: { os: OS; initia
               flex: 1, minWidth: 0,
               overflow: 'hidden',
               background: 'var(--ol-surface)',
-              borderRadius: os === 'mac' ? 20 : 14,
+              borderRadius: os === 'mac' ? 20 : 10,
               border: '0.5px solid rgba(0,0,0,0.06)',
               boxShadow: '0 1px 0 rgba(255,255,255,0.8) inset, 0 8px 24px -12px rgba(15,17,22,0.10), 0 2px 6px -2px rgba(15,17,22,0.06)',
               display: 'flex',

--- a/openless-all/app/src/components/WindowChrome.tsx
+++ b/openless-all/app/src/components/WindowChrome.tsx
@@ -11,8 +11,9 @@
 //   │ [icon footer]                                 │
 //   └───────────────────────────────────────────────┘
 
-import { type CSSProperties, type ReactNode } from 'react';
+import { useState, type CSSProperties, type ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
+import { getCurrentWindow } from '@tauri-apps/api/window';
 
 export type OS = 'mac' | 'win' | 'linux';
 
@@ -32,6 +33,18 @@ const MAC_TITLEBAR_HEIGHT = 36;
 const MAC_SYSTEM_CONTROLS_RESERVED_WIDTH = 80;
 const MAC_WINDOW_RADIUS = 20;
 const WIN_WINDOW_RADIUS = 0;
+const WIN_RESIZE_EDGE = 6;
+const WIN_RESIZE_CORNER = 14;
+
+type ResizeDirection =
+  | 'East'
+  | 'North'
+  | 'NorthEast'
+  | 'NorthWest'
+  | 'South'
+  | 'SouthEast'
+  | 'SouthWest'
+  | 'West';
 
 interface WindowChromeProps {
   os?: OS;
@@ -63,6 +76,7 @@ export function WindowChrome({ os = 'mac', title = 'OpenLess', children, height 
       }}
     >
       {os === 'win' && <WinTitleBar title={title} />}
+      {os === 'win' && <WindowsResizeHandles />}
       {/* macOS：三色窗口按钮交给系统绘制和定位。这里只保留顶部拖动区，
           并避开系统按钮热区，防止拖动层吞掉 close/minimize/zoom 点击。 */}
       {os === 'mac' && (
@@ -99,7 +113,7 @@ function WinTitleBar({ title }: WinTitleBarProps) {
         display: 'flex',
         alignItems: 'stretch',
         position: 'relative',
-        zIndex: 5,
+        zIndex: 70,
       }}
     >
       <div
@@ -109,24 +123,105 @@ function WinTitleBar({ title }: WinTitleBarProps) {
         <img src="AppIcon.png" alt="" style={{ width: 14, height: 14, borderRadius: 3 }} />
         <span style={{ fontSize: 12, color: 'var(--ol-ink-3)', fontWeight: 500 }}>{title}</span>
       </div>
-      <div style={{ display: 'flex' }}>
-        <button style={winBtnStyle} title={t('windowChrome.minimize')} onClick={() => runWindowsWindowAction('minimize')}>
+      <div style={{ display: 'flex', pointerEvents: 'auto' }}>
+        <WinTitleButton title={t('windowChrome.minimize')} action="minimize">
           <svg width="10" height="10" viewBox="0 0 10 10"><path d="M0 5h10" stroke="currentColor" strokeWidth="1" /></svg>
-        </button>
-        <button style={winBtnStyle} title={t('windowChrome.maximize')} onClick={() => runWindowsWindowAction('toggleMaximize')}>
+        </WinTitleButton>
+        <WinTitleButton title={t('windowChrome.maximize')} action="toggleMaximize">
           <svg width="10" height="10" viewBox="0 0 10 10"><rect x="0.5" y="0.5" width="9" height="9" stroke="currentColor" strokeWidth="1" fill="none" /></svg>
-        </button>
-        <button style={winCloseBtnStyle} title={t('windowChrome.close')} onClick={() => runWindowsWindowAction('close')}>
+        </WinTitleButton>
+        <WinTitleButton title={t('windowChrome.close')} action="close" tone="danger">
           <svg width="10" height="10" viewBox="0 0 10 10"><path d="M0 0L10 10M10 0L0 10" stroke="currentColor" strokeWidth="1" /></svg>
-        </button>
+        </WinTitleButton>
       </div>
     </div>
   );
 }
 
+function WindowsResizeHandles() {
+  const handles: Array<{
+    direction: ResizeDirection;
+    cursor: CSSProperties['cursor'];
+    style: CSSProperties;
+  }> = [
+    { direction: 'North', cursor: 'ns-resize', style: { top: 0, left: WIN_RESIZE_CORNER, right: WIN_RESIZE_CORNER, height: WIN_RESIZE_EDGE } },
+    { direction: 'South', cursor: 'ns-resize', style: { bottom: 0, left: WIN_RESIZE_CORNER, right: WIN_RESIZE_CORNER, height: WIN_RESIZE_EDGE } },
+    { direction: 'West', cursor: 'ew-resize', style: { top: WIN_RESIZE_CORNER, bottom: WIN_RESIZE_CORNER, left: 0, width: WIN_RESIZE_EDGE } },
+    { direction: 'East', cursor: 'ew-resize', style: { top: WIN_RESIZE_CORNER, bottom: WIN_RESIZE_CORNER, right: 0, width: WIN_RESIZE_EDGE } },
+    { direction: 'NorthWest', cursor: 'nwse-resize', style: { top: 0, left: 0, width: WIN_RESIZE_CORNER, height: WIN_RESIZE_CORNER } },
+    { direction: 'NorthEast', cursor: 'nesw-resize', style: { top: 0, right: 0, width: WIN_RESIZE_CORNER, height: WIN_RESIZE_CORNER } },
+    { direction: 'SouthWest', cursor: 'nesw-resize', style: { bottom: 0, left: 0, width: WIN_RESIZE_CORNER, height: WIN_RESIZE_CORNER } },
+    { direction: 'SouthEast', cursor: 'nwse-resize', style: { bottom: 0, right: 0, width: WIN_RESIZE_CORNER, height: WIN_RESIZE_CORNER } },
+  ];
+
+  return (
+    <div aria-hidden style={{ position: 'absolute', inset: 0, pointerEvents: 'none', zIndex: 60 }}>
+      {handles.map(handle => (
+        <div
+          key={handle.direction}
+          onMouseDown={event => {
+            if (event.button !== 0) return;
+            event.preventDefault();
+            event.stopPropagation();
+            void startWindowsResize(handle.direction);
+          }}
+          style={{
+            position: 'absolute',
+            pointerEvents: 'auto',
+            cursor: handle.cursor,
+            ...handle.style,
+          }}
+        />
+      ))}
+    </div>
+  );
+}
+
+interface WinTitleButtonProps {
+  title: string;
+  action: 'minimize' | 'toggleMaximize' | 'close';
+  children: ReactNode;
+  tone?: 'default' | 'danger';
+}
+
+function WinTitleButton({ title, action, children, tone = 'default' }: WinTitleButtonProps) {
+  const [hovered, setHovered] = useState(false);
+  const [pressed, setPressed] = useState(false);
+  const danger = tone === 'danger';
+  const background = pressed
+    ? danger ? '#c42b1c' : 'rgba(0,0,0,0.12)'
+    : hovered ? danger ? '#e81123' : 'rgba(0,0,0,0.08)'
+      : 'transparent';
+  const color = danger && (hovered || pressed) ? '#fff' : 'var(--ol-ink-3)';
+
+  return (
+    <button
+      style={{ ...winBtnStyle, background, color }}
+      title={title}
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => {
+        setHovered(false);
+        setPressed(false);
+      }}
+      onMouseDown={() => setPressed(true)}
+      onMouseUp={() => setPressed(false)}
+      onClick={() => runWindowsWindowAction(action)}
+    >
+      {children}
+    </button>
+  );
+}
+
+async function startWindowsResize(direction: ResizeDirection) {
+  try {
+    await getCurrentWindow().startResizeDragging(direction);
+  } catch (error) {
+    console.warn(`[window] Windows resize ${direction} failed`, error);
+  }
+}
+
 async function runWindowsWindowAction(action: 'minimize' | 'toggleMaximize' | 'close') {
   try {
-    const { getCurrentWindow } = await import('@tauri-apps/api/window');
     const currentWindow = getCurrentWindow();
     if (action === 'minimize') {
       await currentWindow.minimize();
@@ -151,9 +246,4 @@ const winBtnStyle: CSSProperties = {
   color: 'var(--ol-ink-3)',
   cursor: 'default',
   transition: 'background 0.12s ease-out, color 0.12s ease-out',
-};
-
-const winCloseBtnStyle: CSSProperties = {
-  ...winBtnStyle,
-  color: 'var(--ol-ink-3)',
 };

--- a/openless-all/app/src/components/WindowChrome.tsx
+++ b/openless-all/app/src/components/WindowChrome.tsx
@@ -1,16 +1,3 @@
-// WindowChrome.tsx — frosted outer frame + raised inner console pattern.
-// The OUTER frame is a translucent shell with a tinted backdrop showing through.
-// The INNER content lives in a single raised card that floats above it.
-//
-// Layout per window:
-//   ┌─ frosted outer ───────────────────────────────┐
-//   │ [titlebar]                                    │
-//   │     ┌─ raised console (white, shadow) ─┐      │
-//   │     │  sidebar │ main                  │      │
-//   │     └──────────────────────────────────┘      │
-//   │ [icon footer]                                 │
-//   └───────────────────────────────────────────────┘
-
 import { useState, type CSSProperties, type ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
 import { getCurrentWindow } from '@tauri-apps/api/window';
@@ -31,8 +18,9 @@ export function detectOS(): OS {
 
 const MAC_TITLEBAR_HEIGHT = 36;
 const MAC_SYSTEM_CONTROLS_RESERVED_WIDTH = 80;
-const MAC_WINDOW_RADIUS = 20;
-const WIN_WINDOW_RADIUS = 0;
+export const WIN_TITLEBAR_HEIGHT = 36;
+export const WIN_WINDOW_RADIUS = 10;
+export const WIN_CONSOLE_RADIUS = 10;
 const WIN_RESIZE_EDGE = 6;
 const WIN_RESIZE_CORNER = 14;
 
@@ -53,19 +41,32 @@ interface WindowChromeProps {
   height?: number | string;
 }
 
-export function WindowChrome({ os = 'mac', title = 'OpenLess', children, height = 800 }: WindowChromeProps) {
+export function WindowChrome({
+  os = 'mac',
+  title = 'OpenLess',
+  children,
+  height = 800,
+}: WindowChromeProps) {
+  const shellRadius = os === 'mac' ? 20 : os === 'win' ? WIN_WINDOW_RADIUS : 14;
+  const consoleRadius = os === 'mac' ? 20 : os === 'win' ? WIN_CONSOLE_RADIUS : 14;
+
   return (
     <div
       style={{
+        '--ol-window-shell-radius': `${shellRadius}px`,
+        '--ol-window-console-radius': `${consoleRadius}px`,
+        '--ol-window-titlebar-height': `${os === 'mac' ? MAC_TITLEBAR_HEIGHT : WIN_TITLEBAR_HEIGHT}px`,
         width: '100%',
         height,
         position: 'relative',
-        borderRadius: os === 'mac' ? MAC_WINDOW_RADIUS : WIN_WINDOW_RADIUS,
-        boxShadow: 'var(--ol-shadow-xl)',
+        borderRadius: 'var(--ol-window-shell-radius)',
+        boxShadow: os === 'win'
+          ? '0 22px 54px -28px rgba(15, 17, 22, 0.38), 0 10px 30px -20px rgba(15, 17, 22, 0.22), 0 0 0 0.5px rgba(0, 0, 0, 0.10)'
+          : 'var(--ol-shadow-xl)',
         overflow: 'hidden',
         display: 'flex',
         flexDirection: 'column',
-        border: '0.5px solid rgba(0,0,0,.10)',
+        border: os === 'win' ? '1px solid rgba(255,255,255,0.18)' : '0.5px solid rgba(0,0,0,.10)',
         background: `
           radial-gradient(120% 80% at 0% 0%, rgba(255,255,255,0.7) 0%, rgba(255,255,255,0) 60%),
           radial-gradient(100% 70% at 100% 100%, rgba(37,99,235,0.07) 0%, rgba(37,99,235,0) 55%),
@@ -73,12 +74,10 @@ export function WindowChrome({ os = 'mac', title = 'OpenLess', children, height 
         `,
         backdropFilter: 'blur(40px) saturate(180%)',
         WebkitBackdropFilter: 'blur(40px) saturate(180%)',
-      }}
+      } as CSSProperties}
     >
       {os === 'win' && <WinTitleBar title={title} />}
       {os === 'win' && <WindowsResizeHandles />}
-      {/* macOS：三色窗口按钮交给系统绘制和定位。这里只保留顶部拖动区，
-          并避开系统按钮热区，防止拖动层吞掉 close/minimize/zoom 点击。 */}
       {os === 'mac' && (
         <div
           data-tauri-drag-region
@@ -108,12 +107,14 @@ function WinTitleBar({ title }: WinTitleBarProps) {
   return (
     <div
       style={{
-        height: 36,
+        height: WIN_TITLEBAR_HEIGHT,
         flexShrink: 0,
         display: 'flex',
         alignItems: 'stretch',
         position: 'relative',
         zIndex: 70,
+        borderBottom: '0.5px solid rgba(0, 0, 0, 0.08)',
+        background: 'linear-gradient(180deg, rgba(255,255,255,0.20) 0%, rgba(255,255,255,0.08) 100%)',
       }}
     >
       <div
@@ -163,7 +164,7 @@ function WindowsResizeHandles() {
             if (event.button !== 0) return;
             event.preventDefault();
             event.stopPropagation();
-            void startWindowsResize(handle.direction);
+            void startResizeDragging(handle.direction);
           }}
           style={{
             position: 'absolute',
@@ -180,17 +181,17 @@ function WindowsResizeHandles() {
 interface WinTitleButtonProps {
   title: string;
   action: 'minimize' | 'toggleMaximize' | 'close';
-  children: ReactNode;
   tone?: 'default' | 'danger';
+  children: ReactNode;
 }
 
-function WinTitleButton({ title, action, children, tone = 'default' }: WinTitleButtonProps) {
+function WinTitleButton({ title, action, tone = 'default', children }: WinTitleButtonProps) {
   const [hovered, setHovered] = useState(false);
   const [pressed, setPressed] = useState(false);
   const danger = tone === 'danger';
   const background = pressed
-    ? danger ? '#c42b1c' : 'rgba(0,0,0,0.12)'
-    : hovered ? danger ? '#e81123' : 'rgba(0,0,0,0.08)'
+    ? danger ? '#c42b1c' : 'rgba(0, 0, 0, 0.12)'
+    : hovered ? danger ? '#e81123' : 'rgba(0, 0, 0, 0.08)'
       : 'transparent';
   const color = danger && (hovered || pressed) ? '#fff' : 'var(--ol-ink-3)';
 
@@ -198,6 +199,7 @@ function WinTitleButton({ title, action, children, tone = 'default' }: WinTitleB
     <button
       style={{ ...winBtnStyle, background, color }}
       title={title}
+      onClick={() => runWindowsWindowAction(action)}
       onMouseEnter={() => setHovered(true)}
       onMouseLeave={() => {
         setHovered(false);
@@ -205,14 +207,13 @@ function WinTitleButton({ title, action, children, tone = 'default' }: WinTitleB
       }}
       onMouseDown={() => setPressed(true)}
       onMouseUp={() => setPressed(false)}
-      onClick={() => runWindowsWindowAction(action)}
     >
       {children}
     </button>
   );
 }
 
-async function startWindowsResize(direction: ResizeDirection) {
+async function startResizeDragging(direction: ResizeDirection) {
   try {
     await getCurrentWindow().startResizeDragging(direction);
   } catch (error) {

--- a/openless-all/app/src/components/WindowChrome.tsx
+++ b/openless-all/app/src/components/WindowChrome.tsx
@@ -30,6 +30,8 @@ export function detectOS(): OS {
 
 const MAC_TITLEBAR_HEIGHT = 36;
 const MAC_SYSTEM_CONTROLS_RESERVED_WIDTH = 80;
+const MAC_WINDOW_RADIUS = 20;
+const WIN_WINDOW_RADIUS = 0;
 
 interface WindowChromeProps {
   os?: OS;
@@ -45,7 +47,7 @@ export function WindowChrome({ os = 'mac', title = 'OpenLess', children, height 
         width: '100%',
         height,
         position: 'relative',
-        borderRadius: os === 'mac' ? 20 : 14,
+        borderRadius: os === 'mac' ? MAC_WINDOW_RADIUS : WIN_WINDOW_RADIUS,
         boxShadow: 'var(--ol-shadow-xl)',
         overflow: 'hidden',
         display: 'flex',

--- a/openless-all/app/src/styles/global.css
+++ b/openless-all/app/src/styles/global.css
@@ -3,17 +3,19 @@ html, body, #root {
   width: 100%;
   margin: 0;
   padding: 0;
+  background: transparent;
+  overflow: hidden;
 }
 
 body {
   background: transparent;
   user-select: none;
   -webkit-user-select: none;
-  overflow: hidden;
 }
 
 #root {
   display: flex;
+  isolation: isolate;
 }
 
 button {


### PR DESCRIPTION
## 治理归属

- 族群：A 族群 / 窗口外观契约
- canonical issue：#127
- 主修范围：主窗口圆角、外框、titlebar、shadow、首帧 shell 贴合
- 不默认并入：capsule geometry、helper-window 生命周期、QA helper-window 语义、双热键事件源
- 参考：
  - `docs/windows-window-governance-board.zh-CN.md`
  - `docs/2026-05-02-window-capability-family-audit.md`
  - `docs/github-tracking/windows-window-family-canonical-map.md`

## 摘要

Closes #127

这条 PR 承接 Windows 主窗口 shell 外观契约修复。
本轮重点是把：

- frameless shell
- custom titlebar
- outer shell radius / inner console radius
- Windows resize affordance

收敛成同一条主窗口外观线，不再和 capsule geometry、helper-window lifecycle 混修。

## 修复 / 新增 / 改进

- 收紧 `WindowChrome.tsx` 的 Windows shell / titlebar / button / resize handle 契约
- 让 `FloatingShell.tsx` 消费 shared console radius，而不是单独硬编码 Windows 半径
- 将 `tauri.conf.json` 的 main window 收口到 frameless create
- 扩充 `windows-ui-config.test.mjs`，锁住主窗口外观契约

## 兼容

- 不包含：Capsule geometry / clipping / distortion
- 不包含：helper-window lifecycle ownership
- 不包含：startup visible / ready ownership
- 对现有用户 / 本地环境 / 构建流程的影响：只聚焦 Windows main shell 外观线

## 测试计划

- [x] `node openless-all/app/scripts/windows-ui-config.test.mjs`
- [x] `npm run build`
- [x] `cargo check --manifest-path openless-all/app/src-tauri/Cargo.toml`
- [x] `powershell -ExecutionPolicy Bypass -File openless-all/app/scripts/windows-build-gnu.ps1`
- [x] `powershell -ExecutionPolicy Bypass -File openless-all/app/scripts/windows-open-dev.ps1 -ExePath <GNU dev exe>`
- [ ] Windows 100% / 125% DPI 人工视觉回归

## 说明

- 这是对已关闭 PR #125 的后续承接入口，用于继续推进回归评审。
- 自动 smoke 已通过；剩余重点是人工 Windows 视觉贴合回归。