### PR TITLE
fix(llm): 允许无密钥 LLM 配置

### DIFF
--- a/openless-all/app/src-tauri/src/commands.rs
+++ b/openless-all/app/src-tauri/src/commands.rs
@@ -225,18 +225,17 @@ async fn fetch_provider_models(config: &ProviderConfig) -> Result<Vec<String>, S
         .timeout(Duration::from_secs(15))
         .build()
         .map_err(|e| format!("HTTP client 初始化失败: {e}"))?;
-    let response = client
-        .get(&url)
-        .header("Authorization", format!("Bearer {}", config.api_key))
-        .send()
-        .await
-        .map_err(|e| {
-            if e.is_timeout() {
-                "请求超时".to_string()
-            } else {
-                format!("网络错误: {e}")
-            }
-        })?;
+    let mut request = client.get(&url);
+    if !config.api_key.trim().is_empty() {
+        request = request.header("Authorization", format!("Bearer {}", config.api_key));
+    }
+    let response = request.send().await.map_err(|e| {
+        if e.is_timeout() {
+            "请求超时".to_string()
+        } else {
+            format!("网络错误: {e}")
+        }
+    })?;
     let status = response.status();
     let body = response
         .text()
@@ -558,11 +557,17 @@ fn _ensure_snapshot_used(_: CredentialsSnapshot) {}
 
 #[cfg(test)]
 mod tests {
-    use super::{models_url, parse_model_ids, persist_settings, SettingsWriter};
+    use super::{
+        fetch_provider_models, models_url, parse_model_ids, persist_settings, ProviderConfig,
+        SettingsWriter,
+    };
     use crate::types::{
         HotkeyBinding, HotkeyMode, HotkeyTrigger, QaHotkeyBinding, UserPreferences,
     };
+    use std::io::{Read, Write};
+    use std::net::TcpListener;
     use std::sync::Mutex;
+    use std::thread;
 
     #[derive(Default)]
     struct FakeSettingsWriter {
@@ -637,5 +642,47 @@ mod tests {
         );
         assert_eq!(*writer.dictation_refreshes.lock().unwrap(), 1);
         assert_eq!(*writer.qa_refreshes.lock().unwrap(), 1);
+    }
+
+    #[tokio::test]
+    async fn fetch_provider_models_omits_authorization_when_api_key_is_empty() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        let server = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut buf = [0u8; 8192];
+            let mut request = Vec::new();
+            loop {
+                let n = stream.read(&mut buf).unwrap();
+                if n == 0 {
+                    break;
+                }
+                request.extend_from_slice(&buf[..n]);
+                if request.windows(4).any(|w| w == b"\r\n\r\n") {
+                    break;
+                }
+            }
+            let request_text = String::from_utf8_lossy(&request);
+            assert!(!request_text.contains("Authorization: Bearer"));
+
+            let body = r#"{"data":[{"id":"m1"},{"id":"m2"}]}"#;
+            let response = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                body.len(),
+                body
+            );
+            stream.write_all(response.as_bytes()).unwrap();
+        });
+
+        let models = fetch_provider_models(&ProviderConfig {
+            base_url: format!("http://{}", addr),
+            api_key: String::new(),
+        })
+        .await
+        .unwrap();
+
+        assert_eq!(models, vec!["m1".to_string(), "m2".to_string()]);
+        server.join().unwrap();
     }
 }

