### PR TITLE
Add Intel macOS artifacts to Tauri release matrix

### DIFF
--- a/.github/workflows/release-tauri.yml
+++ b/.github/workflows/release-tauri.yml
@@ -4,7 +4,7 @@ name: Release Tauri (cross-platform)
 #   - 手动 dispatch（用于测试构建,不发版）
 #
 # 输出：
-#   macOS arm64 .dmg + Windows x64 .msi/.exe + Linux x64 .deb/.rpm/.AppImage，自动作为 GitHub Release 资产上传。
+#   macOS arm64/x64 .dmg + Windows x64 .msi/.exe + Linux x64 .deb/.rpm/.AppImage，自动作为 GitHub Release 资产上传。
 #
 # macOS 分发：
 #   - 配好 APPLE_CERTIFICATE / APPLE_CERTIFICATE_PASSWORD / APPLE_ID /
@@ -32,6 +32,10 @@ jobs:
             rust-target: aarch64-apple-darwin
             updater-target: darwin
             updater-arch: aarch64
+          - platform: macos-13
+            rust-target: x86_64-apple-darwin
+            updater-target: darwin
+            updater-arch: x86_64
           - platform: windows-latest
             rust-target: x86_64-pc-windows-msvc
             updater-target: windows
@@ -97,7 +101,7 @@ jobs:
           fi
 
       - name: Check Apple signing availability
-        if: matrix.platform == 'macos-latest' && startsWith(github.ref, 'refs/tags/v') && endsWith(github.ref, '-tauri')
+        if: startsWith(matrix.platform, 'macos') && startsWith(github.ref, 'refs/tags/v') && endsWith(github.ref, '-tauri')
         shell: bash
         env:
           APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
@@ -117,7 +121,7 @@ jobs:
           fi
 
       - name: Import Apple Developer ID certificate
-        if: matrix.platform == 'macos-latest'
+        if: startsWith(matrix.platform, 'macos')
         shell: bash
         env:
           APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
@@ -158,7 +162,7 @@ jobs:
           echo "Imported Apple signing identity: $CERT_ID"
 
       - name: Configure Apple notarization
-        if: matrix.platform == 'macos-latest'
+        if: startsWith(matrix.platform, 'macos')
         shell: bash
         env:
           APPLE_ID: ${{ secrets.APPLE_ID }}
@@ -175,7 +179,7 @@ jobs:
 
       # ── macOS：用我们自己的 build-mac.sh，统一处理签名、公证和 artifact 清理 ──
       - name: Build (macOS)
-        if: matrix.platform == 'macos-latest'
+        if: startsWith(matrix.platform, 'macos')
         working-directory: 'openless-all/app'
         env:
           INSTALL: '0'        # CI 不要装到 /Applications,也不要 reset TCC
@@ -237,7 +241,7 @@ jobs:
       # 让"云端 artifact 一定干净"成为可验证的承诺。用户下载后再被本地浏览器
       # 加 quarantine 时，按 release notes 的 `xattr -cr` 一行即可消除。
       - name: Strip xattr / quarantine on macOS bundles
-        if: matrix.platform == 'macos-latest'
+        if: startsWith(matrix.platform, 'macos')
         shell: bash
         working-directory: 'openless-all/app/src-tauri/target/release/bundle'
         run: |
@@ -250,24 +254,24 @@ jobs:
           done
 
       - name: Upload macOS artifacts
-        if: matrix.platform == 'macos-latest'
+        if: startsWith(matrix.platform, 'macos')
         uses: actions/upload-artifact@v4
         with:
