### PR TITLE
security(qa): sanitize assistant markdown rendering in QA panel

### DIFF
--- a/openless-all/app/src/lib/qaMarkdown.test.ts
+++ b/openless-all/app/src/lib/qaMarkdown.test.ts
@@ -28,3 +28,7 @@ assertIncludes(goodMarkdown, 'href="https://example.com"', 'safe link should ren
 
 const safeQueryLink = renderQaMarkdown('[ok](https://example.com?a=1&b=2)');
 assertIncludes(safeQueryLink, 'href="https://example.com?a=1&amp;b=2"', 'safe query link should keep a single escaped ampersand');
+
+const codeSnippet = renderQaMarkdown('`<div class=\"x\">`');
+assertIncludes(codeSnippet, '&lt;div class=&quot;x&quot;&gt;', 'inline code should stay single-escaped');
+assertNotIncludes(codeSnippet, '&amp;lt;', 'inline code should not be double-escaped');

--- a/openless-all/app/src/lib/qaMarkdown.test.ts
+++ b/openless-all/app/src/lib/qaMarkdown.test.ts
@@ -1,0 +1,28 @@
+import { renderQaMarkdown } from './qaMarkdown';
+
+function assertIncludes(text: string, expected: string, name: string) {
+  if (!text.includes(expected)) {
+    throw new Error(`${name}: expected to include "${expected}", got "${text}"`);
+  }
+}
+
+function assertNotIncludes(text: string, expected: string, name: string) {
+  if (text.includes(expected)) {
+    throw new Error(`${name}: expected not to include "${expected}", got "${text}"`);
+  }
+}
+
+const htmlEscaped = renderQaMarkdown('<img src=x onerror=alert(1)><script>alert(1)</script>');
+assertIncludes(htmlEscaped, '&lt;img src=x onerror=alert(1)&gt;', 'raw html should be escaped');
+assertNotIncludes(htmlEscaped, '<script>', 'script tag should not be rendered');
+assertNotIncludes(htmlEscaped, 'onerror=', 'event attribute should stay inert');
+
+const badHref = renderQaMarkdown('[xss](javascript:alert(1))');
+assertNotIncludes(badHref, 'href="javascript:alert(1)"', 'javascript href should be dropped');
+
+const goodMarkdown = renderQaMarkdown('**bold**\n\n- a\n- b\n\n`code`\n\n[ok](https://example.com)');
+assertIncludes(goodMarkdown, '<strong>bold</strong>', 'bold markdown should render');
+assertIncludes(goodMarkdown, '<li>a</li>', 'list markdown should render');
+assertIncludes(goodMarkdown, '<code>code</code>', 'code markdown should render');
+assertIncludes(goodMarkdown, 'href="https://example.com"', 'safe link should render');
+

--- a/openless-all/app/src/lib/qaMarkdown.test.ts
+++ b/openless-all/app/src/lib/qaMarkdown.test.ts
@@ -15,7 +15,7 @@ function assertNotIncludes(text: string, expected: string, name: string) {
 const htmlEscaped = renderQaMarkdown('<img src=x onerror=alert(1)><script>alert(1)</script>');
 assertIncludes(htmlEscaped, '&lt;img src=x onerror=alert(1)&gt;', 'raw html should be escaped');
 assertNotIncludes(htmlEscaped, '<script>', 'script tag should not be rendered');
-assertNotIncludes(htmlEscaped, 'onerror=', 'event attribute should stay inert');
+assertNotIncludes(htmlEscaped, '<img src=x onerror=alert(1)>', 'raw html img should not become live dom tag');
 
 const badHref = renderQaMarkdown('[xss](javascript:alert(1))');
 assertNotIncludes(badHref, 'href="javascript:alert(1)"', 'javascript href should be dropped');
@@ -26,3 +26,5 @@ assertIncludes(goodMarkdown, '<li>a</li>', 'list markdown should render');
 assertIncludes(goodMarkdown, '<code>code</code>', 'code markdown should render');
 assertIncludes(goodMarkdown, 'href="https://example.com"', 'safe link should render');
 
+const safeQueryLink = renderQaMarkdown('[ok](https://example.com?a=1&b=2)');
+assertIncludes(safeQueryLink, 'href="https://example.com?a=1&amp;b=2"', 'safe query link should keep a single escaped ampersand');

--- a/openless-all/app/src/lib/qaMarkdown.ts
+++ b/openless-all/app/src/lib/qaMarkdown.ts
@@ -35,6 +35,7 @@ function normalizeHref(href: string | null | undefined): string | null {
 }
 
 const QA_MARKDOWN_RENDERER = new marked.Renderer();
+QA_MARKDOWN_RENDERER.html = (html: string) => escapeHtml(html);
 QA_MARKDOWN_RENDERER.link = (href: string | null, title: string | null, text: string) => {
   const safeHref = normalizeHref(decodeHtmlEntities(href ?? ''));
   if (!safeHref) return `<span>${text}</span>`;
@@ -54,9 +55,8 @@ export function renderQaPlainText(raw: string): string {
 }
 
 export function renderQaMarkdown(markdown: string): string {
-  // 禁用 markdown 中 raw HTML：统一转义后再走 marked，仅保留安全 markdown 子集。
-  const escaped = escapeHtml(markdown);
-  return marked.parse(escaped, {
+  // 保留 markdown 语义（尤其代码块），但把 raw HTML token 转义为纯文本，避免注入。
+  return marked.parse(markdown, {
     async: false,
     gfm: true,
     breaks: true,

--- a/openless-all/app/src/lib/qaMarkdown.ts
+++ b/openless-all/app/src/lib/qaMarkdown.ts
@@ -1,0 +1,51 @@
+import { marked } from 'marked';
+
+const SAFE_LINK_PROTOCOLS = new Set(['http:', 'https:', 'mailto:', 'tel:']);
+
+function escapeHtml(raw: string): string {
+  return raw
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function normalizeHref(href: string | null | undefined): string | null {
+  if (!href) return null;
+  const trimmed = href.trim();
+  if (!trimmed) return null;
+  if (trimmed.startsWith('#')) return trimmed;
+  try {
+    const url = new URL(trimmed, 'https://openless.local/');
+    if (!SAFE_LINK_PROTOCOLS.has(url.protocol)) return null;
+    return trimmed;
+  } catch {
+    return null;
+  }
+}
+
+const QA_MARKDOWN_RENDERER = new marked.Renderer();
+QA_MARKDOWN_RENDERER.link = (href: string | null, title: string | null, text: string) => {
+  const safeHref = normalizeHref(href);
+  if (!safeHref) return `<span>${text}</span>`;
+  const titleAttr = title ? ` title="${escapeHtml(title)}"` : '';
+  return `<a href="${escapeHtml(safeHref)}"${titleAttr} target="_blank" rel="noreferrer noopener">${text}</a>`;
+};
+QA_MARKDOWN_RENDERER.image = (href: string | null, title: string | null, text: string) => {
+  const safeHref = normalizeHref(href);
+  if (!safeHref) return '';
+  const titleAttr = title ? ` title="${escapeHtml(title)}"` : '';
+  const alt = escapeHtml(text || '');
+  return `<img src="${escapeHtml(safeHref)}" alt="${alt}"${titleAttr} loading="lazy" />`;
+};
+
+export function renderQaMarkdown(markdown: string): string {
+  // 禁用 markdown 中 raw HTML：统一转义后再走 marked，仅保留安全 markdown 子集。
+  const escaped = escapeHtml(markdown);
+  return marked.parse(escaped, {
+    async: false,
+    gfm: true,
+    renderer: QA_MARKDOWN_RENDERER,
+  }) as string;
+}

--- a/openless-all/app/src/lib/qaMarkdown.ts
+++ b/openless-all/app/src/lib/qaMarkdown.ts
@@ -11,6 +11,15 @@ function escapeHtml(raw: string): string {
     .replace(/'/g, '&#39;');
 }
 
+function decodeHtmlEntities(raw: string): string {
+  return raw
+    .replace(/&amp;/g, '&')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>');
+}
+
 function normalizeHref(href: string | null | undefined): string | null {
   if (!href) return null;
   const trimmed = href.trim();
@@ -27,18 +36,22 @@ function normalizeHref(href: string | null | undefined): string | null {
 
 const QA_MARKDOWN_RENDERER = new marked.Renderer();
 QA_MARKDOWN_RENDERER.link = (href: string | null, title: string | null, text: string) => {
-  const safeHref = normalizeHref(href);
+  const safeHref = normalizeHref(decodeHtmlEntities(href ?? ''));
   if (!safeHref) return `<span>${text}</span>`;
   const titleAttr = title ? ` title="${escapeHtml(title)}"` : '';
   return `<a href="${escapeHtml(safeHref)}"${titleAttr} target="_blank" rel="noreferrer noopener">${text}</a>`;
 };
 QA_MARKDOWN_RENDERER.image = (href: string | null, title: string | null, text: string) => {
-  const safeHref = normalizeHref(href);
+  const safeHref = normalizeHref(decodeHtmlEntities(href ?? ''));
   if (!safeHref) return '';
   const titleAttr = title ? ` title="${escapeHtml(title)}"` : '';
   const alt = escapeHtml(text || '');
   return `<img src="${escapeHtml(safeHref)}" alt="${alt}"${titleAttr} loading="lazy" />`;
 };
+
+export function renderQaPlainText(raw: string): string {
+  return `<pre>${escapeHtml(raw)}</pre>`;
+}
 
 export function renderQaMarkdown(markdown: string): string {
   // 禁用 markdown 中 raw HTML：统一转义后再走 marked，仅保留安全 markdown 子集。

--- a/openless-all/app/src/lib/qaMarkdown.ts
+++ b/openless-all/app/src/lib/qaMarkdown.ts
@@ -59,6 +59,7 @@ export function renderQaMarkdown(markdown: string): string {
   return marked.parse(escaped, {
     async: false,
     gfm: true,
+    breaks: true,
     renderer: QA_MARKDOWN_RENDERER,
   }) as string;
 }

--- a/openless-all/app/src/pages/QaPanel.tsx
+++ b/openless-all/app/src/pages/QaPanel.tsx
@@ -15,7 +15,7 @@ import { useTranslation } from 'react-i18next';
 import { getSettings, isTauri, qaWindowDismiss, qaWindowPin } from '../lib/ipc';
 import type { QaChatMessage, QaStatePayload, UserPreferences } from '../lib/types';
 import { getHotkeyTriggerLabel } from '../lib/hotkey';
-import { renderQaMarkdown } from '../lib/qaMarkdown';
+import { renderQaMarkdown, renderQaPlainText } from '../lib/qaMarkdown';
 
 const SELECTION_PREVIEW_MAX = 60;
 
@@ -406,7 +406,7 @@ function MessageRow({ message }: { message: QaChatMessage }) {
       return renderQaMarkdown(message.content);
     } catch (error) {
       console.error('[qa] failed to render markdown', error);
-      return message.content;
+      return renderQaPlainText(String(message.content ?? ''));
     }
   }, [message.content, message.role]);
 
@@ -446,7 +446,7 @@ function StreamingAssistantBubble({ markdown }: { markdown: string }) {
       return renderQaMarkdown(markdown);
     } catch (error) {
       console.error('[qa] failed to render streaming markdown', error);
-      return markdown;
+      return renderQaPlainText(String(markdown ?? ''));
     }
   }, [markdown]);
   return (

--- a/openless-all/app/src/pages/QaPanel.tsx
+++ b/openless-all/app/src/pages/QaPanel.tsx
@@ -12,14 +12,12 @@
 
 import { useEffect, useMemo, useRef, useState, type CSSProperties } from 'react';
 import { useTranslation } from 'react-i18next';
-import { marked } from 'marked';
 import { getSettings, isTauri, qaWindowDismiss, qaWindowPin } from '../lib/ipc';
 import type { QaChatMessage, QaStatePayload, UserPreferences } from '../lib/types';
 import { getHotkeyTriggerLabel } from '../lib/hotkey';
+import { renderQaMarkdown } from '../lib/qaMarkdown';
 
 const SELECTION_PREVIEW_MAX = 60;
-
-marked.setOptions({ gfm: true, breaks: true });
 
 type Status = 'idle' | 'recording' | 'thinking' | 'error';
 
@@ -405,7 +403,7 @@ function MessageRow({ message }: { message: QaChatMessage }) {
   const html = useMemo(() => {
     if (message.role !== 'assistant') return '';
     try {
-      return marked.parse(message.content, { async: false }) as string;
+      return renderQaMarkdown(message.content);
     } catch (error) {
       console.error('[qa] failed to render markdown', error);
       return message.content;
@@ -445,7 +443,7 @@ function MessageRow({ message }: { message: QaChatMessage }) {
 function StreamingAssistantBubble({ markdown }: { markdown: string }) {
   const html = useMemo(() => {
     try {
-      return marked.parse(markdown, { async: false }) as string;
+      return renderQaMarkdown(markdown);
     } catch (error) {
       console.error('[qa] failed to render streaming markdown', error);
       return markdown;


### PR DESCRIPTION
### **User description**
## Summary
- address #221 by routing QA assistant markdown through a shared safe renderer
- escape raw HTML and restrict link/image protocols to safe allowlisted schemes
- apply the same rendering path to streaming and final assistant answers
- harden fallback path so render failures never inject raw model output into dangerouslySetInnerHTML
- add minimal regression checks for malicious markdown/html and safe markdown rendering

## Validation
- npm run build (openless-all/app)

Closes #221


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Centralize markdown sanitization in a shared renderer

- Escape raw HTML and restrict link protocols

- Unify streaming and final answer rendering paths

- Harden error fallback to prevent unsafe injection


___

### Diagram Walkthrough


```mermaid
flowchart LR
  QA["QaPanel assistant & streaming bubbles"] -- use --> RM["renderQaMarkdown()"]
  RM -- sanitizes via --> CR["Custom marked.Renderer"]
  CR -- escapes HTML, restricts protocols --> OUT["Safe HTML"]
  QA -- fallback on error --> PT["renderQaPlainText()"]
  PT -- outputs --> PRE["<pre> inert text </pre>"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>qaMarkdown.ts</strong><dd><code>Add safe QA markdown renderer with XSS guards</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src/lib/qaMarkdown.ts

<ul><li>Escape raw HTML with character replacements<br> <li> Normalize and allowlist link/image protocols<br> <li> Override marked renderer for html, link, image<br> <li> Export renderQaMarkdown and renderQaPlainText functions</ul>


</details>


  </td>
  <td><a href="https://github.com/appergb/openless/pull/241/files#diff-85dfc324580524fd043d91d379537ee3f9c16078cd24aa66040febc93816bdf5">+65/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>QaPanel.tsx</strong><dd><code>Adopt safe markdown renderer in QaPanel</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src/pages/QaPanel.tsx

<ul><li>Replace direct marked.parse with renderQaMarkdown<br> <li> Use renderQaPlainText for error fallback instead of raw content<br> <li> Remove redundant marked.setOptions call</ul>


</details>


  </td>
  <td><a href="https://github.com/appergb/openless/pull/241/files#diff-26b9b5ef15d0d88c7f7ad27838fcc84e0a457c3db5e14a59047412125b4a7de0">+5/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>qaMarkdown.test.ts</strong><dd><code>Add regression tests for markdown sanitization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src/lib/qaMarkdown.test.ts

<ul><li>Test that raw HTML and script tags are escaped<br> <li> Test that dangerous hrefs like javascript: are stripped<br> <li> Test that safe markdown (bold, lists, code, link) renders correctly<br> <li> Verify code snippets are not double-escaped</ul>


</details>


  </td>
  <td><a href="https://github.com/appergb/openless/pull/241/files#diff-261ee1afd1d6adf03af7ea7d76bf66e8cbfad964335c1d4396384a3d9f3756d0">+34/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

