### PR TITLE
fix(ops): 为 openless.log 增加启动轮转

### DIFF
--- a/openless-all/app/src-tauri/src/lib.rs
+++ b/openless-all/app/src-tauri/src/lib.rs
@@ -38,6 +38,8 @@ use std::sync::Arc;
 #[cfg(target_os = "macos")]
 use std::time::Duration;
 
+const LOG_ROTATE_LIMIT_BYTES: u64 = 10 * 1024 * 1024;
+
 /// 第一次 show 时把 QA 浮窗摆到屏幕底部居中；之后的 show 不再 reposition，
 /// 让用户拖动后的位置在 hide → show 之间得以保持。详见 issue #118 v2。
 static QA_WINDOW_POSITIONED: AtomicBool = AtomicBool::new(false);
@@ -47,9 +49,6 @@ use tauri::{AppHandle, Emitter, LogicalPosition, LogicalSize, Manager, RunEvent,
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
-    init_file_logger();
-    log::info!("=== OpenLess 启动 ===");
-
     let coordinator = Arc::new(coordinator::Coordinator::new());
     let local_asr_download_manager = Arc::new(asr::local::DownloadManager::new());
 
@@ -76,6 +75,9 @@ pub fn run() {
         .manage(coordinator.clone())
         .manage(local_asr_download_manager.clone())
         .setup(move |app| {
+            init_file_logger();
+            log::info!("=== OpenLess 启动 ===");
+
             // Capsule 启动时定位到屏幕底部居中并隐藏；coordinator 按需显示。
             // 与 Swift `CapsuleWindowController.repositionToBottomCenter` 同语义。
             if let Some(capsule) = app.get_webview_window("capsule") {
@@ -430,6 +432,9 @@ fn init_file_logger() {
     let log_dir = log_dir_path();
     let _ = std::fs::create_dir_all(&log_dir);
     let log_file = log_dir.join("openless.log");
+    if let Err(e) = rotate_log_if_too_large(&log_file) {
+        eprintln!("[logger] WARN 日志轮转失败: {e}");
+    }
     let config = ConfigBuilder::new().set_time_format_rfc3339().build();
     let mut loggers: Vec<Box<dyn simplelog::SharedLogger>> = vec![TermLogger::new(
         LevelFilter::Info,
@@ -445,6 +450,23 @@ fn init_file_logger() {
         loggers.push(WriteLogger::new(LevelFilter::Info, config, file));
     }
     let _ = CombinedLogger::init(loggers);
+}
+
+fn rotate_log_if_too_large(path: &std::path::Path) -> std::io::Result<()> {
+    let Ok(metadata) = std::fs::metadata(path) else {
+        return Ok(());
+    };
+    if metadata.len() <= LOG_ROTATE_LIMIT_BYTES {
+        return Ok(());
+    }
+
+    let archive = path.with_file_name("openless.log.1");
+    match std::fs::remove_file(&archive) {
+        Ok(()) => {}
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+        Err(e) => return Err(e),
+    }
+    std::fs::rename(path, archive)
 }
 
 pub fn log_dir_path() -> std::path::PathBuf {
@@ -837,7 +859,11 @@ fn capsule_height_for_qa() -> f64 {
 
 #[cfg(test)]
 mod tests {
-    use super::{capsule_height_for_qa, capsule_visual_height, capsule_window_bounds};
+    use super::{
+        capsule_height_for_qa, capsule_visual_height, capsule_window_bounds,
+        rotate_log_if_too_large, LOG_ROTATE_LIMIT_BYTES,
+    };
+    use std::io::Write;
 
     #[test]
     fn capsule_window_bounds_leave_room_for_windows_shadow() {
@@ -887,5 +913,63 @@ mod tests {
 
         #[cfg(not(target_os = "windows"))]
         assert_eq!(capsule_height_for_qa(), 96.0);
+    }
+
+    #[test]
+    fn oversized_log_rotates_to_single_archive() {
+        let dir = std::env::temp_dir().join(format!("openless-log-rotate-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let log = dir.join("openless.log");
+        let archive = dir.join("openless.log.1");
+
+        {
+            let mut file = std::fs::File::create(&log).unwrap();
+            file.set_len(LOG_ROTATE_LIMIT_BYTES + 1).unwrap();
+            file.write_all(b"x").unwrap();
+        }
+        std::fs::write(&archive, b"old").unwrap();
+
+        rotate_log_if_too_large(&log).unwrap();
+
+        assert!(!log.exists());
+        assert!(archive.exists());
+        assert!(std::fs::metadata(&archive).unwrap().len() > LOG_ROTATE_LIMIT_BYTES);
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn small_log_does_not_rotate() {
+        let dir = std::env::temp_dir().join(format!("openless-log-small-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let log = dir.join("openless.log");
+        let archive = dir.join("openless.log.1");
+        std::fs::write(&log, b"small").unwrap();
+
+        rotate_log_if_too_large(&log).unwrap();
+
+        assert!(log.exists());
+        assert!(!archive.exists());
+        assert_eq!(std::fs::read(&log).unwrap(), b"small");
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn missing_log_does_not_rotate() {
+        let dir = std::env::temp_dir().join(format!("openless-log-missing-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let log = dir.join("openless.log");
+        let archive = dir.join("openless.log.1");
+
+        rotate_log_if_too_large(&log).unwrap();
+
+        assert!(!log.exists());
+        assert!(!archive.exists());
+
+        let _ = std::fs::remove_dir_all(&dir);
     }
 }


### PR DESCRIPTION
### **User description**
## 变更
- 启动初始化日志前检查 `openless.log` 大小，超过 10 MiB 时轮转为 `openless.log.1`
- 轮转失败不阻塞启动，但会输出 warning，便于在文件 logger 初始化前排查失败原因
- 保持“导出错误日志”只导出当前 `openless.log`，不包含历史归档
- 补充日志轮转边界单测：超限轮转、未超限不轮转、文件不存在不轮转

## 验证
- `cargo test --manifest-path src-tauri/Cargo.toml log_`
- `cargo check --manifest-path src-tauri/Cargo.toml`
- `git diff --check`

Closes #303


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Rotate `openless.log` on startup if > 10 MiB

- Archive to `openless.log.1`, delete old archive

- Move logger init to `setup` to avoid duplicate rotation

- Add tests for rotation, small, and missing log


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["App startup"] --> B["Check openless.log size"]
  B --> C{"Size > 10 MiB?"}
  C -- Yes --> D["Remove old archive openless.log.1"]
  D --> E["Rename current log to archive"]
  E --> F["Initialize file logger"]
  C -- No --> F
  F --> G["Append new logs"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>lib.rs</strong><dd><code>Implement startup log rotation to cap openless.log at 10 MiB</code></dd></summary>
<hr>

openless-all/app/src-tauri/src/lib.rs

<ul><li>Added constant <code>LOG_ROTATE_LIMIT_BYTES</code> (10 MiB)<br> <li> Added <code>rotate_log_if_too_large</code> to archive oversized log<br> <li> Called rotation in <code>init_file_logger</code>, warning on failure<br> <li> Moved <code>init_file_logger</code> to <code>setup</code> closure after single‑instance check<br> <li> Added three unit tests: oversized rotates, small skips, missing file <br>is no‑op</ul>


</details>


  </td>
  <td><a href="https://github.com/appergb/openless/pull/309/files#diff-6b8eb1bbf8e378bab914f1a12962f7add5cc4ba9e013c37c9921a1032fa5e110">+88/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

