### PR TITLE
fix(i18n): render translation hotkey placeholder

### DIFF
--- a/openless-all/app/src/pages/Translation.tsx
+++ b/openless-all/app/src/pages/Translation.tsx
@@ -137,7 +137,7 @@ export function Translation() {
           <div style={{ fontSize: 13, fontWeight: 600, marginBottom: 10 }}>{t('translation.howto.title')}</div>
           <ol style={{ margin: 0, paddingLeft: 18, fontSize: 12.5, color: 'var(--ol-ink-2)', lineHeight: 1.7 }}>
             <li>{t('translation.howto.step1', { trigger: triggerLabel })}</li>
-            <li>{t('translation.howto.step2')}</li>
+            <li>{t('translation.howto.step2', { trigger: triggerLabel })}</li>
             <li>{t('translation.howto.step3')}</li>
             <li>{t('translation.howto.step4')}</li>
             <li>{t('translation.howto.step5')}</li>


### PR DESCRIPTION
### **User description**
## 问题描述

翻译设置页「使用方法」第 2 步中的快捷键占位符没有被替换，界面会直接显示 `{{trigger}}`。

截图中的表现是：

- 文案显示为「按一下“录音快捷键”（当前是 {{trigger}}），开始录音。」
- 用户无法看到当前实际配置的录音触发键

## 根本原因

`translation.howto.step2` 这条 i18n 文案包含 `{{trigger}}` 插值变量，但 `Translation.tsx` 渲染该文案时没有传入 `trigger` 参数。

## 修复方案

**文件**: `openless-all/app/src/pages/Translation.tsx`

为 `translation.howto.step2` 补充 `trigger: triggerLabel` 参数，使其和第 1 步保持一致，正常显示当前录音快捷键。

## 测试验证

- `npm run build`

结果：通过。Vite 仅输出已有的动态导入 chunk 提示。

## 风险评估

**低风险**：

- 只修改翻译设置页的一处 i18n 参数传递。
- 不改变快捷键配置、录音、翻译或插入逻辑。
- 只影响 UI 文案显示。


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed missing `trigger` parameter in the `translation.howto.step2` i18n call.

- Ensures the recording hotkey placeholder `{{trigger}}` is now replaced with the actual configured key.


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Translation.tsx</strong><dd><code>Pass trigger parameter to step2 translation call</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src/pages/Translation.tsx

<ul><li>Added <code>{ trigger: triggerLabel }</code> argument to the <br><code>t('translation.howto.step2')</code> call.<br> <li> Previously, the <code>{{trigger}}</code> placeholder was displayed as literal text <br>instead of the actual hotkey.</ul>


</details>


  </td>
  <td><a href="https://github.com/appergb/openless/pull/272/files#diff-ac2243e818f550360a2beccf9a687f0e6c42d75fe8736a09d8823d15d20bc761">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

