### PR TITLE
fix(providers): 按 active ASR provider 返回配置状态

### DIFF
--- a/openless-all/app/src-tauri/src/commands.rs
+++ b/openless-all/app/src-tauri/src/commands.rs
@@ -14,8 +14,7 @@ use crate::polish::{LLMError, OpenAICompatibleConfig, OpenAICompatibleLLMProvide
 use crate::types::{
     ChineseScriptPreference, CredentialsStatus, DictationSession, DictionaryEntry,
     HotkeyCapability, HotkeyStatus, OutputLanguagePreference, PolishMode, QaHotkeyBinding,
-    UserPreferences,
-    VocabPresetStore, WindowsImeStatus,
+    UserPreferences, VocabPresetStore, WindowsImeStatus,
 };
 
 type CoordinatorState<'a> = State<'a, Arc<Coordinator>>;
@@ -100,16 +99,47 @@ pub fn get_windows_ime_status() -> WindowsImeStatus {
 #[tauri::command]
 pub fn get_credentials() -> CredentialsStatus {
     let snap = CredentialsVault::snapshot();
+    let active_asr_provider = CredentialsVault::get_active_asr();
+    let active_llm_provider = CredentialsVault::get_active_llm();
+    let volcengine_configured = volcengine_configured(&snap);
+    let asr_configured = asr_configured_for_provider(&active_asr_provider, &snap);
+    let llm_configured = llm_configured_for_snapshot(&snap);
     CredentialsStatus {
-        volcengine_configured: configured(&snap.volcengine_app_key)
-            && configured(&snap.volcengine_access_key)
-            && configured(&snap.volcengine_resource_id),
-        ark_configured: configured(&snap.ark_api_key),
+        active_asr_provider,
+        active_llm_provider,
+        asr_configured,
+        llm_configured,
+        volcengine_configured,
+        ark_configured: llm_configured,
     }
 }
 
+fn volcengine_configured(snap: &CredentialsSnapshot) -> bool {
+    configured(&snap.volcengine_app_key)
+        && configured(&snap.volcengine_access_key)
+        && configured(&snap.volcengine_resource_id)
+}
+
+fn asr_configured_for_provider(provider: &str, snap: &CredentialsSnapshot) -> bool {
+    if provider == "volcengine" {
+        return volcengine_configured(snap);
+    }
+    if provider == crate::asr::local::PROVIDER_ID {
+        // 本地 ASR 不依赖云端凭据。
+        return true;
+    }
+    configured(&snap.asr_endpoint) && configured(&snap.asr_model)
+}
+
+fn llm_configured_for_snapshot(snap: &CredentialsSnapshot) -> bool {
+    configured(&snap.ark_endpoint) && configured(&snap.ark_model_id)
+}
+
 fn configured(field: &Option<String>) -> bool {
-    field.as_ref().map(|s| !s.is_empty()).unwrap_or(false)
+    field
+        .as_ref()
+        .map(|s| !s.trim().is_empty())
+        .unwrap_or(false)
 }
 
 #[tauri::command]
@@ -851,9 +881,11 @@ fn _ensure_snapshot_used(_: CredentialsSnapshot) {}
 #[cfg(test)]
 mod tests {
     use super::{
-        asr_transcriptions_url, fetch_provider_models, models_url, parse_model_ids,
-        persist_settings, ProviderConfig, SettingsWriter,
+        asr_configured_for_provider, asr_transcriptions_url, fetch_provider_models,
+        llm_configured_for_snapshot, models_url, parse_model_ids, persist_settings,
+        ProviderConfig, SettingsWriter,
     };
+    use crate::persistence::CredentialsSnapshot;
     use crate::types::{
         HotkeyBinding, HotkeyMode, HotkeyTrigger, QaHotkeyBinding, UserPreferences,
     };
@@ -867,6 +899,65 @@ mod tests {
         saved: Mutex<Option<UserPreferences>>,
         dictation_refreshes: Mutex<u32>,
         qa_refreshes: Mutex<u32>,
+    }
+
+    fn snapshot() -> CredentialsSnapshot {
+        CredentialsSnapshot::default()
+    }
+
+    #[test]
+    fn credentials_status_follows_active_asr_provider_requirements() {
+        let volcengine = CredentialsSnapshot {
+            volcengine_app_key: Some("app".into()),
+            volcengine_access_key: Some("access".into()),
+            volcengine_resource_id: Some("resource".into()),
+            ..snapshot()
+        };
+        assert!(asr_configured_for_provider("volcengine", &volcengine));
+
+        let whisper_key_only = CredentialsSnapshot {
+            asr_api_key: Some("key".into()),
+            ..snapshot()
+        };
+        assert!(!asr_configured_for_provider("whisper", &whisper_key_only));
+
+        let whisper_keyless_ready = CredentialsSnapshot {
+            asr_endpoint: Some("https://api.openai.com/v1".into()),
+            asr_model: Some("whisper-1".into()),
+            ..snapshot()
+        };
+        assert!(asr_configured_for_provider(
+            "whisper",
+            &whisper_keyless_ready
+        ));
+
+        assert!(asr_configured_for_provider(
+            crate::asr::local::PROVIDER_ID,
+            &snapshot()
+        ));
+    }
+
+    #[test]
+    fn credentials_status_accepts_keyless_llm_with_endpoint_and_model() {
+        let keyless_ready = CredentialsSnapshot {
+            ark_endpoint: Some("http://localhost:11434/v1".into()),
+            ark_model_id: Some("qwen".into()),
+            ..snapshot()
+        };
+        assert!(llm_configured_for_snapshot(&keyless_ready));
+
+        let key_without_endpoint = CredentialsSnapshot {
+            ark_api_key: Some("key".into()),
+            ark_model_id: Some("qwen".into()),
+            ..snapshot()
+        };
+        assert!(!llm_configured_for_snapshot(&key_without_endpoint));
+
+        let endpoint_without_model = CredentialsSnapshot {
+            ark_endpoint: Some("http://localhost:11434/v1".into()),
+            ..snapshot()
+        };
+        assert!(!llm_configured_for_snapshot(&endpoint_without_model));
     }
 
     impl SettingsWriter for FakeSettingsWriter {

--- a/openless-all/app/src-tauri/src/persistence.rs
+++ b/openless-all/app/src-tauri/src/persistence.rs
@@ -674,6 +674,9 @@ pub struct CredentialsSnapshot {
     pub volcengine_app_key: Option<String>,
     pub volcengine_access_key: Option<String>,
     pub volcengine_resource_id: Option<String>,
+    pub asr_api_key: Option<String>,
+    pub asr_endpoint: Option<String>,
+    pub asr_model: Option<String>,
     pub ark_api_key: Option<String>,
     pub ark_model_id: Option<String>,
     pub ark_endpoint: Option<String>,
@@ -730,6 +733,11 @@ impl CredentialsVault {
         save_credentials(&root)
     }
 
+    pub fn get_active_llm() -> String {
+        let _guard = credentials_lock().lock();
+        load_credentials().active.llm
+    }
+
     pub fn snapshot() -> CredentialsSnapshot {
         let _guard = credentials_lock().lock();
         let root = load_credentials();
@@ -737,6 +745,9 @@ impl CredentialsVault {
             volcengine_app_key: lookup_account(&root, CredentialAccount::VolcengineAppKey),
             volcengine_access_key: lookup_account(&root, CredentialAccount::VolcengineAccessKey),
             volcengine_resource_id: lookup_account(&root, CredentialAccount::VolcengineResourceId),
+            asr_api_key: lookup_account(&root, CredentialAccount::AsrApiKey),
+            asr_endpoint: lookup_account(&root, CredentialAccount::AsrEndpoint),
+            asr_model: lookup_account(&root, CredentialAccount::AsrModel),
             ark_api_key: lookup_account(&root, CredentialAccount::ArkApiKey),
             ark_model_id: lookup_account(&root, CredentialAccount::ArkModelId),
             ark_endpoint: lookup_account(&root, CredentialAccount::ArkEndpoint),

--- a/openless-all/app/src-tauri/src/types.rs
+++ b/openless-all/app/src-tauri/src/types.rs
@@ -548,6 +548,11 @@ pub struct CapsulePayload {
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct CredentialsStatus {
+    pub active_asr_provider: String,
+    pub active_llm_provider: String,
+    pub asr_configured: bool,
+    pub llm_configured: bool,
+    // 兼容旧前端字段（逐步迁移中）
     pub volcengine_configured: bool,
     pub ark_configured: bool,
 }

--- a/openless-all/app/src/lib/ipc.ts
+++ b/openless-all/app/src/lib/ipc.ts
@@ -71,6 +71,10 @@ const mockHotkeyCapability: HotkeyCapability = {
 };
 
 const mockCredentialsStatus: CredentialsStatus = {
+  activeAsrProvider: 'volcengine',
+  activeLlmProvider: 'ark',
+  asrConfigured: true,
+  llmConfigured: true,
   volcengineConfigured: true,
   arkConfigured: true,
 };

--- a/openless-all/app/src/lib/providerSetup.test.ts
+++ b/openless-all/app/src/lib/providerSetup.test.ts
@@ -10,26 +10,67 @@ function assertEqual(actual: boolean, expected: boolean, name: string) {
 }
 
 assertEqual(
-  areProvidersConfigured({ volcengineConfigured: true, arkConfigured: true }),
+  areProvidersConfigured({
+    activeAsrProvider: 'volcengine',
+    activeLlmProvider: 'ark',
+    asrConfigured: true,
+    llmConfigured: true,
+    volcengineConfigured: true,
+    arkConfigured: true,
+  }),
   true,
   'configured when ASR and LLM are both ready',
 );
 
 assertEqual(
-  areProvidersConfigured({ volcengineConfigured: false, arkConfigured: true }),
+  areProvidersConfigured({
+    activeAsrProvider: 'volcengine',
+    activeLlmProvider: 'ark',
+    asrConfigured: false,
+    llmConfigured: true,
+    volcengineConfigured: false,
+    arkConfigured: true,
+  }),
   false,
   'not configured when ASR provider is missing',
 );
 
 assertEqual(
-  areProvidersConfigured({ volcengineConfigured: true, arkConfigured: false }),
+  areProvidersConfigured({
+    activeAsrProvider: 'volcengine',
+    activeLlmProvider: 'ark',
+    asrConfigured: true,
+    llmConfigured: false,
+    volcengineConfigured: true,
+    arkConfigured: false,
+  }),
   false,
   'not configured when LLM provider is missing',
 );
 
 assertEqual(
+  areProvidersConfigured({
+    activeAsrProvider: 'whisper',
+    activeLlmProvider: 'ark',
+    asrConfigured: true,
+    llmConfigured: true,
+    volcengineConfigured: false,
+    arkConfigured: true,
+  }),
+  true,
+  'configured when active ASR is non-volcengine but already ready',
+);
+
+assertEqual(
   shouldShowProviderSetupPrompt(
-    { volcengineConfigured: false, arkConfigured: false },
+    {
+      activeAsrProvider: 'whisper',
+      activeLlmProvider: 'ark',
+      asrConfigured: false,
+      llmConfigured: false,
+      volcengineConfigured: false,
+      arkConfigured: false,
+    },
     null,
   ),
   true,
@@ -38,7 +79,14 @@ assertEqual(
 
 assertEqual(
   shouldShowProviderSetupPrompt(
-    { volcengineConfigured: false, arkConfigured: false },
+    {
+      activeAsrProvider: 'whisper',
+      activeLlmProvider: 'ark',
+      asrConfigured: false,
+      llmConfigured: false,
+      volcengineConfigured: false,
+      arkConfigured: false,
+    },
     '1',
   ),
   false,
@@ -47,7 +95,14 @@ assertEqual(
 
 assertEqual(
   shouldShowProviderSetupPrompt(
-    { volcengineConfigured: true, arkConfigured: true },
+    {
+      activeAsrProvider: 'whisper',
+      activeLlmProvider: 'ark',
+      asrConfigured: true,
+      llmConfigured: true,
+      volcengineConfigured: false,
+      arkConfigured: true,
+    },
     null,
   ),
   false,

--- a/openless-all/app/src/lib/providerSetup.ts
+++ b/openless-all/app/src/lib/providerSetup.ts
@@ -3,7 +3,9 @@ import type { CredentialsStatus } from './types';
 export const PROVIDER_SETUP_PROMPT_DEFERRED_KEY = 'ol.providerSetupPromptDeferredThisSession';
 
 export function areProvidersConfigured(credentials: CredentialsStatus): boolean {
-  return credentials.volcengineConfigured && credentials.arkConfigured;
+  const asrConfigured = credentials.asrConfigured ?? credentials.volcengineConfigured;
+  const llmConfigured = credentials.llmConfigured ?? credentials.arkConfigured;
+  return asrConfigured && llmConfigured;
 }
 
 export function shouldShowProviderSetupPrompt(

--- a/openless-all/app/src/lib/types.ts
+++ b/openless-all/app/src/lib/types.ts
@@ -206,6 +206,11 @@ export interface CapsulePayload {
 }
 
 export interface CredentialsStatus {
+  activeAsrProvider: string;
+  activeLlmProvider: string;
+  asrConfigured: boolean;
+  llmConfigured: boolean;
+  /** 兼容旧字段（过渡期保留）。 */
   volcengineConfigured: boolean;
   arkConfigured: boolean;
 }

--- a/openless-all/app/src/pages/Overview.tsx
+++ b/openless-all/app/src/pages/Overview.tsx
@@ -23,11 +23,32 @@ interface OverviewProps {
   onOpenHistory?: () => void;
 }
 
+const ASR_NAME_KEY_BY_ID: Record<string, string> = {
+  volcengine: 'asrVolcengine',
+  siliconflow: 'asrSiliconflow',
+  zhipu: 'asrZhipu',
+  groq: 'asrGroq',
+  whisper: 'asrWhisper',
+  'local-qwen3': 'asrLocalQwen3',
+};
+
+const LLM_NAME_KEY_BY_ID: Record<string, string> = {
+  ark: 'ark',
+  deepseek: 'deepseek',
+  siliconflow: 'siliconflow',
+  openai: 'openai',
+  custom: 'custom',
+};
+
 export function Overview({ onOpenHistory }: OverviewProps) {
   const { t } = useTranslation();
   const modeLabel = useModeLabels();
   const [history, setHistory] = useState<DictationSession[]>([]);
   const [creds, setCreds] = useState<CredentialsStatus>({
+    activeAsrProvider: 'volcengine',
+    activeLlmProvider: 'ark',
+    asrConfigured: false,
+    llmConfigured: false,
     volcengineConfigured: false,
     arkConfigured: false,
   });
@@ -64,6 +85,17 @@ export function Overview({ onOpenHistory }: OverviewProps) {
     return buckets;
   }, [history]);
 
+  const asrProviderId = creds.activeAsrProvider || 'volcengine';
+  const llmProviderId = creds.activeLlmProvider || 'ark';
+  const asrNameKey = ASR_NAME_KEY_BY_ID[asrProviderId];
+  const llmNameKey = LLM_NAME_KEY_BY_ID[llmProviderId];
+  const asrProviderName = asrNameKey
+    ? t(`settings.providers.presets.${asrNameKey}`)
+    : asrProviderId;
+  const llmProviderName = llmNameKey
+    ? t(`settings.providers.presets.${llmNameKey}`)
+    : llmProviderId;
+
   return (
     <>
       <PageHeader
@@ -75,15 +107,15 @@ export function Overview({ onOpenHistory }: OverviewProps) {
       <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 12, marginBottom: 18 }}>
         <ProviderCard
           kind={t('overview.asrKind')}
-          name={t('overview.asrName')}
-          subname={t('overview.asrSubname')}
-          configured={creds.volcengineConfigured}
+          name={asrProviderName}
+          subname={asrProviderId}
+          configured={creds.asrConfigured}
         />
         <ProviderCard
           kind={t('overview.llmKind')}
-          name={t('overview.llmName')}
-          subname={creds.arkConfigured ? t('overview.llmConfigured') : t('overview.llmNotConfigured')}
-          configured={creds.arkConfigured}
+          name={llmProviderName}
+          subname={llmProviderId}
+          configured={creds.llmConfigured}
         />
       </div>
 


### PR DESCRIPTION
### **User description**
## 变更说明
- 后端 `get_credentials()` 改为基于 **active ASR provider** 计算配置状态，新增返回字段：
  - `activeAsrProvider`
  - `activeLlmProvider`
  - `asrConfigured`
  - `llmConfigured`
- ASR 状态判定规则：
  - `volcengine`：仍按 `appKey + accessKey + resourceId` 判定。
  - `local-qwen3`：不依赖云端凭据，视为已配置。
  - 其余 OpenAI-compatible ASR（如 whisper/siliconflow/zhipu/groq）：按 `asr.endpoint + asr.model` 判定，API Key 可空以支持 keyless endpoint。
- LLM 状态判定同样支持 keyless endpoint：按 `ark.endpoint + ark.model_id` 判定，API Key 可空。
- 前端 `providerSetup` 改为使用通用 `asrConfigured/llmConfigured`，不再硬依赖 `volcengineConfigured`。
- `Overview` ASR/LLM 卡片改为显示 active provider 名称与其真实配置状态，不再固定显示火山引擎状态。
- 保留旧字段 `volcengineConfigured` / `arkConfigured` 作为兼容过渡。
- 增加配置状态判定回归用例。

## 验证
- `npm run -s build`
- `cargo test -q`（74 passed）

## 影响与风险
- 修复非 Volcengine 用户“已配置却仍提示未配置”的误判。
- 避免 endpoint/model 缺失时误报已配置；API Key 可空用于支持 keyless provider。
- 保持最小侵入：不改现有凭据存储结构，仅补充状态合约并迁移 UI 读取。

Closes #223


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Active provider drives status checks

- Add ASR/LLM status fields

- Refresh overview and prompts

- Expand regression coverage


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Vault["Credentials vault"]
  Status["get_credentials()"]
  Prompt["Provider setup prompt"]
  Overview["Overview cards"]

  Vault -- "snapshot + active provider" --> Status
  Status -- "asrConfigured / llmConfigured" --> Prompt
  Status -- "active names + state" --> Overview
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>commands.rs</strong><dd><code>Compute active-provider credential status</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/appergb/openless/pull/273/files#diff-8215873d09604b1dbb99088131ba7fc2fd6c537e67588cba5bd9160c2138b035">+100/-9</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>providerSetup.ts</strong><dd><code>Accept new and legacy flags</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/appergb/openless/pull/273/files#diff-9c93cb7ce29155faef731224c1a60d90ca580d10bcc9e5162fb1e7a7a9e718f8">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>persistence.rs</strong><dd><code>Snapshot ASR credential fields</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/appergb/openless/pull/273/files#diff-fe150b5c0806f2cac2827075208fe552ab2b17590ad3dddfbdbdc240084e1adb">+11/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>types.rs</strong><dd><code>Extend credentials status contract</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/appergb/openless/pull/273/files#diff-702c533512690147fd6f9342d29f6258530afc2c9ada765f4af3bd082080c952">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>types.ts</strong><dd><code>Add active provider status fields</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/appergb/openless/pull/273/files#diff-f22942a2f6ef50f13345f6b2781790a4a99e38a1a39702ce4bca3b2b2eb95e5a">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>Overview.tsx</strong><dd><code>Show active provider names and state</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/appergb/openless/pull/273/files#diff-87ea690f4abf573183a65635bee8aae0f788da0bc4b4f030f53756fa16f8aae2">+38/-6</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Miscellaneous</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>ipc.ts</strong><dd><code>Update mocked credentials status shape</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/appergb/openless/pull/273/files#diff-ef5ae5193f0c45b487cbf9b509e52f941a85d5bffc201561a2fa1394a5ff160a">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>providerSetup.test.ts</strong><dd><code>Cover active-provider setup logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/appergb/openless/pull/273/files#diff-bb6a42a32a62f80b5ab593706bb9a80ea816d8ca3677e9f5d5f6a43b3fb1dc4c">+61/-6</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

