### PR TITLE
fix(windows): suppress consumed hotkey trigger events

### DIFF
--- a/openless-all/app/src-tauri/src/hotkey.rs
+++ b/openless-all/app/src-tauri/src/hotkey.rs
@@ -559,7 +559,9 @@ mod platform {
             if let Some(ctx) = callback_context() {
                 let keyboard = *(lparam.0 as *const KBDLLHOOKSTRUCT);
                 if keyboard.flags.0 & LLKHF_INJECTED == 0 || accept_injected_events() {
-                    dispatch_keyboard_event(ctx, keyboard.vkCode, wparam.0);
+                    if dispatch_keyboard_event(ctx, keyboard.vkCode, wparam.0) {
+                        return LRESULT(1);
+                    }
                 }
             }
         }
@@ -576,10 +578,10 @@ mod platform {
         }
     }
 
-    fn dispatch_keyboard_event(ctx: &CallbackContext, vk_code: u32, message: usize) {
+    fn dispatch_keyboard_event(ctx: &CallbackContext, vk_code: u32, message: usize) -> bool {
         if vk_code == VK_ESCAPE && (message == WM_KEYDOWN || message == WM_SYSKEYDOWN) {
             send_or_log(&ctx.tx, HotkeyEvent::Cancelled);
-            return;
+            return false;
         }
 
         // Shift（任一侧）= 翻译模式修饰键。在录音过程中任意时刻按下都生效。详见 issue #4。
@@ -601,12 +603,12 @@ mod platform {
                 }
                 _ => {}
             }
-            return;
+            return false;
         }
 
         let trigger = ctx.shared.binding.read().trigger;
         if vk_code != trigger_to_vk_code(trigger) {
-            return;
+            return false;
         }
 
         match message {
@@ -626,6 +628,7 @@ mod platform {
             }
             _ => {}
         }
+        true
     }
 
     fn trigger_to_vk_code(trigger: HotkeyTrigger) -> u32 {


### PR DESCRIPTION
### **User description**
## 问题描述

修复 #195：Windows 浏览器输入框在语音输入完成后丢失光标，导致识别文本无法插入。

已在 Windows 11 + Chrome 中复现，影响 Gemini、Google 搜索、百度搜索等网页输入框。ASR 和文本生成本身成功，但插入阶段找不到有效的网页光标位置。

**根本原因**：

Windows 低级键盘 hook 已经识别并处理 OpenLess 的触发键，但处理后仍继续调用 `CallNextHookEx`，导致配置的触发键事件继续传递给前台应用。

当触发键是右 Alt / AltGr 等修饰键时，Chrome 网页输入框会收到这个按键事件，并可能清空 DOM caret / selection。后续 TSF、Unicode SendInput 或剪贴板粘贴 fallback 虽然执行了，但页面输入框已经没有可插入位置。

## 修复方案

### 1. 消费已处理的 Windows 触发键事件

**文件**: `openless-all/app/src-tauri/src/hotkey.rs`

在 Windows `WH_KEYBOARD_LL` 回调中，让 `dispatch_keyboard_event` 返回当前事件是否已经被 OpenLess 作为触发键处理。

如果事件是配置的触发键，则在发送 `Pressed` / `Released` 事件后返回 `LRESULT(1)`，阻止该触发键继续传递到前台应用。

### 2. 保持非触发键行为不变

以下路径继续透传，不改变现有行为：

- 非 OpenLess 触发键
- Esc 取消录音
- Shift 翻译模式修饰键
- 注入事件过滤逻辑

## 测试验证

### 自动检查

- `cargo check --manifest-path src-tauri/Cargo.toml`

结果：通过。当前仓库已有的 Rust warnings 仍存在，本 PR 未新增相关 warning。

### 手动验证

环境：Windows 11 + Chrome。

已验证以下网页输入框可以正常保留光标并插入语音识别结果：

- Gemini 网页输入框
- Google 搜索框
- 百度搜索框

## 风险评估

**低风险**：

- 修改范围仅限 Windows hotkey hook。
- 只消费“已被 OpenLess 识别为当前配置触发键”的事件。
- 不改变 ASR、文本润色、TSF、Unicode SendInput 或剪贴板插入流程。

**行为影响**：

如果用户将右 Alt、右 Ctrl 等单键配置为 OpenLess 触发键，该触发键在 OpenLess 运行并被 hook 捕获时不会再传递给前台应用。这符合全局触发键的预期行为，并避免浏览器输入框丢失光标。


___

### **PR Type**
Bug fix


___

### **Description**
- Consume Windows trigger hotkeys

- Preserve non-trigger key behavior

- Prevent input focus loss


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Windows low-level keyboard hook"] -->|dispatch result| B["Detect consumed trigger key"]
  B -->|return LRESULT(1)| C["Stop event propagation"]
  C -->|keeps focus| D["Browser input retains cursor"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>hotkey.rs</strong><dd><code>Stop consumed hotkeys from reaching apps</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src-tauri/src/hotkey.rs

<ul><li><code>dispatch_keyboard_event</code> now returns a boolean indicating whether the <br>key was consumed.<br> <li> The Windows keyboard hook returns <code>LRESULT(1)</code> when the configured <br>trigger key is handled.<br> <li> Non-trigger keys, <code>Esc</code>, and <code>Shift</code> handling continue to pass through <br>unchanged.</ul>


</details>


  </td>
  <td><a href="https://github.com/appergb/openless/pull/261/files#diff-f37b55b08938663b38e59e53ba8da02d59954d3f07dfbfa3a6c84aa7a43a3148">+8/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

