### PR TITLE
feat(autostart): macOS / Linux / Windows 三平台开机自启

### DIFF
--- a/openless-all/app/package-lock.json
+++ b/openless-all/app/package-lock.json
@@ -1,14 +1,15 @@
 {
   "name": "openless-app",
-  "version": "1.2.8",
+  "version": "1.2.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openless-app",
-      "version": "1.2.8",
+      "version": "1.2.13",
       "dependencies": {
         "@tauri-apps/api": "^2.1.1",
+        "@tauri-apps/plugin-autostart": "^2.5.1",
         "@tauri-apps/plugin-shell": "^2.0.1",
         "@tauri-apps/plugin-updater": "^2.10.1",
         "i18next": "^26.0.8",
@@ -1340,6 +1341,15 @@
       ],
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/@tauri-apps/plugin-autostart": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-autostart/-/plugin-autostart-2.5.1.tgz",
+      "integrity": "sha512-zS/xx7yzveCcotkA+8TqkI2lysmG2wvQXv2HGAVExITmnFfHAdj1arGsbbfs3o6EktRHf6l34pJxc3YGG2mg7w==",
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@tauri-apps/api": "^2.8.0"
       }
     },
     "node_modules/@tauri-apps/plugin-shell": {

--- a/openless-all/app/package.json
+++ b/openless-all/app/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@tauri-apps/api": "^2.1.1",
+    "@tauri-apps/plugin-autostart": "^2.5.1",
     "@tauri-apps/plugin-shell": "^2.0.1",
     "@tauri-apps/plugin-updater": "^2.10.1",
     "i18next": "^26.0.8",

--- a/openless-all/app/src-tauri/Cargo.lock
+++ b/openless-all/app/src-tauri/Cargo.lock
@@ -309,6 +309,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "auto-launch"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f012b8cc0c850f34117ec8252a44418f2e34a2cf501de89e29b241ae5f79471"
+dependencies = [
+ "dirs 4.0.0",
+ "thiserror 1.0.69",
+ "winreg 0.10.1",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1092,11 +1103,31 @@ dependencies = [
 
 [[package]]
 name = "dirs"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
+dependencies = [
+ "dirs-sys 0.3.7",
+]
+
+[[package]]
+name = "dirs"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
 dependencies = [
- "dirs-sys",
+ "dirs-sys 0.5.0",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
+dependencies = [
+ "libc",
+ "redox_users 0.4.6",
+ "winapi",
 ]
 
 [[package]]
@@ -1107,7 +1138,7 @@ checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
 dependencies = [
  "libc",
  "option-ext",
- "redox_users",
+ "redox_users 0.5.2",
  "windows-sys 0.61.2",
 ]
 
@@ -3278,6 +3309,7 @@ dependencies = [
  "simplelog",
  "tauri",
  "tauri-build",
+ "tauri-plugin-autostart",
  "tauri-plugin-shell",
  "tauri-plugin-single-instance",
  "tauri-plugin-updater",
@@ -4040,6 +4072,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
 dependencies = [
  "bitflags 2.11.1",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -5026,7 +5069,7 @@ dependencies = [
  "anyhow",
  "bytes",
  "cookie",
- "dirs",
+ "dirs 6.0.0",
  "dunce",
  "embed_plist",
  "getrandom 0.3.4",
@@ -5076,7 +5119,7 @@ checksum = "4bbc990d1dbf57a8e1c7fa2327f2a614d8b757805603c1b9ba5c81bade09fd4d"
 dependencies = [
  "anyhow",
  "cargo_toml",
- "dirs",
+ "dirs 6.0.0",
  "glob",
  "heck 0.5.0",
  "json-patch",
@@ -5149,6 +5192,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-autostart"
+version = "2.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "459383cebc193cdd03d1ba4acc40f2c408a7abce419d64bdcd2d745bc2886f70"
+dependencies = [
+ "auto-launch",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "tauri-plugin-shell"
 version = "2.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5191,7 +5248,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "806d9dac662c2e4594ff03c647a552f2c9bd544e7d0f683ec58f872f952ce4af"
 dependencies = [
  "base64 0.22.1",
- "dirs",
+ "dirs 6.0.0",
  "flate2",
  "futures-util",
  "http",
@@ -5742,7 +5799,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5e85aa143ceb072062fc4d6356c1b520a51d636e7bc8e77ec94be3608e5e80c"
 dependencies = [
  "crossbeam-channel",
- "dirs",
+ "dirs 6.0.0",
  "libappindicator",
  "muda",
  "objc2 0.6.4",
@@ -6929,6 +6986,15 @@ dependencies = [
 
 [[package]]
 name = "winreg"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "winreg"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a277a57398d4bfa075df44f501a17cfdf8542d224f0d36095a2adc7aee4ef0a5"
@@ -7057,7 +7123,7 @@ dependencies = [
  "block2 0.6.2",
  "cookie",
  "crossbeam-channel",
- "dirs",
+ "dirs 6.0.0",
  "dom_query",
  "dpi",
  "dunce",

--- a/openless-all/app/src-tauri/Cargo.toml
+++ b/openless-all/app/src-tauri/Cargo.toml
@@ -18,6 +18,7 @@ tauri = { version = "2", features = ["macos-private-api", "tray-icon"] }
 tauri-plugin-shell = "2"
 tauri-plugin-updater = "2"
 tauri-plugin-single-instance = "2"
+tauri-plugin-autostart = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["full"] }

--- a/openless-all/app/src-tauri/capabilities/default.json
+++ b/openless-all/app/src-tauri/capabilities/default.json
@@ -16,6 +16,7 @@
     "core:webview:default",
     "core:event:default",
     "shell:allow-open",
-    "updater:default"
+    "updater:default",
+    "autostart:default"
   ]
 }

--- a/openless-all/app/src-tauri/src/lib.rs
+++ b/openless-all/app/src-tauri/src/lib.rs
@@ -56,6 +56,13 @@ pub fn run() {
         }))
         .plugin(tauri_plugin_shell::init())
         .plugin(tauri_plugin_updater::Builder::new().build())
+        // 跨平台开机自启：mac 写 LaunchAgent plist，linux 写 ~/.config/autostart/*.desktop，
+        // windows 写 HKCU\Software\Microsoft\Windows\CurrentVersion\Run。前端 toggle 直接
+        // 调插件 isEnabled / enable / disable，不维持本地 prefs，让 OS 当唯一真相。issue #194。
+        .plugin(tauri_plugin_autostart::init(
+            tauri_plugin_autostart::MacosLauncher::LaunchAgent,
+            None,
+        ))
         .manage(coordinator.clone())
         .setup(move |app| {
             // Capsule 启动时定位到屏幕底部居中并隐藏；coordinator 按需显示。

--- a/openless-all/app/src/i18n/en.ts
+++ b/openless-all/app/src/i18n/en.ts
@@ -266,6 +266,8 @@ export const en: typeof zhCN = {
       capsuleDesc: 'Show a translucent capsule at the bottom of the screen while recording / transcribing.',
       restoreClipboardLabel: 'Restore clipboard after insert',
       restoreClipboardDesc: 'Windows / Linux only: restore your original clipboard after a successful paste (default on). Turn off to keep the dictation text in the clipboard so you can manually Ctrl+V if the simulated paste did not actually land. See issue #111.',
+      startupAtBoot: 'Launch at login',
+      startupAtBootDesc: 'Start OpenLess automatically when you sign in. macOS uses a LaunchAgent, Linux writes ~/.config/autostart, Windows writes HKCU\\Run (no admin required). See issue #194.',
     },
     providers: {
       llmTitle: 'LLM (polishing)',

--- a/openless-all/app/src/i18n/en.ts
+++ b/openless-all/app/src/i18n/en.ts
@@ -268,6 +268,7 @@ export const en: typeof zhCN = {
       restoreClipboardDesc: 'Windows / Linux only: restore your original clipboard after a successful paste (default on). Turn off to keep the dictation text in the clipboard so you can manually Ctrl+V if the simulated paste did not actually land. See issue #111.',
       startupAtBoot: 'Launch at login',
       startupAtBootDesc: 'Start OpenLess automatically when you sign in. macOS uses a LaunchAgent, Linux writes ~/.config/autostart, Windows writes HKCU\\Run (no admin required). See issue #194.',
+      startupAtBootError: 'Failed to toggle launch at login: {{message}}',
     },
     providers: {
       llmTitle: 'LLM (polishing)',

--- a/openless-all/app/src/i18n/zh-CN.ts
+++ b/openless-all/app/src/i18n/zh-CN.ts
@@ -264,6 +264,8 @@ export const zhCN = {
       capsuleDesc: '录音 / 转写时在屏幕底部显示半透明胶囊。',
       restoreClipboardLabel: '插入后恢复剪贴板',
       restoreClipboardDesc: '仅 Windows / Linux：粘贴成功后恢复你原来的剪贴板内容（默认开）。关掉就把听写文本留在剪贴板，模拟粘贴没真正落地时可以手动 Ctrl+V 找回。详见 issue #111。',
+      startupAtBoot: '开机自启',
+      startupAtBootDesc: '登录后自动启动 OpenLess。macOS 写 LaunchAgent，Linux 写 ~/.config/autostart，Windows 写 HKCU\\Run（不需要管理员）。详见 issue #194。',
     },
     providers: {
       llmTitle: 'LLM 模型（润色）',

--- a/openless-all/app/src/i18n/zh-CN.ts
+++ b/openless-all/app/src/i18n/zh-CN.ts
@@ -266,6 +266,7 @@ export const zhCN = {
       restoreClipboardDesc: '仅 Windows / Linux：粘贴成功后恢复你原来的剪贴板内容（默认开）。关掉就把听写文本留在剪贴板，模拟粘贴没真正落地时可以手动 Ctrl+V 找回。详见 issue #111。',
       startupAtBoot: '开机自启',
       startupAtBootDesc: '登录后自动启动 OpenLess。macOS 写 LaunchAgent，Linux 写 ~/.config/autostart，Windows 写 HKCU\\Run（不需要管理员）。详见 issue #194。',
+      startupAtBootError: '开机自启切换失败：{{message}}',
     },
     providers: {
       llmTitle: 'LLM 模型（润色）',

--- a/openless-all/app/src/pages/Settings.tsx
+++ b/openless-all/app/src/pages/Settings.tsx
@@ -4,6 +4,7 @@
 
 import { useEffect, useRef, useState, type CSSProperties, type ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
+import { disable as disableAutostart, enable as enableAutostart, isEnabled as isAutostartEnabled } from '@tauri-apps/plugin-autostart';
 import { Icon } from '../components/Icon';
 import { isDialogStatus, UpdateDialog, useAutoUpdate } from '../components/AutoUpdate';
 import { APP_VERSION_LABEL } from '../lib/appVersion';
@@ -231,12 +232,59 @@ function RecordingSection() {
       >
         <Toggle on={prefs.restoreClipboardAfterPaste} onToggle={onRestoreClipboardChange} />
       </SettingRow>
+      <AutostartRow />
       {capability.statusHint && (
         <div style={{ marginTop: 6, fontSize: 11.5, color: 'var(--ol-ink-4)', lineHeight: 1.5 }}>
           {capability.statusHint}
         </div>
       )}
     </Card>
+  );
+}
+
+// 不存进 prefs：autostart 状态由 OS 持有（mac LaunchAgent plist / linux .desktop /
+// windows HKCU\Run），prefs 缓存反而会与 OS 真相不一致。issue #194。
+function AutostartRow() {
+  const { t } = useTranslation();
+  const [enabled, setEnabled] = useState(false);
+  const [loaded, setLoaded] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    isAutostartEnabled()
+      .then(v => {
+        if (!cancelled) {
+          setEnabled(v);
+          setLoaded(true);
+        }
+      })
+      .catch(err => {
+        console.error('[autostart] isEnabled failed', err);
+        if (!cancelled) setLoaded(true);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const onToggle = async (next: boolean) => {
+    setEnabled(next);
+    try {
+      if (next) await enableAutostart();
+      else await disableAutostart();
+    } catch (err) {
+      console.error('[autostart] toggle failed', err);
+      setEnabled(!next);
+    }
+  };
+
+  return (
+    <SettingRow
+      label={t('settings.recording.startupAtBoot')}
+      desc={t('settings.recording.startupAtBootDesc')}
+    >
+      {loaded ? <Toggle on={enabled} onToggle={onToggle} /> : null}
+    </SettingRow>
   );
 }
 

--- a/openless-all/app/src/pages/Settings.tsx
+++ b/openless-all/app/src/pages/Settings.tsx
@@ -248,6 +248,10 @@ function AutostartRow() {
   const { t } = useTranslation();
   const [enabled, setEnabled] = useState(false);
   const [loaded, setLoaded] = useState(false);
+  // 切 plist / 注册表失败时给用户看的错误。null = 没有失败/上次操作已成功。
+  // 不渲染等于把失败吞掉 —— Windows 写 HKCU\Run 被组策略拦、macOS 写
+  // LaunchAgent plist 权限不够 都是真实可能。issue #194。
+  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     let cancelled = false;
@@ -269,12 +273,14 @@ function AutostartRow() {
 
   const onToggle = async (next: boolean) => {
     setEnabled(next);
+    setError(null);
     try {
       if (next) await enableAutostart();
       else await disableAutostart();
     } catch (err) {
       console.error('[autostart] toggle failed', err);
       setEnabled(!next);
+      setError(err instanceof Error ? err.message : String(err));
     }
   };
 
@@ -283,7 +289,14 @@ function AutostartRow() {
       label={t('settings.recording.startupAtBoot')}
       desc={t('settings.recording.startupAtBootDesc')}
     >
-      {loaded ? <Toggle on={enabled} onToggle={onToggle} /> : null}
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+        {loaded ? <Toggle on={enabled} onToggle={onToggle} /> : null}
+        {error && (
+          <div style={{ fontSize: 11, color: 'var(--ol-err)', marginTop: 4, lineHeight: 1.5 }}>
+            {t('settings.recording.startupAtBootError', { message: error })}
+          </div>
+        )}
+      </div>
     </SettingRow>
   );
 }


### PR DESCRIPTION
### **User description**
Closes #194

## Summary
- 设置页 → 录制 区追加「开机自启」Toggle
- 三平台都用 Tauri 官方 `tauri-plugin-autostart`，零自写：
  - macOS：`~/Library/LaunchAgents/com.openless.app.plist`（LaunchAgent）
  - Linux：`~/.config/autostart/openless.desktop`（XDG）
  - Windows：`HKCU\Software\Microsoft\Windows\CurrentVersion\Run`（per-user，不需 admin）
- 状态以 OS 为唯一真相：直接调 `isEnabled` / `enable` / `disable`，不写 prefs（避免缓存与系统设置不一致）

## 改动

### Backend
- `Cargo.toml`：加 `tauri-plugin-autostart = \"2\"`
- `lib.rs`：注册插件 `tauri_plugin_autostart::init(MacosLauncher::LaunchAgent, None)`
- `capabilities/default.json`：加 `\"autostart:default\"`

### Frontend
- `package.json`：加 `@tauri-apps/plugin-autostart`
- `Settings.tsx`：新增 `<AutostartRow />` 子组件（mount 时读 OS 真值，toggle 失败回滚）
- `i18n/zh-CN.ts` / `en.ts`：在 `settings.recording` 节点加 `startupAtBoot` + `startupAtBootDesc`

> 旧 `settings.personalize.startupAtBoot` 是孤儿 key（personalize section 没渲染），未删除以保持 surgical。

### 关于 millionart 的「别走注册表」评论
插件无内置的 startup-folder `.lnk` 模式。HKCU\\Run 是 Microsoft 文档化的 per-user 标准方式、不需要管理员，本 issue 验收标准（"用户可设置开机启动"）已满足。如必须走 `.lnk`，单独追加 follow-up（需要自己写 Windows 子流程）。

## 验证
- [x] `cargo check` 通过
- [x] `npm run build` (tsc + vite) 通过
- [ ] 用户侧手测：
  - [ ] macOS：toggle ON → `ls ~/Library/LaunchAgents/ | grep openless`，重启或注销 / 登录后 OpenLess 自启
  - [ ] Linux：toggle ON → `ls ~/.config/autostart/`，重新登录后自启
  - [ ] Windows：toggle ON → `reg query \"HKCU\\Software\\Microsoft\\Windows\\CurrentVersion\\Run\"` 看到 OpenLess，重登后自启
  - [ ] toggle OFF 后对应记录消失


___

### **PR Type**
Enhancement


___

### **Description**
- Add cross-platform autostart toggle in Settings

- Use OS as source of truth for state

- Show error message if toggle fails

- Register tauri-plugin-autostart and grant permissions


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["User toggles autostart"] -- "onToggle" --> B["AutostartRow component"]
  B -- "enable/disable" --> C["tauri-plugin-autostart"]
  C -- "writes" --> D["OS (LaunchAgent/XDG/Registry)"]
  C -- "on error" --> E["Set error state"]
  E -- "shows" --> F["Error message in UI"]
  B -- "on mount" --> G["isEnabled check"]
  G -- "reads" --> D
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>lib.rs</strong><dd><code>Register autostart plugin init</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/appergb/openless/pull/217/files#diff-6b8eb1bbf8e378bab914f1a12962f7add5cc4ba9e013c37c9921a1032fa5e110">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>en.ts</strong><dd><code>Add autostart i18n keys in English</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/appergb/openless/pull/217/files#diff-bb2f4fa05787923f8aeb23b6f11ad8705e02d9ff03a45790f9181e4615c79d83">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>zh-CN.ts</strong><dd><code>Add autostart i18n keys in Chinese</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/appergb/openless/pull/217/files#diff-571576f3c7b6c4a78ae0f91accdccc5da5cbed00409955c9914c046fee6c80ea">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>Settings.tsx</strong><dd><code>Implement AutostartRow with error feedback</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/appergb/openless/pull/217/files#diff-b493ca85e083b07f67da1b3ac96aeab153b20c97405e26292b47b95e13368c38">+61/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Dependencies</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>package.json</strong><dd><code>Add @tauri-apps/plugin-autostart dependency</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/appergb/openless/pull/217/files#diff-2650f8aa2f7ec97aa8af47f1f8a7c9ae4677fb69754b20d554e1d542507cf4ea">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>Cargo.toml</strong><dd><code>Add tauri-plugin-autostart crate</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/appergb/openless/pull/217/files#diff-334952ba03e62939865bbf0351f0916ea88c6457f8ea1259336e73ee4e2f088b">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>default.json</strong><dd><code>Grant autostart:default permission</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/appergb/openless/pull/217/files#diff-fd7afbf1e2138ebe2dc148ea92e35bf4e18715df7296c0940efa6e184217ccd6">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

