### PR TITLE
fix(local-asr): 切走/删模型/手动释放时真正归还 RAM

### DIFF
--- a/openless-all/app/src-tauri/src/asr/local/cache.rs
+++ b/openless-all/app/src-tauri/src/asr/local/cache.rs
@@ -94,29 +94,39 @@ impl LocalAsrCache {
     pub fn release_if_idle(&self, idle_threshold: Duration) -> bool {
         #[cfg(target_os = "macos")]
         {
-            let mut slot = self.inner.lock();
-            if let Some(cached) = slot.as_ref() {
-                if cached.last_used.elapsed() >= idle_threshold {
-                    log::info!(
-                        "[local-asr cache] release engine {} after idle {:?}",
-                        cached.model_id,
-                        cached.last_used.elapsed()
-                    );
-                    slot.take();
-                    return true;
+            let taken = {
+                let mut slot = self.inner.lock();
+                match slot.as_ref() {
+                    Some(c) if c.last_used.elapsed() >= idle_threshold => {
+                        log::info!(
+                            "[local-asr cache] release engine {} after idle {:?}",
+                            c.model_id,
+                            c.last_used.elapsed()
+                        );
+                        slot.take()
+                    }
+                    _ => None,
                 }
+            };
+            if let Some(cached) = taken {
+                drop(cached);
+                pressure_relief_macos();
+                return true;
             }
         }
         let _ = idle_threshold;
         false
     }
 
-    /// 立刻释放（用户点"立即释放"或删模型时调）。
+    /// 立刻释放（用户点"立即释放"、切走 provider、删模型时调）。
     pub fn release_now(&self) {
         #[cfg(target_os = "macos")]
         {
-            if let Some(cached) = self.inner.lock().take() {
+            let taken = self.inner.lock().take();
+            if let Some(cached) = taken {
                 log::info!("[local-asr cache] release engine {} on demand", cached.model_id);
+                drop(cached);
+                pressure_relief_macos();
             }
         }
     }
@@ -129,4 +139,19 @@ impl LocalAsrCache {
         #[cfg(not(target_os = "macos"))]
         None
     }
+}
+
+/// drop QwenAsrEngine 后调一次：让 macOS libmalloc 把 freelist 上的物理页归还内核。
+/// 不调的话，encoder f32 weights 那 ~几百 MB 的 free 不会立刻反映到 RSS，活动监视器
+/// 看起来"释放按钮没生效"。decoder bf16 走 mmap，munmap 时已立即生效，不依赖这个调用。
+#[cfg(target_os = "macos")]
+fn pressure_relief_macos() {
+    // SAFETY: 系统 API；NULL zone + goal=0 = 对所有 zone 尽量多地归还，无内存安全风险。
+    let freed = unsafe { malloc_zone_pressure_relief(std::ptr::null_mut(), 0) };
+    log::info!("[local-asr cache] malloc_zone_pressure_relief freed ~{} bytes", freed);
+}
+
+#[cfg(target_os = "macos")]
+extern "C" {
+    fn malloc_zone_pressure_relief(zone: *mut libc::c_void, goal: libc::size_t) -> libc::size_t;
 }

--- a/openless-all/app/src-tauri/src/commands.rs
+++ b/openless-all/app/src-tauri/src/commands.rs
@@ -123,9 +123,14 @@ pub fn set_credential(account: String, value: String) -> Result<(), String> {
 #[tauri::command]
 pub fn set_active_asr_provider(coord: CoordinatorState<'_>, provider: String) -> Result<(), String> {
     CredentialsVault::set_active_asr_provider(&provider).map_err(|e| e.to_string())?;
-    // 切到本地 ASR → 后台预加载模型，下次按 hotkey 时不必等数秒。
     if provider == crate::asr::local::PROVIDER_ID {
+        // 切到本地 ASR → 后台预加载模型，下次按 hotkey 时不必等数秒。
         coord.preload_local_asr_in_background();
+    } else {
+        // 切回云端 → 用户已不需要本地引擎，立刻释放 1.2GB+ RAM；不释放的话只会等到
+        // schedule_local_asr_release 的下一次 dictation 才触发，而切回云端后根本不会
+        // 再走 local 路径，引擎会驻留到进程退出。
+        coord.release_local_asr_engine();
     }
     Ok(())
 }
@@ -780,8 +785,16 @@ pub fn local_asr_cancel_download(
 }
 
 #[tauri::command]
-pub fn local_asr_delete_model(model_id: String) -> Result<(), String> {
+pub fn local_asr_delete_model(
+    coord: CoordinatorState<'_>,
+    model_id: String,
+) -> Result<(), String> {
     let id = ModelId::from_str(&model_id).ok_or_else(|| format!("unknown model id: {model_id}"))?;
+    // 如果内存里加载的就是要删的这个模型，先释放：否则 mmap 残留指向已 unlink 的文件，
+    // 且 RAM 直到下次切模型 / 用户手动按"释放"才回收。
+    if coord.local_asr_loaded_model().as_deref() == Some(id.as_str()) {
+        coord.release_local_asr_engine();
+    }
     crate::asr::local::models::delete_model(id).map_err(|e| e.to_string())
 }
 


### PR DESCRIPTION
### **User description**
## Summary

修复"按了释放按钮内存没掉"以及一并查出的两个相关泄漏点。三处都是同一主题：本地 Qwen3-ASR engine 该走时却没真走。

### 1. macOS 主动归还内核（用户报告主因）
按"释放"按钮后 `Arc<QwenAsrEngine>` 已经 drop、`qwen_free` 也跑完了，但活动监视器看 RSS 几乎不动。原因：encoder weights 是 f32 malloc 出来的几百 MB，`free()` 后 macOS libmalloc 把页留在 freelist 上不归还内核。decoder bf16 走 mmap，munmap 已立即生效，所以会"掉一部分但不掉大头"。

修：在 `LocalAsrCache::release_now` / `release_if_idle` 真 drop 完 engine 后调 `malloc_zone_pressure_relief(NULL, 0)`，让 libmalloc 主动归还。

### 2. 切回云端时本地引擎不释放
`set_active_asr_provider` 当前只在切到 local 时预加载，切回云端时没有镜像处理。结果：用户切走后 1.2GB+ RAM 一直留到进程退出，下次再走 dictation 是云端路径，根本不会触发 `schedule_local_asr_release`。

修：切到非 `local-qwen3` 时 `coord.release_local_asr_engine()`。

### 3. 删模型时不释放内存里同 id 引擎
`local_asr_delete_model` 直接 `delete_model(id)` 删盘，不看内存里有没有加载这个 id。删完后 mmap 还指着已 unlink 的文件，RAM 还在。

修：`local_asr_delete_model` 注入 `coord`，删之前若 `loaded_model_id == 要删的 id` 先 release。

### 平台范围
Windows 端本地 ASR 本期不上线（issue #256），改动全部在 `#[cfg(target_os = "macos")]` 块内或只影响 macOS 唯一持有引擎的代码路径。

## Test plan

- [ ] 设置页 → 加载本地模型 → 按"释放" → 日志出现 `release engine ... on demand` + `malloc_zone_pressure_relief freed ~N bytes`，活动监视器 RSS 立即下降几百 MB（含 encoder malloc 部分）
- [ ] 设置页 → 加载本地模型 → 切到火山引擎 → 上述两条日志同样出现，RAM 立即释放
- [ ] 设置页 → 加载本地模型 → 删除该模型 → 释放日志出现，磁盘文件被删除
- [ ] 跑一次正常听写，确认 dictation 路径未受影响（cache hit / `schedule_local_asr_release` 行为不变）
- [ ] 跑 `cargo check --manifest-path src-tauri/Cargo.toml` 通过


___

### **PR Type**
Bug fix


___

### **Description**
- Manually release engine now reclaims memory on macOS
  - Added `malloc_zone_pressure_relief` after engine drop to return pages to kernel
  - Heavy drop and pressure relief moved outside the lock for better concurrency

- Switching ASR provider frees local engine immediately
  - `set_active_asr_provider` now calls `release_local_asr_engine` when selecting cloud providers

- Deleting model safely releases engine before file removal
  - `local_asr_delete_model` receives coordinator, releases engine if loaded model matches the one being deleted


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Manual Release"] -- "drop + pressure_relief" --> B["RSS Drops"]
  C["Switch to Cloud"] -- "release_local_asr_engine" --> D["Free 1.2GB+"]
  E["Delete Model"] -- "release if loaded" --> F["Safe unlink"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cache.rs</strong><dd><code>macOS memory pressure relief after ASR engine drop</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src-tauri/src/asr/local/cache.rs

<ul><li>Added <code>pressure_relief_macos()</code> to force macOS malloc to return freed <br>pages to the kernel<br> <li> Moved engine drop and pressure relief after lock release to improve <br>concurrency</ul>


</details>


  </td>
  <td><a href="https://github.com/appergb/openless/pull/270/files#diff-15eec1d82b6ef59c43f3d3115142d8ef7cf199145b75cade7c5f144be8764004">+37/-12</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>commands.rs</strong><dd><code>Release engine on ASR provider switch and model deletion</code>&nbsp; </dd></summary>
<hr>

openless-all/app/src-tauri/src/commands.rs

<ul><li><code>set_active_asr_provider</code>: release local engine when switching to a <br>non-local provider<br> <li> <code>local_asr_delete_model</code>: accept coordinator, release engine if loaded <br>model is targeted for deletion</ul>


</details>


  </td>
  <td><a href="https://github.com/appergb/openless/pull/270/files#diff-8215873d09604b1dbb99088131ba7fc2fd6c537e67588cba5bd9160c2138b035">+15/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

