### PR TITLE
fix(capsule): keep confirm icon inside pill on done/error states

### DIFF
--- a/openless-all/app/src/components/Capsule.tsx
+++ b/openless-all/app/src/components/Capsule.tsx
@@ -83,7 +83,9 @@ function CenterText({ os, kind, text, color = 'var(--ol-ink-3)' }: CenterTextPro
         fontSize: 11,
         fontWeight: 500,
         color,
-        width: metrics.textWidth,
+        width: '100%',
+        maxWidth: metrics.textWidth,
+        minWidth: 0,
         textAlign: 'center',
         lineHeight: layout.allowWrap ? 1.2 : 1,
         whiteSpace: layout.allowWrap ? 'normal' : 'nowrap',
@@ -176,7 +178,9 @@ function Pill({ os, state, level, insertedChars, message, onCancel, onConfirm }:
             flexDirection: os === 'win' ? 'column' : 'row',
             alignItems: 'center',
             gap: os === 'win' ? 4 : 6,
-            width: metrics.textWidth,
+            width: '100%',
+            maxWidth: metrics.textWidth,
+            minWidth: 0,
             justifyContent: 'center',
           }}
         >
@@ -186,6 +190,7 @@ function Pill({ os, state, level, insertedChars, message, onCancel, onConfirm }:
               fontSize: 10.5,
               fontWeight: 500,
               color: 'var(--ol-ink-2)',
+              minWidth: 0,
               textAlign: 'center',
               lineHeight: processingLayout.allowWrap ? 1.15 : 1,
               whiteSpace: processingLayout.allowWrap ? 'normal' : 'nowrap',
@@ -249,7 +254,7 @@ function Pill({ os, state, level, insertedChars, message, onCancel, onConfirm }:
       }}
     >
       <CircleButton variant="cancel" enabled={enabled} onClick={onCancel} />
-      <div style={{ flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+      <div style={{ flex: 1, minWidth: 0, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
         {center}
       </div>
       <CircleButton variant="confirm" enabled={enabled} onClick={onConfirm} />


### PR DESCRIPTION
### **User description**
## 摘要

修复 capsule 在 done/error 状态下确认图标溢出 pill 的问题。

当 capsule 进入 done 或 error 状态时，确认图标可能会在视觉上超出 pill 边界。本 PR 将确认图标保持在 capsule pill 内部，同时保留现有的布局行为。

## 修复 / 新增 / 改进

- 将确认图标限制在 done/error 状态下的 capsule pill 内部。
- 保留现有的 capsule 间距和状态行为。
- 将改动范围限制在 capsule UI 布局/样式。

## 兼容

- 不改动 ASR、polish、文本插入、快捷键或 provider 行为。
- 不影响本地环境或构建流程。
- 仅包含 UI 改动。

## 测试计划

- [ ] 已运行 `npm run build`
- [ ] 已运行 `cargo check --manifest-path src-tauri/Cargo.toml`
- [ ] 已目测验证 capsule done 状态
- [ ] 已目测验证 capsule error 状态


___

### **PR Type**
Bug fix


___

### **Description**
- Replace fixed widths with flexible constraints

- Add min-width:0 to inner elements and flex container

- Preserve existing visual spacing and behavior


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["CenterText span"] -- "width:100%, maxWidth, minWidth:0" --> B["Prevents overflow"]
  C["Polishing flex container"] -- "width:100%, maxWidth, minWidth:0" --> B
  D["Button flex container"] -- "minWidth:0 added" --> B
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Capsule.tsx</strong><dd><code>Constrain pill content with flexible widths to prevent overflow</code></dd></summary>
<hr>

openless-all/app/src/components/Capsule.tsx

<ul><li>Replace fixed width with width:'100%', maxWidth, minWidth:0 on <br>CenterText span<br> <li> Apply same flexible constraints to polishing layout container<br> <li> Add minWidth:0 to processing text span and the flex container between <br>buttons</ul>


</details>


  </td>
  <td><a href="https://github.com/appergb/openless/pull/260/files#diff-864fa6eaba61a50b436891d4a11265927947abf4d5447192368d26b12e9eaa67">+8/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

