### PR TITLE
fix(windows): make QA panel close button clickable

### DIFF
--- a/openless-all/app/src-tauri/src/lib.rs
+++ b/openless-all/app/src-tauri/src/lib.rs
@@ -645,12 +645,10 @@ pub(crate) fn show_qa_window<R: tauri::Runtime>(app: &AppHandle<R>, content_kind
         });
     }
     #[cfg(target_os = "windows")]
-    {
-        if !show_qa_window_no_activate(&window) {
-            log::warn!("[qa] show_no_activate failed; falling back to window.show()");
-            if let Err(e) = window.show() {
-                log::warn!("[qa] show fallback failed: {e}");
-            }
+    if !show_qa_window_no_activate(&window) {
+        log::warn!("[qa] show_no_activate failed; falling back to window.show()");
+        if let Err(e) = window.show() {
+            log::warn!("[qa] show fallback failed: {e}");
         }
     }
     #[cfg(all(not(target_os = "macos"), not(target_os = "windows")))]
@@ -703,10 +701,7 @@ pub(crate) fn hide_qa_window<R: tauri::Runtime>(app: &AppHandle<R>) {
 fn show_qa_window_no_activate<R: tauri::Runtime>(window: &tauri::WebviewWindow<R>) -> bool {
     use raw_window_handle::{HasWindowHandle, RawWindowHandle};
     use windows::Win32::Foundation::HWND;
-    use windows::Win32::UI::WindowsAndMessaging::{
-        SetWindowPos, ShowWindow, HWND_TOPMOST, SWP_NOACTIVATE, SWP_NOMOVE, SWP_NOSIZE,
-        SWP_SHOWWINDOW, SW_SHOWNOACTIVATE,
-    };
+    use windows::Win32::UI::WindowsAndMessaging::{ShowWindow, SW_SHOWNOACTIVATE};
 
     let Ok(handle) = window.window_handle() else {
         return false;
@@ -720,17 +715,6 @@ fn show_qa_window_no_activate<R: tauri::Runtime>(window: &tauri::WebviewWindow<R
     }
 
     let _ = unsafe { ShowWindow(hwnd, SW_SHOWNOACTIVATE) };
-    let _ = unsafe {
-        SetWindowPos(
-            hwnd,
-            HWND_TOPMOST,
-            0,
-            0,
-            0,
-            0,
-            SWP_NOMOVE | SWP_NOSIZE | SWP_SHOWWINDOW | SWP_NOACTIVATE,
-        )
-    };
     true
 }
 


### PR DESCRIPTION
### **User description**
## Summary
- fix issue #239 where the Windows selection-QA panel close button could not be clicked
- remove the Windows no-activate show path for the QA window
- use the standard window.show() path so the webview reliably receives click events

## Validation
- cargo check -q (run in openless-all/app/src-tauri)

Closes #239


___

### **PR Type**
Bug fix


___

### **Description**
- Fix Windows QA panel close clicks
    - Preserve no-activate showing with simpler native call
    - Remove topmost `SetWindowPos` from show path


___

### Diagram Walkthrough


```mermaid
    flowchart LR
      A["Windows QA window show logic"] -- "simplify" --> B["Use ShowWindow(SW_SHOWNOACTIVATE) only"]
      B -- "improves" --> C["Close button receives clicks"]
  ```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>lib.rs</strong><dd><code>Simplify Windows QA window show behavior</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src-tauri/src/lib.rs

<ul><li>Simplifies <code>show_qa_window_no_activate</code> on Windows to call only <br><code>ShowWindow(SW_SHOWNOACTIVATE)</code>.<br> <li> Removes the extra <code>SetWindowPos(..., HWND_TOPMOST, SWP_NOACTIVATE)</code> <br>step.<br> <li> Keeps the existing fallback to <code>window.show()</code> when native no-activate <br>display fails.</ul>


</details>


  </td>
  <td><a href="https://github.com/appergb/openless/pull/240/files#diff-6b8eb1bbf8e378bab914f1a12962f7add5cc4ba9e013c37c9921a1032fa5e110">+5/-21</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