--- a/openless-all/app/src-tauri/src/commands.rs
+++ b/openless-all/app/src-tauri/src/commands.rs
@@ -165,9 +165,17 @@ struct ProviderConfig {
 }
 
 fn read_openai_provider_config(kind: &str) -> Result<ProviderConfig, String> {
-    let (api_key_account, endpoint_account) = match kind {
-        "llm" => (CredentialAccount::ArkApiKey, CredentialAccount::ArkEndpoint),
-        "asr" => (CredentialAccount::AsrApiKey, CredentialAccount::AsrEndpoint),
+    let (api_key_account, endpoint_account, api_key_required) = match kind {
+        "llm" => (
+            CredentialAccount::ArkApiKey,
+            CredentialAccount::ArkEndpoint,
+            false,
+        ),
+        "asr" => (
+            CredentialAccount::AsrApiKey,
+            CredentialAccount::AsrEndpoint,
+            true,
+        ),
         _ => return Err(format!("unknown provider kind: {kind}")),
     };
     let api_key = CredentialsVault::get(api_key_account)
@@ -176,7 +184,7 @@ fn read_openai_provider_config(kind: &str) -> Result<ProviderConfig, String> {
     let base_url = CredentialsVault::get(endpoint_account)
         .map_err(|e| e.to_string())?
         .unwrap_or_default();
-    if api_key.trim().is_empty() {
+    if api_key_required && api_key.trim().is_empty() {
         return Err("API Key 为空".to_string());
     }
     if base_url.trim().is_empty() {

--- a/openless-all/app/src-tauri/src/coordinator.rs
+++ b/openless-all/app/src-tauri/src/coordinator.rs
@@ -1588,7 +1588,7 @@ async fn polish_text(
     working_languages: &[String],
     front_app: Option<&str>,
 ) -> anyhow::Result<String> {
-    let api_key = CredentialsVault::get(CredentialAccount::ArkApiKey)?.unwrap_or_default();
+    let api_key = require_ark_api_key()?;
     let model = CredentialsVault::get(CredentialAccount::ArkModelId)?
         .filter(|s| !s.is_empty())
         .unwrap_or_else(|| "deepseek-v3-2".to_string());
@@ -1630,7 +1630,7 @@ async fn translate_text(
     working_languages: &[String],
     front_app: Option<&str>,
 ) -> anyhow::Result<String> {
-    let api_key = CredentialsVault::get(CredentialAccount::ArkApiKey)?.unwrap_or_default();
+    let api_key = require_ark_api_key()?;
     let model = CredentialsVault::get(CredentialAccount::ArkModelId)?
         .filter(|s| !s.is_empty())
         .unwrap_or_else(|| "deepseek-v3-2".to_string());
@@ -2147,7 +2147,7 @@ where
     F: Fn(&str) + Send + Sync,
     C: Fn() -> bool + Send + Sync,
 {
-    let api_key = CredentialsVault::get(CredentialAccount::ArkApiKey)?.unwrap_or_default();
+    let api_key = require_ark_api_key()?;
     let model = CredentialsVault::get(CredentialAccount::ArkModelId)?
         .filter(|s| !s.is_empty())
         .unwrap_or_else(|| "deepseek-v3-2".to_string());
@@ -2169,6 +2169,19 @@ where
             should_cancel,
         )
         .await?)
+}
+
+fn require_ark_api_key() -> anyhow::Result<String> {
+    let api_key = CredentialsVault::get(CredentialAccount::ArkApiKey)?.unwrap_or_default();
+    validate_ark_api_key(&api_key)?;
+    Ok(api_key)
+}
+
+fn validate_ark_api_key(api_key: &str) -> anyhow::Result<()> {
+    if api_key.trim().is_empty() {
+        anyhow::bail!("API Key 为空");
+    }
+    Ok(())
 }
 
 #[cfg(test)]
@@ -2221,6 +2234,14 @@ mod tests {
             "AltLeft"
         ));
         assert!(!window_key_matches_trigger(HotkeyTrigger::Fn, "Fn", "Fn"));
+    }
+
+    #[test]
+    fn require_ark_api_key_rejects_blank_key() {
+        assert_eq!(
+            validate_ark_api_key("").unwrap_err().to_string(),
+            "API Key 为空"
+        );
     }
 
     #[test]

--- a/openless-all/app/src-tauri/src/coordinator.rs
+++ b/openless-all/app/src-tauri/src/coordinator.rs
@@ -1589,9 +1589,6 @@ async fn polish_text(
     front_app: Option<&str>,
 ) -> anyhow::Result<String> {
     let api_key = CredentialsVault::get(CredentialAccount::ArkApiKey)?.unwrap_or_default();
-    if api_key.is_empty() {
-        anyhow::bail!("ark api key missing");
-    }
     let model = CredentialsVault::get(CredentialAccount::ArkModelId)?
         .filter(|s| !s.is_empty())
         .unwrap_or_else(|| "deepseek-v3-2".to_string());
@@ -1634,9 +1631,6 @@ async fn translate_text(
     front_app: Option<&str>,
 ) -> anyhow::Result<String> {
     let api_key = CredentialsVault::get(CredentialAccount::ArkApiKey)?.unwrap_or_default();
-    if api_key.is_empty() {
-        anyhow::bail!("ark api key missing");
-    }
     let model = CredentialsVault::get(CredentialAccount::ArkModelId)?
         .filter(|s| !s.is_empty())
         .unwrap_or_else(|| "deepseek-v3-2".to_string());
@@ -2154,9 +2148,6 @@ where
     C: Fn() -> bool + Send + Sync,
 {
     let api_key = CredentialsVault::get(CredentialAccount::ArkApiKey)?.unwrap_or_default();
-    if api_key.is_empty() {
-        anyhow::bail!("ark api key missing");
-    }
     let model = CredentialsVault::get(CredentialAccount::ArkModelId)?
         .filter(|s| !s.is_empty())
         .unwrap_or_else(|| "deepseek-v3-2".to_string());
@@ -2170,7 +2161,13 @@ where
     let config = OpenAICompatibleConfig::new("ark", "Doubao Ark", base_url, api_key, model);
     let provider = OpenAICompatibleLLMProvider::new(config);
     Ok(provider
-        .answer_chat_streaming(messages, working_languages, front_app, on_delta, should_cancel)
+        .answer_chat_streaming(
+            messages,
+            working_languages,
+            front_app,
+            on_delta,
+            should_cancel,
+        )
         .await?)
 }
 

--- a/openless-all/app/src-tauri/src/coordinator.rs
+++ b/openless-all/app/src-tauri/src/coordinator.rs
@@ -1588,13 +1588,11 @@ async fn polish_text(
     working_languages: &[String],
     front_app: Option<&str>,
 ) -> anyhow::Result<String> {
-    let api_key = require_ark_api_key()?;
+    let api_key = CredentialsVault::get(CredentialAccount::ArkApiKey)?.unwrap_or_default();
     let model = CredentialsVault::get(CredentialAccount::ArkModelId)?
         .filter(|s| !s.is_empty())
         .unwrap_or_else(|| "deepseek-v3-2".to_string());
-    let endpoint = CredentialsVault::get(CredentialAccount::ArkEndpoint)?
-        .filter(|s| !s.is_empty())
-        .unwrap_or_else(|| "https://ark.cn-beijing.volces.com/api/v3/chat/completions".to_string());
+    let endpoint = resolve_ark_endpoint(&api_key)?;
     let base_url = endpoint
         .trim_end_matches("/chat/completions")
         .trim_end_matches('/')
@@ -1630,13 +1628,11 @@ async fn translate_text(
     working_languages: &[String],
     front_app: Option<&str>,
 ) -> anyhow::Result<String> {
-    let api_key = require_ark_api_key()?;
+    let api_key = CredentialsVault::get(CredentialAccount::ArkApiKey)?.unwrap_or_default();
     let model = CredentialsVault::get(CredentialAccount::ArkModelId)?
         .filter(|s| !s.is_empty())
         .unwrap_or_else(|| "deepseek-v3-2".to_string());
-    let endpoint = CredentialsVault::get(CredentialAccount::ArkEndpoint)?
-        .filter(|s| !s.is_empty())
-        .unwrap_or_else(|| "https://ark.cn-beijing.volces.com/api/v3/chat/completions".to_string());
+    let endpoint = resolve_ark_endpoint(&api_key)?;
     let base_url = endpoint
         .trim_end_matches("/chat/completions")
         .trim_end_matches('/')
@@ -2147,13 +2143,11 @@ where
     F: Fn(&str) + Send + Sync,
     C: Fn() -> bool + Send + Sync,
 {
-    let api_key = require_ark_api_key()?;
+    let api_key = CredentialsVault::get(CredentialAccount::ArkApiKey)?.unwrap_or_default();
     let model = CredentialsVault::get(CredentialAccount::ArkModelId)?
         .filter(|s| !s.is_empty())
         .unwrap_or_else(|| "deepseek-v3-2".to_string());
-    let endpoint = CredentialsVault::get(CredentialAccount::ArkEndpoint)?
-        .filter(|s| !s.is_empty())
-        .unwrap_or_else(|| "https://ark.cn-beijing.volces.com/api/v3/chat/completions".to_string());
+    let endpoint = resolve_ark_endpoint(&api_key)?;
     let base_url = endpoint
         .trim_end_matches("/chat/completions")
         .trim_end_matches('/')
@@ -2171,17 +2165,20 @@ where
         .await?)
 }
 
-fn require_ark_api_key() -> anyhow::Result<String> {
-    let api_key = CredentialsVault::get(CredentialAccount::ArkApiKey)?.unwrap_or_default();
-    validate_ark_api_key(&api_key)?;
-    Ok(api_key)
+fn resolve_ark_endpoint(api_key: &str) -> anyhow::Result<String> {
+    let endpoint = CredentialsVault::get(CredentialAccount::ArkEndpoint)?.filter(|s| !s.is_empty());
+    resolve_ark_endpoint_with_policy(api_key, endpoint)
 }
 
-fn validate_ark_api_key(api_key: &str) -> anyhow::Result<()> {
-    if api_key.trim().is_empty() {
+fn resolve_ark_endpoint_with_policy(
+    api_key: &str,
+    endpoint: Option<String>,
+) -> anyhow::Result<String> {
+    if api_key.trim().is_empty() && endpoint.is_none() {
         anyhow::bail!("API Key 为空");
     }
-    Ok(())
+    Ok(endpoint
+        .unwrap_or_else(|| "https://ark.cn-beijing.volces.com/api/v3/chat/completions".to_string()))
 }
 
 #[cfg(test)]
@@ -2237,11 +2234,23 @@ mod tests {
     }
 
     #[test]
-    fn require_ark_api_key_rejects_blank_key() {
+    fn resolve_ark_endpoint_rejects_blank_key_without_custom_endpoint() {
         assert_eq!(
-            validate_ark_api_key("").unwrap_err().to_string(),
+            resolve_ark_endpoint_with_policy("", None)
+                .unwrap_err()
+                .to_string(),
             "API Key 为空"
         );
+    }
+
+    #[test]
+    fn resolve_ark_endpoint_allows_blank_key_with_custom_endpoint() {
+        let endpoint = resolve_ark_endpoint_with_policy(
+            "",
+            Some("https://example.com/v1/chat/completions".to_string()),
+        )
+        .unwrap();
+        assert_eq!(endpoint, "https://example.com/v1/chat/completions");
     }
 
     #[test]

--- a/openless-all/app/src-tauri/src/polish.rs
+++ b/openless-all/app/src-tauri/src/polish.rs
@@ -146,10 +146,6 @@ impl OpenAICompatibleLLMProvider {
         system_prompt: &str,
         user_prompt: &str,
     ) -> Result<String, LLMError> {
-        if self.config.api_key.trim().is_empty() {
-            return Err(LLMError::MissingCredentials);
-        }
-
         let url = chat_completions_url(&self.config.base_url);
         let body = json!({
             "model": self.config.model,
@@ -171,8 +167,10 @@ impl OpenAICompatibleLLMProvider {
         let mut request = self
             .client
             .post(&url)
-            .header("Content-Type", "application/json")
-            .header("Authorization", format!("Bearer {}", self.config.api_key));
+            .header("Content-Type", "application/json");
+        if !self.config.api_key.trim().is_empty() {
+            request = request.header("Authorization", format!("Bearer {}", self.config.api_key));
+        }
         for (k, v) in &self.config.extra_headers {
             request = request.header(k.as_str(), v.as_str());
         }
@@ -222,10 +220,6 @@ impl OpenAICompatibleLLMProvider {
         F: Fn(&str) + Send + Sync,
         C: Fn() -> bool + Send + Sync,
     {
-        if self.config.api_key.trim().is_empty() {
-            return Err(LLMError::MissingCredentials);
-        }
-
         let mut msgs: Vec<Value> = Vec::with_capacity(history.len() + 1);
         msgs.push(json!({ "role": "system", "content": system_prompt }));
         for m in history {
@@ -252,8 +246,10 @@ impl OpenAICompatibleLLMProvider {
             .client
             .post(&url)
             .header("Content-Type", "application/json")
-            .header("Accept", "text/event-stream")
-            .header("Authorization", format!("Bearer {}", self.config.api_key));
+            .header("Accept", "text/event-stream");
+        if !self.config.api_key.trim().is_empty() {
+            request = request.header("Authorization", format!("Bearer {}", self.config.api_key));
+        }
         for (k, v) in &self.config.extra_headers {
             request = request.header(k.as_str(), v.as_str());
         }
@@ -310,7 +306,10 @@ impl OpenAICompatibleLLMProvider {
                 let event = buffer[..idx].to_string();
                 buffer.drain(..idx + 2);
                 for line in event.lines() {
-                    let Some(payload) = line.strip_prefix("data: ").or_else(|| line.strip_prefix("data:")) else {
+                    let Some(payload) = line
+                        .strip_prefix("data: ")
+                        .or_else(|| line.strip_prefix("data:"))
+                    else {
                         continue;
                     };
                     let payload = payload.trim();
@@ -320,7 +319,10 @@ impl OpenAICompatibleLLMProvider {
                     let v: Value = match serde_json::from_str(payload) {
                         Ok(v) => v,
                         Err(e) => {
-                            log::warn!("[llm] SSE parse skip: {e}; payload preview: {}", safe_str_slice(payload, 80));
+                            log::warn!(
+                                "[llm] SSE parse skip: {e}; payload preview: {}",
+                                safe_str_slice(payload, 80)
+                            );
                             continue;
                         }
                     };
@@ -382,9 +384,7 @@ fn context_premise(working_languages: &[String], front_app: Option<&str>) -> Opt
         .map(|s| s.trim())
         .filter(|s| !s.is_empty())
         .collect();
-    let app = front_app
-        .map(str::trim)
-        .filter(|s| !s.is_empty());
+    let app = front_app.map(str::trim).filter(|s| !s.is_empty());
 
     if langs.is_empty() && app.is_none() {
         return None;
@@ -832,6 +832,9 @@ pub mod prompts {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::io::{Read, Write};
+    use std::net::TcpListener;
+    use std::thread;
 
     #[test]
     fn clean_polish_output_strips_think_tag_block() {
@@ -900,11 +903,60 @@ mod tests {
 
     #[test]
     fn compose_system_prompt_prefers_correct_spelling_for_hotwords() {
-        let prompt = compose_system_prompt(PolishMode::Light, &["GitHub".into(), "OpenLess".into()]);
+        let prompt =
+            compose_system_prompt(PolishMode::Light, &["GitHub".into(), "OpenLess".into()]);
 
         assert!(prompt.contains("用户希望以下写法在输出中保持准确"));
         assert!(prompt.contains("同音 / 近形误识别时，优先按上述写法输出"));
         assert!(prompt.contains("- GitHub"));
         assert!(prompt.contains("- OpenLess"));
+    }
+
+    #[tokio::test]
+    async fn chat_completion_omits_authorization_when_api_key_is_empty() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        let server = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut buf = [0u8; 8192];
+            let mut request = Vec::new();
+            loop {
+                let n = stream.read(&mut buf).unwrap();
+                if n == 0 {
+                    break;
+                }
+                request.extend_from_slice(&buf[..n]);
+                if request.windows(4).any(|w| w == b"\r\n\r\n") {
+                    break;
+                }
+            }
+            let request_text = String::from_utf8_lossy(&request);
+            assert!(!request_text.contains("Authorization: Bearer"));
+
+            let body = r#"{"choices":[{"message":{"content":"最终文本。"}}]}"#;
+            let response = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                body.len(),
+                body
+            );
+            stream.write_all(response.as_bytes()).unwrap();
+        });
+
+        let provider = OpenAICompatibleLLMProvider::new(OpenAICompatibleConfig::new(
+            "ark",
+            "Doubao Ark",
+            format!("http://{}", addr),
+            "",
+            "deepseek-v3-2",
+        ));
+
+        let output = provider
+            .polish("原文", PolishMode::Raw, &[], &[], None)
+            .await
+            .unwrap();
+        assert_eq!(output, "最终文本。");
+
+        server.join().unwrap();
     }
 }


### PR DESCRIPTION
### **User description**
## 摘要

Fixes #192。

本 PR 修复 LLM 配置时 API Key 被强制要求的问题。

部分本地或自托管 OpenAI-compatible LLM endpoint 不需要 API Key，例如本地 11443 类服务或内网代理服务。此前 LLM 验证和运行时 polish 路径会把空 API Key 直接视为凭据缺失，导致这类 endpoint 即使本身可用，也会在客户端被提前判定为配置错误。

本次改动允许 OpenAI-compatible LLM 在 API Key 为空时继续验证和运行。API Key 为空时不会发送 `Authorization` header；API Key 非空时继续发送 `Authorization: Bearer ...`。ASR 路径仍保持 API Key 必填，避免把 LLM 的无密钥兼容逻辑扩散到语音识别服务。

## 修复 / 新增 / 改进

- LLM provider 配置读取时不再强制要求 API Key。

- ASR provider 配置读取仍保持 API Key 必填。

- LLM polish 非流式请求中：
  - API Key 为空时不发送 `Authorization` header
  - API Key 非空时继续发送 `Authorization: Bearer ...`

- LLM streaming 请求中：
  - API Key 为空时不发送 `Authorization` header
  - API Key 非空时继续发送 `Authorization: Bearer ...`

- coordinator 运行时 polish / translate / chat 路径不再因为 LLM API Key 为空提前失败。

- 设置页 LLM 验证可以覆盖无密钥 OpenAI-compatible endpoint。

- 保持现有 HTTP status 错误映射不变。

- 新增测试覆盖：
  - API Key 为空时，chat completion 请求不会包含 `Authorization: Bearer`
  - 无密钥请求成功时仍能返回最终文本

## 兼容

- 不包含：
  - 不放宽 ASR API Key 要求。
  - 不改变凭据存储格式。
  - 不改变 provider 配置结构。
  - 不改变已有带 API Key endpoint 的请求行为。
  - 不修改 HTTP status 错误映射。
  - 不引入新依赖。
  - 不在日志或 UI 中打印明文 API Key。

- 对现有用户 / 本地环境 / 构建流程的影响：
  - 使用云端 OpenAI-compatible LLM 且已配置 API Key 的用户无行为变化。
  - 使用本地或自托管无密钥 LLM endpoint 的用户，可以在 API Key 留空时完成验证和 polish 调用。
  - ASR 仍要求 API Key。
  - 构建流程无变化。

## 测试计划

- [x] 命令：`npm run build`
- [x] 结果：通过
- [x] 证据路径：本地构建输出

- [x] 命令：`cargo test --lib`
- [x] 结果：通过
- [x] 证据路径：本地测试输出

- [ ] 真实无密钥 OpenAI-compatible endpoint 联调
- [ ] 说明：未在测试 harness 之外使用真实 keyless endpoint 验证 live 行为。

## 主要改动文件

- `openless-all/app/src-tauri/src/commands.rs`
- `openless-all/app/src-tauri/src/coordinator.rs`
- `openless-all/app/src-tauri/src/polish.rs`

## 备注

本 PR 只允许 OpenAI-compatible LLM 路径接受空 API Key。空 Key 时不会伪造 `Authorization` header；非空 Key 时仍沿用现有 Bearer 鉴权行为。ASR 仍保持密钥必填。


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Allow empty API key for LLM providers in config, HTTP requests, and coordinator flows
  - read_openai_provider_config uses api_key_required flag (false for LLM, true for ASR)
  - fetch_provider_models and polish requests omit Authorization header when key blank

- Coordinator Ark content paths now require either API key or custom endpoint to prevent leaks
  - resolve_ark_endpoint errors if key empty and no custom endpoint provided

- Retain mandatory API key for ASR provider

- Add unit tests for keyless LLM headers, endpoint policy, and successful completion


___

### Diagram Walkthrough


```mermaid
flowchart LR
    A["read_openai_provider_config"] -->|"llm: key optional"| B["LLM provider"]
    A -->|"asr: key required"| C["ASR provider unchanged"]
    B --> D["HTTP requests: omit Authorization if key empty"]
    B --> E["coordinator: resolve_ark_endpoint blocks empty key without custom endpoint"]
    D --> F["Tests check header omission"]
    E --> G["Tests check endpoint policy"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>commands.rs</strong><dd><code>Make LLM API key optional in provider config and model fetch</code></dd></summary>
<hr>

openless-all/app/src-tauri/src/commands.rs

<ul><li>Add api_key_required flag to differentiate LLM (false) and ASR (true) <br>provider config<br> <li> Conditionally check for empty API key only when required<br> <li> In fetch_provider_models, set Authorization header only if API key is <br>non-empty<br> <li> Add test verifying Authorization header omitted when API key is absent</ul>


</details>


  </td>
  <td><a href="https://github.com/appergb/openless/pull/193/files#diff-8215873d09604b1dbb99088131ba7fc2fd6c537e67588cba5bd9160c2138b035">+72/-17</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>polish.rs</strong><dd><code>Remove mandatory key check, conditionally send Authorization header</code></dd></summary>
<hr>

openless-all/app/src-tauri/src/polish.rs

<ul><li>Remove MissingCredentials early return in chat_completion and <br>answer_chat_streaming<br> <li> Conditionally add Authorization header only if API key is non-empty<br> <li> Add test that chat completion succeeds and omits Authorization when <br>key empty</ul>


</details>


  </td>
  <td><a href="https://github.com/appergb/openless/pull/193/files#diff-1be30d25d0bf8fc3e6c11bf4fa179521045a52ef4843271545acedfd0535e38b">+70/-18</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Error handling</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>coordinator.rs</strong><dd><code>Guard Ark content flows, allow keyless with custom endpoint</code></dd></summary>
<hr>

openless-all/app/src-tauri/src/coordinator.rs

<ul><li>Remove early bail on empty API key in polish, translate, and QA chat <br>paths<br> <li> Introduce resolve_ark_endpoint that allows keyless only when custom <br>endpoint is provided<br> <li> Block access to default Ark endpoint when API key empty to prevent <br>content leaks<br> <li> Add tests for endpoint resolution policy (blank key rejected, custom <br>endpoint allowed)</ul>


</details>


  </td>
  <td><a href="https://github.com/appergb/openless/pull/193/files#diff-73d8c004670b27293f74f0f3991b9a6fc28f0ff0b883214de2b078b1e09797ca">+46/-19</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

