### PR TITLE
fix(windows): stabilize capsule visuals and audio meter

### DIFF
--- a/openless-all/app/src/components/Capsule.tsx
+++ b/openless-all/app/src/components/Capsule.tsx
@@ -15,9 +15,14 @@ interface AudioBarsProps {
 
 function AudioBars({ level }: AudioBarsProps) {
   const envelope = [0.55, 0.85, 1.0, 0.85, 0.55];
-  const base = 4;
-  const max = 18;
+  const base = 2;
+  const max = 24;
   const voice = Math.min(1, Math.max(0, level));
+  const silenceGate = 0.012;
+  const responseCeiling = 0.34;
+  const gatedVoice = Math.min(1, Math.max(0, (voice - silenceGate) / (responseCeiling - silenceGate)));
+  const easedVoice = gatedVoice * gatedVoice * (3 - 2 * gatedVoice);
+  const visualVoice = Math.pow(easedVoice, 0.42);
   return (
     <div
       style={{
@@ -35,10 +40,11 @@ function AudioBars({ level }: AudioBarsProps) {
           style={{
             display: 'inline-block',
             width: 3,
-            height: base + (max - base) * voice * env,
+            height: base + (max - base) * visualVoice * env,
             borderRadius: 999,
             background: 'var(--ol-blue)',
             opacity: 0.82,
+            transformOrigin: 'center',
             transition: 'height 0.08s var(--ol-motion-quick)',
           }}
         />
@@ -108,6 +114,8 @@ interface CircleButtonProps {
 function CircleButton({ variant, enabled, onClick }: CircleButtonProps) {
   const { t } = useTranslation();
   const isCancel = variant === 'cancel';
+  const os = detectOS();
+  const useBackdrop = os !== 'win' && isCancel;
   return (
     <button
       onClick={enabled ? onClick : undefined}
@@ -118,8 +126,8 @@ function CircleButton({ variant, enabled, onClick }: CircleButtonProps) {
         height: 28,
         borderRadius: 999,
         background: isCancel ? 'rgba(255, 255, 255, 0.55)' : 'rgba(255, 255, 255, 0.92)',
-        backdropFilter: isCancel ? 'blur(12px) saturate(160%)' : 'none',
-        WebkitBackdropFilter: isCancel ? 'blur(12px) saturate(160%)' : 'none',
+        backdropFilter: useBackdrop ? 'blur(12px) saturate(160%)' : 'none',
+        WebkitBackdropFilter: useBackdrop ? 'blur(12px) saturate(160%)' : 'none',
         color: 'var(--ol-ink)',
         border: '0.8px solid rgba(0, 0, 0, 0.08)',
         display: 'inline-flex',
@@ -127,6 +135,7 @@ function CircleButton({ variant, enabled, onClick }: CircleButtonProps) {
         justifyContent: 'center',
         cursor: enabled ? 'default' : 'not-allowed',
         opacity: enabled ? 1 : 0.42,
+        visibility: 'visible',
         flexShrink: 0,
         padding: 0,
         boxShadow: '0 1px 2px rgba(0, 0, 0, 0.06)',
@@ -217,9 +226,7 @@ function Pill({ os, state, level, insertedChars, message, onCancel, onConfirm }:
   const ambient = state === 'recording' ? Math.min(1, Math.max(0, level)) : 0;
   const scale = os === 'win' ? 1 : 1 + ambient * 0.018;
   const shadowAlpha = 0.20 + ambient * 0.10;
-  const dropShadow = os === 'win'
-    ? `drop-shadow(0 12px 24px rgba(0, 0, 0, ${(0.15 + ambient * 0.06).toFixed(3)}))`
-    : 'none';
+  const useBackdrop = os !== 'win';
 
   return (
     <div
@@ -233,11 +240,11 @@ function Pill({ os, state, level, insertedChars, message, onCancel, onConfirm }:
         height: metrics.height,
         borderRadius: 999,
         background: 'rgba(255, 255, 255, 0.62)',
-        backdropFilter: 'blur(28px) saturate(180%)',
-        WebkitBackdropFilter: 'blur(28px) saturate(180%)',
+        backdropFilter: useBackdrop ? 'blur(28px) saturate(180%)' : 'none',
+        WebkitBackdropFilter: useBackdrop ? 'blur(28px) saturate(180%)' : 'none',
         border: '1px solid rgba(255, 255, 255, 0.55)',
         boxShadow: os === 'win'
-          ? '0 0 0 0.5px rgba(0, 0, 0, 0.08), inset 0 0.5px 0 rgba(255, 255, 255, 0.55)'
+          ? `0 10px 24px -14px rgba(0, 0, 0, ${(0.24 + ambient * 0.06).toFixed(3)}), 0 0 0 0.5px rgba(0, 0, 0, 0.08), inset 0 0.5px 0 rgba(255, 255, 255, 0.55)`
           : `0 18px 50px -10px rgba(0, 0, 0, ${shadowAlpha.toFixed(3)}), 0 0 0 0.5px rgba(0, 0, 0, 0.08), inset 0 0.5px 0 rgba(255, 255, 255, 0.55)`,
         color: 'var(--ol-ink)',
         fontFamily: 'var(--ol-font-sans)',
@@ -245,11 +252,10 @@ function Pill({ os, state, level, insertedChars, message, onCancel, onConfirm }:
         transformOrigin: 'center',
         transition: 'transform 0.08s var(--ol-motion-quick), box-shadow 0.08s var(--ol-motion-quick)',
         willChange: 'transform, box-shadow',
-        filter: dropShadow,
       }}
     >
       <CircleButton variant="cancel" enabled={enabled} onClick={onCancel} />
-      <div style={{ flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+      <div style={{ flex: 1, minWidth: 0, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
         {center}
       </div>
       <CircleButton variant="confirm" enabled={enabled} onClick={onConfirm} />

--- a/openless-all/app/src/lib/capsuleLayout.test.ts
+++ b/openless-all/app/src/lib/capsuleLayout.test.ts
@@ -12,7 +12,7 @@ function assertEqual<T>(actual: T, expected: T, name: string) {
 const winMetrics = getCapsulePillMetrics('win');
 assertEqual(winMetrics.width, 196, 'windows capsule widens pill');
 assertEqual(winMetrics.height, 52, 'windows capsule increases pill height');
-assertEqual(winMetrics.textWidth, 118, 'windows capsule widens text slot');
+assertEqual(winMetrics.textWidth, 104, 'windows capsule keeps side controls clear');
 
 const macMetrics = getCapsulePillMetrics('mac');
 assertEqual(macMetrics.width, 176, 'mac capsule keeps existing pill width');

--- a/openless-all/app/src/lib/capsuleLayout.ts
+++ b/openless-all/app/src/lib/capsuleLayout.ts
@@ -22,7 +22,7 @@ export interface CapsuleMessageLayout {
 
 export function getCapsulePillMetrics(os: OS): CapsulePillMetrics {
   if (os === 'win') {
-    return { width: 196, height: 52, textWidth: 118 };
+    return { width: 196, height: 52, textWidth: 104 };
   }
 
   return { width: 176, height: 42, textWidth: 84 };


### PR DESCRIPTION
### **User description**
## 摘要

修复 Windows 11 上录音胶囊的几个 UI 问题：

1. 胶囊窗口周围偶发出现浅灰色矩形底，像是透明窗口没有完全裁掉。
2. 录音中间的蓝色音量条反馈不明显，普通说话时看起来像没有在录音。
3. “正在思考 / 已插入”等状态下右侧对号会被状态文字挤到胶囊边缘。

## 修复 / 新增 / 改进

- Windows 胶囊禁用 `backdrop-filter` 和 `filter: drop-shadow(...)`，避免 WebView2 透明窗口合成时露出矩形背景。
- Windows 改用普通 `box-shadow` 保留胶囊浮起感，不再依赖 `filter`。
- 录音音量条改为更明显的 RMS 映射：
  - 无声 / 低于噪声门限时保持静止。
  - 有声音时随真实麦克风电平变化。
  - 普通说话时幅度更明显，大声时接近满高。
- Windows 胶囊 `textWidth` 从 `118` 收窄到 `104`，给左右圆形按钮留出稳定空间。
- 中间内容容器增加 `minWidth: 0`，减少状态文字挤压两侧按钮的情况。
- 更新 `capsuleLayout.test.ts` 中 Windows 文本槽宽度期望。

## Before / After

### 修复前
<img width="492" height="144" alt="屏幕截图 2026-05-05 003913" src="https://github.com/user-attachments/assets/7d2af03d-b3b2-4a86-ac3d-6bff278117c3" />

<img width="576" height="106" alt="image" src="https://github.com/user-attachments/assets/9577bc8a-6da7-412b-9429-2bcf184885d1" />



### 修复后
<img width="477" height="179" alt="image copy" src="https://github.com/user-attachments/assets/5980cacd-4768-4762-9784-b0a4e74d0935" />

<img width="764" height="203" alt="屏幕截图 2026-05-05 020804" src="https://github.com/user-attachments/assets/b9648c85-fdad-4157-a895-c045de93d929" />




## 兼容

- 仅调整 Windows 胶囊 UI 表现，不改录音、ASR、插入、热键或后端状态机逻辑。
- macOS / Linux 仍保留原来的 `backdrop-filter` 玻璃效果。
- Windows 胶囊尺寸不变，只收窄内部文本槽，避免按钮被状态文字挤压。

## 测试计划

- [x] 命令：`npm run build`
- [x] 结果：TypeScript + Vite build 通过。
- [x] 命令：`npx tsx src/lib/capsuleLayout.test.ts`
- [x] 结果：通过。
- [x] 手动测试：Windows 11 真机运行 `npm run tauri dev`，验证录音胶囊外侧不再出现浅灰矩形底。
- [x] 手动测试：Windows 11 真机验证录音音量条随真实声音强弱变化。
- [x] 手动测试：Windows 11 真机验证“正在思考 / 已插入”状态下右侧对号位置稳定，没有挤到胶囊边框。
- [ ] 未测试：macOS / Linux 真机 UI。


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Windows: disable backdrop-filter and filter drop-shadow, use box-shadow to eliminate gray rectangle artifact

- Capsule: add silence gate, response ceiling, eased mapping, and increased bar height for more visible audio meter

- Layout: reduce textWidth (118→104) and add minWidth:0 to prevent status text squeezing side buttons

- Cancel button: conditionally remove backdrop-filter on Windows to avoid compositing artifact

- Tests: update expected Windows textWidth to 104


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["AudioBars (Capsule)"] -- "silence gate, easing, power curve" --> B["More responsive visual bars"]
  C["Pill (Capsule)"] -- "remove backdrop & drop-shadow" --> D["Windows: clean glass effect"]
  C -- "add minWidth:0, shrink textWidth" --> E["Prevent button squeezing"]
  F["CircleButton"] -- "conditional backdrop" --> D
  G["capsuleLayout.ts"] -- "textWidth 118→104" --> E
  H["capsuleLayout.test.ts"] -- "updated assertion" --> E
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Capsule.tsx</strong><dd><code>Enhance audio meter dynamics and fix Windows compositing artifacts</code></dd></summary>
<hr>

openless-all/app/src/components/Capsule.tsx

<ul><li>AudioBars: add silence gate (0.012), response ceiling (0.34), <br>smoothstep easing, power curve (0.42), base=2, max=24, and transition <br>to use visualVoice for more visible meter<br> <li> CircleButton: detect OS and disable backdropFilter on Windows for the <br>cancel button; add 'visibility' property<br> <li> Pill: replace filter drop-shadow with a box-shadow on Windows <br>(including ambient adjustment), remove filter attribute, add <br>minWidth:0 to center flex container to prevent layout squeeze</ul>


</details>


  </td>
  <td><a href="https://github.com/appergb/openless/pull/253/files#diff-864fa6eaba61a50b436891d4a11265927947abf4d5447192368d26b12e9eaa67">+19/-13</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>capsuleLayout.ts</strong><dd><code>Narrow Windows capsule text slot width</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src/lib/capsuleLayout.ts

<ul><li>Reduce Windows capsule text width from 118 to 104 to give side buttons <br>stable space and avoid text overflow</ul>


</details>


  </td>
  <td><a href="https://github.com/appergb/openless/pull/253/files#diff-64a0fa382ce669f9eb4d0aa71205f37ecbc20817808cbc9f8fb792d7b8db9d7f">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>capsuleLayout.test.ts</strong><dd><code>Update test expectation for Windows textWidth</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src/lib/capsuleLayout.test.ts

<ul><li>Update Windows textWidth assertion from 118 to 104 to match new layout <br>metrics<br> <li> Update assertion message to reflect the purpose: "windows capsule <br>keeps side controls clear"</ul>


</details>


  </td>
  <td><a href="https://github.com/appergb/openless/pull/253/files#diff-35940b0097fce05abe23d3a34b7ffcafd5e9d219e44e285d77e95523dc28a64d">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

