### PR TITLE
fix: register Windows IME from NSIS installer

### DIFF
--- a/.github/workflows/release-tauri.yml
+++ b/.github/workflows/release-tauri.yml
@@ -308,7 +308,13 @@ jobs:
           if (-not $nsis) { throw "NSIS installer not found." }
           if (-not $msi) { throw "MSI installer not found." }
           powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\scripts\windows-ime-install-smoke.ps1 -InstallerPath $nsis.FullName -InstallerKind nsis
+          if ($LASTEXITCODE -ne 0) {
+            throw "NSIS installer smoke failed with exit $LASTEXITCODE"
+          }
           powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\scripts\windows-ime-install-smoke.ps1 -InstallerPath $msi.FullName -InstallerKind msi
+          if ($LASTEXITCODE -ne 0) {
+            throw "MSI installer smoke failed with exit $LASTEXITCODE"
+          }
 
       # ── Linux：产 deb / rpm / AppImage ──
       - name: Build (Linux)

--- a/.github/workflows/release-tauri.yml
+++ b/.github/workflows/release-tauri.yml
@@ -298,6 +298,18 @@ jobs:
           }
           Write-Host "[ok] MSI rebuilt at $msiPath"
 
+      - name: Verify Windows installers register TSF IME
+        if: matrix.platform == 'windows-latest'
+        shell: pwsh
+        working-directory: 'openless-all/app'
+        run: |
+          $nsis = Get-ChildItem "src-tauri\target\release\bundle\nsis\*.exe" -ErrorAction Stop | Select-Object -First 1
+          $msi = Get-ChildItem "src-tauri\target\release\bundle\msi\*.msi" -ErrorAction Stop | Select-Object -First 1
+          if (-not $nsis) { throw "NSIS installer not found." }
+          if (-not $msi) { throw "MSI installer not found." }
+          powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\scripts\windows-ime-install-smoke.ps1 -InstallerPath $nsis.FullName -InstallerKind nsis
+          powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\scripts\windows-ime-install-smoke.ps1 -InstallerPath $msi.FullName -InstallerKind msi
+
       # ── Linux：产 deb / rpm / AppImage ──
       - name: Build (Linux)
         if: matrix.platform == 'ubuntu-22.04'

