### PR TITLE
fix(recording): 录音条出现时 mic 已 capture，不再吞开头字

### DIFF
--- a/openless-all/app/src-tauri/src/coordinator.rs
+++ b/openless-all/app/src-tauri/src/coordinator.rs
@@ -1125,8 +1125,10 @@ async fn begin_session(inner: &Arc<Inner>) -> Result<(), String> {
         return Err(message);
     }
 
-    emit_capsule(inner, CapsuleState::Recording, 0.0, 0, None, None);
-
+    // 不在这里 emit Recording capsule —— 让 start_recorder_for_starting 在
+    // Recorder::start 成功后再发，确保「用户看到录音条」时 mic 已经在 capture。
+    // 之前在这一行就 emit 会让用户看到录音条后立刻开口，但 mic 还在 cpal init
+    // 窗口（50-200ms）内 → 开头几个字物理上录不到。详见 issue 备注。
     let active_asr = CredentialsVault::get_active_asr();
 
     #[cfg(target_os = "macos")]
@@ -1301,6 +1303,11 @@ fn start_recorder_for_starting(
             spawn_recorder_error_monitor(inner, runtime_errors);
             stop_recorder_if_pending_start_stop(inner);
             log::info!("[coord] recorder started (asr={active_asr}, phase=Starting)");
+            // ★ 关键：录音器实际启动后再发 Recording capsule，避免用户「看到录音条但
+            //   mic 还没开」的 50-200ms 窗口里开口讲话被吞。begin_session 把这一行
+            //   挪到这里以后，三条 ASR 路径（Local / Whisper / Volcengine）共享。
+            //   ASR 连接慢的间隙仍由 DeferredAsrBridge 缓存 PCM，按顺序后送，不丢字。
+            emit_capsule(inner, CapsuleState::Recording, 0.0, 0, None, None);
         }
         Err(e) => {
             log::error!("[coord] recorder start failed: {e}");

--- a/openless-all/app/src-tauri/src/coordinator.rs
+++ b/openless-all/app/src-tauri/src/coordinator.rs
@@ -1301,13 +1301,28 @@ fn start_recorder_for_starting(
         Ok((rec, runtime_errors)) => {
             store_recorder_for_session(inner, session_id, rec);
             spawn_recorder_error_monitor(inner, runtime_errors);
+            // ★ 录音器实际启动后再发 Recording capsule —— 避免用户「看到录音条但
+            //   mic 还没开」的 50-200ms 窗口里开口讲话被吞（三条 ASR 路径共享）。
+            //   ASR 连接慢的间隙由 DeferredAsrBridge 缓存 PCM，按顺序后送，不丢字。
+            //
+            //   竞态保护：必须在 stop_recorder_if_pending_start_stop 之前 emit，
+            //   并且仅当 recorder 真的会继续运行（phase 仍是 Starting、无待处理的
+            //   stop / cancel）时才 emit。否则用户在 cpal init 期间松开热键时，
+            //   stop / cancel 路径可能已经发出 Transcribing / Cancelled，本行
+            //   再无条件覆盖回 Recording 会让 UI 短暂闪烁错误状态（短按尤其明显）。
+            //   Codex review (PR #289 P2) 指出。
+            let should_emit_recording = {
+                let state = inner.state.lock();
+                state.session_id == session_id
+                    && state.phase == SessionPhase::Starting
+                    && !state.pending_stop
+                    && !state.cancelled
+            };
+            if should_emit_recording {
+                emit_capsule(inner, CapsuleState::Recording, 0.0, 0, None, None);
+            }
             stop_recorder_if_pending_start_stop(inner);
             log::info!("[coord] recorder started (asr={active_asr}, phase=Starting)");
-            // ★ 关键：录音器实际启动后再发 Recording capsule，避免用户「看到录音条但
-            //   mic 还没开」的 50-200ms 窗口里开口讲话被吞。begin_session 把这一行
-            //   挪到这里以后，三条 ASR 路径（Local / Whisper / Volcengine）共享。
-            //   ASR 连接慢的间隙仍由 DeferredAsrBridge 缓存 PCM，按顺序后送，不丢字。
-            emit_capsule(inner, CapsuleState::Recording, 0.0, 0, None, None);
         }
         Err(e) => {
             log::error!("[coord] recorder start failed: {e}");


### PR DESCRIPTION
### **User description**
## 用户反馈
按 Option 键后已经看到录音条，但开口的前几个字被吞掉，应该立即开始录音。如果当时 ASR 没连上不要紧，按顺序发送即可（这部分 \`DeferredAsrBridge\` 已经做了，本次不动）。

## 根因
\`coordinator.rs::begin_session()\` 在 \`line 1128\` 就 \`emit_capsule(Recording)\`，但 \`Recorder::start\` 还要再走 ~57 行（read creds / new ASR / new bridge / acquire mute / cpal init），其中 **cpal init 在 macOS 上有 50-200ms 启动延迟**。

窗口期内：
- 视觉：录音条已显示 → 用户以为可以说话了
- 物理：mic 还没产生第一帧 PCM
- 用户开口的前几个字 **物理上无法被 capture**（不是丢字，是没录到）

\`DeferredAsrBridge\` 已经覆盖 「recorder 已开 → ASR 没连上」的间隙（缓存 PCM 等 ASR attach 后按顺序后送），但 「录音条已显 → recorder 没开」之前没人覆盖。

## 修复（surgical）
\`emit_capsule(Recording)\` 从 \`begin_session()\` 挪到 \`start_recorder_for_starting()\` 内部 \`Recorder::start\` 成功的 \`Ok\` 分支：

\`\`\`diff
-    emit_capsule(inner, CapsuleState::Recording, 0.0, 0, None, None);  // 提前 emit 删除
+    // 不在这里 emit Recording：让 start_recorder_for_starting 在 Recorder::start
+    // 成功后再发，确保「录音条出现」时 mic 已经在 capture。

     match Recorder::start(consumer, level_handler) {
         Ok((rec, runtime_errors)) => {
             ...
             log::info!("[coord] recorder started ...");
+            // ★ 录音器实际启动后再发 Recording capsule
+            emit_capsule(inner, CapsuleState::Recording, 0.0, 0, None, None);
         }
\`\`\`

三条 ASR 路径（Local Qwen3 / Whisper / Volcengine）共用 \`start_recorder_for_starting\`，自动受益。代价是用户按热键到看到录音条多 ~50-200ms 延迟，但「录音条出现 = mic 100% 在 capture」体感诚实。

## 不动的部分（已合规）
- \`DeferredAsrBridge\` 按顺序缓冲 PCM + ASR attach 后 drain — 保留
- \`finish_starting_session\` cancel race 检查 — 保留
- error / cancel 路径的 emit_capsule(Error) — 保留

## Test plan
- [x] \`cargo check\` 通过
- [ ] CI \`Windows Tauri checks\` + \`pr_agent_job\`
- [ ] 真机 mac：按 Option 立刻说"测试一二三"，转录出"测试一二三"完整无丢
- [ ] 真机 mac：按 Option 立刻看到录音条 + 50-200ms 延迟体感可接受


___

### **PR Type**
Bug fix


___

### **Description**
- 延后 `Recording` capsule 发送时机

- 改为录音器启动成功后再显示录音条

- 增加 stop/cancel 竞态保护

- 避免短按热键时状态闪回


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["begin_session"] -- "prepare session" --> B["start_recorder_for_starting"]
  B -- "Recorder::start succeeds" --> C["emit Recording capsule"]
  B -- "stop/cancel pending" --> D["skip overwrite"]
  C -- "mic already capturing" --> E["user speaks safely"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>coordinator.rs</strong><dd><code>Delay recording capsule until mic starts</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src-tauri/src/coordinator.rs

<ul><li>Removed the early <code>emit_capsule(Recording)</code> from <code>begin_session()</code>.<br> <li> Emit <code>Recording</code> only after <code>Recorder::start</code> returns <code>Ok</code>.<br> <li> Added a state check for <code>Starting</code>, <code>pending_stop</code>, and <code>cancelled</code>.<br> <li> Prevents overwriting <code>stop</code>/<code>cancel</code> transitions during startup.</ul>


</details>


  </td>
  <td><a href="https://github.com/appergb/openless/pull/289/files#diff-73d8c004670b27293f74f0f3991b9a6fc28f0ff0b883214de2b078b1e09797ca">+24/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

