### PR TITLE
fix(local-asr): 修 PR #262 review 提的两个 bug

### DIFF
--- a/openless-all/app/src-tauri/src/asr/local/download.rs
+++ b/openless-all/app/src-tauri/src/asr/local/download.rs
@@ -384,7 +384,11 @@ async fn run_download(
         }));
     }
 
+    // 区分"用户主动取消" vs "我们因为某个 worker 失败了主动 abort 其它 worker"：
+    // 都共用同一个 cancel AtomicBool（worker 端只看一个 flag 就够），但外层用
+    // `self_aborted` 记是哪种情况，决定最后 emit Cancelled 还是 Failed。
     let mut first_err: Option<anyhow::Error> = None;
+    let mut self_aborted = false;
     while let Some(joined) = futs.next().await {
         match joined {
             Ok(Ok(())) => {}
@@ -392,9 +396,12 @@ async fn run_download(
                 if first_err.is_none() {
                     first_err = Some(e);
                 }
-                // 取消其它正在跑的：cancel flag 设为 true，让所有 spawn task 早退
+                // 一个 worker 失败 → 让其它 worker 立即停，免得它们继续吃带宽
+                // 然后用户还得等到所有任务完成才看到失败。
                 if !cancel.load(Ordering::SeqCst) {
-                    log::warn!("[local-asr] one file failed; signaling others to stop");
+                    log::warn!("[local-asr] one file failed; aborting other workers");
+                    cancel.store(true, Ordering::SeqCst);
+                    self_aborted = true;
                 }
             }
             Err(e) => {
@@ -405,7 +412,8 @@ async fn run_download(
         }
     }
 
-    if cancel.load(Ordering::SeqCst) {
+    // 用户主动 cancel（不是我们因为错误自己 set 的）→ Cancelled
+    if cancel.load(Ordering::SeqCst) && !self_aborted {
         emit_cancelled(app, model_id, "", 0, file_count, total_bytes);
         return Ok(());
     }
@@ -684,17 +692,24 @@ async fn try_download_range_append(
     if status.as_u16() != 200 && status.as_u16() != 206 {
         anyhow::bail!("HTTP {status} for {url}");
     }
-    if status.as_u16() == 200 && range_start > 0 {
-        let _ = std::fs::remove_file(partial);
-    }
     let effective_start = if status.as_u16() == 200 { 0 } else { range_start };
 
+    // 截断 partial 到本次 attempt 的起点，再 seek 写入。
+    // 老 append 实现的 bug：若上一次 attempt 已写了部分字节后失败，retry 拿到的还是
+    // 完整 chunk → append → 文件比应有大小多 N 字节 → 永久损坏。
+    // 小文件路径每个 chunk 是整个文件（≤ 32MB），用 truncate 重写最直白。
     let mut file = tokio::fs::OpenOptions::new()
         .create(true)
-        .append(true)
+        .write(true)
         .open(partial)
         .await
         .with_context(|| format!("open partial failed: {}", partial.display()))?;
+    file.set_len(effective_start)
+        .await
+        .with_context(|| format!("truncate partial failed: {}", partial.display()))?;
+    file.seek(std::io::SeekFrom::Start(effective_start))
+        .await
+        .with_context(|| format!("seek partial failed: {}", partial.display()))?;
 
     let mut stream = resp.bytes_stream();
     let mut written: u64 = 0;


### PR DESCRIPTION
### **User description**
## 这个 PR 做什么

跟进 PR #262 的 [PR Reviewer Guide](https://github.com/appergb/openless/pull/262#issuecomment) 提的两个真 bug。

## Bug 1 — 小文件 retry 污染

**位置**：`asr/local/download.rs::try_download_range_append`

**症状**：小文件（≤32MB）路径用 append 模式打开 `.partial`。若上一次 attempt 写了 N 字节后断流，retry 拿到的还是完整 chunk → append → `.partial` 比应有大小多 N 字节，**永久损坏**且哨兵 `.openless-asr-ready` 写完后 `qwen_load` 仍会失败。

**修法**：每次 attempt 用 `truncate(effective_start) + seek` 重写，干净起点。小文件每个 chunk 就是整个文件，重写无成本。

## Bug 2 — 多文件并发一个失败不 abort 其它 worker

**位置**：`asr/local/download.rs::run_download` 主 join 循环

**症状**：原代码 \"signaling others to stop\" 只是 log，**没**真 set cancel flag。某文件持久失败时，剩下的 worker 继续吃带宽直到全部完成才冒错误，浪费用户几分钟。

**修法**：错误时主动 `cancel.store(true)`；外层加 `self_aborted` 标记区分 \"用户主动 cancel\" vs \"我们因错误自 abort\"——前者 emit Cancelled，后者 emit Failed，不会把错误误报成用户取消。

## Test plan

- [x] `cargo check` 全绿
- [ ] 故意配错 mirror 触发 Bug 2 → 期望 emit Failed 而非 Cancelled，剩余 worker 立即停
- [ ] 小文件下载到一半 kill app → 重启再下 → 期望文件大小匹配 HF 报告值（不会膨胀）
- [ ] 用户中途点取消 → 期望 emit Cancelled（不要被误判 Failed）

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Bug fix


___

### **Description**
- Fix retry corruption on small files by switching from append to truncate+seek

- Make any download worker failure immediately abort all parallel workers and report the error


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>download.rs</strong><dd><code>Fix retry corruption and abort parallel download workers on error</code></dd></summary>
<hr>

openless-all/app/src-tauri/src/asr/local/download.rs

<ul><li>In <code>try_download_range_append</code>, open the partial file with <code>.write(true)</code> <br>instead of <code>.append(true)</code>, then truncate to <code>effective_start</code> and seek to <br>that position before writing the chunk. This prevents file size <br>inflation when a retry writes the full chunk again over a partially <br>written file.<br> <li> In <code>run_download</code>, when any per‑file worker fails, set the shared <code>cancel</code> <br>flag and record <code>self_aborted = true</code>. The final result now correctly <br>emits <code>Failed</code> rather than <code>Cancelled</code>, and other workers stop immediately <br>instead of wasting bandwidth.</ul>


</details>


  </td>
  <td><a href="https://github.com/appergb/openless/pull/263/files#diff-dbd7bd9cec398fa32b1660e9bc1d043899ab0a016ca3c196d4f0a1038ba67b75">+22/-7</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

