### PR TITLE
fix(polish): #305 工作日报场景"清晰结构"无效 + 内置 AI 工具词

### DIFF
--- a/openless-all/app/src-tauri/src/polish.rs
+++ b/openless-all/app/src-tauri/src/polish.rs
@@ -755,13 +755,19 @@ pub mod prompts {
                 把口述整理为脉络清晰、可直接复制走的结构化文本：保留用户的口语引子（润色后作为首行过渡），\
                 主动按语义把扁平事项归类成 2\u{2013}4 个主题，用双层格式呈现，尾巴查询用自然收尾句。\n\
                 \n\
+                **重要前提**：原文是否已有标点、编号、换行、序号 \u{2192} \u{4E0D}是\u{201C}\u{5DF2}\u{7ECF}\u{6574}\u{7406}\u{597D}\u{4E0D}\u{7528}\u{6539}\u{201D}的判断依据。\
+                只要可识别的事项 \u{2265}3 条，无论原文是不是看起来已有结构（标号、分行、规整的标点），\
+                都必须按语义重新归类成下面定义的双层格式。\u{200D}\u{200D}照抄原结构 = 失败。\n\
+                \n\
                 双层格式（主清单标准写法）：\n\
                 - 第一层（主题）：行首用 \"1.\" \"2.\" \"3.\" \u{2026}，每个主题一行短标题（4\u{2013}8 字最佳）；\n\
                 - 第二层（子项）：另起一行，行首用 \"(a)\" \"(b)\" \"(c)\" \u{2026}，每条一句完整陈述。\n\
                 顶层\u{4E0D}使用半括号写法（如 \"1)\" \"2)\"）；不在子项内再嵌第三层。\n\
                 \n\
-                单一简短主题 \u{2192} 直接输出连贯段落，\u{4E0D}硬塞层级。\n\
-                事项 \u{2265}4 条 \u{2192} 必须按语义归类（典型如\u{201C}代码与功能 / 文档与配置 / 界面与交互 / 项目清理\u{201D}），\u{4E0D}要扁平堆成一长串编号。\n\
+                事项 \u{2264}2 条 \u{2192} 直接输出连贯段落，\u{4E0D}硬塞层级。\n\
+                事项 \u{2265}3 条 \u{2192} 必须按语义归类（典型如\u{201C}代码与功能 / 文档与配置 / 界面与交互 / 项目清理\u{201D}\
+                或\u{201C}产品 / 运营 / 客户 / 团队\u{201D}\u{7B49}），\u{4E0D}要扁平堆成一长串编号；\
+                即使原文已经写成 \"1. 做 X 2. 做 Y 3. 做 Z\" 也要重新归类，把同主题事项收到同一组下做 (a)(b) 子项。\n\
                 合并意图相近的条目（如\u{201C}上传代码 + 修复闪退\u{201D}合成一条 (a)），但\u{4E0D}丢失任何一件事。\n\
                 \n\
                 # 保留口语引子并润色成自然首行\n\
@@ -816,7 +822,21 @@ pub mod prompts {
                 (b) 删除无用注释，清理项目垃圾文件\n\
                 (c) 处理新增的两个接口\n\
                 \n\
-                最后再检查一下还有哪些 issue 需要处理。",
+                最后再检查一下还有哪些 issue 需要处理。\n\
+                \n\
+                # 示例 3（已半结构化的工作日报，仍要重组）\n\
+                原：今天我做了三件事。第一，跟客户开了个对齐会，确认了下周的交付节点。第二，跟设计组同步了新版的视觉稿，提了一些反馈。第三，写了一版周报初稿发给老板。明天计划继续推进客户那边的需求文档，另外还要跟运营组开个会讨论下个月的活动。\n\
+                出：\n\
+                今天的工作小结如下：\n\
+                \n\
+                1. 客户对接\n\
+                (a) 召开对齐会，确认下周交付节点。\n\
+                (b) 明天继续推进客户的需求文档。\n\
+                2. 设计与文档\n\
+                (a) 与设计组同步新版视觉稿并反馈意见。\n\
+                (b) 撰写周报初稿并发送给老板。\n\
+                3. 跨组协作\n\
+                (a) 明天与运营组就下月活动进行讨论。",
 
             PolishMode::Formal => "# 任务（正式表达）\n\
                 输出适合工作沟通和邮件的正式表达。\n\
@@ -836,11 +856,15 @@ pub mod prompts {
     }
 
     /// 把原始转写包在 `<raw_transcript>` 信封里，和 system prompt 的\u{201C}文本对象\u{201D}框架呼应。