-          name: openless-macos-arm64
+          name: openless-macos-${{ matrix.updater-arch }}
           path: |
             openless-all/app/src-tauri/target/release/bundle/dmg/*.dmg
           if-no-files-found: error
 
       - name: Upload macOS updater artifacts
-        if: matrix.platform == 'macos-latest' && env.TAURI_SIGNING_PRIVATE_KEY != ''
+        if: startsWith(matrix.platform, 'macos') && env.TAURI_SIGNING_PRIVATE_KEY != ''
         uses: actions/upload-artifact@v4
         with:
-          name: openless-macos-arm64-updater
+          name: openless-macos-${{ matrix.updater-arch }}-updater
           path: |
             openless-all/app/src-tauri/target/release/bundle/macos/*.app.tar.gz
             openless-all/app/src-tauri/target/release/bundle/macos/*.app.tar.gz.sig
-            openless-all/app/src-tauri/target/release/bundle/latest-darwin-aarch64.json
-            openless-all/app/src-tauri/target/release/bundle/latest-darwin-aarch64-mirror.json
+            openless-all/app/src-tauri/target/release/bundle/latest-darwin-${{ matrix.updater-arch }}.json
+            openless-all/app/src-tauri/target/release/bundle/latest-darwin-${{ matrix.updater-arch }}-mirror.json
           if-no-files-found: error
 
       - name: Upload Windows artifacts
@@ -325,7 +329,7 @@ jobs:
           prerelease: false
           # Matrix jobs all upload assets to the same release. Generate notes once
           # so macOS, Windows, and Linux jobs do not duplicate the release body.
-          generate_release_notes: ${{ matrix.platform == 'macos-latest' }}
+          generate_release_notes: ${{ matrix.updater-target == 'darwin' && matrix.updater-arch == 'aarch64' }}
           files: |
             openless-all/app/src-tauri/target/release/bundle/dmg/*.dmg
             openless-all/app/src-tauri/target/release/bundle/macos/*.app.tar.gz

--- a/.github/workflows/release-tauri.yml
+++ b/.github/workflows/release-tauri.yml
@@ -217,6 +217,18 @@ jobs:
             npm run tauri -- build --bundles deb,rpm,appimage
           fi
 
+      - name: Disambiguate macOS updater bundle filename
+        if: startsWith(matrix.platform, 'macos') && env.TAURI_SIGNING_PRIVATE_KEY != ''
+        shell: bash
+        working-directory: 'openless-all/app/src-tauri/target/release/bundle/macos'
+        run: |
+          if [ -f OpenLess.app.tar.gz ]; then
+            mv OpenLess.app.tar.gz "OpenLess_${{ matrix.updater-arch }}.app.tar.gz"
+          fi
+          if [ -f OpenLess.app.tar.gz.sig ]; then
+            mv OpenLess.app.tar.gz.sig "OpenLess_${{ matrix.updater-arch }}.app.tar.gz.sig"
+          fi
+
       - name: Write updater manifest
         if: env.TAURI_SIGNING_PRIVATE_KEY != ''
         shell: bash

--- a/openless-all/app/scripts/write-updater-manifest.mjs
+++ b/openless-all/app/scripts/write-updater-manifest.mjs
@@ -17,7 +17,10 @@ const packageJson = JSON.parse(readFileSync(new URL('../package.json', import.me
 const bundleDir = fileURLToPath(new URL('../src-tauri/target/release/bundle/', import.meta.url));
 
 const candidatesByTarget = {
-  darwin: ['macos/OpenLess.app.tar.gz'],
+  darwin: [
+    `macos/OpenLess_${arch}.app.tar.gz`,
+    'macos/OpenLess.app.tar.gz',
+  ],
   windows: ['nsis/OpenLess_*_x64-setup.exe', 'nsis/OpenLess*_x64-setup.exe'],
   linux: ['appimage/OpenLess_*.AppImage', 'appimage/OpenLess*.AppImage'],
 };


### PR DESCRIPTION
### **User description**
The release workflow only produced Apple Silicon macOS packages, so Intel users had no official GitHub Release artifact. Extend the matrix with an x86_64 macOS lane and align artifact naming and updater-manifest paths with per-arch outputs.

Constraint: Keep existing release pipeline shape and signing flow unchanged
Rejected: Split Intel build into separate workflow file | higher maintenance and duplicated logic
Confidence: high
Scope-risk: narrow
Reversibility: clean
Directive: Keep macOS conditions architecture-agnostic so new mac runners are not skipped accidentally
Tested: YAML syntax parse via python yaml.safe_load; workflow diff reviewed for mac gating/artifact paths
Not-tested: Full GitHub Actions matrix run on tag push


___

### **PR Type**
Enhancement


___

### **Description**
- Add Intel macOS (x86_64) matrix lane to release workflow

- Make macOS-specific conditions architecture-agnostic (startsWith)

- Disambiguate updater bundle filenames per architecture

- Update updater manifest script to prefer arch-specific bundle


___

### Diagram Walkthrough


```mermaid
flowchart LR
  R["Release Workflow"] -- "Add Intel macOS matrix" --> M["macOS-13 (x86_64)"]
  R -- "Generic macOS conditions" --> C["startsWith(platform,'macos')"]
  M -- "Rename updater bundle" --> U["OpenLess_{arch}.app.tar.gz"]
  U -- "Update manifest paths" --> P["latest-darwin-x86_64.json"]
  S["Manifest Script"] -- "Prefer arch-specific" --> D["macos/OpenLess_x86_64.app.tar.gz"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>release-tauri.yml</strong><dd><code>Add Intel macOS build lane and arch-agnostic conditions</code>&nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/release-tauri.yml

<ul><li>Add new matrix entry for Intel macOS (macos-13, x86_64-apple-darwin)<br> <li> Replace platform checks <code>== 'macos-latest'</code> with <code>startsWith(platform, </code><br><code>'macos')</code> for future compatibility<br> <li> Add step to rename updater bundle with architecture suffix to avoid <br>collisions<br> <li> Use dynamic arch in artifact names and updater manifest paths instead <br>of hardcoded aarch64</ul>


</details>


  </td>
  <td><a href="https://github.com/appergb/openless/pull/215/files#diff-cac78cd4d340dc05703d65bee14ea766337499de655e15553ceb8181eef097cb">+29/-13</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>write-updater-manifest.mjs</strong><dd><code>Prefer arch-specific updater bundle in manifest script</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/scripts/write-updater-manifest.mjs

<ul><li>Search for architecture-specific updater bundle first, then fallback <br>to generic bundle</ul>


</details>


  </td>
  <td><a href="https://github.com/appergb/openless/pull/215/files#diff-f177f84545804ad96174bee0eb1cf8f690ccba062130a6483bce7189e43ab417">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

