### PR TITLE
docs(readme): document macOS-only qwen-asr submodule init step

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,9 +166,12 @@ Full end-user walkthrough: [USAGE.md](USAGE.md).
 
 ## Build from source (developers)
 
-The active codebase is in `openless-all/app/` (Tauri 2 + Rust + React/TS).
+The active codebase is in `openless-all/app/` (Tauri 2 + Rust + React/TS). The macOS build links a vendored C ASR engine ([`antirez/qwen-asr`](https://github.com/antirez/qwen-asr)) pulled in as a git submodule under `src-tauri/vendor/qwen-asr/`, so initialize submodules on first clone.
 
 ```bash
+# First clone only — pull in vendored submodules
+git submodule update --init --recursive
+
 cd "openless-all/app"
 npm ci
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -169,9 +169,12 @@ OpenLess 只做一件事：**把语音变成可用的书面文字（尤其是 AI
 
 ## 从源码构建（开发者）
 
-当前活跃代码库在 `openless-all/app/`（Tauri 2 + Rust + React/TS）。
+当前活跃代码库在 `openless-all/app/`（Tauri 2 + Rust + React/TS）。macOS 构建会链接一份 vendored 的本地 ASR 引擎（[`antirez/qwen-asr`](https://github.com/antirez/qwen-asr)），以 git submodule 形式挂在 `src-tauri/vendor/qwen-asr/`，首次 clone 后必须先拉子模块。
 
 ```bash
+# 首次 clone 后拉取子模块
+git submodule update --init --recursive
+
 cd "openless-all/app"
 npm ci
 

--- a/openless-all/README.md
+++ b/openless-all/README.md
@@ -4,9 +4,12 @@ This is the current cross-platform OpenLess workspace.
 
 ## App Directory
 
-The runnable Tauri app lives in `app/`.
+The runnable Tauri app lives in `app/`. The macOS build links a vendored C ASR engine (`antirez/qwen-asr`) tracked as a git submodule under `app/src-tauri/vendor/qwen-asr/`, so initialize submodules on first clone.
 
 ```bash
+# First clone only — pull in vendored submodules
+git submodule update --init --recursive
+
 cd app
 npm ci
 npm run tauri dev


### PR DESCRIPTION
### **User description**
## 摘要

docs(readme): document macOS-only qwen-asr submodule init step


___

### **PR Type**
Documentation


___

### **Description**
- Document macOS vendored ASR submodule

- Add first-clone submodule init command

- Mirror setup instructions in Chinese docs


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["README docs"] -- "add submodule init step" --> B["Build instructions"]
  A -- "mirror update" --> C["README.zh docs"]
  A -- "cross-workspace note" --> D["openless-all README"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Document macOS submodule setup</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

<ul><li>Explains that macOS builds depend on the vendored <code>qwen-asr</code> submodule.<br> <li> Adds <code>git submodule update --init --recursive</code> to first-clone setup <br>steps.<br> <li> Clarifies the submodule path under <code>src-tauri/vendor/qwen-asr/</code>.</ul>


</details>


  </td>
  <td><a href="https://github.com/appergb/openless/pull/275/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>README.zh.md</strong><dd><code>补充 macOS 子模块初始化说明</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.zh.md

<ul><li>Adds the Chinese explanation for the macOS vendored ASR engine.<br> <li> Documents the required submodule initialization command.<br> <li> Notes the <code>src-tauri/vendor/qwen-asr/</code> submodule location.</ul>


</details>


  </td>
  <td><a href="https://github.com/appergb/openless/pull/275/files#diff-b024066e6d6250813a9bc9284332cc3b84edc264857d6a671b7513f2c7ef90a8">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Update workspace build instructions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/README.md

<ul><li>Describes the app-level workspace and macOS ASR dependency.<br> <li> Adds the first-clone submodule initialization command.<br> <li> Points readers to the vendored <code>app/src-tauri/vendor/qwen-asr/</code> path.</ul>


</details>


  </td>
  <td><a href="https://github.com/appergb/openless/pull/275/files#diff-8ef407d59b06770de238fdd10b58968ed239cc0db8686e099d8fbbf49741f31b">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

