### PR TITLE
fix(ci): checkout 拉 submodules — 修 mac 端 qwen-asr build fail

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,10 @@ jobs:
         working-directory: openless-all/app
     steps:
       - uses: actions/checkout@v4
+        with:
+          # vendor/qwen-asr 是 macOS 上 build.rs 必须的 git submodule。Windows
+          # checkout 也拉一份保持与 release-tauri.yml 一致，开销几秒可以忽略。
+          submodules: recursive
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/release-tauri.yml
+++ b/.github/workflows/release-tauri.yml
@@ -50,6 +50,10 @@ jobs:
       TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          # vendor/qwen-asr 是 macOS 上 build.rs 必须的 git submodule（cc-rs 编译
+          # antirez/qwen-asr 的 C 源），不拉就会在 mac 端 cargo build 阶段挂掉。
+          submodules: recursive
 
       - uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
### **User description**
## 现象
[release-tauri run 25415755417](https://github.com/appergb/openless/actions/runs/25415755417) 中 mac arm64 在 \`cargo build\` 阶段挂掉：

\`\`\`
error: no such file or directory: 'vendor/qwen-asr/qwen_asr.c'
clang: error: no input files
```

Linux / Windows 这次同 run 都过了（验证 PR #281 的 Tauri 版本锁有效）。

## 根因
- \`build.rs\` 的 \`#[cfg(target_os = "macos")]\` 分支用 cc-rs 编译 \`vendor/qwen-asr/*.c\`
- \`vendor/qwen-asr\` 是 git submodule（\`.gitmodules\` → antirez/qwen-asr）
- CI \`actions/checkout@v4\` 默认 \*\*不\*\* 拉 submodule → 目录空 → cc 找不到源文件
- Linux / Windows \`build.rs\` 不进 cc 路径，没踩；mac 是唯一编译 qwen-asr 的平台

## 修复
\`release-tauri.yml\` + \`ci.yml\` 两处 \`actions/checkout@v4\` 都加 \`with: submodules: recursive\`。

ci.yml 实际只跑 windows，理论上不需要 submodule，但跟 release-tauri.yml 保持一致避免后续踩同一坑。

## Test plan
- [ ] PR CI 通过
- [ ] 合并后 \`workflow_dispatch release-tauri.yml\` 全 4 platform build 成功（这次 mac 应能编 qwen-asr）


___

### **PR Type**
Bug fix


___

### **Description**
- Enable recursive submodule checkout

- Fix macOS `qwen-asr` build failures

- Keep CI and release workflows aligned


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["actions/checkout@v4"] -- "without submodules" --> B["Empty vendor/qwen-asr"]
  B -- "macOS build.rs compiles C sources" --> C["cargo build fails"]
  A -- "with `submodules: recursive`" --> D["Submodule sources available"]
  D -- "shared workflow fix" --> E["CI and release builds succeed"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ci.yml</strong><dd><code>Fetch submodules in Windows CI</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/ci.yml

<ul><li>Added <code>submodules: recursive</code> to <code>actions/checkout@v4</code>.<br> <li> Ensures the Windows CI job also fetches <code>vendor/qwen-asr</code>.<br> <li> Keeps CI checkout behavior consistent with the release workflow.</ul>


</details>


  </td>
  <td><a href="https://github.com/appergb/openless/pull/282/files#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03f">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>release-tauri.yml</strong><dd><code>Fix release workflow submodule checkout</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/release-tauri.yml

<ul><li>Added recursive submodule checkout to the release workflow.<br> <li> Prevents macOS <code>cargo build</code> failures caused by missing <code>vendor/qwen-asr</code> <br>sources.<br> <li> Documents why the submodule is required for <code>build.rs</code>.</ul>


</details>


  </td>
  <td><a href="https://github.com/appergb/openless/pull/282/files#diff-cac78cd4d340dc05703d65bee14ea766337499de655e15553ceb8181eef097cb">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

