### PR TITLE
fix(windows-ime): 静态链接 CRT 防 host 进程 MSVCP140 劫持（修 QQ 切微软拼音崩溃）

### DIFF
--- a/openless-all/app/windows-ime/OpenLessIme.vcxproj
+++ b/openless-all/app/windows-ime/OpenLessIme.vcxproj
@@ -75,6 +75,12 @@
       <PreprocessorDefinitions>WIN32;_WINDOWS;_USRDLL;OPENLESSIME_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <LanguageStandard>stdcpp17</LanguageStandard>
+      <!-- 静态链接 CRT：让 OpenLessIme.dll 自带 MSVCP / VCRUNTIME / UCRT，
+           避免被宿主进程（如 QQ）app/ 目录下的私有 MSVCP140 副本劫持。
+           QQ 把 MSVCP140.dll 放在 versions/<ver>/resources/app/，DLL 搜索
+           顺序优先 → 我们的 std::* 调用会跑 QQ 那份旧版 → ABI 漂移 → 0xc0000005。
+           DLL 大小 +~300 KB；DLL 内部 STL 不再可跨边界共享（我们也不需要）。 -->
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -89,6 +95,7 @@
       <PreprocessorDefinitions>WIN32;_WINDOWS;_USRDLL;OPENLESSIME_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <LanguageStandard>stdcpp17</LanguageStandard>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -105,6 +112,7 @@
       <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_USRDLL;OPENLESSIME_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <LanguageStandard>stdcpp17</LanguageStandard>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -123,6 +131,7 @@
       <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_USRDLL;OPENLESSIME_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <LanguageStandard>stdcpp17</LanguageStandard>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/openless-all/app/windows-ime/src/dllmain.cpp
+++ b/openless-all/app/windows-ime/src/dllmain.cpp
@@ -13,9 +13,13 @@ LONG g_object_count = 0;
 BOOL APIENTRY DllMain(HINSTANCE instance, DWORD reason, LPVOID reserved) {
   UNREFERENCED_PARAMETER(reserved);
 
+  // 不调用 DisableThreadLibraryCalls：DLL 现在用 /MT 静态链接 CRT，CRT 需要
+  // DLL_THREAD_ATTACH / DLL_THREAD_DETACH 通知做 per-thread TLS 初始化与清理。
+  // 在 host 进程（如 QQ / Office）切输入法新建 input thread 时禁用通知，会让
+  // 静态 CRT 的 thread-local 资源泄漏 / 行为不稳定，反而把这次想修的崩溃问题
+  // 重新引回来。详见 Microsoft 文档 DisableThreadLibraryCalls 备注。
   if (reason == DLL_PROCESS_ATTACH) {
     g_module = instance;
-    DisableThreadLibraryCalls(instance);
   }
 
   return TRUE;


### PR DESCRIPTION
### **User description**
## 用户反馈
Windows 11 上 QQ (QQEX.exe v9.9.26.44725) 切到微软拼音时崩溃：

\`\`\`
异常代码：0xc0000005 (STATUS_ACCESS_VIOLATION)
故障模块：D:\\program\\QQ\\versions\\<ver>\\resources\\app\\MSVCP140.dll
偏移：0x13080
\`\`\`

## 根因（DLL Hell）
1. QQ 把私有 MSVCP140.dll 放在 app/ 目录，**DLL 搜索顺序优先于系统**
2. ctfmon 切微软拼音 → 把已注册 TSF DLL 全部加载进 QQ 进程
3. 我们 \`OpenLessIme.dll\` 用 MSBuild 默认 \`RuntimeLibrary=MultiThreadedDLL\` —— 动态链接 MSVCP140
4. 在 QQ 进程内被绑给 QQ 自带的旧版 MSVCP140 → 调 \`std::wstring/thread/mutex\` 跑的是 QQ 那份 → ABI 漂移 → AV

## 修复（surgical）
\`OpenLessIme.vcxproj\` 4 处 \`ItemDefinitionGroup\` 加 \`<RuntimeLibrary>MultiThreaded(Debug)</RuntimeLibrary>\`：
- DLL 自带 MSVCP / VCRUNTIME / UCRT 副本
- QQ 私有 CRT 劫持不到我们
- DLL 体积 +~300 KB（可接受）
- DLL 内部 STL 不能跨边界共享 —— 我们 IPC 走 named pipe + JSON，不受影响

## 不动的部分（已合规）
- TSF 接口本身已是 COM C ABI（vtable + COM-typed 参数）
- 重量级 ASR/LLM/polish 早已在 OpenLess.exe 主进程做，DLL 只做 TSF text service hooks + IPC

## QQ 客观脆弱性（已整理详细报告，用于 TSRC 上报）
- app/ 目录 MSVCP140.dll 劫持系统 CRT
- 版本目录嵌套混乱（崩溃报告里 9.9.26.44725 vs 路径里 9.9.29-47354）
- 无 IME 崩溃隔离机制（任何第三方 IME 崩 = QQ 全进程崩）
- 自带 CRT 与系统 CRT 行为漂移

## Test plan
- [ ] CI \`Windows Tauri checks\` + \`pr_agent_job\`
- [ ] 真机 Windows：QQ 切微软拼音不再崩
- [ ] OpenLessIme.dll 体积 +~300 KB（确认在可接受范围）


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- 静态链接 `OpenLessIme.dll` 的 CRT

- 避免宿主进程 DLL 劫持崩溃

- 保留线程库通知用于 CRT 初始化


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["QQ / Office 宿主进程"] -- "加载 TSF DLL" --> B["OpenLessIme.dll"]
  B -- "改为 /MT 静态 CRT" --> C["自带 MSVCP/VCRUNTIME/UCRT"]
  A -- "app/ 目录私有 DLL 劫持" --> D["旧版 MSVCP140.dll"]
  C -- "不再依赖宿主 CRT" --> E["避免 ABI 漂移与崩溃"]
  B -- "保留线程通知" --> F["CRT 线程本地初始化/清理"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>dllmain.cpp</strong><dd><code>Preserve thread notifications for static CRT</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/windows-ime/src/dllmain.cpp

<ul><li>Removed <code>DisableThreadLibraryCalls</code> during process attach<br> <li> Added comment explaining static CRT thread attach/detach needs<br> <li> Prevents TLS initialization and cleanup issues in host input threads</ul>


</details>


  </td>
  <td><a href="https://github.com/appergb/openless/pull/287/files#diff-9e020cbb534e172e3bc61fd67fb5d5f15642aba05aabf91ea6c2a2fd3c012cd7">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>OpenLessIme.vcxproj</strong><dd><code>Switch DLL build to static CRT</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/windows-ime/OpenLessIme.vcxproj

<ul><li>Set <code>RuntimeLibrary</code> to <code>MultiThreadedDebug</code> for Debug builds<br> <li> Set <code>RuntimeLibrary</code> to <code>MultiThreaded</code> for Release builds<br> <li> Applied changes for both <code>Win32</code> and <code>x64</code> configurations<br> <li> Documented why static CRT avoids host-side <code>MSVCP140.dll</code> hijacking</ul>


</details>


  </td>
  <td><a href="https://github.com/appergb/openless/pull/287/files#diff-812c1652952c5b367b16f3044948eed5372b80c0cae4978314071e62ed3c13ab">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

