### PR TITLE
fix(app): 修正浏览器 timeout ref 类型

### DIFF
--- a/openless-all/app/src/components/Onboarding.tsx
+++ b/openless-all/app/src/components/Onboarding.tsx
@@ -25,7 +25,7 @@ export function Onboarding({ onComplete }: OnboardingProps) {
   const [accessibility, setAccessibility] = useState<PermissionStatus>('notDetermined');
   const [microphone, setMicrophone] = useState<PermissionStatus>('notDetermined');
   const [busy, setBusy] = useState(false);
-  const refreshTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const refreshTimeoutRef = useRef<number | null>(null);
   const { capability } = useHotkeySettings();
 
   const refresh = async () => {

--- a/openless-all/app/src/pages/Settings.tsx
+++ b/openless-all/app/src/pages/Settings.tsx
@@ -526,8 +526,8 @@ function CredentialField({ label, account, placeholder, mono, mask, defaultValue
   const [loaded, setLoaded] = useState(false);
   const [dirty, setDirty] = useState(false);
   const [status, setStatus] = useState<CredentialFieldStatus>('idle');
-  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const statusRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const debounceRef = useRef<number | null>(null);
+  const statusRef = useRef<number | null>(null);
 
   useEffect(() => {
     let cancelled = false;
@@ -588,7 +588,7 @@ function CredentialField({ label, account, placeholder, mono, mask, defaultValue
     if (!loaded) return;
     setDirty(true);
     if (debounceRef.current) clearTimeout(debounceRef.current);
-    debounceRef.current = setTimeout(() => save(v, true), 300);
+    debounceRef.current = window.setTimeout(() => save(v, true), 300);
   };
 
   const onBlur = () => {
@@ -913,7 +913,7 @@ function LanguageSection() {
 function AboutSection() {
   const { t } = useTranslation();
   const [qqCopied, setQqCopied] = useState(false);
-  const qqCopiedRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const qqCopiedRef = useRef<number | null>(null);
 
   useEffect(() => {
     return () => {


### PR DESCRIPTION
### **User description**
## 摘要

修复前端浏览器环境下 timeout ref 类型不匹配导致的构建问题。

此前部分组件使用 `ReturnType<typeof setTimeout>` 保存 timeout handle。在当前前端构建环境中，该类型可能被解析为非浏览器侧的 timeout 类型，导致与 `clearTimeout` / browser timeout handle 的使用不一致。

本 PR 将相关 timeout ref 明确收敛为浏览器环境的 `number | null`，并在 debounce 保存处显式使用 `window.setTimeout`，保证类型与实际运行环境一致。

## 修复 / 新增 / 改进

- 修正 `Onboarding.tsx` 中 refresh timeout ref 类型：
  - 从 `ReturnType<typeof setTimeout> | null`
  - 改为 `number | null`

- 修正 `Settings.tsx` 中凭据字段 debounce / status timeout ref 类型：
  - 从 `ReturnType<typeof setTimeout> | null`
  - 改为 `number | null`

- 修正 `Settings.tsx` 中 AboutSection 的复制提示 timeout ref 类型：
  - 从 `ReturnType<typeof setTimeout> | null`
  - 改为 `number | null`

- debounce 保存时显式使用：
  - `window.setTimeout(...)`

- 保持现有 timeout cleanup 行为不变。

## 兼容

- 不包含：
  - 不改变 UI 交互行为。
  - 不改变凭据保存逻辑。
  - 不改变 Onboarding 权限刷新逻辑。
  - 不改变 AboutSection 复制提示逻辑。
  - 不引入新依赖。
  - 不调整构建配置。

- 对现有用户 / 本地环境 / 构建流程的影响：
  - 用户可见行为无变化。
  - 前端 timeout handle 类型与浏览器环境保持一致。
  - 可避免构建阶段因 timeout ref 类型推导不一致导致失败。
  - 构建流程无变化。

## 主要改动文件

- `openless-all/app/src/components/Onboarding.tsx`
- `openless-all/app/src/pages/Settings.tsx`

## 备注

本 PR 是纯类型修复，只收敛浏览器 timeout handle 的类型表达，不改变此前为 timeout cleanup 增加的运行时逻辑。


___

### **PR Type**
Bug fix


___

### **Description**
- Update timeout refs to use `number | null` type

- Explicitly call `window.setTimeout` for debounce saves

- Fix build issue from browser/Node timeout type mismatch


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Onboarding.tsx</strong><dd><code>Fix refreshTimeoutRef type for browser timeout</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src/components/Onboarding.tsx

<ul><li>Changed <code>refreshTimeoutRef</code> type from <code>ReturnType<typeof setTimeout> | </code><br><code>null</code> to <code>number | null</code>.</ul>


</details>


  </td>
  <td><a href="https://github.com/appergb/openless/pull/208/files#diff-b268b8893cf3791067a27e6509d5721b260046fd4c7093f958697c09f3eeb5f7">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Settings.tsx</strong><dd><code>Update timeout refs and use window.setTimeout</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src/pages/Settings.tsx

<ul><li>Changed <code>debounceRef</code> and <code>statusRef</code> types to <code>number | null</code>.<br> <li> Updated <code>handleChange</code> to use <code>window.setTimeout</code> instead of <code>setTimeout</code>.<br> <li> Changed <code>qqCopiedRef</code> type to <code>number | null</code>.</ul>


</details>


  </td>
  <td><a href="https://github.com/appergb/openless/pull/208/files#diff-b493ca85e083b07f67da1b3ac96aeab153b20c97405e26292b47b95e13368c38">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