--- a/openless-all/app/scripts/windows-ime-install-smoke.ps1
+++ b/openless-all/app/scripts/windows-ime-install-smoke.ps1
@@ -158,7 +158,7 @@ function Assert-OpenLessImeInstalled {
   Assert-RegistryKey -View Registry64 -SubKey "Software\Microsoft\CTF\TIP\$TextServiceClsid\Category\Category\$SystrayCategoryGuid\$TextServiceClsid" -Label "TSF systray category"
 
   foreach ($key in $ExpectedBackendKeys) {
-    Write-Host "[trace] backend-required key: HKLM\$key"
+    Assert-RegistryKey -View Registry64 -SubKey $key -Label "backend-required"
   }
 
   Write-Host "[ok] Windows IME backend would report installed"

--- a/openless-all/app/scripts/windows-ime-install-smoke.ps1
+++ b/openless-all/app/scripts/windows-ime-install-smoke.ps1
@@ -33,6 +33,25 @@ function Test-IsAdministrator {
   return $principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
 }
 
+function Join-ProcessArguments {
+  param(
+    [string[]]$ArgumentList = @()
+  )
+
+  $quoted = foreach ($argument in $ArgumentList) {
+    if ($argument.Length -eq 0) {
+      '""'
+    } elseif ($argument -notmatch '[\s"]') {
+      $argument
+    } else {
+      $escaped = $argument -replace '(\\*)"', '$1$1\"'
+      $escaped = $escaped -replace '(\\+)$', '$1$1'
+      '"' + $escaped + '"'
+    }
+  }
+  return ($quoted -join " ")
+}
+
 function Invoke-CheckedProcess {
   param(
     [Parameter(Mandatory = $true)]
@@ -42,8 +61,9 @@ function Invoke-CheckedProcess {
     [string]$Label
   )
 
-  Write-Host "[run] $Label`: $FilePath $($ArgumentList -join ' ')"
-  $process = Start-Process -FilePath $FilePath -ArgumentList $ArgumentList -Wait -PassThru
+  $commandLine = Join-ProcessArguments $ArgumentList
+  Write-Host "[run] $Label`: $FilePath $commandLine"
+  $process = Start-Process -FilePath $FilePath -ArgumentList $commandLine -Wait -PassThru
   if ($process.ExitCode -ne 0) {
     throw "$Label failed with exit code $($process.ExitCode)"
   }

--- a/openless-all/app/scripts/windows-ime-install-smoke.ps1
+++ b/openless-all/app/scripts/windows-ime-install-smoke.ps1
@@ -1,0 +1,179 @@
+param(
+  [Parameter(Mandatory = $true)]
+  [string]$InstallerPath,
+  [Parameter(Mandatory = $true)]
+  [ValidateSet("nsis", "msi")]
+  [string]$InstallerKind,
+  [switch]$SkipUninstall
+)
+
+$ErrorActionPreference = "Stop"
+
+$TextServiceClsid = "{6B9F3F4F-5EE7-42D6-9C61-9F80B03A5D7D}"
+$ProfileGuid = "{9B5F5E04-23F6-47DA-9A26-D221F6C3F02E}"
+$LangId = "0x00000804"
+$KeyboardCategoryGuid = "{34745C63-B2F0-4784-8B67-5E12C8701A31}"
+$ImmersiveCategoryGuid = "{13A016DF-560B-46CD-947A-4C3AF1E0E35D}"
+$SystrayCategoryGuid = "{25504FB4-7BAB-4BC1-9C69-CF81890F0EF5}"
+
+# Keep this script aligned with the backend status check and the TSF IPC path
+# used by OpenLessImeSubmit-* named pipes.
+$ExpectedBackendKeys = @(
+  "Software\Classes\CLSID\{6B9F3F4F-5EE7-42D6-9C61-9F80B03A5D7D}\InprocServer32",
+  "Software\WOW6432Node\Classes\CLSID\{6B9F3F4F-5EE7-42D6-9C61-9F80B03A5D7D}\InprocServer32",
+  "Software\Microsoft\CTF\TIP\{6B9F3F4F-5EE7-42D6-9C61-9F80B03A5D7D}\LanguageProfile\0x00000804\{9B5F5E04-23F6-47DA-9A26-D221F6C3F02E}",
+  "Software\Microsoft\CTF\TIP\{6B9F3F4F-5EE7-42D6-9C61-9F80B03A5D7D}\Category\Category\{34745C63-B2F0-4784-8B67-5E12C8701A31}\{6B9F3F4F-5EE7-42D6-9C61-9F80B03A5D7D}",
+  "Software\Microsoft\CTF\TIP\{6B9F3F4F-5EE7-42D6-9C61-9F80B03A5D7D}\Category\Category\{13A016DF-560B-46CD-947A-4C3AF1E0E35D}\{6B9F3F4F-5EE7-42D6-9C61-9F80B03A5D7D}",
+  "Software\Microsoft\CTF\TIP\{6B9F3F4F-5EE7-42D6-9C61-9F80B03A5D7D}\Category\Category\{25504FB4-7BAB-4BC1-9C69-CF81890F0EF5}\{6B9F3F4F-5EE7-42D6-9C61-9F80B03A5D7D}"
+)
+
+function Test-IsAdministrator {
+  $identity = [Security.Principal.WindowsIdentity]::GetCurrent()
+  $principal = [Security.Principal.WindowsPrincipal]::new($identity)
+  return $principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+}
+
+function Invoke-CheckedProcess {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$FilePath,
+    [string[]]$ArgumentList = @(),
+    [Parameter(Mandatory = $true)]
+    [string]$Label
+  )
+
+  Write-Host "[run] $Label`: $FilePath $($ArgumentList -join ' ')"
+  $process = Start-Process -FilePath $FilePath -ArgumentList $ArgumentList -Wait -PassThru
+  if ($process.ExitCode -ne 0) {
+    throw "$Label failed with exit code $($process.ExitCode)"
+  }
+}
+
+function Open-LocalMachineSubKey {
+  param(
+    [Parameter(Mandatory = $true)]
+    [Microsoft.Win32.RegistryView]$View,
+    [Parameter(Mandatory = $true)]
+    [string]$SubKey
+  )
+
+  $baseKey = [Microsoft.Win32.RegistryKey]::OpenBaseKey([Microsoft.Win32.RegistryHive]::LocalMachine, $View)
+  try {
+    return $baseKey.OpenSubKey($SubKey)
+  } finally {
+    $baseKey.Dispose()
+  }
+}
+
+function Assert-RegistryKey {
+  param(
+    [Parameter(Mandatory = $true)]
+    [Microsoft.Win32.RegistryView]$View,
+    [Parameter(Mandatory = $true)]
+    [string]$SubKey,
+    [Parameter(Mandatory = $true)]
+    [string]$Label
+  )
+
+  $key = Open-LocalMachineSubKey -View $View -SubKey $SubKey
+  if ($null -eq $key) {
+    throw "Missing $Label registry key ($View): HKLM\$SubKey"
+  }
+  $key.Close()
+  Write-Host "[ok] $Label registry key present ($View)"
+}
+
+function Get-DefaultRegistryValue {
+  param(
+    [Parameter(Mandatory = $true)]
+    [Microsoft.Win32.RegistryView]$View,
+    [Parameter(Mandatory = $true)]
+    [string]$SubKey,
+    [Parameter(Mandatory = $true)]
+    [string]$Label
+  )
+
+  $key = Open-LocalMachineSubKey -View $View -SubKey $SubKey
+  if ($null -eq $key) {
+    throw "Missing $Label registry key ($View): HKLM\$SubKey"
+  }
+  try {
+    $value = [string]$key.GetValue("")
+    if ([string]::IsNullOrWhiteSpace($value)) {
+      throw "$Label default registry value is empty ($View): HKLM\$SubKey"
+    }
+    return $value
+  } finally {
+    $key.Close()
+  }
+}
+
+function Assert-OpenLessImeInstalled {
+  $comKey = "Software\Classes\CLSID\$TextServiceClsid\InprocServer32"
+  $x64Dll = Get-DefaultRegistryValue -View Registry64 -SubKey $comKey -Label "x64 COM"
+  $x86Dll = Get-DefaultRegistryValue -View Registry32 -SubKey $comKey -Label "x86 COM"
+
+  foreach ($dll in @($x64Dll, $x86Dll)) {
+    if (-not (Test-Path -LiteralPath $dll -PathType Leaf)) {
+      throw "Registered IME DLL path does not exist: $dll"
+    }
+  }
+
+  $installRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $x64Dll))
+  $expectedX64 = Join-Path $installRoot "windows-ime\x64\OpenLessIme.dll"
+  $expectedX86 = Join-Path $installRoot "windows-ime\x86\OpenLessIme.dll"
+  if ($x64Dll -ne $expectedX64) {
+    throw "x64 COM DLL path points outside the installed IME directory. Expected '$expectedX64', got '$x64Dll'"
+  }
+  if ($x86Dll -ne $expectedX86) {
+    throw "x86 COM DLL path points outside the installed IME directory. Expected '$expectedX86', got '$x86Dll'"
+  }
+  if (-not (Test-Path -LiteralPath (Join-Path $installRoot "openless.exe") -PathType Leaf)) {
+    throw "Installed OpenLess executable not found under $installRoot"
+  }
+
+  Assert-RegistryKey -View Registry64 -SubKey "Software\Microsoft\CTF\TIP\$TextServiceClsid\LanguageProfile\$LangId\$ProfileGuid" -Label "TSF language profile"
+  Assert-RegistryKey -View Registry64 -SubKey "Software\Microsoft\CTF\TIP\$TextServiceClsid\Category\Category\$KeyboardCategoryGuid\$TextServiceClsid" -Label "TSF keyboard category"
+  Assert-RegistryKey -View Registry64 -SubKey "Software\Microsoft\CTF\TIP\$TextServiceClsid\Category\Category\$ImmersiveCategoryGuid\$TextServiceClsid" -Label "TSF immersive category"
+  Assert-RegistryKey -View Registry64 -SubKey "Software\Microsoft\CTF\TIP\$TextServiceClsid\Category\Category\$SystrayCategoryGuid\$TextServiceClsid" -Label "TSF systray category"
+
+  foreach ($key in $ExpectedBackendKeys) {
+    Write-Host "[trace] backend-required key: HKLM\$key"
+  }
+
+  Write-Host "[ok] Windows IME backend would report installed"
+  return $installRoot
+}
+
+function Uninstall-OpenLess {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$InstallRoot
+  )
+
+  if ($InstallerKind -eq "nsis") {
+    $uninstaller = Join-Path $InstallRoot "uninstall.exe"
+    if (-not (Test-Path -LiteralPath $uninstaller -PathType Leaf)) {
+      throw "NSIS uninstaller not found: $uninstaller"
+    }
+    Invoke-CheckedProcess -FilePath $uninstaller -ArgumentList @("/S") -Label "NSIS uninstall"
+  } else {
+    Invoke-CheckedProcess -FilePath "msiexec.exe" -ArgumentList @("/x", $InstallerPath, "/qn", "/norestart") -Label "MSI uninstall"
+  }
+}
+
+if (-not (Test-IsAdministrator)) {
+  throw "Windows IME install smoke must run from an elevated Administrator PowerShell."
+}
+
+$InstallerPath = (Resolve-Path -LiteralPath $InstallerPath).Path
+if ($InstallerKind -eq "nsis") {
+  Invoke-CheckedProcess -FilePath $InstallerPath -ArgumentList @("/S", "/AllUsers") -Label "NSIS install"
+} else {
+  Invoke-CheckedProcess -FilePath "msiexec.exe" -ArgumentList @("/i", $InstallerPath, "/qn", "/norestart") -Label "MSI install"
+}
+
+$installRoot = Assert-OpenLessImeInstalled
+if (-not $SkipUninstall) {
+  Uninstall-OpenLess -InstallRoot $installRoot
+}

