### PR TITLE
fix(settings): 切换 LLM/ASR preset UI 不刷新 (#219)

### DIFF
--- a/openless-all/app/src/pages/Settings.tsx
+++ b/openless-all/app/src/pages/Settings.tsx
@@ -366,8 +366,13 @@ function ProvidersSection() {
     setAsrProvider(knownAsr ? knownAsr.id : 'volcengine');
   }, [prefs]);
 
+  // issue #219：底层 providers HashMap 是 per-provider 的，切换 active 后
+  // CredentialField 重挂载读 'ark.api_key' 会自动落到新 active 的 entry。
+  // 所以**必须先 await setActive*Provider 再改前端 state**——顺序反了的话
+  // CredentialField 读到的是旧 active 的 entry，用户看到「切换没生效」。
+  // 默认 endpoint/model 改成「仅在新 active entry 该字段为空时」才填，
+  // 不再无条件覆盖用户自定义值。
   const onLlmProviderChange = async (id: LlmPresetId) => {
-    setLlmProvider(id);
     await setActiveLlmProvider(id);
     if (prefs) {
       const next = { ...prefs, activeLlmProvider: id };
@@ -375,27 +380,34 @@ function ProvidersSection() {
     }
     const preset = LLM_PRESETS.find(p => p.id === id);
     if (preset?.baseUrl) {
-      await setCredential('ark.endpoint', preset.baseUrl);
+      const existing = await readCredential('ark.endpoint');
+      if (!existing) await setCredential('ark.endpoint', preset.baseUrl);
     }
+    setLlmProvider(id);
   };
 
   const onAsrProviderChange = async (id: AsrPresetId) => {
-    setAsrProvider(id);
     await setActiveAsrProvider(id);
     if (prefs) {
       const next = { ...prefs, activeAsrProvider: id };
       await updatePrefs(next);
     }
-    // 切换到 OpenAI 兼容厂商时同步预填 endpoint + model：每家 base URL / 模型 ID
-    // 都是固定的，不预填用户必然踩坑。volcengine 走另一套凭据，跳过。
+    // OpenAI 兼容厂商首次切换时预填 baseUrl / model 默认值，省得用户必踩
+    // 「跨厂商 model 名根本不一样」的坑；但用户已自定义后就不再覆盖。
+    // volcengine 走另一套凭据，跳过。
     const preset = ASR_PRESETS.find(p => p.id === id);
     if (preset && preset.baseUrl) {
-      await setCredential('asr.endpoint', preset.baseUrl);
+      const existing = await readCredential('asr.endpoint');
+      if (!existing) await setCredential('asr.endpoint', preset.baseUrl);
     }
     if (preset && preset.model) {
-      await setCredential('asr.model', preset.model);
-      setAsrModelRevision(v => v + 1);
+      const existing = await readCredential('asr.model');
+      if (!existing) {
+        await setCredential('asr.model', preset.model);
+        setAsrModelRevision(v => v + 1);
+      }
     }
+    setAsrProvider(id);
   };
 
   const preset = LLM_PRESETS.find(p => p.id === llmProvider) ?? LLM_PRESETS[LLM_PRESETS.length - 1];

--- a/openless-all/app/src/pages/Settings.tsx
+++ b/openless-all/app/src/pages/Settings.tsx
@@ -353,44 +353,71 @@ type AsrPresetId = typeof ASR_PRESETS[number]['id'];
 function ProvidersSection() {
   const { t } = useTranslation();
   const { prefs, updatePrefs } = useHotkeySettings();
+  // `*Provider` 立即跟随 <select> 改动（受控组件必须实时反映用户输入）；
+  // `committed*Provider` 才决定 CredentialField 的 key，仅在后端 active
+  // 切换 + 默认值写完后再 commit。两者拆开是为了同时满足：
+  //   - <select> 立刻显示用户的选择（issue #220 P2：codex 指出受控选不应等 await）
+  //   - CredentialField 不要在后端 active 切完前 remount（issue #219：避免读到旧 entry）
+  // `*SwitchSeq` 是 stale-write 守卫：用户 100ms 内连点两次时，先发的请求晚到不
+  // 会覆盖后发的 commit。
   const [llmProvider, setLlmProvider] = useState<LlmPresetId>('ark');
   const [asrProvider, setAsrProvider] = useState<AsrPresetId>('volcengine');
+  const [committedLlmProvider, setCommittedLlmProvider] = useState<LlmPresetId>('ark');
+  const [committedAsrProvider, setCommittedAsrProvider] = useState<AsrPresetId>('volcengine');
+  const llmSwitchSeqRef = useRef(0);
+  const asrSwitchSeqRef = useRef(0);
   const [llmModelRevision, setLlmModelRevision] = useState(0);
   const [asrModelRevision, setAsrModelRevision] = useState(0);
 
   useEffect(() => {
     if (!prefs) return;
     const knownLlm = LLM_PRESETS.find(x => x.id === prefs.activeLlmProvider);
-    setLlmProvider(knownLlm ? knownLlm.id : 'custom');
+    const llmId = knownLlm ? knownLlm.id : 'custom';
+    setLlmProvider(llmId);
+    setCommittedLlmProvider(llmId);
     const knownAsr = ASR_PRESETS.find(x => x.id === prefs.activeAsrProvider);
-    setAsrProvider(knownAsr ? knownAsr.id : 'volcengine');
+    const asrId = knownAsr ? knownAsr.id : 'volcengine';
+    setAsrProvider(asrId);
+    setCommittedAsrProvider(asrId);
   }, [prefs]);
 
-  // issue #219：底层 providers HashMap 是 per-provider 的，切换 active 后
-  // CredentialField 重挂载读 'ark.api_key' 会自动落到新 active 的 entry。
-  // 所以**必须先 await setActive*Provider 再改前端 state**——顺序反了的话
-  // CredentialField 读到的是旧 active 的 entry，用户看到「切换没生效」。
-  // 默认 endpoint/model 改成「仅在新 active entry 该字段为空时」才填，
-  // 不再无条件覆盖用户自定义值。
+  // issue #219 / #220 P2：
+  //   1. 立刻 setLlmProvider —— 受控 <select> 必须反映用户最新选择。
+  //   2. 用 seq 守卫每个 await：用户连点两次时旧请求晚到也不会盖掉新选择。
+  //   3. 仅 setCommittedLlmProvider 之后 CredentialField 才 remount 读新 entry，
+  //      此时后端 root.active.llm 已经是 id，lookup_account 落到正确 entry。
+  //   4. endpoint/model 默认值仅在该 provider entry 该字段为空时才填，不覆盖用户自定义。
   const onLlmProviderChange = async (id: LlmPresetId) => {
+    setLlmProvider(id);
+    const seq = ++llmSwitchSeqRef.current;
     await setActiveLlmProvider(id);
+    if (seq !== llmSwitchSeqRef.current) return;
     if (prefs) {
       const next = { ...prefs, activeLlmProvider: id };
       await updatePrefs(next);
+      if (seq !== llmSwitchSeqRef.current) return;
     }
     const preset = LLM_PRESETS.find(p => p.id === id);
     if (preset?.baseUrl) {
       const existing = await readCredential('ark.endpoint');
-      if (!existing) await setCredential('ark.endpoint', preset.baseUrl);
+      if (seq !== llmSwitchSeqRef.current) return;
+      if (!existing) {
+        await setCredential('ark.endpoint', preset.baseUrl);
+        if (seq !== llmSwitchSeqRef.current) return;
+      }
     }
-    setLlmProvider(id);
+    setCommittedLlmProvider(id);
   };
 
   const onAsrProviderChange = async (id: AsrPresetId) => {
+    setAsrProvider(id);
+    const seq = ++asrSwitchSeqRef.current;
     await setActiveAsrProvider(id);
+    if (seq !== asrSwitchSeqRef.current) return;
     if (prefs) {
       const next = { ...prefs, activeAsrProvider: id };
       await updatePrefs(next);
+      if (seq !== asrSwitchSeqRef.current) return;
     }
     // OpenAI 兼容厂商首次切换时预填 baseUrl / model 默认值，省得用户必踩
     // 「跨厂商 model 名根本不一样」的坑；但用户已自定义后就不再覆盖。
@@ -398,20 +425,28 @@ function ProvidersSection() {
     const preset = ASR_PRESETS.find(p => p.id === id);
     if (preset && preset.baseUrl) {
       const existing = await readCredential('asr.endpoint');
-      if (!existing) await setCredential('asr.endpoint', preset.baseUrl);
+      if (seq !== asrSwitchSeqRef.current) return;
+      if (!existing) {
+        await setCredential('asr.endpoint', preset.baseUrl);
+        if (seq !== asrSwitchSeqRef.current) return;
+      }
     }
     if (preset && preset.model) {
       const existing = await readCredential('asr.model');
+      if (seq !== asrSwitchSeqRef.current) return;
       if (!existing) {
         await setCredential('asr.model', preset.model);
-        setAsrModelRevision(v => v + 1);
+        if (seq !== asrSwitchSeqRef.current) return;
       }
     }
-    setAsrProvider(id);
+    setCommittedAsrProvider(id);
   };
 
-  const preset = LLM_PRESETS.find(p => p.id === llmProvider) ?? LLM_PRESETS[LLM_PRESETS.length - 1];
-  const asrPreset = ASR_PRESETS.find(p => p.id === asrProvider);
+  // preset 决定 placeholder 与 default —— 必须跟着 committed*Provider 走，
+  // 否则受控 <select> 立刻切到新厂商，但凭据字段还在显示旧 entry，placeholder
+  // 会先于实际数据切换、视觉上对不上。
+  const preset = LLM_PRESETS.find(p => p.id === committedLlmProvider) ?? LLM_PRESETS[LLM_PRESETS.length - 1];
+  const asrPreset = ASR_PRESETS.find(p => p.id === committedAsrProvider);
 
   return (
     <>
@@ -433,12 +468,12 @@ function ProvidersSection() {
             ))}
           </select>
         </SettingRow>
-        <CredentialField key={`${llmProvider}:api_key`} label={t('settings.providers.apiKeyLabel')} account="ark.api_key" mono mask />
-        <CredentialField key={`${llmProvider}:endpoint`} label={t('settings.providers.baseUrlLabel')} account="ark.endpoint"
+        <CredentialField key={`${committedLlmProvider}:api_key`} label={t('settings.providers.apiKeyLabel')} account="ark.api_key" mono mask />
+        <CredentialField key={`${committedLlmProvider}:endpoint`} label={t('settings.providers.baseUrlLabel')} account="ark.endpoint"
           placeholder={preset.baseUrl || 'https://your-endpoint/v1'} />
-        <CredentialField key={`${llmProvider}:model:${llmModelRevision}`} label={t('settings.providers.modelLabel')} account="ark.model_id"
+        <CredentialField key={`${committedLlmProvider}:model:${llmModelRevision}`} label={t('settings.providers.modelLabel')} account="ark.model_id"
           placeholder={preset.modelPlaceholder || 'model-name'} mono />
-        <ProviderTools key={llmProvider} kind="llm" modelAccount="ark.model_id" onModelSelected={() => setLlmModelRevision(v => v + 1)} />
+        <ProviderTools key={committedLlmProvider} kind="llm" modelAccount="ark.model_id" onModelSelected={() => setLlmModelRevision(v => v + 1)} />
       </Card>
 
       <Card>
@@ -457,24 +492,24 @@ function ProvidersSection() {
             ))}
           </select>
         </SettingRow>