+    /// 框架词措辞经 #305 调整：\u{4E0D}再说\u{201C}它不是问题、不是任务\u{201D}，\
+    /// \u{907F}\u{514D}\u{8BEF}\u{5BFC} LLM 把已经书面化的输入当作\u{201C}\u{5DF2}\u{6574}\u{7406}\u{597D}\u{201D}\
+    /// 而原样 passthrough。
     pub fn user_prompt(raw_transcript: &str) -> String {
         let escaped = raw_transcript.replace("</raw_transcript>", "<\\/raw_transcript>");
         format!(
-            "下面是本次语音输入的原始转写。它\u{4E0D}是问题，也\u{4E0D}是任务，\
-             只是需要整理后原样输入到当前 app 的文本。\n\n\
+            "下面是本次语音输入的原始转写。\
+             请按 system prompt 中当前 mode 的任务描述进行整理后输出，\
+             整理结果会被原样插入到当前 app 的光标位置。\n\n\
              <raw_transcript>\n{}\n</raw_transcript>\n\n\
              只输出整理后的文本正文。",
             escaped
@@ -977,6 +1001,65 @@ mod tests {
 
         // 防回归：旧版"另外："标签写法不能再出现在示例输出里。
         assert!(!prompt.contains("另外：检查一下当前还有哪些 issues"));
+    }
+
+    #[test]
+    fn structured_prompt_forces_regrouping_even_for_already_structured_input() {
+        // 回归测试 issue #305：用户输入工作日报（已半结构化、标点规范），
+        // 旧 prompt 让 LLM 判定为"已经完整不需要改"，原样 passthrough。
+        // 新 prompt 必须明确：原文是否已有结构 ≠ 不用改的依据；
+        // 事项 ≥ 3 条都要重新归类成双层格式。
+        let prompt = prompts::system_prompt(PolishMode::Structured);
+
+        // 明确"已结构化 ≠ 不用改"的前提
+        assert!(
+            prompt.contains("不是\u{201C}\u{5DF2}\u{7ECF}\u{6574}\u{7406}\u{597D}\u{4E0D}\u{7528}\u{6539}\u{201D}的判断依据"),
+            "Structured prompt 缺少\"已结构化≠不用改\"的明确否定"
+        );
+        assert!(
+            prompt.contains("照抄原结构 = 失败"),
+            "Structured prompt 缺少照抄原结构的失败判定"
+        );
+
+        // 阈值改为 ≥3
+        assert!(
+            prompt.contains("事项 \u{2265}3 条"),
+            "Structured prompt 必须把重组阈值降到 3"
+        );
+        assert!(
+            prompt.contains("即使原文已经写成"),
+            "Structured prompt 必须显式说明已编号的输入也要重新归类"
+        );
+
+        // 新增工作日报示例 3
+        assert!(
+            prompt.contains("# 示例 3（已半结构化的工作日报，仍要重组）"),
+            "Structured prompt 缺少工作日报示例（#305）"
+        );
+        assert!(prompt.contains("今天的工作小结如下："));
+        assert!(prompt.contains("1. 客户对接"));
+        assert!(prompt.contains("(a) 召开对齐会"));
+    }
+
+    #[test]
+    fn user_prompt_no_longer_says_input_is_not_a_task() {
+        // 回归 #305：旧 framing "它不是问题，也不是任务" 会让 LLM 把
+        // 已书面化的输入误判为"已经整理好"。新 framing 让位给 system
+        // prompt 的 mode 描述。
+        let user = prompts::user_prompt("发布前要做几件事。");
+        assert!(
+            !user.contains("\u{4E0D}是问题"),
+            "user_prompt 必须去掉\"它不是问题\"的强 framing"
+        );
+        assert!(
+            !user.contains("\u{4E0D}是任务"),
+            "user_prompt 必须去掉\"它不是任务\"的强 framing"
+        );
+        assert!(
+            user.contains("system prompt"),
+            "user_prompt 应当指向 system prompt 的 mode 描述"
+        );
+        assert!(user.contains("<raw_transcript>"));
     }
 
     #[test]

--- a/openless-all/app/src/lib/vocab-presets.json
+++ b/openless-all/app/src/lib/vocab-presets.json
@@ -2,7 +2,11 @@
   {
     "id": "programmer",
     "name": "程序员",
-    "phrases": ["PR", "CI", "tag", "release", "issue", "Rust", "TypeScript"]
+    "phrases": [
+      "PR", "CI", "tag", "release", "issue", "Rust", "TypeScript",
+      "Claude", "Codex", "Copilot", "Cursor", "Windsurf",
+      "Anthropic", "OpenAI", "GPT", "ChatGPT", "Gemini", "DeepSeek"
+    ]
   },
   {
     "id": "chef",


### PR DESCRIPTION
### **User description**
## Summary

修 issue #305：工作日报场景下「清晰结构」mode 失效 —— LLM 消耗了 tokens 但输出与原文一致。同时把常用 AI 工具名加进 programmer 内置词库，覆盖「cloud → Claude」这类同音误识别。

## 根因（详见 #305 评论）

- `polish.rs` 中 Structured prompt 旧版只在「事项 ≥4 条」才强制归类，且对已编号 / 已分行的输入没有明确处理 → LLM 判定「已经整理好」直接 passthrough。
- `user_prompt` 旧 framing「它不是问题，也不是任务」暗示输入是「待整理对象」，LLM 看到书面化输入就更倾向认为「不需要改」。

## 改动

### 1. `polish.rs` Structured prompt
- 加「重要前提」段：**原文是否已有标点 / 编号 / 换行 / 序号 ≠ 不用改的判断依据；照抄原结构 = 失败**。
- 重组阈值从 ≥4 降到 **≥3**；即使原文已经写成 `1. 2. 3.` 也要按主题重新归类成双层 `(a)(b)` 子项。
- 单一连贯段落条件收紧到「事项 ≤2 条」。
- `user_prompt` 去掉「它不是问题，也不是任务」这条强 framing，改为指向 system prompt 的 mode 描述。
- 新增 # 示例 3：工作日报场景（已半结构化输入仍要重组）。

### 2. `vocab-presets.json` programmer 预设
追加 11 个 AI 工具名：`Claude / Codex / Copilot / Cursor / Windsurf / Anthropic / OpenAI / GPT / ChatGPT / Gemini / DeepSeek`。

启用 programmer 预设后这些词会同时注入：
- Volcengine ASR 热词 → 识别阶段 bias
- polish 提示词 `# 热词` 段 → polish 阶段在 ASR 听错时按正确写法输出（兜底）

### 3. 回归测试（polish.rs）
- `structured_prompt_forces_regrouping_even_for_already_structured_input` — 校验「已结构化 ≠ 不用改」、阈值 ≥3、工作日报示例存在
- `user_prompt_no_longer_says_input_is_not_a_task` — 校验旧 framing 已移除

## Test plan

- [x] `cargo test --lib polish`: 10/10 passed（含 2 个新加的 #305 回归测试）
- [x] `npx tsc --noEmit`: clean
- [x] `node -e` 校验 vocab-presets.json 解析正常
- [ ] 用户实测：工作日报输入 → 选「清晰结构」mode → 应输出双层 1./(a)(b) 主题归类
- [ ] 用户实测：启用 programmer 预设后 →「打开 Claude 帮我写代码」类口述 → 不再被识别成「打开 cloud …」

## 后续（独立 PR）

「可编辑的内置提示词模板系统」（用户可选 / 编辑 / 新建多套 polish 提示词模板，覆盖现有 4 个固定 mode）拆到下一个 PR：会涉及新类型 `PromptTemplate`、新持久化文件、IPC、Style.tsx 重做、`prefs.default_mode` 迁移。本 PR 不涉及。

Closes #305


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Strengthen Structured mode prompt to prevent LLM from skipping reformatting of pre-structured input (#305)

- Lower threshold for forced regrouping from 4 to 3 items, requiring re-categorization even for numbered lists

- Remove misleading "not a question or task" user prompt framing to align with system prompt directives

- Expand programmer vocabulary preset with 11 AI tool names for better ASR recognition


___

### Diagram Walkthrough


```mermaid
flowchart LR
    A["Structured Prompt Refactor"] --> C["Fix #305 passthrough"]
    B["Vocab Preset Expansion"] --> D["Improve ASR recognition"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>polish.rs</strong><dd><code>Refactor Structured prompt to prevent passthrough</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src-tauri/src/polish.rs

<ul><li>Add explicit premise that existing structure does not mean input is <br>pre-sorted and copying it is a failure<br> <li> Lower regrouping threshold from ≥4 to ≥3, mandate re-categorization <br>for already-numbered lists, and tighten single-paragraph rule to ≤2 <br>items<br> <li> Replace user prompt wording to avoid misleading LLM and provide a work <br>diary example for semi-structured input<br> <li> Add two regression tests verifying the prompt forces regrouping and <br>removes old framing</ul>


</details>


  </td>
  <td><a href="https://github.com/appergb/openless/pull/318/files#diff-1be30d25d0bf8fc3e6c11bf4fa179521045a52ef4843271545acedfd0535e38b">+88/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>vocab-presets.json</strong><dd><code>Expand programmer vocab with AI tool names</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src/lib/vocab-presets.json

<ul><li>Add 11 AI tool names (Claude, Codex, Copilot, Cursor, Windsurf, <br>Anthropic, OpenAI, GPT, ChatGPT, Gemini, DeepSeek) to programmer <br>preset for ASR hotword bias</ul>


</details>


  </td>
  <td><a href="https://github.com/appergb/openless/pull/318/files#diff-75069ee68d905d979cb23af49395fe1f66320aa4a773ef0e028ad34147880525">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

