### PR TITLE
chore(ci): 暂时搁置 macos-13 (Intel mac) 构建 — GH runner pool 卡死

### DIFF
--- a/.github/workflows/release-tauri.yml
+++ b/.github/workflows/release-tauri.yml
@@ -32,10 +32,15 @@ jobs:
             rust-target: aarch64-apple-darwin
             updater-target: darwin
             updater-arch: aarch64
-          - platform: macos-13
-            rust-target: x86_64-apple-darwin
-            updater-target: darwin
-            updater-arch: x86_64
+          # 暂时搁置 Intel mac 构建：GitHub Actions 把 macos-13 标记为 deprecated
+          # runner，pool 容量紧张到每次 dispatch 都 queue 1-2h 拿不到分配，多次
+          # release 都因这个 job 卡住整个 run 的 conclusion。等 GH 把 macOS x86_64
+          # 迁移到非 deprecated runner（macos-14 / macos-15-large）或 macos-13
+          # pool 缓解后再恢复。Apple Silicon dmg 在 Intel mac 上跑 Rosetta 仍可用。
+          # - platform: macos-13
+          #   rust-target: x86_64-apple-darwin
+          #   updater-target: darwin
+          #   updater-arch: x86_64
           - platform: windows-latest
             rust-target: x86_64-pc-windows-msvc
             updater-target: windows


### PR DESCRIPTION
### **User description**
## 背景
GitHub Actions 把 \`macos-13\` 标记为 deprecated runner，pool 容量紧张。已观测 4 次 release run 都因 mac-13 卡 queue（每次 1-2h）阻塞整个 run conclusion：

| Run | mac-13 等待时长 |
|---|---|
| 25415755417 | 30+ min |
| 25417633813 | 1h+ |
| 25419948896 | 5min（手动 cancel） |
| 25420193625 | 1h+ |

## 改动
release-tauri.yml matrix 注释掉 \`macos-13\` 项：
\`\`\`diff
+          # 暂时搁置 Intel mac 构建：...
+          # - platform: macos-13
+          #   rust-target: x86_64-apple-darwin
+          #   updater-target: darwin
+          #   updater-arch: x86_64
\`\`\`

## 影响
- macOS arm64 (Apple Silicon) 仍发 dmg
- Windows x64 + Linux 不变
- Intel mac 用户在 v1.2.21+ 期间用 Apple Silicon dmg + Rosetta（性能稍降但可用）

## 恢复条件（任一）
- GH 把 macos-13 pool 容量恢复
- GH 提供 macos-14-x86_64 / macos-15-large-x86_64 替代 runner
- 项目自建 self-host runner

恢复方法：删 4 行注释符即可。


___

### **PR Type**
Bug fix, Other


___

### **Description**
- Comment out `macos-13` matrix entry to avoid CI queue delays

- Retain `macos-latest` (arm64) build for Apple Silicon and Rosetta

- Document recovery plan and deprecated runner context in comments


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Release CI Matrix"] -- "disables" --> B["macos-13 (Intel)"]
  A -- "keeps" --> C["macos-latest (Arm)"]
  C -- "provides dmg for Intel via Rosetta" --> D["Intel Mac Users"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>release-tauri.yml</strong><dd><code>Disable Intel macOS build in release CI matrix</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/release-tauri.yml

<ul><li>Comment out the <code>macos-13</code> matrix entry, preventing runner queue delays<br> <li> Add a detailed explanation about the deprecated runner and recovery <br>steps<br> <li> Keep <code>macos-latest</code> (arm64) job for Apple Silicon and Rosetta fallback</ul>


</details>


  </td>
  <td><a href="https://github.com/appergb/openless/pull/290/files#diff-cac78cd4d340dc05703d65bee14ea766337499de655e15553ceb8181eef097cb">+9/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

