### PR TITLE
fix(startup): splash 透明背景 + 卡片化，避免长启动时左半白屏

### DIFF
--- a/openless-all/app/src/App.tsx
+++ b/openless-all/app/src/App.tsx
@@ -147,18 +147,38 @@ function isWindowHotkeyCandidate(event: KeyboardEvent): boolean {
 }
 
 function StartupShell() {
+  // 用透明背景：main window 是 transparent + macOSPrivateApi（NSVisualEffectView 磨砂）。
+  // 之前用 linear-gradient(rgba(245,245,247,0.96)...) 会盖过 macOS vibrancy，启动时
+  // 长时间在 'checking' phase（凭据迁移 / 权限 probe 慢）会让窗口看起来「左侧白屏 +
+  // 右侧磨砂」割裂。现在背景全透明，让磨砂统一展开，提示文字 + icon 用一个轻量
+  // pill 卡片承载，跟 capsule 视觉一致。
   return (
     <div
       style={{
         minHeight: '100vh',
         display: 'grid',
         placeItems: 'center',
-        background: 'linear-gradient(180deg, rgba(245,245,247,0.96) 0%, rgba(232,232,236,0.96) 100%)',
+        background: 'transparent',
         color: 'var(--ol-ink-3)',
         fontFamily: 'var(--ol-font-sans)',
       }}
     >
-      <div style={{ display: 'flex', alignItems: 'center', gap: 10, fontSize: 13, fontWeight: 500 }}>
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 10,
+          fontSize: 13,
+          fontWeight: 500,
+          padding: '10px 16px',
+          borderRadius: 999,
+          background: 'rgba(255, 255, 255, 0.55)',
+          backdropFilter: 'blur(20px) saturate(180%)',
+          WebkitBackdropFilter: 'blur(20px) saturate(180%)',
+          border: '0.5px solid rgba(0, 0, 0, 0.06)',
+          boxShadow: '0 4px 14px -6px rgba(0, 0, 0, 0.18), 0 0 0 0.5px rgba(0,0,0,0.04)',
+        }}
+      >
         <img src="AppIcon.png" alt="" style={{ width: 18, height: 18, borderRadius: 4 }} />
         <span>OpenLess 正在启动</span>
       </div>


### PR DESCRIPTION
### **User description**
## 用户反馈
启动时间较长时（凭据迁移 / 权限 probe / hotkey hook 还没 ready），main window 左侧出现白色矩形显示「OpenLess 正在启动」，本应是纯磨砂玻璃背景。

## 根因
main window 在 \`tauri.conf.json\` 是 \`transparent: true\` + \`macOSPrivateApi: true\`（NSVisualEffectView vibrancy）。但 \`App.tsx::StartupShell\` 之前用：
\`\`\`tsx
background: linear-gradient(180deg, rgba(245,245,247,0.96), rgba(232,232,236,0.96))
\`\`\`
96% 不透明渐变 → 盖过 vibrancy。在 'checking' phase 持续较长时（mac 端权限 probe / Windows 端 hotkey poll 10s 上限），左侧已 paint StartupShell 浅灰，右侧 vibrancy 区域看起来成了割裂的「白 + 磨砂」。

## 修复
\`\`\`diff
- background: linear-gradient(180deg, rgba(245,245,247,0.96) 0%, rgba(232,232,236,0.96) 100%),
+ background: transparent,
\`\`\`
让 vibrancy 全屏展开。提示文字 + icon 用一个圆角 pill 卡片承载（\`rgba(255,255,255,0.55)\` + \`backdrop-filter: blur(20px) saturate(180%)\`），跟 Capsule 视觉一致。

## Test plan
- [x] frontend build 通过
- [ ] CI \`Windows Tauri checks\` + \`pr_agent_job\`
- [ ] 真机 mac：刻意拖慢启动（断网 / 等 hotkey hook poll 满 10s）观察是否仍出现白屏


___

### **PR Type**
Bug fix


___

### **Description**
- 将 StartupShell 背景改为透明，允许全屏磨砂 vibrancy 效果

- 用圆角卡片包裹提示文字与图标，带模糊和阴影

- 消除长启动时左侧白屏割裂问题


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>App.tsx</strong><dd><code>startup splash transparent background and pill card</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src/App.tsx

<ul><li>替换 <code>StartupShell</code> 背景渐变（96% 不透明）为 <code>transparent</code>，避免遮盖 macOS vibrancy 效果<br> <li> 为启动提示容器新增圆角卡片样式：<code>padding</code>、<code>borderRadius: 999</code>、半透明白色背景、<code>backdropFilter</code> <br>模糊与饱和度、阴影及细边框<br> <li> 添加 <code>WebkitBackdropFilter</code> 保证 Safari 兼容<br> <li> 保留原有图标与文字布局，仅改动样式</ul>


</details>


  </td>
  <td><a href="https://github.com/appergb/openless/pull/291/files#diff-de79c17c8d207a15e4b63b322a56e9f063721228677fe7e3c4a49813ab4c3576">+22/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

