### PR TITLE
fix(ui): 概览页整屏不滚 + 其他页 scrollbar 变细 (#243)

### DIFF
--- a/openless-all/app/src/components/FloatingShell.tsx
+++ b/openless-all/app/src/components/FloatingShell.tsx
@@ -260,9 +260,13 @@ function FloatingShellBody({ os, initialTab, initialSettings }: { os: OS; initia
                     两列内部各自的 overflow:auto 才能独立滚动 */}
             <div
               key={displayTab}
+              // issue #243：Overview 是 dashboard，期望「一眼看完」不滚动；
+              // 其余页（History / Vocab / Style / Translation / SelectionAsk）继续允许
+              // 滚动但走细 scrollbar，不抢眼。
+              className={displayTab === 'overview' ? undefined : 'ol-thinscroll'}
               style={{
                 flex: 1, minHeight: 0,
-                overflow: 'auto',
+                overflow: displayTab === 'overview' ? 'hidden' : 'auto',
                 padding: '24px 28px 32px',
                 // 苹果"spring out"风格的曲线：开始快、收尾顺滑，符合人体直觉
                 animation: tabPhase === 'exiting'

--- a/openless-all/app/src/components/FloatingShell.tsx
+++ b/openless-all/app/src/components/FloatingShell.tsx
@@ -260,13 +260,17 @@ function FloatingShellBody({ os, initialTab, initialSettings }: { os: OS; initia
                     两列内部各自的 overflow:auto 才能独立滚动 */}
             <div
               key={displayTab}
-              // issue #243：Overview 是 dashboard，期望「一眼看完」不滚动；
-              // 其余页（History / Vocab / Style / Translation / SelectionAsk）继续允许
-              // 滚动但走细 scrollbar，不抢眼。
-              className={displayTab === 'overview' ? undefined : 'ol-thinscroll'}
+              // issue #243：所有 tab 都允许 overflow:auto，让窗口被压缩 / 文案
+              //   变长时仍可触达底部内容（Codex P1：之前 overview 用 hidden
+              //   会让缩窗后 Recent 卡彻底不可见）。
+              //   - Overview 借 Overview.tsx 内部 flex 把底部行 grow 到撑满，
+              //     正常尺寸下内容刚好占满 → 浏览器自动不显示 scrollbar；
+              //     真挤不下了才 fallback 出细滚动条。
+              //   - 其他 tab 同样走细滚动条。
+              className="ol-thinscroll"
               style={{
                 flex: 1, minHeight: 0,
-                overflow: displayTab === 'overview' ? 'hidden' : 'auto',
+                overflow: 'auto',
                 padding: '24px 28px 32px',
                 // 苹果"spring out"风格的曲线：开始快、收尾顺滑，符合人体直觉
                 animation: tabPhase === 'exiting'

--- a/openless-all/app/src/components/SettingsModal.tsx
+++ b/openless-all/app/src/components/SettingsModal.tsx
@@ -164,7 +164,7 @@ export function SettingsModal({ os: _os, onClose, initialSettingsSection }: Sett
             </div>
           ) : (
             // personalize / about 短内容：单一 scroll wrapper，超出时本块滚动。
-            <div style={{ flex: 1, minHeight: 0, overflow: 'auto', padding: '10px 28px 28px' }}>
+            <div className="ol-thinscroll" style={{ flex: 1, minHeight: 0, overflow: 'auto', padding: '10px 28px 28px' }}>
               {section === 'personalize' && <PersonalizeSection />}
               {section === 'about' && <AboutMini />}
             </div>

--- a/openless-all/app/src/pages/History.tsx
+++ b/openless-all/app/src/pages/History.tsx
@@ -126,7 +126,7 @@ export function History() {
               ))}
             </div>
           </div>
-          <div style={{ flex: 1, overflow: 'auto', padding: 6 }}>
+          <div className="ol-thinscroll" style={{ flex: 1, overflow: 'auto', padding: 6 }}>
             {loading && <div style={{ padding: 16, fontSize: 12, color: 'var(--ol-ink-4)' }}>{t('common.loading')}</div>}
             {!loading && filtered.length === 0 && (
               <div style={{ padding: 16, fontSize: 12, color: 'var(--ol-ink-4)' }}>
@@ -164,7 +164,7 @@ export function History() {
           </div>
         </Card>
 
-        <Card padding={20} style={{ overflow: 'auto' }}>
+        <Card padding={20} className="ol-thinscroll" style={{ overflow: 'auto' }}>
           {item ? (
             <>
               <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 14 }}>

--- a/openless-all/app/src/pages/Overview.tsx
+++ b/openless-all/app/src/pages/Overview.tsx
@@ -94,8 +94,11 @@ export function Overview({ onOpenHistory }: OverviewProps) {
         <Metric icon="bolt" label={t('overview.metricTotal')} value={String(history.length)} trend={t('overview.metricTotalTrend')} accent />
       </div>
 
-      <div style={{ display: 'grid', gridTemplateColumns: '1fr 1.4fr', gap: 12 }}>
-        <Card padding={18}>
+      {/* 底部一行 = flex:1 撑满剩余高度（父 wrapper 是 display:flex/column）。
+          只有「最近识别」内部允许滚动；其他卡片按内容自然高度，不破裂底部圆角。
+          issue #243 follow-up：去掉外层 overflow 后底部圆角被裁的视觉问题。 */}
+      <div style={{ display: 'grid', gridTemplateColumns: '1fr 1.4fr', gap: 12, flex: 1, minHeight: 0 }}>
+        <Card padding={18} style={{ display: 'flex', flexDirection: 'column', minHeight: 0 }}>
           <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 14 }}>
             <span style={{ fontSize: 12, fontWeight: 600, color: 'var(--ol-ink-2)' }}>{t('overview.weekTitle')}</span>
             <span style={{ fontSize: 11, color: 'var(--ol-ink-4)' }}>{t('overview.weekUnit')}</span>
@@ -106,12 +109,12 @@ export function Overview({ onOpenHistory }: OverviewProps) {
           </div>
         </Card>
 
-        <Card padding={0}>
-          <div style={{ padding: '14px 18px', borderBottom: '0.5px solid var(--ol-line)', display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+        <Card padding={0} style={{ display: 'flex', flexDirection: 'column', minHeight: 0, overflow: 'hidden' }}>
+          <div style={{ padding: '14px 18px', borderBottom: '0.5px solid var(--ol-line)', display: 'flex', alignItems: 'center', justifyContent: 'space-between', flexShrink: 0 }}>
             <span style={{ fontSize: 12, fontWeight: 600, color: 'var(--ol-ink-2)' }}>{t('overview.recentTitle')}</span>
             <Btn size="sm" variant="ghost" onClick={onOpenHistory}>{t('overview.recentAll')}</Btn>
           </div>
-          <div>
+          <div className="ol-thinscroll" style={{ flex: 1, minHeight: 0, overflow: 'auto' }}>
             {history.length === 0 && (
               <div style={{ padding: 24, textAlign: 'center', fontSize: 12, color: 'var(--ol-ink-4)' }}>
                 {t('overview.recentEmpty', { trigger: getHotkeyTriggerLabel(hotkey?.trigger) })}

--- a/openless-all/app/src/pages/Settings.tsx
+++ b/openless-all/app/src/pages/Settings.tsx
@@ -115,6 +115,7 @@ export function Settings({ embedded = false, initialSection = 'recording' }: Set
           ))}
         </div>
         <div
+          className={embedded ? 'ol-thinscroll' : undefined}
           style={{
             display: 'flex',
             flexDirection: 'column',

--- a/openless-all/app/src/pages/_atoms.tsx
+++ b/openless-all/app/src/pages/_atoms.tsx
@@ -32,11 +32,13 @@ interface CardProps {
   style?: CSSProperties;
   padding?: number;
   glassy?: boolean;
+  className?: string;
 }
 
-export function Card({ children, style, padding = 18, glassy = false }: CardProps) {
+export function Card({ children, style, padding = 18, glassy = false, className }: CardProps) {
   return (
     <div
+      className={className}
       style={{
         background: glassy ? 'rgba(255,255,255,0.55)' : 'var(--ol-surface)',
         backdropFilter: glassy ? 'blur(20px) saturate(160%)' : undefined,

--- a/openless-all/app/src/styles/tokens.css
+++ b/openless-all/app/src/styles/tokens.css
@@ -78,6 +78,16 @@ body {
 .ol-noscrollbar::-webkit-scrollbar { display: none; }
 .ol-noscrollbar { scrollbar-width: none; }
 
+/* Thin scrollbar — 细而可见，保留"可以滚"的可见性，但不抢眼。issue #243 */
+.ol-thinscroll::-webkit-scrollbar { width: 6px; height: 6px; }
+.ol-thinscroll::-webkit-scrollbar-track { background: transparent; }
+.ol-thinscroll::-webkit-scrollbar-thumb {
+  background: rgba(0, 0, 0, 0.18);
+  border-radius: 3px;
+}
+.ol-thinscroll::-webkit-scrollbar-thumb:hover { background: rgba(0, 0, 0, 0.28); }
+.ol-thinscroll { scrollbar-width: thin; scrollbar-color: rgba(0, 0, 0, 0.18) transparent; }
+
 /* Glass surface */
 .ol-glass {
   background: var(--ol-glass-bg);


### PR DESCRIPTION
### **User description**
Closes #243

## Summary
- Overview tab：右侧 scrollbar 消失，内容整屏铺开
- History / Vocab / Style / Translation / Selection Ask：scrollbar 由默认粗细改为 6px 细条，不抢眼

## 改动（2 文件 / +15 / -1）

\`FloatingShell.tsx\` page wrapper：
- \`overflow: displayTab === 'overview' ? 'hidden' : 'auto'\`
- \`className={displayTab === 'overview' ? undefined : 'ol-thinscroll'}\`

\`styles/tokens.css\`：新增 \`.ol-thinscroll\` —— 6px 宽 webkit + \`scrollbar-width: thin\` (Firefox)，与既有 \`.ol-noscrollbar\` 同位置但保留可滚动 affordance。

## Test plan
- [ ] Overview tab：无右侧 scrollbar
- [ ] 其他 tab：scrollbar 仍可见但比之前细
- [ ] 内容仍可滚（细只是视觉，功能未破）


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Introduce .ol-thinscroll CSS class for 6px thin scrollbars

- Refactor Overview bottom row to flex layout to fill viewport and avoid unnecessary scrollbar

- Apply thin scrollbar in FloatingShell, History, Settings, SettingsModal, and Overview

- Extend Card atom with className prop for style application


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["tokens.css: .ol-thinscroll class"] --> B["FloatingShell body"]
  A --> C["History panels"]
  A --> D["SettingsModal sections"]
  A --> E["Overview recent list"]
  F["Overview.tsx flex layout"] --> G["Bottom row fills height"]
  G --> H["No scrollbar unless overflow"]
  H --> E
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>FloatingShell.tsx</strong><dd><code>Replace conditional overflow hidden with uniform thin scrollbar</code></dd></td>
  <td><a href="https://github.com/appergb/openless/pull/248/files#diff-ef6d623d372a1cb87a4833f1435927fc2e2ceeedb75c18ea4064d45e1f44df38">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>Overview.tsx</strong><dd><code>Refactor bottom row to flex layout to prevent overflow</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/appergb/openless/pull/248/files#diff-87ea690f4abf573183a65635bee8aae0f788da0bc4b4f030f53756fa16f8aae2">+8/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>SettingsModal.tsx</strong><dd><code>Add thin scrollbar to personalize and about sections</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/appergb/openless/pull/248/files#diff-518aaa44065a9800e52b80d874e513ea210188d25cba2cff3e258b88c05c96cf">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>History.tsx</strong><dd><code>Apply thin scrollbar to list and detail panels</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/appergb/openless/pull/248/files#diff-46c1ec3909029ec66e43bf7cab4914b700aad500151f9ed7f569936df22d5528">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>Settings.tsx</strong><dd><code>Conditionally apply thin scrollbar in embedded settings</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/appergb/openless/pull/248/files#diff-b493ca85e083b07f67da1b3ac96aeab153b20c97405e26292b47b95e13368c38">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>_atoms.tsx</strong><dd><code>Add className prop to Card component</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/appergb/openless/pull/248/files#diff-06fc5179e965d949fd2d430cc292848831340a20b4308770eec9a3262a495a6b">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>tokens.css</strong><dd><code>Define .ol-thinscroll class for thin scrollbar style</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/appergb/openless/pull/248/files#diff-d460e1c9cd1000682a9f2e7b0bd4f890746ec3189922dd71aee816e1319a849e">+10/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

