### PR TITLE
加固 PR-Agent workflow 的 secrets 暴露面

### DIFF
--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -1,8 +1,9 @@
 name: PR-Agent
 
 on:
-  # 使用 pull_request_target，让外部 PR 也能读取仓库 Secrets，并获得声明的写权限。
-  # 本 workflow 不 checkout / 执行 PR 分支代码，只让 PR-Agent 通过 GitHub API 读取 diff。
+  # 使用 pull_request_target 让同仓库与外部 fork PR 都能自动运行 PR-Agent，
+  # 并在 synchronize 事件跟进每次新 commit。
+  # 本 workflow 不 checkout / 执行 PR 分支代码，只让 digest-pinned PR-Agent 镜像通过 GitHub API 读取 diff。
   pull_request_target:
     types: [opened, reopened, ready_for_review, synchronize]
   issue_comment:
@@ -10,17 +11,31 @@ on:
 
 jobs:
   pr_agent_job:
-    if: ${{ github.event.sender.type != 'Bot' && (github.event_name != 'issue_comment' || github.event.issue.pull_request) }}
+    # PR 与每次新 commit 自动运行；评论触发仍限制为可信成员，避免任意评论滥用 Secrets。
+    if: >-
+      ${{
+        github.event.sender.type != 'Bot' &&
+        (
+          github.event_name == 'pull_request_target' ||
+          (
+            github.event_name == 'issue_comment' &&
+            github.event.issue.pull_request &&
+            contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
+          )
+        )
+      }}
     runs-on: ubuntu-latest
 
     permissions:
+      # PR-Agent 需要在 PR/issue 上评论，并通过 GitHub API 读取 diff/文件内容。
       issues: write
       pull-requests: write
       contents: read
 
     steps:
       - name: Run PR Agent
-        uses: the-pr-agent/pr-agent@main
+        # Pin the actual PR-Agent container image because this job can access repo Secrets.
+        uses: docker://pragent/pr-agent@sha256:a0b36966ca3a197ca739fa1e65c16703076fc1c744cd423ca203b8c21707d71c
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
### **User description**
## 变更
- 不再通过 `the-pr-agent/pr-agent@...` wrapper action 运行 PR-Agent，改为直接使用 digest-pinned Docker action：`docker://pragent/pr-agent@sha256:a0b36966ca3a197ca739fa1e65c16703076fc1c744cd423ca203b8c21707d71c`。
- 保留 `pull_request_target` 对所有 PR 的自动触发，包含外部 fork PR 和 `synchronize` 新 commit。
- `issue_comment` 手动触发路径限制为 OWNER/MEMBER/COLLABORATOR，避免任意评论滥用带 secrets 的 job。
- 更新 workflow 注释，明确当前模型：便利优先，runtime image digest pinning + 不 checkout PR head code 降低风险。

## 影响
- 每个 PR 打开/重开/ready_for_review 会自动跑 PR-Agent。
- 每次 PR 新 commit 会通过 `synchronize` 自动再次触发。
- 外部 fork PR 仍会进入带 `OPENAI_KEY` 的 `pull_request_target` 路径；这是为了保持自动审查便利性而接受的剩余风险。
- PR-Agent 升级需要手动更新镜像 digest。

## 验证
- `python - <<'PY' ... yaml.safe_load(...)`：workflow YAML 可解析，并断言 `uses` 为 `docker://...@sha256:` 形式。
- `git diff --check`：通过。
- `grep` 确认 workflow 中无 `the-pr-agent/pr-agent@` 或 `pragent/pr-agent:github_action` 残留。

Closes #222


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Pin PR-Agent runtime container to an immutable Docker image digest (removes mutable action ref)

- Restrict `issue_comment` trigger to OWNER/MEMBER/COLLABORATOR to prevent abuse

- Update workflow comments to document current security model and permissions


___

### Diagram Walkthrough


```mermaid
flowchart LR
    A["pull_request_target (all PRs)"] -- "trigger" --> C["Job: pr_agent_job"]
    B["issue_comment (trusted members)"] -- "trigger" --> C
    C -- "runs" --> D["Pinned Docker image (digest)"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pr-agent.yml</strong><dd><code>Pin PR-Agent runtime and restrict comment trigger</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/pr-agent.yml

<ul><li>Replaced <code>uses: the-pr-agent/pr-agent@main</code> with a digest-pinned Docker <br>image <code>docker://pragent/pr-agent@sha256:...</code><br> <li> Added <code>author_association</code> check for <code>issue_comment</code> trigger to restrict <br>to OWNER/MEMBER/COLLABORATOR<br> <li> Updated inline comments to document the security rationale and <br>permission requirements</ul>


</details>


  </td>
  <td><a href="https://github.com/appergb/openless/pull/276/files#diff-69fd3473f15a98f47918e81bc4d0ca86a71131f21db13b39bebf76d27cf483b4">+19/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

