### PR TITLE
feat(recording): mute system output while recording

### DIFF
--- a/openless-all/app/src-tauri/Cargo.toml
+++ b/openless-all/app/src-tauri/Cargo.toml
@@ -65,6 +65,8 @@ windows = { version = "0.58", features = [
   "Win32_Globalization",
   "Win32_Graphics_Dwm",
   "Win32_Graphics_Gdi",
+  "Win32_Media_Audio",
+  "Win32_Media_Audio_Endpoints",
   "Win32_System_Com",
   "Win32_System_Ole",
   "Win32_System_Registry",

--- a/openless-all/app/src-tauri/src/audio_mute.rs
+++ b/openless-all/app/src-tauri/src/audio_mute.rs
@@ -1,0 +1,261 @@
+//! Temporary system-output mute while recording.
+
+pub struct AudioMuteGuard {
+    inner: Option<platform::PlatformMuteGuard>,
+}
+
+impl AudioMuteGuard {
+    pub fn activate() -> Result<Self, String> {
+        Ok(Self {
+            inner: Some(platform::activate()?),
+        })
+    }
+}
+
+impl Drop for AudioMuteGuard {
+    fn drop(&mut self) {
+        if let Some(inner) = self.inner.take() {
+            inner.restore();
+        }
+    }
+}
+
+#[cfg(target_os = "windows")]
+mod platform {
+    use windows::Win32::Foundation::{BOOL, RPC_E_CHANGED_MODE};
+    use windows::Win32::Media::Audio::{eConsole, eRender, IMMDeviceEnumerator, MMDeviceEnumerator};
+    use windows::Win32::Media::Audio::Endpoints::IAudioEndpointVolume;
+    use windows::Win32::System::Com::{
+        CoCreateInstance, CoInitializeEx, CoUninitialize, CLSCTX_ALL, COINIT_APARTMENTTHREADED,
+    };
+
+    pub struct PlatformMuteGuard {
+        was_muted: bool,
+    }
+
+    pub fn activate() -> Result<PlatformMuteGuard, String> {
+        let was_muted = endpoint_muted()?;
+        if !was_muted {
+            set_endpoint_muted(true)?;
+        }
+        Ok(PlatformMuteGuard { was_muted })
+    }
+
+    impl PlatformMuteGuard {
+        pub fn restore(self) {
+            if let Err(err) = set_endpoint_muted(self.was_muted) {
+                log::warn!("[audio-mute] restore endpoint mute failed: {err}");
+            }
+        }
+    }
+
+    fn endpoint_muted() -> Result<bool, String> {
+        with_endpoint_volume(|endpoint| unsafe {
+            let muted = endpoint
+                .GetMute()
+                .map_err(|e| format!("read endpoint mute state failed: {e}"))?;
+            Ok(muted.as_bool())
+        })
+    }
+
+    fn set_endpoint_muted(muted: bool) -> Result<(), String> {
+        with_endpoint_volume(|endpoint| unsafe {
+            endpoint
+                .SetMute(BOOL(muted as i32), std::ptr::null())
+                .map_err(|e| format!("set endpoint mute failed: {e}"))
+        })
+    }
+
+    fn with_endpoint_volume<T>(
+        f: impl FnOnce(&IAudioEndpointVolume) -> Result<T, String>,
+    ) -> Result<T, String> {
+        unsafe {
+            let hr = CoInitializeEx(None, COINIT_APARTMENTTHREADED);
+            let uninit_com = hr.is_ok();
+            if !hr.is_ok() && hr != RPC_E_CHANGED_MODE {
+                return Err(format!("CoInitializeEx failed: {hr:?}"));
+            }
+
+            let result = (|| {
+                let enumerator: IMMDeviceEnumerator =
+                    CoCreateInstance(&MMDeviceEnumerator, None, CLSCTX_ALL)
+                        .map_err(|e| format!("create audio device enumerator failed: {e}"))?;
+                let device = enumerator
+                    .GetDefaultAudioEndpoint(eRender, eConsole)
+                    .map_err(|e| format!("get default render endpoint failed: {e}"))?;
+                let endpoint: IAudioEndpointVolume = device
+                    .Activate(CLSCTX_ALL, None)
+                    .map_err(|e| format!("activate endpoint volume failed: {e}"))?;
+                f(&endpoint)
+            })();
+
+            if uninit_com {
+                CoUninitialize();
+            }
+            result
+        }
+    }
+}
+
+#[cfg(target_os = "macos")]
+mod platform {
+    use std::process::Command;
+
+    pub struct PlatformMuteGuard {
+        was_muted: bool,
+    }
+
+    pub fn activate() -> Result<PlatformMuteGuard, String> {
+        let was_muted = output_muted()?;
+        if !was_muted {
+            set_output_muted(true)?;
+        }
+        Ok(PlatformMuteGuard { was_muted })
+    }
+
+    impl PlatformMuteGuard {
+        pub fn restore(self) {
+            if let Err(err) = set_output_muted(self.was_muted) {
+                log::warn!("[audio-mute] restore output mute failed: {err}");
+            }
+        }
+    }
+
+    fn output_muted() -> Result<bool, String> {
+        let output = Command::new("osascript")
+            .args(["-e", "output muted of (get volume settings)"])
+            .output()
+            .map_err(|e| format!("query output mute failed: {e}"))?;
+        if !output.status.success() {
+            return Err(String::from_utf8_lossy(&output.stderr).trim().to_string());
+        }
+        Ok(String::from_utf8_lossy(&output.stdout).trim() == "true")
+    }
+
+    fn set_output_muted(muted: bool) -> Result<(), String> {
+        let script = if muted {
+            "set volume output muted true"
+        } else {
+            "set volume output muted false"
+        };
+        let output = Command::new("osascript")
+            .args(["-e", script])
+            .output()
+            .map_err(|e| format!("set output mute failed: {e}"))?;
+        if output.status.success() {
+            Ok(())
+        } else {
+            Err(String::from_utf8_lossy(&output.stderr).trim().to_string())
+        }
+    }
+}
+
+#[cfg(target_os = "linux")]
+mod platform {
+    use std::process::Command;
+
+    enum Backend {
+        Wpctl,
+        Pactl,
+    }
+
+    pub struct PlatformMuteGuard {
+        backend: Backend,
+        was_muted: bool,
+    }
+
+    pub fn activate() -> Result<PlatformMuteGuard, String> {
+        if let Ok(was_muted) = wpctl_output_muted() {
+            if !was_muted {
+                wpctl_set_output_muted(true)?;
+            }
+            return Ok(PlatformMuteGuard {
+                backend: Backend::Wpctl,
+                was_muted,
+            });
+        }
+
+        let was_muted = pactl_output_muted()?;
+        if !was_muted {
+            pactl_set_output_muted(true)?;
+        }
+        Ok(PlatformMuteGuard {
+            backend: Backend::Pactl,
+            was_muted,
+        })
+    }
+
+    impl PlatformMuteGuard {
+        pub fn restore(self) {
+            let result = match self.backend {
+                Backend::Wpctl => wpctl_set_output_muted(self.was_muted),
+                Backend::Pactl => pactl_set_output_muted(self.was_muted),
+            };
+            if let Err(err) = result {
+                log::warn!("[audio-mute] restore output mute failed: {err}");
+            }
+        }
+    }
+
+    fn wpctl_output_muted() -> Result<bool, String> {
+        let output = Command::new("wpctl")
+            .args(["get-volume", "@DEFAULT_AUDIO_SINK@"])
+            .output()
+            .map_err(|e| format!("wpctl get-volume failed: {e}"))?;
+        if !output.status.success() {
+            return Err(String::from_utf8_lossy(&output.stderr).trim().to_string());
+        }
+        Ok(String::from_utf8_lossy(&output.stdout).contains("[MUTED]"))
+    }
+
+    fn wpctl_set_output_muted(muted: bool) -> Result<(), String> {
+        let value = if muted { "1" } else { "0" };
+        let output = Command::new("wpctl")
+            .args(["set-mute", "@DEFAULT_AUDIO_SINK@", value])
+            .output()
+            .map_err(|e| format!("wpctl set-mute failed: {e}"))?;
+        if output.status.success() {
+            Ok(())
+        } else {
+            Err(String::from_utf8_lossy(&output.stderr).trim().to_string())
+        }
+    }
+
+    fn pactl_output_muted() -> Result<bool, String> {
+        let output = Command::new("pactl")
+            .args(["get-sink-mute", "@DEFAULT_SINK@"])
+            .output()
+            .map_err(|e| format!("pactl get-sink-mute failed: {e}"))?;
+        if !output.status.success() {
+            return Err(String::from_utf8_lossy(&output.stderr).trim().to_string());
+        }
+        let stdout = String::from_utf8_lossy(&output.stdout).to_ascii_lowercase();
+        Ok(stdout.contains("yes") || stdout.contains("是"))
+    }
+
+    fn pactl_set_output_muted(muted: bool) -> Result<(), String> {
+        let value = if muted { "1" } else { "0" };
+        let output = Command::new("pactl")
+            .args(["set-sink-mute", "@DEFAULT_SINK@", value])
+            .output()
+            .map_err(|e| format!("pactl set-sink-mute failed: {e}"))?;
+        if output.status.success() {
+            Ok(())
+        } else {
+            Err(String::from_utf8_lossy(&output.stderr).trim().to_string())
+        }
+    }
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "windows", target_os = "linux")))]
+mod platform {
+    pub struct PlatformMuteGuard;
+
+    pub fn activate() -> Result<PlatformMuteGuard, String> {
+        Err("output mute is not supported on this platform".to_string())
+    }
+
+    impl PlatformMuteGuard {
+        pub fn restore(self) {}
+    }
+}

