### PR TITLE
恢复 Intel Mac release 构建

### DIFF
--- a/.github/workflows/release-tauri.yml
+++ b/.github/workflows/release-tauri.yml
@@ -32,15 +32,10 @@ jobs:
             rust-target: aarch64-apple-darwin
             updater-target: darwin
             updater-arch: aarch64
-          # 暂时搁置 Intel mac 构建：GitHub Actions 把 macos-13 标记为 deprecated
-          # runner，pool 容量紧张到每次 dispatch 都 queue 1-2h 拿不到分配，多次
-          # release 都因这个 job 卡住整个 run 的 conclusion。等 GH 把 macOS x86_64
-          # 迁移到非 deprecated runner（macos-14 / macos-15-large）或 macos-13
-          # pool 缓解后再恢复。Apple Silicon dmg 在 Intel mac 上跑 Rosetta 仍可用。
-          # - platform: macos-13
-          #   rust-target: x86_64-apple-darwin
-          #   updater-target: darwin
-          #   updater-arch: x86_64
+          - platform: macos-15-intel
+            rust-target: x86_64-apple-darwin
+            updater-target: darwin
+            updater-arch: x86_64
           - platform: windows-latest
             rust-target: x86_64-pc-windows-msvc
             updater-target: windows


### PR DESCRIPTION
### **User description**
## 变更
- 在 release matrix 中恢复 macOS Intel 构建 lane。
- 使用 `macos-15-intel` + `x86_64-apple-darwin`，生成 `darwin/x86_64` updater manifest。
- 保留现有按架构重命名 macOS updater 包的逻辑，避免 arm64 和 x86_64 资产互相覆盖。

## 为什么不是 macos-13
之前 Intel Mac lane 被注释掉，是因为 `macos-13` runner 已被标记为 deprecated，且队列不稳定，曾经拖住 release run。
这次没有恢复旧的 `macos-13`，而是改用 GitHub 当前明确提供的 Intel macOS runner：`macos-15-intel`。这样可以恢复 Intel Mac 产物，同时避免回到旧 runner 的排队/弃用风险。

## 验证
- `git diff --check`
- 解析 `.github/workflows/release-tauri.yml` matrix，确认同时包含：
  - `macos-latest / aarch64-apple-darwin / darwin aarch64`
  - `macos-15-intel / x86_64-apple-darwin / darwin x86_64`
- 检查 updater 路径仍使用 `${{ matrix.updater-arch }}` 区分架构

## 未验证
- 尚未跑完整 GitHub Actions release workflow。


___

### **PR Type**
Enhancement


___

### **Description**
- Restore Intel Mac release lane with `macos-15-intel`

- Set `x86_64-apple-darwin` target and `x86_64` updater arch

- Avoid deprecated `macos-13` runner instability


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Release matrix"] --> B["macos-latest (aarch64)"]
  A --> C["macos-15-intel (x86_64)"]
  B --> D["darwin/aarch64 updater"]
  C --> E["darwin/x86_64 updater"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>release-tauri.yml</strong><dd><code>Add Intel Mac release lane with macos-15-intel</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/release-tauri.yml

<ul><li>Removed commented-out <code>macos-13</code> matrix entry<br> <li> Added new <code>macos-15-intel</code> entry with <code>x86_64-apple-darwin</code> target<br> <li> Kept architecture-qualified updater path logic intact</ul>


</details>


  </td>
  <td><a href="https://github.com/appergb/openless/pull/317/files#diff-cac78cd4d340dc05703d65bee14ea766337499de655e15553ceb8181eef097cb">+4/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

