### PR TITLE
feat(vocab): 增加词汇表场景预设

### DIFF
--- a/openless-all/app/src-tauri/src/commands.rs
+++ b/openless-all/app/src-tauri/src/commands.rs
@@ -13,7 +13,7 @@ use crate::persistence::{CredentialAccount, CredentialsSnapshot, CredentialsVaul
 use crate::polish::{LLMError, OpenAICompatibleConfig, OpenAICompatibleLLMProvider};
 use crate::types::{
     CredentialsStatus, DictationSession, DictionaryEntry, HotkeyCapability, HotkeyStatus,
-    PolishMode, QaHotkeyBinding, UserPreferences, WindowsImeStatus,
+    PolishMode, QaHotkeyBinding, UserPreferences, VocabPreset, WindowsImeStatus,
 };
 
 type CoordinatorState<'a> = State<'a, Arc<Coordinator>>;
@@ -354,6 +354,16 @@ pub fn set_vocab_enabled(
         .vocab()
         .set_enabled(&id, enabled)
         .map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub fn list_vocab_presets() -> Result<Vec<VocabPreset>, String> {
+    crate::persistence::list_vocab_presets().map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub fn save_vocab_presets(presets: Vec<VocabPreset>) -> Result<(), String> {
+    crate::persistence::save_vocab_presets(&presets).map_err(|e| e.to_string())
 }
 
 // ─────────────────────────── dictation lifecycle ───────────────────────────

--- a/openless-all/app/src-tauri/src/commands.rs
+++ b/openless-all/app/src-tauri/src/commands.rs
@@ -13,7 +13,7 @@ use crate::persistence::{CredentialAccount, CredentialsSnapshot, CredentialsVaul
 use crate::polish::{LLMError, OpenAICompatibleConfig, OpenAICompatibleLLMProvider};
 use crate::types::{
     CredentialsStatus, DictationSession, DictionaryEntry, HotkeyCapability, HotkeyStatus,
-    PolishMode, QaHotkeyBinding, UserPreferences, VocabPreset, WindowsImeStatus,
+    PolishMode, QaHotkeyBinding, UserPreferences, VocabPresetStore, WindowsImeStatus,
 };
 
 type CoordinatorState<'a> = State<'a, Arc<Coordinator>>;
@@ -357,13 +357,13 @@ pub fn set_vocab_enabled(
 }
 
 #[tauri::command]
-pub fn list_vocab_presets() -> Result<Vec<VocabPreset>, String> {
+pub fn list_vocab_presets() -> Result<VocabPresetStore, String> {
     crate::persistence::list_vocab_presets().map_err(|e| e.to_string())
 }
 
 #[tauri::command]
-pub fn save_vocab_presets(presets: Vec<VocabPreset>) -> Result<(), String> {
-    crate::persistence::save_vocab_presets(&presets).map_err(|e| e.to_string())
+pub fn save_vocab_presets(store: VocabPresetStore) -> Result<(), String> {
+    crate::persistence::save_vocab_presets(&store).map_err(|e| e.to_string())
 }
 
 // ─────────────────────────── dictation lifecycle ───────────────────────────

--- a/openless-all/app/src-tauri/src/lib.rs
+++ b/openless-all/app/src-tauri/src/lib.rs
@@ -202,6 +202,8 @@ pub fn run() {
             commands::add_vocab,
             commands::remove_vocab,
             commands::set_vocab_enabled,
+            commands::list_vocab_presets,
+            commands::save_vocab_presets,
             commands::start_dictation,
             commands::stop_dictation,
             commands::cancel_dictation,

--- a/openless-all/app/src-tauri/src/persistence.rs
+++ b/openless-all/app/src-tauri/src/persistence.rs
@@ -22,7 +22,7 @@ use parking_lot::Mutex;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-use crate::types::{DictationSession, DictionaryEntry, UserPreferences};
+use crate::types::{DictationSession, DictionaryEntry, UserPreferences, VocabPreset};
 
 const HISTORY_CAP: usize = 200;
 const HISTORY_FILE: &str = "history.json";
@@ -30,6 +30,7 @@ const PREFERENCES_FILE: &str = "preferences.json";
 /// 与 Swift `Sources/OpenLessPersistence/DictionaryStore.swift` 同名，
 /// 让旧版词汇表在升级后无缝继承。**不要**改成 `vocab.json`，会丢用户数据。
 const VOCAB_FILE: &str = "dictionary.json";
+const VOCAB_PRESETS_FILE: &str = "vocab-presets.json";
 
 /// Swift 老 `CredentialsVault` 的 JSON 备用路径。
 /// 升级到 Tauri 版后，先尝试 Keychain；Keychain 没有时回落读这个文件，
@@ -591,6 +592,20 @@ fn count_occurrences(haystack: &str, needle: &str) -> u64 {
         }
     }
     count
+}
+
+pub fn list_vocab_presets() -> Result<Vec<VocabPreset>> {
+    let dir = data_dir()?;
+    ensure_dir(&dir)?;
+    read_or_default::<Vec<VocabPreset>>(&dir.join(VOCAB_PRESETS_FILE))
+}
+
+pub fn save_vocab_presets(presets: &[VocabPreset]) -> Result<()> {
+    let dir = data_dir()?;
+    ensure_dir(&dir)?;
+    let path = dir.join(VOCAB_PRESETS_FILE);
+    let json = serde_json::to_vec_pretty(presets).context("encode vocab presets failed")?;
+    atomic_write(&path, &json)
 }
 
 // ───────────────────────── CredentialsVault ─────────────────────────

--- a/openless-all/app/src-tauri/src/persistence.rs
+++ b/openless-all/app/src-tauri/src/persistence.rs
@@ -22,7 +22,7 @@ use parking_lot::Mutex;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-use crate::types::{DictationSession, DictionaryEntry, UserPreferences, VocabPreset};
+use crate::types::{DictationSession, DictionaryEntry, UserPreferences, VocabPresetStore};
 
 const HISTORY_CAP: usize = 200;
 const HISTORY_FILE: &str = "history.json";
@@ -594,17 +594,17 @@ fn count_occurrences(haystack: &str, needle: &str) -> u64 {
     count
 }
 
-pub fn list_vocab_presets() -> Result<Vec<VocabPreset>> {
+pub fn list_vocab_presets() -> Result<VocabPresetStore> {
     let dir = data_dir()?;
     ensure_dir(&dir)?;
-    read_or_default::<Vec<VocabPreset>>(&dir.join(VOCAB_PRESETS_FILE))
+    read_or_default::<VocabPresetStore>(&dir.join(VOCAB_PRESETS_FILE))
 }
 
-pub fn save_vocab_presets(presets: &[VocabPreset]) -> Result<()> {
+pub fn save_vocab_presets(store: &VocabPresetStore) -> Result<()> {
     let dir = data_dir()?;
     ensure_dir(&dir)?;
     let path = dir.join(VOCAB_PRESETS_FILE);
-    let json = serde_json::to_vec_pretty(presets).context("encode vocab presets failed")?;
+    let json = serde_json::to_vec_pretty(store).context("encode vocab presets failed")?;
     atomic_write(&path, &json)
 }
 
@@ -738,7 +738,7 @@ impl CredentialsVault {
 #[cfg(test)]
 mod tests {
     use super::{list_vocab_presets, save_vocab_presets};
-    use crate::types::VocabPreset;
+    use crate::types::{VocabPreset, VocabPresetStore};
     use std::fs;
     use std::path::PathBuf;
 
@@ -750,16 +750,21 @@ mod tests {
         unsafe {
             std::env::set_var("XDG_DATA_HOME", &tmp);
         }
-        let presets = vec![VocabPreset {
-            id: "test".into(),
-            name: "测试".into(),
-            phrases: vec!["PR".into(), "CI".into()],
-        }];
-        save_vocab_presets(&presets).expect("save presets");
+        let store = VocabPresetStore {
+            custom: vec![VocabPreset {
+                id: "test".into(),
+                name: "测试".into(),
+                phrases: vec!["PR".into(), "CI".into()],
+            }],
+            overrides: vec![],
+            disabled_builtin_preset_ids: vec!["chef".into()],
+        };
+        save_vocab_presets(&store).expect("save presets");
         let loaded = list_vocab_presets().expect("list presets");
-        assert_eq!(loaded.len(), 1);
-        assert_eq!(loaded[0].id, "test");
-        assert_eq!(loaded[0].phrases, vec!["PR".to_string(), "CI".to_string()]);
+        assert_eq!(loaded.custom.len(), 1);
+        assert_eq!(loaded.custom[0].id, "test");
+        assert_eq!(loaded.custom[0].phrases, vec!["PR".to_string(), "CI".to_string()]);
+        assert_eq!(loaded.disabled_builtin_preset_ids, vec!["chef".to_string()]);
         let _ = fs::remove_dir_all(&tmp);
     }
 }

--- a/openless-all/app/src-tauri/src/persistence.rs
+++ b/openless-all/app/src-tauri/src/persistence.rs
@@ -734,3 +734,32 @@ impl CredentialsVault {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{list_vocab_presets, save_vocab_presets};
+    use crate::types::VocabPreset;
+    use std::fs;
+    use std::path::PathBuf;
+
+    #[test]
+    fn vocab_presets_roundtrip_json_file() {
+        let tmp: PathBuf = std::env::temp_dir().join(format!("openless-test-{}", uuid::Uuid::new_v4()));
+        fs::create_dir_all(&tmp).expect("create temp dir");
+        // Linux path helper uses XDG_DATA_HOME first.
+        unsafe {
+            std::env::set_var("XDG_DATA_HOME", &tmp);
+        }
+        let presets = vec![VocabPreset {
+            id: "test".into(),
+            name: "测试".into(),
+            phrases: vec!["PR".into(), "CI".into()],
+        }];
+        save_vocab_presets(&presets).expect("save presets");
+        let loaded = list_vocab_presets().expect("list presets");
+        assert_eq!(loaded.len(), 1);
+        assert_eq!(loaded[0].id, "test");
+        assert_eq!(loaded[0].phrases, vec!["PR".to_string(), "CI".to_string()]);
+        let _ = fs::remove_dir_all(&tmp);
+    }
+}

--- a/openless-all/app/src-tauri/src/types.rs
+++ b/openless-all/app/src-tauri/src/types.rs
@@ -68,6 +68,14 @@ pub struct DictionaryEntry {
     pub created_at: String,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct VocabPreset {
+    pub id: String,
+    pub name: String,
+    pub phrases: Vec<String>,
+}
+
 fn default_true() -> bool {
     true
 }

--- a/openless-all/app/src-tauri/src/types.rs
+++ b/openless-all/app/src-tauri/src/types.rs
@@ -76,6 +76,14 @@ pub struct VocabPreset {
     pub phrases: Vec<String>,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(default, rename_all = "camelCase")]
+pub struct VocabPresetStore {
+    pub custom: Vec<VocabPreset>,
+    pub overrides: Vec<VocabPreset>,
+    pub disabled_builtin_preset_ids: Vec<String>,
+}
+
 fn default_true() -> bool {
     true
 }

--- a/openless-all/app/src/i18n/en.ts
+++ b/openless-all/app/src/i18n/en.ts
@@ -166,6 +166,17 @@ export const en: typeof zhCN = {
     tipDisabled: 'Click to disable this entry',
     tipEnabled: 'Click to enable this entry',
     removeAria: 'Remove',
+    presets: {
+      title: 'Scenario presets',
+      tip: 'Multi-select to apply in batch; supports edit/create and keeps local preset structure ready for future import/export.',
+      create: 'New preset',
+      apply: 'Apply selected',
+      save: 'Save preset',
+      edit: 'Edit {{name}}',
+      newPreset: 'New preset',
+      namePlaceholder: 'Preset name',
+      wordsPlaceholder: 'Terms (comma or newline separated)',
+    },
   },
   style: {
     kicker: 'STYLE',

--- a/openless-all/app/src/i18n/zh-CN.ts
+++ b/openless-all/app/src/i18n/zh-CN.ts
@@ -164,6 +164,17 @@ export const zhCN = {
     tipDisabled: '点击禁用此词条',
     tipEnabled: '点击启用此词条',
     removeAria: '删除',
+    presets: {
+      title: '场景预设',
+      tip: '可多选后批量启用；支持编辑和新建，已为后续导入导出预留本地结构。',
+      create: '新建预设',
+      apply: '启用所选',
+      save: '保存预设',
+      edit: '编辑 {{name}}',
+      newPreset: '新预设',
+      namePlaceholder: '预设名称',
+      wordsPlaceholder: '词条（用逗号或换行分隔）',
+    },
   },
   style: {
     kicker: 'STYLE',

--- a/openless-all/app/src/lib/ipc.ts
+++ b/openless-all/app/src/lib/ipc.ts
@@ -13,6 +13,7 @@ import type {
   QaHotkeyBinding,
   UserPreferences,
   WindowsImeStatus,
+  VocabPreset,
 } from './types';
 import { OL_DATA } from './mockData';
 
@@ -198,6 +199,14 @@ export function removeVocab(id: string): Promise<void> {
 
 export function setVocabEnabled(id: string, enabled: boolean): Promise<void> {
   return invokeOrMock('set_vocab_enabled', { id, enabled }, () => undefined);
+}
+
+export function listVocabPresets(): Promise<VocabPreset[]> {
+  return invokeOrMock('list_vocab_presets', undefined, () => []);
+}
+
+export function saveVocabPresets(presets: VocabPreset[]): Promise<void> {
+  return invokeOrMock('save_vocab_presets', { presets }, () => undefined);
 }
 
 // ── Dictation lifecycle ────────────────────────────────────────────────

--- a/openless-all/app/src/lib/ipc.ts
+++ b/openless-all/app/src/lib/ipc.ts
@@ -14,6 +14,7 @@ import type {
   UserPreferences,
   WindowsImeStatus,
   VocabPreset,
+  VocabPresetStore,
 } from './types';
 import { OL_DATA } from './mockData';
 
@@ -201,12 +202,16 @@ export function setVocabEnabled(id: string, enabled: boolean): Promise<void> {
   return invokeOrMock('set_vocab_enabled', { id, enabled }, () => undefined);
 }
 
-export function listVocabPresets(): Promise<VocabPreset[]> {
-  return invokeOrMock('list_vocab_presets', undefined, () => []);
+export function listVocabPresets(): Promise<VocabPresetStore> {
+  return invokeOrMock('list_vocab_presets', undefined, () => ({
+    custom: [],
+    overrides: [],
+    disabledBuiltinPresetIds: [],
+  }));
 }
 
-export function saveVocabPresets(presets: VocabPreset[]): Promise<void> {
-  return invokeOrMock('save_vocab_presets', { presets }, () => undefined);
+export function saveVocabPresets(store: VocabPresetStore): Promise<void> {
+  return invokeOrMock('save_vocab_presets', { store }, () => undefined);
 }
 
 // ── Dictation lifecycle ────────────────────────────────────────────────

--- a/openless-all/app/src/lib/types.ts
+++ b/openless-all/app/src/lib/types.ts
@@ -29,6 +29,12 @@ export interface DictionaryEntry {
   createdAt: string;
 }
 
+export interface VocabPreset {
+  id: string;
+  name: string;
+  phrases: string[];
+}
+
 export type HotkeyTrigger =
   | 'rightOption'
   | 'leftOption'

--- a/openless-all/app/src/lib/types.ts
+++ b/openless-all/app/src/lib/types.ts
@@ -35,6 +35,12 @@ export interface VocabPreset {
   phrases: string[];
 }
 
+export interface VocabPresetStore {
+  custom: VocabPreset[];
+  overrides: VocabPreset[];
+  disabledBuiltinPresetIds: string[];
+}
+
 export type HotkeyTrigger =
   | 'rightOption'
   | 'leftOption'

--- a/openless-all/app/src/lib/vocab-presets.json
+++ b/openless-all/app/src/lib/vocab-presets.json
@@ -1,0 +1,17 @@
+[
+  {
+    "id": "programmer",
+    "name": "程序员",
+    "phrases": ["PR", "CI", "tag", "release", "issue", "Rust", "TypeScript"]
+  },
+  {
+    "id": "chef",
+    "name": "厨师",
+    "phrases": ["出品", "备料", "火候", "刀工", "摆盘", "sous vide"]
+  },
+  {
+    "id": "civil-servant",
+    "name": "公务员",
+    "phrases": ["公文", "批示", "督办", "政务", "会签", "材料"]
+  }
+]

--- a/openless-all/app/src/lib/vocabPresets.ts
+++ b/openless-all/app/src/lib/vocabPresets.ts
@@ -1,0 +1,17 @@
+import defaultPresetsJson from './vocab-presets.json';
+import { listVocabPresets, saveVocabPresets } from './ipc';
+import type { VocabPreset } from './types';
+
+export const DEFAULT_VOCAB_PRESETS: VocabPreset[] = defaultPresetsJson as VocabPreset[];
+
+export async function loadVocabPresets(): Promise<VocabPreset[]> {
+  const userPresets = await listVocabPresets();
+  if (!Array.isArray(userPresets) || userPresets.length === 0) {
+    return DEFAULT_VOCAB_PRESETS;
+  }
+  return userPresets;
+}
+
+export async function persistVocabPresets(presets: VocabPreset[]) {
+  await saveVocabPresets(presets);
+}

--- a/openless-all/app/src/lib/vocabPresets.ts
+++ b/openless-all/app/src/lib/vocabPresets.ts
@@ -6,10 +6,15 @@ export const DEFAULT_VOCAB_PRESETS: VocabPreset[] = defaultPresetsJson as VocabP
 
 export async function loadVocabPresets(): Promise<VocabPreset[]> {
   const userPresets = await listVocabPresets();
-  if (!Array.isArray(userPresets) || userPresets.length === 0) {
+  if (!Array.isArray(userPresets)) {
     return DEFAULT_VOCAB_PRESETS;
   }
-  return userPresets;
+  const merged = new Map(DEFAULT_VOCAB_PRESETS.map(p => [p.id, p] as const));
+  for (const preset of userPresets) {
+    if (!preset || !preset.id) continue;
+    merged.set(preset.id, preset);
+  }
+  return Array.from(merged.values());
 }
 
 export async function persistVocabPresets(presets: VocabPreset[]) {

--- a/openless-all/app/src/lib/vocabPresets.ts
+++ b/openless-all/app/src/lib/vocabPresets.ts
@@ -1,22 +1,46 @@
 import defaultPresetsJson from './vocab-presets.json';
 import { listVocabPresets, saveVocabPresets } from './ipc';
-import type { VocabPreset } from './types';
+import type { VocabPreset, VocabPresetStore } from './types';
 
 export const DEFAULT_VOCAB_PRESETS: VocabPreset[] = defaultPresetsJson as VocabPreset[];
 
 export async function loadVocabPresets(): Promise<VocabPreset[]> {
-  const userPresets = await listVocabPresets();
-  if (!Array.isArray(userPresets)) {
-    return DEFAULT_VOCAB_PRESETS;
+  const store = await listVocabPresets();
+  const builtin = new Map(DEFAULT_VOCAB_PRESETS.map(p => [p.id, p] as const));
+  for (const id of store.disabledBuiltinPresetIds || []) {
+    builtin.delete(id);
   }
-  const merged = new Map(DEFAULT_VOCAB_PRESETS.map(p => [p.id, p] as const));
-  for (const preset of userPresets) {
+  for (const preset of store.overrides || []) {
     if (!preset || !preset.id) continue;
-    merged.set(preset.id, preset);
+    if (builtin.has(preset.id)) builtin.set(preset.id, preset);
   }
-  return Array.from(merged.values());
+  const custom = (store.custom || []).filter(p => p && p.id);
+  return [...builtin.values(), ...custom];
 }
 
 export async function persistVocabPresets(presets: VocabPreset[]) {
-  await saveVocabPresets(presets);
+  const builtinMap = new Map(DEFAULT_VOCAB_PRESETS.map(p => [p.id, p] as const));
+  const store: VocabPresetStore = {
+    custom: [],
+    overrides: [],
+    disabledBuiltinPresetIds: [],
+  };
+  const seenBuiltin = new Set<string>();
+  for (const preset of presets) {
+    const base = builtinMap.get(preset.id);
+    if (!base) {
+      store.custom.push(preset);
+      continue;
+    }
+    seenBuiltin.add(preset.id);
+    if (JSON.stringify(base) !== JSON.stringify(preset)) {
+      store.overrides.push(preset);
+    }
+  }
+  for (const id of builtinMap.keys()) {
+    if (!seenBuiltin.has(id)) {
+      store.disabledBuiltinPresetIds.push(id);
+    }
+  }
+  await saveVocabPresets(store);
 }

--- a/openless-all/app/src/pages/Settings.tsx
+++ b/openless-all/app/src/pages/Settings.tsx
@@ -4,7 +4,6 @@
 
 import { useEffect, useRef, useState, type CSSProperties, type ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
-import { disable as disableAutostart, enable as enableAutostart, isEnabled as isAutostartEnabled } from '@tauri-apps/plugin-autostart';
 import { Icon } from '../components/Icon';
 import { isDialogStatus, UpdateDialog, useAutoUpdate } from '../components/AutoUpdate';
 import { APP_VERSION_LABEL } from '../lib/appVersion';
@@ -15,6 +14,7 @@ import {
   checkMicrophonePermission,
   getHotkeyStatus,
   getWindowsImeStatus,
+  isTauri,
   openExternal,
   openSystemSettings,
   listProviderModels,
@@ -51,6 +51,17 @@ interface SettingsProps {
 export type SettingsSectionId = 'recording' | 'providers' | 'shortcuts' | 'permissions' | 'language' | 'about';
 
 const SECTION_ORDER: SettingsSectionId[] = ['recording', 'providers', 'shortcuts', 'permissions', 'language', 'about'];
+
+type AutostartPlugin = {
+  enable: () => Promise<void>;
+  disable: () => Promise<void>;
+  isEnabled: () => Promise<boolean>;
+};
+
+async function loadAutostartPlugin(): Promise<AutostartPlugin> {
+  const pluginName = '@tauri-apps/plugin-autostart';
+  return import(/* @vite-ignore */ pluginName) as Promise<AutostartPlugin>;
+}
 
 export function Settings({ embedded = false, initialSection = 'recording' }: SettingsProps) {
   const { t } = useTranslation();
@@ -269,15 +280,20 @@ function AutostartRow() {
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
+    if (!isTauri) {
+      setLoaded(true);
+      return;
+    }
     let cancelled = false;
-    isAutostartEnabled()
-      .then(v => {
+    loadAutostartPlugin()
+      .then(plugin => plugin.isEnabled())
+      .then((v: boolean) => {
         if (!cancelled) {
           setEnabled(v);
           setLoaded(true);
         }
       })
-      .catch(err => {
+      .catch((err: unknown) => {
         console.error('[autostart] isEnabled failed', err);
         if (!cancelled) setLoaded(true);
       });
@@ -290,8 +306,10 @@ function AutostartRow() {
     setEnabled(next);
     setError(null);
     try {
-      if (next) await enableAutostart();
-      else await disableAutostart();
+      if (!isTauri) return;
+      const plugin = await loadAutostartPlugin();
+      if (next) await plugin.enable();
+      else await plugin.disable();
     } catch (err) {
       console.error('[autostart] toggle failed', err);
       setEnabled(!next);

--- a/openless-all/app/src/pages/Settings.tsx
+++ b/openless-all/app/src/pages/Settings.tsx
@@ -52,15 +52,19 @@ export type SettingsSectionId = 'recording' | 'providers' | 'shortcuts' | 'permi
 
 const SECTION_ORDER: SettingsSectionId[] = ['recording', 'providers', 'shortcuts', 'permissions', 'language', 'about'];
 
-type AutostartPlugin = {
-  enable: () => Promise<void>;
-  disable: () => Promise<void>;
-  isEnabled: () => Promise<boolean>;
-};
+async function autostartIsEnabled(): Promise<boolean> {
+  const { invoke } = await import('@tauri-apps/api/core');
+  return invoke<boolean>('plugin:autostart|is_enabled');
+}
 
-async function loadAutostartPlugin(): Promise<AutostartPlugin> {
-  const pluginName = '@tauri-apps/plugin-autostart';
-  return import(/* @vite-ignore */ pluginName) as Promise<AutostartPlugin>;
+async function autostartEnable(): Promise<void> {
+  const { invoke } = await import('@tauri-apps/api/core');
+  await invoke('plugin:autostart|enable');
+}
+
+async function autostartDisable(): Promise<void> {
+  const { invoke } = await import('@tauri-apps/api/core');
+  await invoke('plugin:autostart|disable');
 }
 
 export function Settings({ embedded = false, initialSection = 'recording' }: SettingsProps) {
@@ -285,8 +289,7 @@ function AutostartRow() {
       return;
     }
     let cancelled = false;
-    loadAutostartPlugin()
-      .then(plugin => plugin.isEnabled())
+    autostartIsEnabled()
       .then((v: boolean) => {
         if (!cancelled) {
           setEnabled(v);
@@ -307,9 +310,8 @@ function AutostartRow() {
     setError(null);
     try {
       if (!isTauri) return;
-      const plugin = await loadAutostartPlugin();
-      if (next) await plugin.enable();
-      else await plugin.disable();
+      if (next) await autostartEnable();
+      else await autostartDisable();
     } catch (err) {
       console.error('[autostart] toggle failed', err);
       setEnabled(!next);

--- a/openless-all/app/src/pages/Vocab.tsx
+++ b/openless-all/app/src/pages/Vocab.tsx
@@ -4,7 +4,8 @@
 import { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { addVocab, isTauri, listVocab, removeVocab, setVocabEnabled } from '../lib/ipc';
-import type { DictionaryEntry } from '../lib/types';
+import type { DictionaryEntry, VocabPreset } from '../lib/types';
+import { DEFAULT_VOCAB_PRESETS, loadVocabPresets, persistVocabPresets } from '../lib/vocabPresets';
 import { Btn, Card, PageHeader } from './_atoms';
 
 export function Vocab() {
@@ -14,6 +15,11 @@ export function Vocab() {
   const inputRef = useRef<HTMLInputElement>(null);
 
   const [error, setError] = useState<string | null>(null);
+  const [presets, setPresets] = useState<VocabPreset[]>(DEFAULT_VOCAB_PRESETS);
+  const [selectedPresetIds, setSelectedPresetIds] = useState<string[]>([]);
+  const [editingPresetId, setEditingPresetId] = useState<string | null>(null);
+  const [presetNameDraft, setPresetNameDraft] = useState('');
+  const [presetPhrasesDraft, setPresetPhrasesDraft] = useState('');
 
   const refresh = async () => {
     try {
@@ -30,6 +36,9 @@ export function Vocab() {
 
   useEffect(() => {
     refresh();
+    void loadVocabPresets()
+      .then(setPresets)
+      .catch(err => setError(err instanceof Error ? err.message : String(err)));
     // 订阅后端 vocab:updated：每段口述结束、record_hits 触发后由 coordinator 推送。
     // Vocab 页面打开期间能即时看到命中数累加，无需切到其他 tab 再切回。
     if (!isTauri) return;
@@ -82,6 +91,61 @@ export function Vocab() {
     }
   };
 
+  const togglePreset = (id: string) => {
+    setSelectedPresetIds(prev => (prev.includes(id) ? prev.filter(x => x !== id) : [...prev, id]));
+  };
+
+  const startEditPreset = (preset: VocabPreset) => {
+    setEditingPresetId(preset.id);
+    setPresetNameDraft(preset.name);
+    setPresetPhrasesDraft(preset.phrases.join(', '));
+  };
+
+  const savePreset = () => {
+    if (!editingPresetId) return;
+    const name = presetNameDraft.trim();
+    if (!name) return;
+    const phrases = Array.from(
+      new Set(
+        presetPhrasesDraft
+          .split(/[,\n]/)
+          .map(s => s.trim())
+          .filter(Boolean),
+      ),
+    );
+    const next = presets.map(p => (p.id === editingPresetId ? { ...p, name, phrases } : p));
+    setPresets(next);
+    void persistVocabPresets(next).catch(err => setError(err instanceof Error ? err.message : String(err)));
+    setEditingPresetId(null);
+  };
+
+  const createPreset = () => {
+    const next: VocabPreset = {
+      id: `user-${Date.now()}`,
+      name: t('vocab.presets.newPreset'),
+      phrases: [],
+    };
+    const updated = [...presets, next];
+    setPresets(updated);
+    void persistVocabPresets(updated).catch(err => setError(err instanceof Error ? err.message : String(err)));
+    startEditPreset(next);
+  };
+
+  const applySelectedPresets = async () => {
+    const selected = presets.filter(p => selectedPresetIds.includes(p.id));
+    if (selected.length === 0) return;
+    const phraseSet = new Set(entries.map(e => e.phrase.trim().toLowerCase()));
+    for (const p of selected) {
+      for (const phrase of p.phrases) {
+        if (!phraseSet.has(phrase.trim().toLowerCase())) {
+          await addVocab(phrase);
+          phraseSet.add(phrase.trim().toLowerCase());
+        }
+      }
+    }
+    await refresh();
+  };
+
   return (
     <>
       <PageHeader
@@ -95,6 +159,48 @@ export function Vocab() {
         }
       />
       <Card padding={0}>
+        <div style={{ padding: 18, borderBottom: '0.5px solid var(--ol-line)' }}>
+          <div style={{ display: 'flex', gap: 8, alignItems: 'center', flexWrap: 'wrap' }}>
+            <strong style={{ fontSize: 12 }}>{t('vocab.presets.title')}</strong>
+            {presets.map(p => (
+              <button
+                key={p.id}
+                onClick={() => togglePreset(p.id)}
+                style={{
+                  border: '0.5px solid var(--ol-line-strong)',
+                  borderRadius: 999,
+                  padding: '4px 10px',
+                  fontSize: 12,
+                  background: selectedPresetIds.includes(p.id) ? 'var(--ol-blue-soft)' : 'var(--ol-surface-2)',
+                }}
+              >
+                {p.name}
+              </button>
+            ))}
+            <Btn size="sm" variant="ghost" onClick={createPreset}>{t('vocab.presets.create')}</Btn>
+            <Btn size="sm" variant="primary" onClick={applySelectedPresets}>{t('vocab.presets.apply')}</Btn>
+          </div>
+          <div style={{ fontSize: 11, color: 'var(--ol-ink-4)', marginTop: 10 }}>{t('vocab.presets.tip')}</div>
+          {editingPresetId && (
+            <div style={{ marginTop: 10, display: 'grid', gap: 8 }}>
+              <input value={presetNameDraft} onChange={e => setPresetNameDraft(e.target.value)} placeholder={t('vocab.presets.namePlaceholder')} />
+              <textarea value={presetPhrasesDraft} onChange={e => setPresetPhrasesDraft(e.target.value)} placeholder={t('vocab.presets.wordsPlaceholder')} rows={3} />
+              <div style={{ display: 'flex', gap: 8 }}>
+                <Btn size="sm" variant="primary" onClick={savePreset}>{t('vocab.presets.save')}</Btn>
+                <Btn size="sm" variant="ghost" onClick={() => setEditingPresetId(null)}>{t('common.cancel')}</Btn>
+              </div>
+            </div>
+          )}
+          {!editingPresetId && presets.length > 0 && (
+            <div style={{ marginTop: 8, display: 'flex', gap: 8, flexWrap: 'wrap' }}>
+              {presets.map(p => (
+                <Btn key={`${p.id}-edit`} size="sm" variant="ghost" onClick={() => startEditPreset(p)}>
+                  {t('vocab.presets.edit', { name: p.name })}
+                </Btn>
+              ))}
+            </div>
+          )}
+        </div>
         <div style={{ padding: 18, borderBottom: '0.5px solid var(--ol-line)' }}>
           <div style={{ display: 'flex', gap: 8 }}>
             <input

--- a/openless-all/app/src/pages/Vocab.tsx
+++ b/openless-all/app/src/pages/Vocab.tsx
@@ -8,6 +8,8 @@ import type { DictionaryEntry, VocabPreset } from '../lib/types';
 import { DEFAULT_VOCAB_PRESETS, loadVocabPresets, persistVocabPresets } from '../lib/vocabPresets';
 import { Btn, Card, PageHeader } from './_atoms';
 
+const NEW_PRESET_DRAFT_ID = '__new__';
+
 export function Vocab() {
   const { t } = useTranslation();
   const [entries, setEntries] = useState<DictionaryEntry[]>([]);
@@ -113,22 +115,19 @@ export function Vocab() {
           .filter(Boolean),
       ),
     );
-    const next = presets.map(p => (p.id === editingPresetId ? { ...p, name, phrases } : p));
+    const next =
+      editingPresetId === NEW_PRESET_DRAFT_ID
+        ? [...presets, { id: `user-${Date.now()}`, name, phrases }]
+        : presets.map(p => (p.id === editingPresetId ? { ...p, name, phrases } : p));
     setPresets(next);
     void persistVocabPresets(next).catch(err => setError(err instanceof Error ? err.message : String(err)));
     setEditingPresetId(null);
   };
 
   const createPreset = () => {
-    const next: VocabPreset = {
-      id: `user-${Date.now()}`,
-      name: t('vocab.presets.newPreset'),
-      phrases: [],
-    };
-    const updated = [...presets, next];
-    setPresets(updated);
-    void persistVocabPresets(updated).catch(err => setError(err instanceof Error ? err.message : String(err)));
-    startEditPreset(next);
+    setEditingPresetId(NEW_PRESET_DRAFT_ID);
+    setPresetNameDraft(t('vocab.presets.newPreset'));
+    setPresetPhrasesDraft('');
   };
 
   const applySelectedPresets = async () => {

--- a/openless-all/app/src/pages/Vocab.tsx
+++ b/openless-all/app/src/pages/Vocab.tsx
@@ -103,7 +103,7 @@ export function Vocab() {
     setPresetPhrasesDraft(preset.phrases.join(', '));
   };
 
-  const savePreset = () => {
+  const savePreset = async () => {
     if (!editingPresetId) return;
     const name = presetNameDraft.trim();
     if (!name) return;
@@ -119,9 +119,13 @@ export function Vocab() {
       editingPresetId === NEW_PRESET_DRAFT_ID
         ? [...presets, { id: `user-${Date.now()}`, name, phrases }]
         : presets.map(p => (p.id === editingPresetId ? { ...p, name, phrases } : p));
-    setPresets(next);
-    void persistVocabPresets(next).catch(err => setError(err instanceof Error ? err.message : String(err)));
-    setEditingPresetId(null);
+    try {
+      await persistVocabPresets(next);
+      setPresets(next);
+      setEditingPresetId(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    }
   };
 
   const createPreset = () => {
@@ -134,15 +138,23 @@ export function Vocab() {
     const selected = presets.filter(p => selectedPresetIds.includes(p.id));
     if (selected.length === 0) return;
     const phraseSet = new Set(entries.map(e => e.phrase.trim().toLowerCase()));
+    let failures = 0;
     for (const p of selected) {
       for (const phrase of p.phrases) {
         if (!phraseSet.has(phrase.trim().toLowerCase())) {
-          await addVocab(phrase);
-          phraseSet.add(phrase.trim().toLowerCase());
+          try {
+            await addVocab(phrase);
+            phraseSet.add(phrase.trim().toLowerCase());
+          } catch {
+            failures += 1;
+          }
         }
       }
     }
     await refresh();
+    if (failures > 0) {
+      setError(`部分词条添加失败（${failures}）`);
+    }
   };
 
   return (
@@ -185,7 +197,7 @@ export function Vocab() {
               <input value={presetNameDraft} onChange={e => setPresetNameDraft(e.target.value)} placeholder={t('vocab.presets.namePlaceholder')} />
               <textarea value={presetPhrasesDraft} onChange={e => setPresetPhrasesDraft(e.target.value)} placeholder={t('vocab.presets.wordsPlaceholder')} rows={3} />
               <div style={{ display: 'flex', gap: 8 }}>
-                <Btn size="sm" variant="primary" onClick={savePreset}>{t('vocab.presets.save')}</Btn>
+                <Btn size="sm" variant="primary" onClick={() => void savePreset()}>{t('vocab.presets.save')}</Btn>
                 <Btn size="sm" variant="ghost" onClick={() => setEditingPresetId(null)}>{t('common.cancel')}</Btn>
               </div>
             </div>

--- a/openless-all/app/src/pages/Vocab.tsx
+++ b/openless-all/app/src/pages/Vocab.tsx
@@ -137,16 +137,35 @@ export function Vocab() {
   const applySelectedPresets = async () => {
     const selected = presets.filter(p => selectedPresetIds.includes(p.id));
     if (selected.length === 0) return;
-    const phraseSet = new Set(entries.map(e => e.phrase.trim().toLowerCase()));
+    const byPhrase = new Map<string, DictionaryEntry[]>();
+    const addedPhrases = new Set<string>();
+    for (const entry of entries) {
+      const key = entry.phrase.trim().toLowerCase();
+      if (!byPhrase.has(key)) byPhrase.set(key, []);
+      byPhrase.get(key)?.push(entry);
+    }
     let failures = 0;
     for (const p of selected) {
       for (const phrase of p.phrases) {
-        if (!phraseSet.has(phrase.trim().toLowerCase())) {
+        const key = phrase.trim().toLowerCase();
+        if (addedPhrases.has(key)) continue;
+        const existing = byPhrase.get(key) || [];
+        if (existing.length === 0) {
           try {
             await addVocab(phrase);
-            phraseSet.add(phrase.trim().toLowerCase());
+            addedPhrases.add(key);
           } catch {
             failures += 1;
+          }
+          continue;
+        }
+        for (const item of existing) {
+          if (!item.enabled) {
+            try {
+              await setVocabEnabled(item.id, true);
+            } catch {
+              failures += 1;
+            }
           }
         }
       }

--- a/openless-all/app/src/types/tauri-plugin-autostart.d.ts
+++ b/openless-all/app/src/types/tauri-plugin-autostart.d.ts
@@ -1,0 +1,5 @@
+declare module '@tauri-apps/plugin-autostart' {
+  export function enable(): Promise<void>;
+  export function disable(): Promise<void>;
+  export function isEnabled(): Promise<boolean>;
+}


### PR DESCRIPTION
### **User description**
## 摘要

Fixes #224。

本 PR 为词汇表增加场景预设能力，方便用户按使用场景批量启用常用词，而不是逐条手动输入。

当前实现支持内置场景预设、多选批量启用、编辑预设、新建自定义预设，并将用户预设保存到 app data 目录的 JSON 文件中。内置预设也改为仓库内 JSON 文件，保证内置预设和用户预设使用同一套 `VocabPreset` 数据结构，为后续导入 / 导出功能保留兼容的 JSON 形状。

## 修复 / 新增 / 改进

- 新增词汇表场景预设：
  - 程序员
  - 厨师
  - 公务员

- 新增内置预设文件：
  - `openless-all/app/src/lib/vocab-presets.json`

- 新增统一预设类型：
  - Rust: `VocabPreset`
  - TypeScript: `VocabPreset`

- 新增预设读写 Tauri command：
  - `list_vocab_presets`
  - `save_vocab_presets`

- 用户自定义预设保存到 app data 目录：
  - `vocab-presets.json`

- 词汇表页面新增场景预设区域：
  - 支持多选预设
  - 支持批量启用所选预设
  - 支持编辑预设名称和词条
  - 支持新建自定义预设
  - 支持保存用户自定义预设

- 批量启用预设时会复用现有词汇表入口：
  - 通过 `addVocab()` 添加词条
  - 已存在词条会跳过，避免重复添加
  - 添加后刷新词汇表

- 编辑预设时支持用逗号或换行分隔词条。

- 保存预设时会对词条做基础清洗：
  - trim 空白
  - 过滤空项
  - 去重

- 补充中英文 i18n 文案：
  - 场景预设
  - 新建预设
  - 启用所选
  - 保存预设
  - 编辑预设
  - 预设名称
  - 词条输入提示

## 兼容

- 不包含：
  - 不改变现有词汇表条目的后端存储结构。
  - 不改变词汇表原有新增、删除、启用、禁用行为。
  - 不改变 polish / 热词注入逻辑。
  - 不实现完整导入 / 导出功能。
  - 不使用 localStorage 保存预设。
  - 不把预设硬编码在 TS 常量里作为唯一来源。
  - 不引入新依赖。

- 对现有用户 / 本地环境 / 构建流程的影响：
  - 现有词汇表数据继续沿用原来的 `dictionary.json`。
  - 新增的预设数据单独保存到 `vocab-presets.json`。
  - 用户未保存自定义预设时，会使用仓库内置默认预设。
  - 用户保存自定义预设后，会优先使用用户本地预设。
  - 词汇表原有交互保持不变，预设只是新增的批量启用入口。
  - 为后续导入 / 导出保留统一 JSON schema。

## 测试计划

- [x] 命令：`cargo check --manifest-path openless-all/app/src-tauri/Cargo.toml`
- [x] 结果：通过
- [x] 证据路径：本地 src-tauri 检查输出

- [ ] 命令：`npm run build`
- [ ] 结果：未完成
- [ ] 说明：当前 `npm build` 受既有 `Settings.tsx` typing 问题阻塞，和本次词汇表预设改动无关。

## 主要改动文件

- `openless-all/app/src-tauri/src/commands.rs`
- `openless-all/app/src-tauri/src/lib.rs`
- `openless-all/app/src-tauri/src/persistence.rs`
- `openless-all/app/src-tauri/src/types.rs`
- `openless-all/app/src/i18n/en.ts`
- `openless-all/app/src/i18n/zh-CN.ts`
- `openless-all/app/src/lib/ipc.ts`
- `openless-all/app/src/lib/types.ts`
- `openless-all/app/src/lib/vocab-presets.json`
- `openless-all/app/src/lib/vocabPresets.ts`
- `openless-all/app/src/pages/Vocab.tsx`

## 备注

本 PR 只实现词汇表预设的新增、编辑、保存和批量启用。导入 / 导出没有在本次实现中落地，但预设已经统一为 JSON 结构，后续可以直接基于当前 schema 扩展。


___

### **PR Type**
Enhancement, Bug fix, Tests


___

### **Description**
- Add vocabulary scenario presets with multi‑select apply, create, and edit

- Store built‑in presets in repo JSON and user presets via Tauri commands

- Fix web build failure by lazy‑loading the autostart plugin in Settings

- Add regression test for preset JSON persistence roundtrip


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["User selects presets"] --> B["Frontend loads preset list"]
  B --> C["Backend reads built‑in/user JSON files"]
  C --> D["Apply phrases to vocab entries"]
  E["Create/edit preset"] --> F["Persist via Tauri command"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>10 files</summary><table>
<tr>
  <td><strong>commands.rs</strong><dd><code>Add list_vocab_presets and save_vocab_presets Tauri commands</code></dd></td>
  <td><a href="https://github.com/appergb/openless/pull/233/files#diff-8215873d09604b1dbb99088131ba7fc2fd6c537e67588cba5bd9160c2138b035">+11/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>lib.rs</strong><dd><code>Register new vocab preset commands in the invoke handler</code>&nbsp; </dd></td>
  <td><a href="https://github.com/appergb/openless/pull/233/files#diff-6b8eb1bbf8e378bab914f1a12962f7add5cc4ba9e013c37c9921a1032fa5e110">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>persistence.rs</strong><dd><code>Implement vocab preset persistence with atomic write and roundtrip </code><br><code>test</code></dd></td>
  <td><a href="https://github.com/appergb/openless/pull/233/files#diff-fe150b5c0806f2cac2827075208fe552ab2b17590ad3dddfbdbdc240084e1adb">+50/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>types.rs</strong><dd><code>Define VocabPreset and VocabPresetStore Rust types</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/appergb/openless/pull/233/files#diff-702c533512690147fd6f9342d29f6258530afc2c9ada765f4af3bd082080c952">+16/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>en.ts</strong><dd><code>Add English i18n strings for scenario presets</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/appergb/openless/pull/233/files#diff-bb2f4fa05787923f8aeb23b6f11ad8705e02d9ff03a45790f9181e4615c79d83">+11/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>zh-CN.ts</strong><dd><code>Add Chinese i18n strings for scenario presets</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/appergb/openless/pull/233/files#diff-571576f3c7b6c4a78ae0f91accdccc5da5cbed00409955c9914c046fee6c80ea">+11/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ipc.ts</strong><dd><code>Add listVocabPresets and saveVocabPresets IPC wrappers</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/appergb/openless/pull/233/files#diff-ef5ae5193f0c45b487cbf9b509e52f941a85d5bffc201561a2fa1394a5ff160a">+14/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>types.ts</strong><dd><code>Add TypeScript interfaces for VocabPreset and VocabPresetStore</code></dd></td>
  <td><a href="https://github.com/appergb/openless/pull/233/files#diff-f22942a2f6ef50f13345f6b2781790a4a99e38a1a39702ce4bca3b2b2eb95e5a">+12/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>vocabPresets.ts</strong><dd><code>Add vocab preset loading, merging, and persistence logic</code>&nbsp; </dd></td>
  <td><a href="https://github.com/appergb/openless/pull/233/files#diff-e6d555840b5e8f792609f2f81ed2625e9ccb612afb10b0302a664dcb3888575e">+46/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>Vocab.tsx</strong><dd><code>Add scenario preset UI with multi-select, create, and edit</code></dd></td>
  <td><a href="https://github.com/appergb/openless/pull/233/files#diff-a6cb21d7e7ec6b4ac4f71c19a804a0548087140d62e09f12f8c439c6cf39197e">+137/-1</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>Settings.tsx</strong><dd><code>Fix web build by lazy‑loading autostart plugin imports</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/appergb/openless/pull/233/files#diff-b493ca85e083b07f67da1b3ac96aeab153b20c97405e26292b47b95e13368c38">+26/-6</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>tauri-plugin-autostart.d.ts</strong><dd><code>Add type declaration for the autostart plugin</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/appergb/openless/pull/233/files#diff-c86440a71bfa6f407eb3347192addadf45375536e59568dffa17ab6c3edb3cb4">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>vocab-presets.json</strong><dd><code>Add built‑in vocab preset definitions in JSON</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/appergb/openless/pull/233/files#diff-75069ee68d905d979cb23af49395fe1f66320aa4a773ef0e028ad34147880525">+17/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

