### PR TITLE
fix(window): 恢复 macOS 原生交通灯

### DIFF
--- a/openless-all/app/src-tauri/src/lib.rs
+++ b/openless-all/app/src-tauri/src/lib.rs
@@ -93,6 +93,9 @@ pub fn run() {
                     use window_vibrancy::{
                         apply_vibrancy, NSVisualEffectMaterial, NSVisualEffectState,
                     };
+                    if let Err(e) = main.set_decorations(true) {
+                        log::warn!("[main] enable native decorations failed: {e}");
+                    }
                     if let Err(e) = apply_vibrancy(
                         &main,
                         NSVisualEffectMaterial::HudWindow,

--- a/openless-all/app/src/components/WindowChrome.tsx
+++ b/openless-all/app/src/components/WindowChrome.tsx
@@ -47,7 +47,7 @@ export function WindowChrome({
   children,
   height = 800,
 }: WindowChromeProps) {
-  const shellRadius = os === 'mac' ? 20 : os === 'win' ? WIN_WINDOW_RADIUS : 14;
+  const shellRadius = os === 'mac' ? 0 : os === 'win' ? WIN_WINDOW_RADIUS : 14;
   const consoleRadius = os === 'mac' ? 20 : os === 'win' ? WIN_CONSOLE_RADIUS : 14;
 
   return (
@@ -66,7 +66,11 @@ export function WindowChrome({
         overflow: 'hidden',
         display: 'flex',
         flexDirection: 'column',
-        border: os === 'win' ? '1px solid rgba(255,255,255,0.18)' : '0.5px solid rgba(0,0,0,.10)',
+        border: os === 'mac'
+          ? 'none'
+          : os === 'win'
+            ? '1px solid rgba(255,255,255,0.18)'
+            : '0.5px solid rgba(0,0,0,.10)',
         background: `
           radial-gradient(120% 80% at 0% 0%, rgba(255,255,255,0.7) 0%, rgba(255,255,255,0) 60%),
           radial-gradient(100% 70% at 100% 100%, rgba(37,99,235,0.07) 0%, rgba(37,99,235,0) 55%),


### PR DESCRIPTION
### **User description**
## 摘要

Fixes #183。

本 PR 修复 macOS 下窗口左上角原生红黄绿交通灯消失，以及窗口出现双重圆角的问题。

此前应用使用自定义窗口壳时，macOS 没有显示系统原生 traffic lights，导致窗口关闭 / 最小化 / 最大化按钮缺失或反馈不符合系统习惯。同时 macOS 外层 shell 仍保留额外圆角和边框，叠加原生窗口效果后会出现双重圆角观感。

本次改动在 macOS 运行时单独开启 native decorations，以恢复系统原生交通灯；Windows / Linux 仍保持现有自定义标题栏行为，不通过全局 `tauri.conf` 打开 decorations，避免影响非 macOS 平台窗口样式。

## 修复 / 新增 / 改进

- macOS 主窗口运行时启用 native decorations：
  - 恢复系统原生红黄绿 traffic lights
  - 保留 macOS 原生窗口按钮交互反馈

- 不在 `tauri.conf` 中全局开启 decorations：
  - 避免 Windows / Linux 被切换到原生标题栏
  - 保持非 macOS 平台现有自定义窗口行为

- 调整 `WindowChrome` 的 macOS 外层样式：
  - macOS 外层 shell radius 改为 `0`
  - macOS 外层 border 改为 `none`
  - 避免原生窗口外观与自定义壳叠加形成双重圆角 / 双重边框

- 增加 native decorations 开启失败时的 warning 日志：
  - `[main] enable native decorations failed: ...`

## 兼容

- 不包含：
  - 不全局开启 Tauri native chrome。
  - 不改变 Windows 自定义标题栏行为。
  - 不改变 Linux 自定义标题栏行为。
  - 不重构窗口组件结构。
  - 不引入新依赖。
  - 不调整业务页面布局。

- 对现有用户 / 本地环境 / 构建流程的影响：
  - macOS 用户会重新看到系统原生红黄绿窗口按钮。
  - macOS 窗口外观不再出现额外双重圆角 / 外层边框。
  - Windows / Linux 继续使用现有自定义窗口壳。
  - 构建流程无变化。

## 测试计划

- [x] 命令：`npm run build`
- [x] 结果：通过
- [x] 证据路径：`openless-all/app` 本地构建输出

- [ ] macOS 真机窗口视觉验证
- [ ] Windows 真机窗口视觉验证
- [ ] Linux 真机窗口视觉验证
- [ ] 说明：当前 commit 未做真实 macOS / Windows / Linux 运行时视觉回归验证。

## 主要改动文件

- `openless-all/app/src-tauri/src/lib.rs`
- `openless-all/app/src/components/WindowChrome.tsx`

## 备注

本 PR 采用平台运行时分支处理窗口 decorations：只在 macOS 恢复 native traffic lights，不把该行为扩散到 Windows / Linux。这样可以同时修复 macOS 原生按钮缺失问题，并保留非 macOS 平台的自定义标题栏体验。


___

### **PR Type**
Bug fix


___

### **Description**
- 在 macOS 运行时为主窗口启用原生装饰，恢复系统交通灯按钮

- 移除 macOS 下自定义窗口壳的圆角和边框，消除双重圆角

- 添加 `set_decorations` 失败时的警告日志

- 保持 Windows/Linux 的自定义标题栏行为不变


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["macOS 运行时"] -- "启用原生装饰" --> B["lib.rs: set_decorations(true)"]
  A -- "移除自定义外观" --> C["WindowChrome.tsx: shellRadius=0, border=none"]
  B --> D["恢复系统交通灯"]
  C --> D
  D --> E["消除双重圆角与交互缺失"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>lib.rs</strong><dd><code>macOS 运行时启用原生窗口装饰</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src-tauri/src/lib.rs

<ul><li>在 macOS 构建目标下，为主窗口调用 <code>set_decorations(true)</code> 以启用系统原生交通灯<br> <li> 增加 <code>set_decorations</code> 失败的 <code>warn</code> 日志，输出错误详情</ul>


</details>


  </td>
  <td><a href="https://github.com/appergb/openless/pull/197/files#diff-6b8eb1bbf8e378bab914f1a12962f7add5cc4ba9e013c37c9921a1032fa5e110">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>WindowChrome.tsx</strong><dd><code>移除 macOS 自定义窗口壳的圆角和边框</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src/components/WindowChrome.tsx

<ul><li>将 macOS 外壳圆角半径 <code>shellRadius</code> 从 20 改为 0<br> <li> 将 macOS 外壳边框样式改为 <code>'none'</code>，移除原有 0.5px 深色边框<br> <li> 避免自定义壳与原生窗口视觉叠加导致的双重圆角和多余边框</ul>


</details>


  </td>
  <td><a href="https://github.com/appergb/openless/pull/197/files#diff-ca98272202276bc772e02f5bdd6dfd006d06a0da7bb6d9705d03e1da14edca4c">+6/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