--- a/openless-all/app/src-tauri/src/coordinator.rs
+++ b/openless-all/app/src-tauri/src/coordinator.rs
@@ -926,8 +926,8 @@ fn release_recording_mute(inner: &Arc<Inner>, owner: &str) {
 fn stop_qa_recorder(inner: &Arc<Inner>) {
     if let Some(rec) = inner.qa_recorder.lock().take() {
         rec.stop();
+        release_recording_mute(inner, "qa");
     }
-    release_recording_mute(inner, "qa");
 }
 
 fn take_recorder_for_session(inner: &Arc<Inner>, session_id: u64) -> Option<Recorder> {

--- a/openless-all/app/src-tauri/src/coordinator.rs
+++ b/openless-all/app/src-tauri/src/coordinator.rs
@@ -132,6 +132,7 @@ struct Inner {
     /// 释放时机由 prefs.local_asr_keep_loaded_secs 决定。
     local_asr_cache: Arc<crate::asr::local::LocalAsrCache>,
     recorder: Mutex<Option<SessionResource<Recorder>>>,
+    recording_mute: Mutex<Option<crate::audio_mute::AudioMuteGuard>>,
     hotkey: Mutex<Option<HotkeyMonitor>>,
     hotkey_status: Mutex<HotkeyStatus>,
     hotkey_trigger_held: AtomicBool,
@@ -152,6 +153,8 @@ struct Inner {
     qa_asr: Mutex<Option<Arc<VolcengineStreamingASR>>>,
     /// QA 用的 Recorder 句柄。
     qa_recorder: Mutex<Option<Recorder>>,
+    /// QA 录音期间的系统输出静音 guard。
+    qa_recording_mute: Mutex<Option<crate::audio_mute::AudioMuteGuard>>,
     /// QA SSE 流取消标志。begin_qa_session 重置为 false；cancel_qa_session 设 true；
     /// polish::chat_completion_history_streaming 的 loop 每帧检查，true 时 break loop
     /// 避免取消后 LLM 仍 drain HTTP body 烧 token。详见 issue #161。
@@ -227,6 +230,7 @@ impl Coordinator {
                 state: Mutex::new(SessionState::default()),
                 asr: Mutex::new(None),
                 recorder: Mutex::new(None),
+                recording_mute: Mutex::new(None),
                 hotkey: Mutex::new(None),
                 hotkey_status: Mutex::new(HotkeyStatus::default()),
                 hotkey_trigger_held: AtomicBool::new(false),
@@ -236,6 +240,7 @@ impl Coordinator {
                 capsule_layout: Mutex::new(None),
                 qa_asr: Mutex::new(None),
                 qa_recorder: Mutex::new(None),
+                qa_recording_mute: Mutex::new(None),
                 qa_stream_cancelled: Arc::new(AtomicBool::new(false)),
                 local_asr_cache: Arc::new(crate::asr::local::LocalAsrCache::new()),
             }),
@@ -873,6 +878,55 @@ fn store_recorder_for_session(inner: &Arc<Inner>, session_id: u64, recorder: Rec
     *inner.recorder.lock() = Some(SessionResource::new(session_id, recorder));
 }
 
+fn activate_recording_mute(inner: &Arc<Inner>) {
+    if !inner.prefs.get().mute_during_recording || inner.recording_mute.lock().is_some() {
+        return;
+    }
+    match crate::audio_mute::AudioMuteGuard::activate() {
+        Ok(guard) => {
+            *inner.recording_mute.lock() = Some(guard);
+            log::info!("[audio-mute] system output muted for dictation recording");
+        }
+        Err(err) => {
+            log::warn!("[audio-mute] failed to mute output for dictation: {err}");
+        }
+    }
+}
+
+fn restore_recording_mute(inner: &Arc<Inner>) {
+    if inner.recording_mute.lock().take().is_some() {
+        log::info!("[audio-mute] system output mute restored for dictation");
+    }
+}
+
+fn activate_qa_recording_mute(inner: &Arc<Inner>) {
+    if !inner.prefs.get().mute_during_recording || inner.qa_recording_mute.lock().is_some() {
+        return;
+    }
+    match crate::audio_mute::AudioMuteGuard::activate() {
+        Ok(guard) => {
+            *inner.qa_recording_mute.lock() = Some(guard);
+            log::info!("[audio-mute] system output muted for QA recording");
+        }
+        Err(err) => {
+            log::warn!("[audio-mute] failed to mute output for QA: {err}");
+        }
+    }
+}
+
+fn restore_qa_recording_mute(inner: &Arc<Inner>) {
+    if inner.qa_recording_mute.lock().take().is_some() {
+        log::info!("[audio-mute] system output mute restored for QA");
+    }
+}
+
+fn stop_qa_recorder(inner: &Arc<Inner>) {
+    if let Some(rec) = inner.qa_recorder.lock().take() {
+        rec.stop();
+    }
+    restore_qa_recording_mute(inner);
+}
+
 fn take_recorder_for_session(inner: &Arc<Inner>, session_id: u64) -> Option<Recorder> {
     let mut slot = inner.recorder.lock();
     take_session_resource(&mut slot, session_id)
@@ -881,6 +935,7 @@ fn take_recorder_for_session(inner: &Arc<Inner>, session_id: u64) -> Option<Reco
 fn stop_recorder_for_session(inner: &Arc<Inner>, session_id: u64) {
     if let Some(recorder) = take_recorder_for_session(inner, session_id) {
         recorder.stop();
+        restore_recording_mute(inner);
     }
 }
 
@@ -902,6 +957,7 @@ fn stop_recorder_if_pending_start_stop(inner: &Arc<Inner>) {
     }
     if let Some(rec) = take_recorder_for_session(inner, session_id) {
         rec.stop();
+        restore_recording_mute(inner);
         let elapsed = inner.state.lock().started_at.elapsed().as_millis() as u64;
         emit_capsule(inner, CapsuleState::Transcribing, 0.0, elapsed, None, None);
         log::info!("[coord] stopped recorder while ASR is still connecting");
@@ -1235,6 +1291,7 @@ fn start_recorder_for_starting(
         );
     });
 
+    activate_recording_mute(inner);
     match Recorder::start(consumer, level_handler) {
         Ok((rec, runtime_errors)) => {
             store_recorder_for_session(inner, session_id, rec);
@@ -1254,6 +1311,7 @@ fn start_recorder_for_starting(
                 None,
             );
             restore_prepared_windows_ime_session(inner, session_id);
+            restore_recording_mute(inner);
             inner.state.lock().phase = SessionPhase::Idle;
             schedule_capsule_idle(inner, CAPSULE_AUTO_HIDE_DELAY_MS);
             return Err(e.to_string());
@@ -1439,6 +1497,7 @@ async fn end_session(inner: &Arc<Inner>) -> Result<(), String> {
 
     if let Some(rec) = take_recorder_for_session(inner, current_session_id) {
         rec.stop();
+        restore_recording_mute(inner);
     }
 
     let asr_opt = take_asr_for_session(inner, current_session_id);
@@ -2500,6 +2559,7 @@ async fn begin_qa_session(inner: &Arc<Inner>) -> Result<(), String> {
         );
     });
 
+    activate_qa_recording_mute(inner);
     match Recorder::start(consumer, level_handler) {
         Ok((rec, runtime_errors)) => {
             *inner.qa_recorder.lock() = Some(rec);
@@ -2510,6 +2570,7 @@ async fn begin_qa_session(inner: &Arc<Inner>) -> Result<(), String> {
         Err(e) => {
             log::error!("[coord] QA recorder start failed: {e}");
             inner.qa_asr.lock().take();
+            restore_qa_recording_mute(inner);
             finish_qa_with_error(inner, format!("录音启动失败: {e}"));
             return Err(e.to_string());
         }
@@ -2517,9 +2578,7 @@ async fn begin_qa_session(inner: &Arc<Inner>) -> Result<(), String> {
 
     if let Err(e) = asr.open_session().await {
         log::error!("[coord] QA: open ASR session failed: {e}");
-        if let Some(rec) = inner.qa_recorder.lock().take() {
-            rec.stop();
-        }
+        stop_qa_recorder(inner);
         if let Some(asr) = inner.qa_asr.lock().take() {
             asr.cancel();
         }
@@ -2531,9 +2590,7 @@ async fn begin_qa_session(inner: &Arc<Inner>) -> Result<(), String> {
     if inner.qa_state.lock().cancelled {
         log::info!("[coord] QA cancel raced during open_session — aborting begin");
         asr.cancel();
-        if let Some(rec) = inner.qa_recorder.lock().take() {
-            rec.stop();
-        }
+        stop_qa_recorder(inner);
         inner.qa_state.lock().phase = QaPhase::Idle;
         return Ok(());
     }
@@ -2565,9 +2622,7 @@ async fn end_qa_session(inner: &Arc<Inner>) -> Result<(), String> {
         let _ = app.emit_to("qa", "qa:state", serde_json::json!({ "kind": "loading" }));
     }
 
-    if let Some(rec) = inner.qa_recorder.lock().take() {
-        rec.stop();
-    }
+    stop_qa_recorder(inner);
 
     let asr = match inner.qa_asr.lock().take() {
         Some(a) => a,
@@ -2786,6 +2841,7 @@ async fn end_qa_session(inner: &Arc<Inner>) -> Result<(), String> {
 /// 浮窗保持可见（v2：错误后用户可以再按 Option 重试）；messages 一并送过去
 /// 让前端继续渲染历史对话。
 fn finish_qa_with_error(inner: &Arc<Inner>, message: String) {
+    stop_qa_recorder(inner);
     if let Some(app) = inner.app.lock().clone() {
         let messages = inner.qa_state.lock().messages.clone();
         let _ = app.emit_to(
@@ -2836,9 +2892,7 @@ fn cancel_qa_session(inner: &Arc<Inner>) {
     // 这个 flag，true 时立即 break 不再 drain HTTP body，避免取消后 LLM 仍烧 token。
     // 详见 issue #161。
     inner.qa_stream_cancelled.store(true, Ordering::SeqCst);
-    if let Some(rec) = inner.qa_recorder.lock().take() {
-        rec.stop();
-    }
+    stop_qa_recorder(inner);
     if let Some(asr) = inner.qa_asr.lock().take() {
         asr.cancel();
     }

--- a/openless-all/app/src-tauri/src/coordinator.rs
+++ b/openless-all/app/src-tauri/src/coordinator.rs
@@ -98,6 +98,20 @@ struct SessionState {
     front_app: Option<String>,
 }
 
+struct SharedRecordingMuteState {
+    guard: Option<crate::audio_mute::AudioMuteGuard>,
+    holders: u32,
+}
+
+impl SharedRecordingMuteState {
+    fn new() -> Self {
+        Self {
+            guard: None,
+            holders: 0,
+        }
+    }
+}
+
 impl Default for SessionState {
     fn default() -> Self {
         Self {
@@ -132,7 +146,7 @@ struct Inner {
     /// 释放时机由 prefs.local_asr_keep_loaded_secs 决定。
     local_asr_cache: Arc<crate::asr::local::LocalAsrCache>,
     recorder: Mutex<Option<SessionResource<Recorder>>>,
-    recording_mute: Mutex<Option<crate::audio_mute::AudioMuteGuard>>,
+    recording_mute: Mutex<SharedRecordingMuteState>,
     hotkey: Mutex<Option<HotkeyMonitor>>,
     hotkey_status: Mutex<HotkeyStatus>,
     hotkey_trigger_held: AtomicBool,
@@ -153,8 +167,6 @@ struct Inner {
     qa_asr: Mutex<Option<Arc<VolcengineStreamingASR>>>,
     /// QA 用的 Recorder 句柄。
     qa_recorder: Mutex<Option<Recorder>>,
-    /// QA 录音期间的系统输出静音 guard。
-    qa_recording_mute: Mutex<Option<crate::audio_mute::AudioMuteGuard>>,
     /// QA SSE 流取消标志。begin_qa_session 重置为 false；cancel_qa_session 设 true；
     /// polish::chat_completion_history_streaming 的 loop 每帧检查，true 时 break loop
     /// 避免取消后 LLM 仍 drain HTTP body 烧 token。详见 issue #161。
@@ -230,7 +242,7 @@ impl Coordinator {
                 state: Mutex::new(SessionState::default()),
                 asr: Mutex::new(None),
                 recorder: Mutex::new(None),
-                recording_mute: Mutex::new(None),
+                recording_mute: Mutex::new(SharedRecordingMuteState::new()),
                 hotkey: Mutex::new(None),
                 hotkey_status: Mutex::new(HotkeyStatus::default()),
                 hotkey_trigger_held: AtomicBool::new(false),
@@ -240,7 +252,6 @@ impl Coordinator {
                 capsule_layout: Mutex::new(None),
                 qa_asr: Mutex::new(None),
                 qa_recorder: Mutex::new(None),
-                qa_recording_mute: Mutex::new(None),
                 qa_stream_cancelled: Arc::new(AtomicBool::new(false)),
                 local_asr_cache: Arc::new(crate::asr::local::LocalAsrCache::new()),
             }),
@@ -878,45 +889,37 @@ fn store_recorder_for_session(inner: &Arc<Inner>, session_id: u64, recorder: Rec
     *inner.recorder.lock() = Some(SessionResource::new(session_id, recorder));
 }
 
-fn activate_recording_mute(inner: &Arc<Inner>) {
-    if !inner.prefs.get().mute_during_recording || inner.recording_mute.lock().is_some() {
+fn acquire_recording_mute(inner: &Arc<Inner>, owner: &str) {
+    if !inner.prefs.get().mute_during_recording {
         return;
     }
-    match crate::audio_mute::AudioMuteGuard::activate() {
-        Ok(guard) => {
-            *inner.recording_mute.lock() = Some(guard);
-            log::info!("[audio-mute] system output muted for dictation recording");
-        }
-        Err(err) => {
-            log::warn!("[audio-mute] failed to mute output for dictation: {err}");
+    let mut mute = inner.recording_mute.lock();
+    if mute.holders == 0 {
+        match crate::audio_mute::AudioMuteGuard::activate() {
+            Ok(guard) => {
+                mute.guard = Some(guard);
+                log::info!("[audio-mute] system output muted for recording");
+            }
+            Err(err) => {
+                log::warn!("[audio-mute] failed to mute output for {owner}: {err}");
+                return;
+            }
         }
     }
+    mute.holders = mute.holders.saturating_add(1);
+    log::info!("[audio-mute] acquired by {owner}; holders={}", mute.holders);
 }
 
-fn restore_recording_mute(inner: &Arc<Inner>) {
-    if inner.recording_mute.lock().take().is_some() {
-        log::info!("[audio-mute] system output mute restored for dictation");
-    }
-}
-
-fn activate_qa_recording_mute(inner: &Arc<Inner>) {
-    if !inner.prefs.get().mute_during_recording || inner.qa_recording_mute.lock().is_some() {
+fn release_recording_mute(inner: &Arc<Inner>, owner: &str) {
+    let mut mute = inner.recording_mute.lock();
+    if mute.holders == 0 {
         return;
     }
-    match crate::audio_mute::AudioMuteGuard::activate() {
-        Ok(guard) => {
-            *inner.qa_recording_mute.lock() = Some(guard);
-            log::info!("[audio-mute] system output muted for QA recording");
-        }
-        Err(err) => {
-            log::warn!("[audio-mute] failed to mute output for QA: {err}");
-        }
-    }
-}
-
-fn restore_qa_recording_mute(inner: &Arc<Inner>) {
-    if inner.qa_recording_mute.lock().take().is_some() {
-        log::info!("[audio-mute] system output mute restored for QA");
+    mute.holders -= 1;
+    log::info!("[audio-mute] released by {owner}; holders={}", mute.holders);
+    if mute.holders == 0 {
+        mute.guard.take();
+        log::info!("[audio-mute] system output mute restored after recording");
     }
 }
 
@@ -924,7 +927,7 @@ fn stop_qa_recorder(inner: &Arc<Inner>) {
     if let Some(rec) = inner.qa_recorder.lock().take() {
         rec.stop();
     }
-    restore_qa_recording_mute(inner);
+    release_recording_mute(inner, "qa");
 }
 
 fn take_recorder_for_session(inner: &Arc<Inner>, session_id: u64) -> Option<Recorder> {
@@ -935,7 +938,7 @@ fn take_recorder_for_session(inner: &Arc<Inner>, session_id: u64) -> Option<Reco
 fn stop_recorder_for_session(inner: &Arc<Inner>, session_id: u64) {
     if let Some(recorder) = take_recorder_for_session(inner, session_id) {
         recorder.stop();
-        restore_recording_mute(inner);
+        release_recording_mute(inner, "dictation");
     }
 }
 
@@ -957,7 +960,7 @@ fn stop_recorder_if_pending_start_stop(inner: &Arc<Inner>) {
     }
     if let Some(rec) = take_recorder_for_session(inner, session_id) {
         rec.stop();
-        restore_recording_mute(inner);
+        release_recording_mute(inner, "dictation");
         let elapsed = inner.state.lock().started_at.elapsed().as_millis() as u64;
         emit_capsule(inner, CapsuleState::Transcribing, 0.0, elapsed, None, None);
         log::info!("[coord] stopped recorder while ASR is still connecting");
@@ -1291,7 +1294,7 @@ fn start_recorder_for_starting(
         );
     });
 
-    activate_recording_mute(inner);
+    acquire_recording_mute(inner, "dictation");
     match Recorder::start(consumer, level_handler) {
         Ok((rec, runtime_errors)) => {
             store_recorder_for_session(inner, session_id, rec);
@@ -1311,7 +1314,7 @@ fn start_recorder_for_starting(
                 None,
             );
             restore_prepared_windows_ime_session(inner, session_id);
-            restore_recording_mute(inner);
+            release_recording_mute(inner, "dictation");
             inner.state.lock().phase = SessionPhase::Idle;
             schedule_capsule_idle(inner, CAPSULE_AUTO_HIDE_DELAY_MS);
             return Err(e.to_string());
@@ -1497,7 +1500,7 @@ async fn end_session(inner: &Arc<Inner>) -> Result<(), String> {
 
     if let Some(rec) = take_recorder_for_session(inner, current_session_id) {
         rec.stop();
-        restore_recording_mute(inner);
+        release_recording_mute(inner, "dictation");
     }
 
     let asr_opt = take_asr_for_session(inner, current_session_id);
@@ -2559,7 +2562,7 @@ async fn begin_qa_session(inner: &Arc<Inner>) -> Result<(), String> {
         );
     });
 
-    activate_qa_recording_mute(inner);
+    acquire_recording_mute(inner, "qa");
     match Recorder::start(consumer, level_handler) {
         Ok((rec, runtime_errors)) => {
             *inner.qa_recorder.lock() = Some(rec);
@@ -2570,7 +2573,7 @@ async fn begin_qa_session(inner: &Arc<Inner>) -> Result<(), String> {
         Err(e) => {
             log::error!("[coord] QA recorder start failed: {e}");
             inner.qa_asr.lock().take();
-            restore_qa_recording_mute(inner);
+            release_recording_mute(inner, "qa");
             finish_qa_with_error(inner, format!("录音启动失败: {e}"));
             return Err(e.to_string());
         }

--- a/openless-all/app/src-tauri/src/lib.rs
+++ b/openless-all/app/src-tauri/src/lib.rs
@@ -11,6 +11,7 @@
 //! - commands: Tauri IPC surface
 
 mod asr;
+mod audio_mute;
 mod commands;
 mod coordinator;
 mod hotkey;

--- a/openless-all/app/src-tauri/src/types.rs
+++ b/openless-all/app/src-tauri/src/types.rs
@@ -117,6 +117,9 @@ pub struct UserPreferences {
     pub enabled_modes: Vec<PolishMode>,
     pub launch_at_login: bool,
     pub show_capsule: bool,
+    /// 录音期间临时静音系统输出，停止/取消/出错后恢复原静音状态。
+    #[serde(default)]
+    pub mute_during_recording: bool,
     pub active_asr_provider: String, // "volcengine" | "apple-speech" | ...
     pub active_llm_provider: String, // "ark" | "openai" | ...
     /// Windows/Linux 粘贴成功后是否恢复用户原剪贴板。默认 true 跟历史行为一致；
@@ -203,6 +206,7 @@ impl Default for UserPreferences {
             ],
             launch_at_login: false,
             show_capsule: true,
+            mute_during_recording: false,
             active_asr_provider: "volcengine".into(),
             active_llm_provider: "ark".into(),
             restore_clipboard_after_paste: true,

--- a/openless-all/app/src/i18n/en.ts
+++ b/openless-all/app/src/i18n/en.ts
@@ -276,6 +276,8 @@ export const en: typeof zhCN = {
       migrationNoticeDesc: 'If you changed the hotkey trigger mode before, please confirm it here once. This update changes both the default value and the preference-reading path; if you prefer push-to-talk, switch it back manually.',
       capsuleLabel: 'Recording capsule',
       capsuleDesc: 'Show a translucent capsule at the bottom of the screen while recording / transcribing.',
+      muteDuringRecordingLabel: 'Mute while recording',
+      muteDuringRecordingDesc: 'Temporarily mute system output during voice input, then restore the previous mute state when recording stops, is cancelled, or fails.',
       restoreClipboardLabel: 'Restore clipboard after insert',
       restoreClipboardDesc: 'Windows / Linux only: restore your original clipboard after a successful paste (default on). Turn off to keep the dictation text in the clipboard so you can manually Ctrl+V if the simulated paste did not actually land. See issue #111.',
       allowNonTsfFallbackLabel: 'Allow non-TSF fallback',

--- a/openless-all/app/src/i18n/zh-CN.ts
+++ b/openless-all/app/src/i18n/zh-CN.ts
@@ -274,6 +274,8 @@ export const zhCN = {
       migrationNoticeDesc: '如果你之前改过快捷键触发方式，请在这里手动确认一次。本次更新调整了快捷键方式的默认值与读取逻辑；如果你更习惯按住说话，可以重新切回“按住说话”。',
       capsuleLabel: '录音胶囊',
       capsuleDesc: '录音 / 转写时在屏幕底部显示半透明胶囊。',
+      muteDuringRecordingLabel: '录音时静音',
+      muteDuringRecordingDesc: '开始语音输入时临时静音系统输出，停止、取消或出错后恢复原来的静音状态，避免扬声器声音被麦克风收进去。',
       restoreClipboardLabel: '插入后恢复剪贴板',
       restoreClipboardDesc: '仅 Windows / Linux：粘贴成功后恢复你原来的剪贴板内容（默认开）。关掉就把听写文本留在剪贴板，模拟粘贴没真正落地时可以手动 Ctrl+V 找回。详见 issue #111。',
       allowNonTsfFallbackLabel: '允许非 TSF 兜底',

--- a/openless-all/app/src/i18n/zh-TW.ts
+++ b/openless-all/app/src/i18n/zh-TW.ts
@@ -276,6 +276,8 @@ export const zhTW: typeof zhCN = {
       migrationNoticeDesc: '如果你之前改過快捷鍵觸發方式，請在這裏手動確認一次。本次更新調整了快捷鍵方式的默認值與讀取邏輯；如果你更習慣按住說話，可以重新切回“按住說話”。',
       capsuleLabel: '錄音膠囊',
       capsuleDesc: '錄音 / 轉寫時在屏幕底部顯示半透明膠囊。',
+      muteDuringRecordingLabel: '錄音時靜音',
+      muteDuringRecordingDesc: '開始語音輸入時臨時靜音系統輸出，停止、取消或出錯後恢復原來的靜音狀態，避免揚聲器聲音被麥克風收進去。',
       restoreClipboardLabel: '插入後恢復剪貼板',
       restoreClipboardDesc: '僅 Windows / Linux：粘貼成功後恢復你原來的剪貼板內容（默認開）。關掉就把聽寫文本留在剪貼板，模擬粘貼沒真正落地時可以手動 Ctrl+V 找回。詳見 issue #111。',
       allowNonTsfFallbackLabel: '允許非 TSF 兜底',

--- a/openless-all/app/src/lib/ipc.ts
+++ b/openless-all/app/src/lib/ipc.ts
@@ -45,6 +45,7 @@ const mockSettings: UserPreferences = {
   enabledModes: ['raw', 'light', 'structured', 'formal'],
   launchAtLogin: false,
   showCapsule: true,
+  muteDuringRecording: false,
   activeAsrProvider: 'volcengine',
   activeLlmProvider: 'ark',
   restoreClipboardAfterPaste: true,

--- a/openless-all/app/src/lib/types.ts
+++ b/openless-all/app/src/lib/types.ts
@@ -110,6 +110,8 @@ export interface UserPreferences {
   enabledModes: PolishMode[];
   launchAtLogin: boolean;
   showCapsule: boolean;
+  /** 录音期间临时静音系统输出，停止/取消/出错后恢复原静音状态。 */
+  muteDuringRecording: boolean;
   activeAsrProvider: string;
   activeLlmProvider: string;
   /** 仅 Windows/Linux：粘贴成功后是否恢复用户原剪贴板。默认 true。详见 issue #111。 */

--- a/openless-all/app/src/pages/Settings.tsx
+++ b/openless-all/app/src/pages/Settings.tsx
@@ -183,6 +183,8 @@ function RecordingSection() {
     savePrefs({ ...prefs, hotkey: { ...prefs.hotkey, mode } });
   const onShowCapsuleChange = (showCapsule: boolean) =>
     savePrefs({ ...prefs, showCapsule });
+  const onMuteDuringRecordingChange = (muteDuringRecording: boolean) =>
+    savePrefs({ ...prefs, muteDuringRecording });
   const onRestoreClipboardChange = (restoreClipboardAfterPaste: boolean) =>
     savePrefs({ ...prefs, restoreClipboardAfterPaste });
   const onAllowNonTsfFallbackChange = (allowNonTsfInsertionFallback: boolean) =>
@@ -257,6 +259,12 @@ function RecordingSection() {
       </SettingRow>
       <SettingRow label={t('settings.recording.capsuleLabel')} desc={t('settings.recording.capsuleDesc')}>
         <Toggle on={prefs.showCapsule} onToggle={onShowCapsuleChange} />
+      </SettingRow>
+      <SettingRow
+        label={t('settings.recording.muteDuringRecordingLabel')}
+        desc={t('settings.recording.muteDuringRecordingDesc')}
+      >
+        <Toggle on={prefs.muteDuringRecording} onToggle={onMuteDuringRecordingChange} />
       </SettingRow>
       <SettingRow
         label={t('settings.recording.restoreClipboardLabel')}


### PR DESCRIPTION
### **User description**
## 问题描述

Closes #269.

使用语音输入时，如果后台正在播放 YouTube、Bilibili、音乐客户端等音频，扬声器声音可能被麦克风录入，影响 ASR 准确率，甚至把歌词或视频声音识别进输出文本。

Issue #269 原描述中提到“暂停并恢复播放”，同时提到参考 Typeless。实际体验上 Typeless 的行为更接近“录音期间静音系统输出，结束后恢复原静音状态”，而不是逐个暂停媒体应用。因此本 PR 采用系统输出静音方案，避免跨应用媒体控制带来的误暂停、误恢复或漏恢复。

## 修复方案

### 1. 新增录音设置开关

**文件**:

- `openless-all/app/src/pages/Settings.tsx`
- `openless-all/app/src/lib/types.ts`
- `openless-all/app/src-tauri/src/types.rs`
- `openless-all/app/src/i18n/{zh-CN,zh-TW,en}.ts`

在 设置 → 录音 中新增“录音时静音”开关，默认关闭。

开启后，普通听写和划词追问 QA 录音都会在录音期间临时静音系统输出。

### 2. 跨平台系统输出静音 guard

**文件**: `openless-all/app/src-tauri/src/audio_mute.rs`

新增 `AudioMuteGuard`：

- 激活时记录原本是否静音
- 如果原本未静音，则临时静音系统输出
- guard drop 时恢复原静音状态
- 静音失败不阻断录音，只写 warning

平台实现：

- Windows：CoreAudio `IAudioEndpointVolume`
- macOS：`osascript` 设置 `output muted`
- Linux：优先 `wpctl`，没有时 fallback 到 `pactl`

### 3. 接入录音生命周期

**文件**: `openless-all/app/src-tauri/src/coordinator.rs`

覆盖普通听写与 QA 录音：

- 开始 recorder 前尝试静音
- 正常停止录音后恢复
- 取消录音后恢复
- recorder 启动失败后恢复
- recorder runtime error / ASR 失败 / QA 错误路径后恢复

## 测试验证

### 自动检查

- `npm run build`
- `cargo check --manifest-path src-tauri/Cargo.toml`

结果：通过。Rust 仍有仓库已有 warning，本 PR 未引入阻断编译的问题。

### Windows 11 手动验证

已在 Windows 11 上开启“录音时静音”后测试：

- Chrome 播放 YouTube 视频：录音期间系统输出被静音，结束后恢复
- Chrome 播放 Bilibili 视频：录音期间系统输出被静音，结束后恢复
- QQ 音乐客户端播放音乐：录音期间系统输出被静音，结束后恢复

### 未实机验证

- macOS：实现已加入，但未在 macOS 设备上实机验证
- Linux：实现已加入 `wpctl` / `pactl` 路径，但未在真实 Linux 桌面环境上实机验证。

## 风险评估

**中低风险**：

- 功能默认关闭，不影响现有用户行为。
- 只保存并恢复系统输出的 mute 状态，不修改音量大小。
- 静音失败不会中断录音流程。
- 录音结束、取消、错误路径均尝试恢复。

**行为取舍**：

本 PR 没有暂停具体媒体应用，而是静音系统输出。这与 Typeless 的实际体验更一致，也避免了跨浏览器、网页播放器、音乐客户端分别控制播放状态的复杂性和恢复风险。


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- New `audio_mute` module for cross‑platform system output mute

- Lifecycle hooks mute and restore during dictation and QA

- Preference toggle with UI, types and i18n strings


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["User toggles 'Mute while recording' in Settings"] --> B[Recording starts]
  B --> C["AudioMuteGuard::activate()"]
  C --> D[System output muted]
  D --> E[Recording stops, cancelled or fails]
  E --> F[Restore previous mute state]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>audio_mute.rs</strong><dd><code>Add cross‑platform system output mute module</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/appergb/openless/pull/274/files#diff-352fa0cc5c3e73f833a344e8a8dd39a2f9151a16a43decdb7a1007fb91da1fab">+261/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>coordinator.rs</strong><dd><code>Integrate mute guard into recording lifecycle</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/appergb/openless/pull/274/files#diff-73d8c004670b27293f74f0f3991b9a6fc28f0ff0b883214de2b078b1e09797ca">+69/-12</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>Settings.tsx</strong><dd><code>Add toggle for mute during recording setting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/appergb/openless/pull/274/files#diff-b493ca85e083b07f67da1b3ac96aeab153b20c97405e26292b47b95e13368c38">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>lib.rs</strong><dd><code>Declare audio_mute module</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/appergb/openless/pull/274/files#diff-6b8eb1bbf8e378bab914f1a12962f7add5cc4ba9e013c37c9921a1032fa5e110">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>types.rs</strong><dd><code>Add mute_during_recording preference field</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/appergb/openless/pull/274/files#diff-702c533512690147fd6f9342d29f6258530afc2c9ada765f4af3bd082080c952">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ipc.ts</strong><dd><code>Add mute_during_recording to mock settings</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/appergb/openless/pull/274/files#diff-ef5ae5193f0c45b487cbf9b509e52f941a85d5bffc201561a2fa1394a5ff160a">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>types.ts</strong><dd><code>Add mute_during_recording to frontend type</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/appergb/openless/pull/274/files#diff-f22942a2f6ef50f13345f6b2781790a4a99e38a1a39702ce4bca3b2b2eb95e5a">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>en.ts</strong><dd><code>Add English labels for mute setting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/appergb/openless/pull/274/files#diff-bb2f4fa05787923f8aeb23b6f11ad8705e02d9ff03a45790f9181e4615c79d83">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>zh-CN.ts</strong><dd><code>Add Simplified Chinese labels for mute setting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/appergb/openless/pull/274/files#diff-571576f3c7b6c4a78ae0f91accdccc5da5cbed00409955c9914c046fee6c80ea">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>zh-TW.ts</strong><dd><code>Add Traditional Chinese labels for mute setting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/appergb/openless/pull/274/files#diff-a8d5953f9c76bc3c90ec583270be04c852bd7540297500e6ff3260760fc61ea4">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Dependencies</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>Cargo.toml</strong><dd><code>Add Windows audio API dependencies</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/appergb/openless/pull/274/files#diff-334952ba03e62939865bbf0351f0916ea88c6457f8ea1259336e73ee4e2f088b">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