-        {asrProvider === 'volcengine' ? (
+        {committedAsrProvider === 'volcengine' ? (
           <>
             <CredentialField
-              key={`${asrProvider}:app_key`}
+              key={`${committedAsrProvider}:app_key`}
               label={t('settings.providers.volcengineAppKeyLabel')}
               account="volcengine.app_key"
               mono
               mask
             />
             <CredentialField
-              key={`${asrProvider}:access_key`}
+              key={`${committedAsrProvider}:access_key`}
               label={t('settings.providers.volcengineAccessKeyLabel')}
               account="volcengine.access_key"
               mono
               mask
             />
             <CredentialField
-              key={`${asrProvider}:resource_id`}
+              key={`${committedAsrProvider}:resource_id`}
               label={t('settings.providers.volcengineResourceIdLabel')}
               account="volcengine.resource_id"
               mono
@@ -485,11 +520,11 @@ function ProvidersSection() {
           </>
         ) : (
           <>
-            <CredentialField key={`${asrProvider}:api_key`} label={t('settings.providers.apiKeyLabel')} account="asr.api_key" mono mask />
-            <CredentialField key={`${asrProvider}:endpoint`} label={t('settings.providers.baseUrlLabel')} account="asr.endpoint"
+            <CredentialField key={`${committedAsrProvider}:api_key`} label={t('settings.providers.apiKeyLabel')} account="asr.api_key" mono mask />
+            <CredentialField key={`${committedAsrProvider}:endpoint`} label={t('settings.providers.baseUrlLabel')} account="asr.endpoint"
               placeholder={asrPreset?.baseUrl || 'https://api.openai.com/v1'}
               defaultValue={asrPreset?.baseUrl || undefined} />
-            <CredentialField key={`${asrProvider}:model:${asrModelRevision}`} label={t('settings.providers.modelLabel')} account="asr.model"
+            <CredentialField key={`${committedAsrProvider}:model:${asrModelRevision}`} label={t('settings.providers.modelLabel')} account="asr.model"
               placeholder={asrPreset?.model || 'whisper-1'} />
             <ProviderTools kind="asr" modelAccount="asr.model" onModelSelected={() => setAsrModelRevision(v => v + 1)} />
           </>


### PR DESCRIPTION
### **User description**
Closes #219

## Summary
设置页切换 LLM / ASR 供应商时，凭据输入框显示的还是旧 active provider 的 key/model/endpoint —— 用户以为切换没生效，实际是前端 race。底层 providers HashMap 已经是 per-provider，**不需要改后端**。

## 根因（两条 bug 在同一函数）

1. **Race**：setLlmProvider(id) / setAsrProvider(id) 是同步 React state 改动，立刻让 CredentialField 重挂载读 ark.api_key —— 但此时 await setActive*Provider 还没跑，后端 root.active.llm 还是旧值，lookup_account 落到旧 entry。
2. **覆盖**：setCredential('ark.endpoint', preset.baseUrl) 无条件写默认值，每次切回该 provider 都把用户自定义的 baseUrl 覆盖回出厂默认。

## 改动

Settings.tsx 两个 handler，共 +20/-8：

- 把 await setActive*Provider(id) 挪到 setLlm/AsrProvider(id) **之前**——后端 active 切到位再让 React 重挂载
- endpoint/model 默认值改成「仅当该 provider entry 该字段为空」才填，不再覆盖用户自定义

不动 persistence schema、不动 IPC、不动 coordinator。

## Test plan
- [ ] Ark 填 key A → 切 DeepSeek 填 key D → 切回 Ark 看到 key A（保留）
- [ ] Ark 自定义 baseUrl → 切 DeepSeek 再切回 → Ark 自定义 baseUrl 还在
- [ ] ASR：SiliconFlow ↔ GLM ↔ Groq ↔ OpenAI 切换同款验收
- [ ] 首次切到一个还没填过的 provider，endpoint/model 显示该 preset 默认值


___

### **PR Type**
Bug fix


___

### **Description**
- Fix race: switch backend active before UI remounts

- Preserve user overrides: default endpoint/model only if empty

- Handle rapid switches: split state and sequence ref to abort stale

- Credential field keys now use committed provider for correct reads


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["User selects new provider in <select>"]
  B["Immediate setLlmProvider → UI reflects choice"]
  C["Increment sequence ref (seq = ++ref)"]
  D["await setActiveLlmProvider(id)"]
  E{"seq matches?"}
  F["await updatePrefs(next)"]
  G{"endpoint/field empty?"}
  H["setCredential(default) only if empty"]
  I["setCommittedLlmProvider(id)"]
  J["CredentialField remounts with correct key"]
  K["Abort: stale request, do not commit"]

  A --> B
  B --> C
  C --> D
  D --> E
  E -- yes --> F
  E -- no --> K
  F --> E
  E -- yes --> G
  G -- yes --> H
  G -- no --> E
  H --> E
  E -- yes --> I
  I --> J
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Settings.tsx</strong><dd><code>Fix stale credential display and overwrite protection in provider </code><br><code>switch handlers</code></dd></summary>
<hr>

openless-all/app/src/pages/Settings.tsx

<ul><li>Introduce <code>committedLlmProvider</code> / <code>committedAsrProvider</code> state to defer <br>credential remount until backend active provider is set<br> <li> Add <code>llmSwitchSeqRef</code> / <code>asrSwitchSeqRef</code> to abort stale async flows on <br>rapid switches<br> <li> Reorder: <code>setActive*Provider</code> and <code>updatePrefs</code> before commit; default <br>endpoint/model only written if current value is empty<br> <li> Update all <code>CredentialField</code> keys, <code>ProviderTools</code> key, and volcengine <br>conditional to use <code>committed*Provider</code> instead of immediate state<br> <li> <code>preset</code> lookups and placeholder logic now derive from committed <br>provider, preventing placeholder/credential mismatch</ul>


</details>


  </td>
  <td><a href="https://github.com/appergb/openless/pull/220/files#diff-b493ca85e083b07f67da1b3ac96aeab153b20c97405e26292b47b95e13368c38">+68/-21</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