--- a/openless-all/app/scripts/windows-package-msvc.test.mjs
+++ b/openless-all/app/scripts/windows-package-msvc.test.mjs
@@ -128,8 +128,13 @@ assert.match(nsisHook, /File \/oname=OpenLessIme\.dll/, "NSIS should embed OpenL
 assert.match(nsisHook, /Sysnative\\regsvr32\.exe/, "NSIS should use 64-bit regsvr32 for the x64 IME");
 assert.match(nsisHook, /SysWOW64\\regsvr32\.exe/, "NSIS should use 32-bit regsvr32 for the x86 IME");
 assert.match(nsisHook, /Abort/, "NSIS install should fail if TSF registration fails");
+assert.match(nsisHook, /OPENLESS_IME_ABORT_IF_FAILED \$0 "x64 unregistration"/, "NSIS uninstall should fail if x64 TSF unregistration fails");
+assert.match(nsisHook, /OPENLESS_IME_ABORT_IF_FAILED \$0 "x86 unregistration"/, "NSIS uninstall should fail if x86 TSF unregistration fails");
 
 assert.match(imeInstallSmoke, /\[ValidateSet\("nsis", "msi"\)\]/, "install smoke should support both Windows installers");
+assert.match(imeInstallSmoke, /Join-ProcessArguments/, "install smoke should quote process arguments before Start-Process");
+assert.match(imeInstallSmoke, /\$commandLine = Join-ProcessArguments \$ArgumentList/, "install smoke should build a single quoted command line");
+assert.match(imeInstallSmoke, /Start-Process -FilePath \$FilePath -ArgumentList \$commandLine/, "install smoke should pass a single quoted command line to Start-Process");
 assert.match(imeInstallSmoke, /OpenLessImeSubmit/, "install smoke should preserve TSF backend context");
 assert.match(imeInstallSmoke, /Software\\Classes\\CLSID\\\{6B9F3F4F-5EE7-42D6-9C61-9F80B03A5D7D\}\\InprocServer32/, "install smoke should check x64 COM registration");
 assert.match(imeInstallSmoke, /Software\\WOW6432Node\\Classes\\CLSID\\\{6B9F3F4F-5EE7-42D6-9C61-9F80B03A5D7D\}\\InprocServer32/, "install smoke should check x86 COM registration");

--- a/openless-all/app/scripts/windows-package-msvc.test.mjs
+++ b/openless-all/app/scripts/windows-package-msvc.test.mjs
@@ -131,6 +131,7 @@ assert.match(nsisHook, /System32\\regsvr32\.exe[\s\S]*windows-ime\\x86\\OpenLess
 assert.match(nsisHook, /Abort/, "NSIS install should fail if TSF registration fails");
 assert.match(nsisHook, /OPENLESS_IME_ABORT_IF_FAILED \$0 "x64 registration"/, "NSIS install should fail if x64 TSF registration fails");
 assert.match(nsisHook, /OPENLESS_IME_ABORT_IF_FAILED \$0 "x86 registration"/, "NSIS install should fail if x86 TSF registration fails");
+assert.match(nsisHook, /OPENLESS_IME_REGISTER_X86[\s\S]*\$\{If\} \$0 != 0[\s\S]*StrCpy \$1 \$0[\s\S]*OPENLESS_IME_UNREGISTER_X64[\s\S]*StrCpy \$0 \$1[\s\S]*OPENLESS_IME_ABORT_IF_FAILED \$0 "x86 registration"/, "NSIS install should roll back x64 registration before aborting on x86 registration failure");
 assert.doesNotMatch(nsisHook, /OPENLESS_IME_ABORT_IF_FAILED \$0 "x64 unregistration"/, "NSIS uninstall should not fail if x64 TSF unregistration fails");
 assert.doesNotMatch(nsisHook, /OPENLESS_IME_ABORT_IF_FAILED \$0 "x86 unregistration"/, "NSIS uninstall should not fail if x86 TSF unregistration fails");
 assert.match(nsisHook, /OpenLess x64 TSF IME unregister exit code \$0/, "NSIS uninstall should log x64 TSF unregistration failures");
@@ -145,6 +146,8 @@ assert.match(imeInstallSmoke, /Software\\Classes\\CLSID\\\{6B9F3F4F-5EE7-42D6-9C
 assert.match(imeInstallSmoke, /Software\\WOW6432Node\\Classes\\CLSID\\\{6B9F3F4F-5EE7-42D6-9C61-9F80B03A5D7D\}\\InprocServer32/, "install smoke should check x86 COM registration");
 assert.match(imeInstallSmoke, /LanguageProfile\\0x00000804\\\{9B5F5E04-23F6-47DA-9A26-D221F6C3F02E\}/, "install smoke should check the TSF language profile");
 assert.match(imeInstallSmoke, /Category\\Category\\\{34745C63-B2F0-4784-8B67-5E12C8701A31\}/, "install smoke should check the keyboard TSF category");
+assert.match(imeInstallSmoke, /foreach \(\$key in \$ExpectedBackendKeys\) \{[\s\S]*Assert-RegistryKey -View Registry64 -SubKey \$key[\s\S]*\}/, "install smoke should assert every backend-required registry key exists");
+assert.doesNotMatch(imeInstallSmoke, /foreach \(\$key in \$ExpectedBackendKeys\) \{[\s\S]*Write-Host "\[trace\] backend-required key: HKLM\\\$key"[\s\S]*\}/, "install smoke must not only trace backend-required registry keys");
 assert.match(ciWorkflow, /windows-ime-install-smoke\.ps1[\s\S]*-InstallerKind nsis/, "CI should install and verify the NSIS artifact");
 assert.match(ciWorkflow, /windows-ime-install-smoke\.ps1[\s\S]*-InstallerKind msi/, "CI should install and verify the MSI artifact");
 assert.match(ciWorkflow, /InstallerKind nsis[\s\S]*\$LASTEXITCODE -ne 0[\s\S]*NSIS installer smoke failed/, "CI should fail immediately when the NSIS smoke run fails");

--- a/openless-all/app/scripts/windows-package-msvc.test.mjs
+++ b/openless-all/app/scripts/windows-package-msvc.test.mjs
@@ -5,9 +5,12 @@ import { fileURLToPath } from "node:url";
 
 const scriptsDir = dirname(fileURLToPath(import.meta.url));
 const appRoot = join(scriptsDir, "..");
+const repoRoot = join(appRoot, "..", "..");
 const scriptPath = join(scriptsDir, "windows-package-msvc.ps1");
 const launcherPath = join(scriptsDir, "windows-package-msvc.cmd");
+const ciWorkflowPath = join(repoRoot, ".github", "workflows", "release-tauri.yml");
 const imeBuildPath = join(scriptsDir, "windows-ime-build.ps1");
+const imeInstallSmokePath = join(scriptsDir, "windows-ime-install-smoke.ps1");
 const imeRegisterPath = join(scriptsDir, "windows-ime-register.ps1");
 const imeUnregisterPath = join(scriptsDir, "windows-ime-unregister.ps1");
 const imeSolutionPath = join(appRoot, "windows-ime", "OpenLessIme.sln");
@@ -15,11 +18,14 @@ const imeProjectPath = join(appRoot, "windows-ime", "OpenLessIme.vcxproj");
 const imeEditSessionPath = join(appRoot, "windows-ime", "src", "edit_session.cpp");
 const imeTextServicePath = join(appRoot, "windows-ime", "src", "text_service.cpp");
 const tauriConfigPath = join(appRoot, "src-tauri", "tauri.conf.json");
+const nsisHookPath = join(appRoot, "src-tauri", "nsis", "openless-ime-hooks.nsh");
 const wixFragmentPath = join(appRoot, "src-tauri", "wix", "openless-ime.wxs");
 
 const script = readFileSync(scriptPath, "utf8");
 const launcher = readFileSync(launcherPath, "utf8");
+const ciWorkflow = readFileSync(ciWorkflowPath, "utf8");
 const imeBuild = readFileSync(imeBuildPath, "utf8");
+const imeInstallSmoke = readFileSync(imeInstallSmokePath, "utf8");
 const imeRegister = readFileSync(imeRegisterPath, "utf8");
 const imeUnregister = readFileSync(imeUnregisterPath, "utf8");
 const imeSolution = readFileSync(imeSolutionPath, "utf8");
@@ -27,6 +33,7 @@ const imeProject = readFileSync(imeProjectPath, "utf8");
 const imeEditSession = readFileSync(imeEditSessionPath, "utf8");
 const imeTextService = readFileSync(imeTextServicePath, "utf8");
 const tauriConfig = JSON.parse(readFileSync(tauriConfigPath, "utf8"));
+const nsisHook = readFileSync(nsisHookPath, "utf8");
 const wixFragment = readFileSync(wixFragmentPath, "utf8");
 
 const requiredFragments = [
@@ -84,6 +91,8 @@ assert.deepEqual(tauriConfig.bundle.windows.wix.componentRefs, [
   "OpenLessImeDllX64Component",
   "OpenLessImeDllX86Component",
 ]);
+assert.equal(tauriConfig.bundle.windows.nsis.installMode, "both", "NSIS must request elevation so TSF can register in HKLM");
+assert.equal(tauriConfig.bundle.windows.nsis.installerHooks, "nsis/openless-ime-hooks.nsh", "NSIS must install and register the TSF DLLs");
 
 assert.match(imeSolution, /Release\|Win32/, "IME solution should include a Win32 Release configuration");
 assert.match(imeProject, /Release\|Win32/, "IME project should include a Win32 Release configuration");
@@ -107,6 +116,27 @@ assert.match(wixFragment, /RegisterOpenLessImeX64/, "MSI should register x64 Ope
 assert.match(wixFragment, /RegisterOpenLessImeX86/, "MSI should register x86 OpenLess IME during install");
 assert.match(wixFragment, /UnregisterOpenLessImeX64/, "MSI should unregister x64 OpenLess IME during uninstall");
 assert.match(wixFragment, /UnregisterOpenLessImeX86/, "MSI should unregister x86 OpenLess IME during uninstall");
+
+assert.match(nsisHook, /NSIS_HOOK_PREINSTALL/, "NSIS should copy IME DLLs before install completes");
+assert.match(nsisHook, /NSIS_HOOK_POSTINSTALL/, "NSIS should register IME DLLs after files are installed");
+assert.match(nsisHook, /NSIS_HOOK_PREUNINSTALL/, "NSIS should unregister IME DLLs before uninstall removes them");
+assert.match(nsisHook, /\$%OPENLESS_IME_DLL_X64%/, "NSIS should consume the CI-built x64 IME DLL");
+assert.match(nsisHook, /\$%OPENLESS_IME_DLL_X86%/, "NSIS should consume the CI-built x86 IME DLL");
+assert.match(nsisHook, /SetOutPath "\$INSTDIR\\windows-ime\\x64"/, "NSIS should install the x64 IME DLL beside the app");
+assert.match(nsisHook, /SetOutPath "\$INSTDIR\\windows-ime\\x86"/, "NSIS should install the x86 IME DLL beside the app");
+assert.match(nsisHook, /File \/oname=OpenLessIme\.dll/, "NSIS should embed OpenLessIme.dll in the installer");
+assert.match(nsisHook, /Sysnative\\regsvr32\.exe/, "NSIS should use 64-bit regsvr32 for the x64 IME");
+assert.match(nsisHook, /SysWOW64\\regsvr32\.exe/, "NSIS should use 32-bit regsvr32 for the x86 IME");
+assert.match(nsisHook, /Abort/, "NSIS install should fail if TSF registration fails");
+
+assert.match(imeInstallSmoke, /\[ValidateSet\("nsis", "msi"\)\]/, "install smoke should support both Windows installers");
+assert.match(imeInstallSmoke, /OpenLessImeSubmit/, "install smoke should preserve TSF backend context");
+assert.match(imeInstallSmoke, /Software\\Classes\\CLSID\\\{6B9F3F4F-5EE7-42D6-9C61-9F80B03A5D7D\}\\InprocServer32/, "install smoke should check x64 COM registration");
+assert.match(imeInstallSmoke, /Software\\WOW6432Node\\Classes\\CLSID\\\{6B9F3F4F-5EE7-42D6-9C61-9F80B03A5D7D\}\\InprocServer32/, "install smoke should check x86 COM registration");
+assert.match(imeInstallSmoke, /LanguageProfile\\0x00000804\\\{9B5F5E04-23F6-47DA-9A26-D221F6C3F02E\}/, "install smoke should check the TSF language profile");
+assert.match(imeInstallSmoke, /Category\\Category\\\{34745C63-B2F0-4784-8B67-5E12C8701A31\}/, "install smoke should check the keyboard TSF category");
+assert.match(ciWorkflow, /windows-ime-install-smoke\.ps1[\s\S]*-InstallerKind nsis/, "CI should install and verify the NSIS artifact");
+assert.match(ciWorkflow, /windows-ime-install-smoke\.ps1[\s\S]*-InstallerKind msi/, "CI should install and verify the MSI artifact");
 
 assert.match(launcher, /powershell\.exe/, "launcher should call powershell.exe");
 assert.match(launcher, /-ExecutionPolicy Bypass/, "launcher should bypass execution policy for this process");

--- a/openless-all/app/scripts/windows-package-msvc.test.mjs
+++ b/openless-all/app/scripts/windows-package-msvc.test.mjs
@@ -91,7 +91,7 @@ assert.deepEqual(tauriConfig.bundle.windows.wix.componentRefs, [
   "OpenLessImeDllX64Component",
   "OpenLessImeDllX86Component",
 ]);
-assert.equal(tauriConfig.bundle.windows.nsis.installMode, "both", "NSIS must request elevation so TSF can register in HKLM");
+assert.equal(tauriConfig.bundle.windows.nsis.installMode, "perMachine", "NSIS must force a machine-wide install because TSF registration is machine-wide");
 assert.equal(tauriConfig.bundle.windows.nsis.installerHooks, "nsis/openless-ime-hooks.nsh", "NSIS must install and register the TSF DLLs");
 
 assert.match(imeSolution, /Release\|Win32/, "IME solution should include a Win32 Release configuration");
@@ -127,6 +127,7 @@ assert.match(nsisHook, /SetOutPath "\$INSTDIR\\windows-ime\\x86"/, "NSIS should 
 assert.match(nsisHook, /File \/oname=OpenLessIme\.dll/, "NSIS should embed OpenLessIme.dll in the installer");
 assert.match(nsisHook, /Sysnative\\regsvr32\.exe/, "NSIS should use 64-bit regsvr32 for the x64 IME");
 assert.match(nsisHook, /SysWOW64\\regsvr32\.exe/, "NSIS should use 32-bit regsvr32 for the x86 IME");
+assert.match(nsisHook, /System32\\regsvr32\.exe[\s\S]*windows-ime\\x86\\OpenLessIme\.dll/, "NSIS should use System32 regsvr32 for the x86 IME on 32-bit Windows");
 assert.match(nsisHook, /Abort/, "NSIS install should fail if TSF registration fails");
 assert.match(nsisHook, /OPENLESS_IME_ABORT_IF_FAILED \$0 "x64 registration"/, "NSIS install should fail if x64 TSF registration fails");
 assert.match(nsisHook, /OPENLESS_IME_ABORT_IF_FAILED \$0 "x86 registration"/, "NSIS install should fail if x86 TSF registration fails");
@@ -146,6 +147,8 @@ assert.match(imeInstallSmoke, /LanguageProfile\\0x00000804\\\{9B5F5E04-23F6-47DA
 assert.match(imeInstallSmoke, /Category\\Category\\\{34745C63-B2F0-4784-8B67-5E12C8701A31\}/, "install smoke should check the keyboard TSF category");
 assert.match(ciWorkflow, /windows-ime-install-smoke\.ps1[\s\S]*-InstallerKind nsis/, "CI should install and verify the NSIS artifact");
 assert.match(ciWorkflow, /windows-ime-install-smoke\.ps1[\s\S]*-InstallerKind msi/, "CI should install and verify the MSI artifact");
+assert.match(ciWorkflow, /InstallerKind nsis[\s\S]*\$LASTEXITCODE -ne 0[\s\S]*NSIS installer smoke failed/, "CI should fail immediately when the NSIS smoke run fails");
+assert.match(ciWorkflow, /InstallerKind msi[\s\S]*\$LASTEXITCODE -ne 0[\s\S]*MSI installer smoke failed/, "CI should fail when the MSI smoke run fails");
 
 assert.match(launcher, /powershell\.exe/, "launcher should call powershell.exe");
 assert.match(launcher, /-ExecutionPolicy Bypass/, "launcher should bypass execution policy for this process");

--- a/openless-all/app/scripts/windows-package-msvc.test.mjs
+++ b/openless-all/app/scripts/windows-package-msvc.test.mjs
@@ -128,8 +128,12 @@ assert.match(nsisHook, /File \/oname=OpenLessIme\.dll/, "NSIS should embed OpenL
 assert.match(nsisHook, /Sysnative\\regsvr32\.exe/, "NSIS should use 64-bit regsvr32 for the x64 IME");
 assert.match(nsisHook, /SysWOW64\\regsvr32\.exe/, "NSIS should use 32-bit regsvr32 for the x86 IME");
 assert.match(nsisHook, /Abort/, "NSIS install should fail if TSF registration fails");
-assert.match(nsisHook, /OPENLESS_IME_ABORT_IF_FAILED \$0 "x64 unregistration"/, "NSIS uninstall should fail if x64 TSF unregistration fails");
-assert.match(nsisHook, /OPENLESS_IME_ABORT_IF_FAILED \$0 "x86 unregistration"/, "NSIS uninstall should fail if x86 TSF unregistration fails");
+assert.match(nsisHook, /OPENLESS_IME_ABORT_IF_FAILED \$0 "x64 registration"/, "NSIS install should fail if x64 TSF registration fails");
+assert.match(nsisHook, /OPENLESS_IME_ABORT_IF_FAILED \$0 "x86 registration"/, "NSIS install should fail if x86 TSF registration fails");
+assert.doesNotMatch(nsisHook, /OPENLESS_IME_ABORT_IF_FAILED \$0 "x64 unregistration"/, "NSIS uninstall should not fail if x64 TSF unregistration fails");
+assert.doesNotMatch(nsisHook, /OPENLESS_IME_ABORT_IF_FAILED \$0 "x86 unregistration"/, "NSIS uninstall should not fail if x86 TSF unregistration fails");
+assert.match(nsisHook, /OpenLess x64 TSF IME unregister exit code \$0/, "NSIS uninstall should log x64 TSF unregistration failures");
+assert.match(nsisHook, /OpenLess x86 TSF IME unregister exit code \$0/, "NSIS uninstall should log x86 TSF unregistration failures");
 
 assert.match(imeInstallSmoke, /\[ValidateSet\("nsis", "msi"\)\]/, "install smoke should support both Windows installers");
 assert.match(imeInstallSmoke, /Join-ProcessArguments/, "install smoke should quote process arguments before Start-Process");

--- a/openless-all/app/src-tauri/nsis/openless-ime-hooks.nsh
+++ b/openless-all/app/src-tauri/nsis/openless-ime-hooks.nsh
@@ -18,16 +18,6 @@
   ${EndIf}
 !macroend
 
-!macro OPENLESS_IME_REGISTER_X86
-  DetailPrint "Registering OpenLess x86 TSF IME"
-  ${If} ${RunningX64}
-    ExecWait '"$WINDIR\SysWOW64\regsvr32.exe" /s "$INSTDIR\windows-ime\x86\OpenLessIme.dll"' $0
-  ${Else}
-    ExecWait '"$WINDIR\System32\regsvr32.exe" /s "$INSTDIR\windows-ime\x86\OpenLessIme.dll"' $0
-  ${EndIf}
-  !insertmacro OPENLESS_IME_ABORT_IF_FAILED $0 "x86 registration"
-!macroend
-
 !macro OPENLESS_IME_UNREGISTER_X64
   ${If} ${RunningX64}
     DetailPrint "Unregistering OpenLess x64 TSF IME"
@@ -49,6 +39,21 @@
     ExecWait '"$WINDIR\System32\regsvr32.exe" /s /u "$INSTDIR\windows-ime\x86\OpenLessIme.dll"' $0
   ${EndIf}
   DetailPrint "OpenLess x86 TSF IME unregister exit code $0"
+!macroend
+
+!macro OPENLESS_IME_REGISTER_X86
+  DetailPrint "Registering OpenLess x86 TSF IME"
+  ${If} ${RunningX64}
+    ExecWait '"$WINDIR\SysWOW64\regsvr32.exe" /s "$INSTDIR\windows-ime\x86\OpenLessIme.dll"' $0
+  ${Else}
+    ExecWait '"$WINDIR\System32\regsvr32.exe" /s "$INSTDIR\windows-ime\x86\OpenLessIme.dll"' $0
+  ${EndIf}
+  ${If} $0 != 0
+    StrCpy $1 $0
+    !insertmacro OPENLESS_IME_UNREGISTER_X64
+    StrCpy $0 $1
+  ${EndIf}
+  !insertmacro OPENLESS_IME_ABORT_IF_FAILED $0 "x86 registration"
 !macroend
 
 !macro NSIS_HOOK_PREINSTALL

--- a/openless-all/app/src-tauri/nsis/openless-ime-hooks.nsh
+++ b/openless-all/app/src-tauri/nsis/openless-ime-hooks.nsh
@@ -33,14 +33,14 @@
       ExecWait '"$WINDIR\System32\regsvr32.exe" /s /u "$INSTDIR\windows-ime\x64\OpenLessIme.dll"' $0
       ${EnableX64FSRedirection}
     ${EndIf}
-    DetailPrint "OpenLess x64 TSF IME unregister exit code $0"
+    !insertmacro OPENLESS_IME_ABORT_IF_FAILED $0 "x64 unregistration"
   ${EndIf}
 !macroend
 
 !macro OPENLESS_IME_UNREGISTER_X86
   DetailPrint "Unregistering OpenLess x86 TSF IME"
   ExecWait '"$WINDIR\SysWOW64\regsvr32.exe" /s /u "$INSTDIR\windows-ime\x86\OpenLessIme.dll"' $0
-  DetailPrint "OpenLess x86 TSF IME unregister exit code $0"
+  !insertmacro OPENLESS_IME_ABORT_IF_FAILED $0 "x86 unregistration"
 !macroend
 
 !macro NSIS_HOOK_PREINSTALL

--- a/openless-all/app/src-tauri/nsis/openless-ime-hooks.nsh
+++ b/openless-all/app/src-tauri/nsis/openless-ime-hooks.nsh
@@ -33,14 +33,14 @@
       ExecWait '"$WINDIR\System32\regsvr32.exe" /s /u "$INSTDIR\windows-ime\x64\OpenLessIme.dll"' $0
       ${EnableX64FSRedirection}
     ${EndIf}
-    !insertmacro OPENLESS_IME_ABORT_IF_FAILED $0 "x64 unregistration"
+    DetailPrint "OpenLess x64 TSF IME unregister exit code $0"
   ${EndIf}
 !macroend
 
 !macro OPENLESS_IME_UNREGISTER_X86
   DetailPrint "Unregistering OpenLess x86 TSF IME"
   ExecWait '"$WINDIR\SysWOW64\regsvr32.exe" /s /u "$INSTDIR\windows-ime\x86\OpenLessIme.dll"' $0
-  !insertmacro OPENLESS_IME_ABORT_IF_FAILED $0 "x86 unregistration"
+  DetailPrint "OpenLess x86 TSF IME unregister exit code $0"
 !macroend
 
 !macro NSIS_HOOK_PREINSTALL

--- a/openless-all/app/src-tauri/nsis/openless-ime-hooks.nsh
+++ b/openless-all/app/src-tauri/nsis/openless-ime-hooks.nsh
@@ -20,7 +20,11 @@
 
 !macro OPENLESS_IME_REGISTER_X86
   DetailPrint "Registering OpenLess x86 TSF IME"
-  ExecWait '"$WINDIR\SysWOW64\regsvr32.exe" /s "$INSTDIR\windows-ime\x86\OpenLessIme.dll"' $0
+  ${If} ${RunningX64}
+    ExecWait '"$WINDIR\SysWOW64\regsvr32.exe" /s "$INSTDIR\windows-ime\x86\OpenLessIme.dll"' $0
+  ${Else}
+    ExecWait '"$WINDIR\System32\regsvr32.exe" /s "$INSTDIR\windows-ime\x86\OpenLessIme.dll"' $0
+  ${EndIf}
   !insertmacro OPENLESS_IME_ABORT_IF_FAILED $0 "x86 registration"
 !macroend
 
@@ -39,7 +43,11 @@
 
 !macro OPENLESS_IME_UNREGISTER_X86
   DetailPrint "Unregistering OpenLess x86 TSF IME"
-  ExecWait '"$WINDIR\SysWOW64\regsvr32.exe" /s /u "$INSTDIR\windows-ime\x86\OpenLessIme.dll"' $0
+  ${If} ${RunningX64}
+    ExecWait '"$WINDIR\SysWOW64\regsvr32.exe" /s /u "$INSTDIR\windows-ime\x86\OpenLessIme.dll"' $0
+  ${Else}
+    ExecWait '"$WINDIR\System32\regsvr32.exe" /s /u "$INSTDIR\windows-ime\x86\OpenLessIme.dll"' $0
+  ${EndIf}
   DetailPrint "OpenLess x86 TSF IME unregister exit code $0"
 !macroend
 

--- a/openless-all/app/src-tauri/nsis/openless-ime-hooks.nsh
+++ b/openless-all/app/src-tauri/nsis/openless-ime-hooks.nsh
@@ -1,0 +1,72 @@
+!macro OPENLESS_IME_ABORT_IF_FAILED EXIT_CODE LABEL
+  ${If} ${EXIT_CODE} != 0
+    DetailPrint "OpenLess TSF IME ${LABEL} failed with exit code ${EXIT_CODE}"
+    Abort
+  ${EndIf}
+!macroend
+
+!macro OPENLESS_IME_REGISTER_X64
+  ${If} ${RunningX64}
+    DetailPrint "Registering OpenLess x64 TSF IME"
+    ExecWait '"$WINDIR\Sysnative\regsvr32.exe" /s "$INSTDIR\windows-ime\x64\OpenLessIme.dll"' $0
+    ${If} $0 != 0
+      ${DisableX64FSRedirection}
+      ExecWait '"$WINDIR\System32\regsvr32.exe" /s "$INSTDIR\windows-ime\x64\OpenLessIme.dll"' $0
+      ${EnableX64FSRedirection}
+    ${EndIf}
+    !insertmacro OPENLESS_IME_ABORT_IF_FAILED $0 "x64 registration"
+  ${EndIf}
+!macroend
+
+!macro OPENLESS_IME_REGISTER_X86
+  DetailPrint "Registering OpenLess x86 TSF IME"
+  ExecWait '"$WINDIR\SysWOW64\regsvr32.exe" /s "$INSTDIR\windows-ime\x86\OpenLessIme.dll"' $0
+  !insertmacro OPENLESS_IME_ABORT_IF_FAILED $0 "x86 registration"
+!macroend
+
+!macro OPENLESS_IME_UNREGISTER_X64
+  ${If} ${RunningX64}
+    DetailPrint "Unregistering OpenLess x64 TSF IME"
+    ExecWait '"$WINDIR\Sysnative\regsvr32.exe" /s /u "$INSTDIR\windows-ime\x64\OpenLessIme.dll"' $0
+    ${If} $0 != 0
+      ${DisableX64FSRedirection}
+      ExecWait '"$WINDIR\System32\regsvr32.exe" /s /u "$INSTDIR\windows-ime\x64\OpenLessIme.dll"' $0
+      ${EnableX64FSRedirection}
+    ${EndIf}
+    DetailPrint "OpenLess x64 TSF IME unregister exit code $0"
+  ${EndIf}
+!macroend
+
+!macro OPENLESS_IME_UNREGISTER_X86
+  DetailPrint "Unregistering OpenLess x86 TSF IME"
+  ExecWait '"$WINDIR\SysWOW64\regsvr32.exe" /s /u "$INSTDIR\windows-ime\x86\OpenLessIme.dll"' $0
+  DetailPrint "OpenLess x86 TSF IME unregister exit code $0"
+!macroend
+
+!macro NSIS_HOOK_PREINSTALL
+  SetOutPath "$INSTDIR\windows-ime\x64"
+  File /oname=OpenLessIme.dll "$%OPENLESS_IME_DLL_X64%"
+
+  SetOutPath "$INSTDIR\windows-ime\x86"
+  File /oname=OpenLessIme.dll "$%OPENLESS_IME_DLL_X86%"
+
+  SetOutPath "$INSTDIR"
+!macroend
+
+!macro NSIS_HOOK_POSTINSTALL
+  !insertmacro OPENLESS_IME_REGISTER_X64
+  !insertmacro OPENLESS_IME_REGISTER_X86
+!macroend
+
+!macro NSIS_HOOK_PREUNINSTALL
+  !insertmacro OPENLESS_IME_UNREGISTER_X86
+  !insertmacro OPENLESS_IME_UNREGISTER_X64
+!macroend
+
+!macro NSIS_HOOK_POSTUNINSTALL
+  Delete "$INSTDIR\windows-ime\x64\OpenLessIme.dll"
+  Delete "$INSTDIR\windows-ime\x86\OpenLessIme.dll"
+  RMDir "$INSTDIR\windows-ime\x64"
+  RMDir "$INSTDIR\windows-ime\x86"
+  RMDir "$INSTDIR\windows-ime"
+!macroend

--- a/openless-all/app/src-tauri/tauri.conf.json
+++ b/openless-all/app/src-tauri/tauri.conf.json
@@ -86,7 +86,7 @@
     },
     "windows": {
       "nsis": {
-        "installMode": "both",
+        "installMode": "perMachine",
         "installerHooks": "nsis/openless-ime-hooks.nsh"
       },
       "wix": {

--- a/openless-all/app/src-tauri/tauri.conf.json
+++ b/openless-all/app/src-tauri/tauri.conf.json
@@ -85,6 +85,10 @@
       "entitlements": "Entitlements.plist"
     },
     "windows": {
+      "nsis": {
+        "installMode": "both",
+        "installerHooks": "nsis/openless-ime-hooks.nsh"
+      },
       "wix": {
         "fragmentPaths": [
           "wix/openless-ime.wxs"


### PR DESCRIPTION
### **User description**
## Summary
- Register the Windows TSF IME from the NSIS installer by copying the CI-built x64/x86 `OpenLessIme.dll` artifacts and invoking the matching `regsvr32` during install/uninstall hooks.
- Add an elevated installer smoke script that verifies the same COM, TSF language profile, and category registry keys used by the backend installed-state check.
- Run the smoke in Windows release CI for both the NSIS `.exe` and repaired MSI artifacts after bundle creation.

## Validation
- `node scripts/windows-package-msvc.test.mjs`
- PowerShell parser check for `scripts/windows-ime-install-smoke.ps1`
- `cargo check --manifest-path src-tauri\Cargo.toml`
- `npm.cmd run build`
- `scripts\windows-ime-build.ps1 -Configuration Release -Platform x64`
- `scripts\windows-ime-build.ps1 -Configuration Release -Platform Win32`
- `npm.cmd run tauri -- build --bundles nsis`
- Local elevated install smoke against `OpenLess_1.2.19_x64-setup.exe` passed and reported `Windows IME backend would report installed`, then uninstalled.

Note: local `cargo test --manifest-path src-tauri\Cargo.toml` did not reach tests on this machine because the test executable failed to start with `STATUS_ENTRYPOINT_NOT_FOUND`; this appears to be a local runtime/linkage startup issue separate from this installer change.


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Add NSIS installer hooks for Windows TSF IME registration (x64/x86)

- Create elevated PowerShell smoke test to verify IME installation

- Integrate smoke test into Windows release CI for NSIS and MSI

- Update test assertions to cover NSIS hooks, smoke script, and CI


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["NSIS Installer with hooks"] -- "registers x64/x86 OpenLessIme.dll" --> B["TSF IME Registration"]
  C["windows-ime-install-smoke.ps1"] -- "validates COM/TSF registry keys" --> B
  D["release-tauri.yml (Windows CI)"] -- "runs smoke after build" --> C
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>windows-ime-install-smoke.ps1</strong><dd><code>New Windows IME installer smoke test script</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/scripts/windows-ime-install-smoke.ps1

<ul><li>Implements elevated PowerShell script to install NSIS/MSI and validate <br>IME registration<br> <li> Defines expected COM, TSF language profile, and category registry keys <br>aligned with backend<br> <li> Asserts DLL paths, x64/x86 COM registration, presence of OpenLess <br>executable, and all backend-required keys<br> <li> Supports parameterized installer path/kind and optional skip-uninstall <br>flag</ul>


</details>


  </td>
  <td><a href="https://github.com/appergb/openless/pull/268/files#diff-b869b6d23238e0f37ed5c700ffa8ab6e0d700be611682f8594ae834a5be4c3c5">+199/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>windows-package-msvc.test.mjs</strong><dd><code>Extend build test assertions for NSIS IME and smoke</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/scripts/windows-package-msvc.test.mjs

<ul><li>Adds paths for new NSIS hooks, smoke script, and CI workflow to the <br>test suite<br> <li> Asserts NSIS hooks contain proper macro-based IME registration, <br>rollback, and unregistration logic<br> <li> Asserts tauri.conf.json now includes NSIS perMachine install mode and <br>installerHooks path<br> <li> Asserts smoke script structure (parameter validation, argument <br>quoting, registry checks) and CI workflow integration</ul>


</details>


  </td>
  <td><a href="https://github.com/appergb/openless/pull/268/files#diff-4a04249d55b337623336d4d8ad295ac9b6a73d8471d05454b934cd3fb60e3747">+113/-68</a></td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>release-tauri.yml</strong><dd><code>CI step to run IME installer smoke on Windows</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/release-tauri.yml

<ul><li>Adds a new CI step to verify TSF IME registration for built Windows <br>installers<br> <li> Locates the NSIS .exe and MSI .msi artifacts in the bundle output <br>directories<br> <li> Invokes the smoke script with appropriate InstallerKind and fails job <br>on non-zero exit</ul>


</details>


  </td>
  <td><a href="https://github.com/appergb/openless/pull/268/files#diff-cac78cd4d340dc05703d65bee14ea766337499de655e15553ceb8181eef097cb">+18/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>tauri.conf.json</strong><dd><code>Configure NSIS for machine-wide IME registration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src-tauri/tauri.conf.json

<ul><li>Sets NSIS installMode to "perMachine" to satisfy machine-wide TSF IME <br>requirement<br> <li> Points installerHooks to the newly created nsis/openless-ime-hooks.nsh</ul>


</details>


  </td>
  <td><a href="https://github.com/appergb/openless/pull/268/files#diff-e9c2f15638ea988f61c82aeb2257147fb9cc96d7bda8709e8bad6b6517f5369c">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>openless-ime-hooks.nsh</strong><dd><code>NSIS installer hooks for Windows TSF IME</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src-tauri/nsis/openless-ime-hooks.nsh

<ul><li>Defines NSIS macros to copy x64/x86 OpenLessIme.dll into installation <br>directory<br> <li> Registers IME DLLs via regsvr32 with architecture-appropriate fallback <br>paths (Sysnative/SysWOW64)<br> <li> Aborts installation with detailed message if registration fails; rolls <br>back prior registration<br> <li> Uninstall macros unregister DLLs without blocking on failure and clean <br>up IME files/directories</ul>


</details>


  </td>
  <td><a href="https://github.com/appergb/openless/pull/268/files#diff-368c4067ed1d20a5d2a3b93128b13800eaf60fe1d616cd1e35310734457c0a53">+85/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

