### PR TITLE
[feature] Add brew cask install option

### DIFF
--- a/.github/workflows/update-cask.yml
+++ b/.github/workflows/update-cask.yml
@@ -1,0 +1,83 @@
+name: Update Cask on Release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  update-cask:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    if: startsWith(github.event.release.tag_name, 'v') && endsWith(github.event.release.tag_name, '-tauri')
+    steps:
+      - name: Checkout tap repository
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract version from tag
+        id: version
+        run: |
+          TAG="${{ github.event.release.tag_name }}"
+          VERSION="${TAG#v}"
+          VERSION="${VERSION%-tauri}"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Detected version: $VERSION"
+
+      - name: Fetch release assets SHA256
+        id: sha256
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          REPO="${{ github.repository }}"
+          
+          # Fetch release assets info
+          RESPONSE=$(gh api "repos/$REPO/releases/tags/v${VERSION}-tauri")
+          
+          # Extract SHA256 for aarch64 DMG
+          ARM64_SHA=$(echo "$RESPONSE" | jq -r '.assets[] | select(.name | contains("aarch64.dmg")) | .digest' | sed 's/sha256://')
+          
+          # Extract SHA256 for x64 DMG
+          X64_SHA=$(echo "$RESPONSE" | jq -r '.assets[] | select(.name | contains("_x64.dmg")) | .digest' | sed 's/sha256://')
+          
+          echo "arm64_sha=$ARM64_SHA" >> "$GITHUB_OUTPUT"
+          echo "x64_sha=$X64_SHA" >> "$GITHUB_OUTPUT"
+          
+          echo "aarch64 DMG SHA256: $ARM64_SHA"
+          echo "x64 DMG SHA256: $X64_SHA"
+
+      - name: Update Cask file
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          ARM64_SHA="${{ steps.sha256.outputs.arm64_sha }}"
+          X64_SHA="${{ steps.sha256.outputs.x64_sha }}"
+          CASK_FILE="Casks/openless.rb"
+          
+          # Update version
+          sed -i "s/version \"[^\"]*\"/version \"$VERSION\"/" "$CASK_FILE"
+          
+          # Update SHA256 values
+          sed -i "s/sha256 arm:   \"[^\"]*\"/sha256 arm:   \"$ARM64_SHA\"/" "$CASK_FILE"
+          sed -i "s/intel: \"[^\"]*\"/intel: \"$X64_SHA\"/" "$CASK_FILE"
+          
+          echo "Updated $CASK_FILE:"
+          cat "$CASK_FILE"
+
+      - name: Commit and push changes
+        run: |
+          git config --local user.email "github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+          
+          VERSION="${{ steps.version.outputs.version }}"
+          
+          git add Casks/openless.rb
+          
+          if git diff --cached --quiet; then
+            echo "No changes to commit"
+            exit 0
+          fi
+          
+          git commit -m "[cask] Update openless to $VERSION"
+          git push

--- a/Casks/openless.rb
+++ b/Casks/openless.rb
@@ -1,0 +1,29 @@
+cask "openless" do
+  arch arm: "aarch64", intel: "x64"
+
+  version "1.2.22"
+  sha256 arm:   "8e65729eb671f5fec3ce392d4f8dfd33303f1c84f8f4533683f8d3a3afd1e21d",
+         intel: "6d97fb7cab173b4f3241aa18b3db0f51a03a03d6b2bdea48cab8fe761440df7b"
+
+  url "https://github.com/appergb/openless/releases/download/v#{version}-tauri/OpenLess_#{version}_#{arch}.dmg"
+  name "OpenLess"
+  desc "Menu-bar voice input layer for macOS"
+  homepage "https://github.com/appergb/openless"
+
+  livecheck do
+    url :url
+    regex(/^v?(\d+(?:\.\d+)+)[._-]tauri$/i)
+  end
+
+  auto_updates true
+
+  app "OpenLess.app"
+
+  zap trash: [
+    "~/Library/Application Support/OpenLess",
+    "~/Library/Caches/com.openless.app",
+    "~/Library/Logs/OpenLess",
+    "~/Library/Preferences/com.openless.app.plist",
+    "~/Library/WebKit/com.openless.app",
+  ]
+end

--- a/Formula/openless.rb
+++ b/Formula/openless.rb
@@ -1,0 +1,67 @@
+class Openless < Formula
+  desc "Menu-bar voice input layer for macOS"
+  homepage "https://github.com/appergb/openless"
+  url "https://github.com/appergb/openless/archive/refs/tags/v1.2.20-tauri.tar.gz"
+  sha256 "be1363f7762a42b7e932ec3cc687cfdfb5b550b6cf1c96d52a1f87c906f27863"
+  license "MIT"
+
+  head "https://github.com/appergb/openless.git", branch: "main"
+
+  depends_on "rust" => :build
+  depends_on "node" => :build
+  depends_on :macos
+  depends_on arch: :arm64
+
+  # qwen-asr submodule for local ASR engine on macOS
+  resource "qwen-asr" do
+    url "https://github.com/antirez/qwen-asr.git",
+        revision: "b00b789b17051aea61e9717458171100662318a4"
+  end
+
+  def install
+    # Place submodule at expected path before building
+    vendor_dir = "openless-all/app/src-tauri/vendor/qwen-asr"
+    rm_rf vendor_dir
+    resource("qwen-asr").stage(vendor_dir)
+
+    cd "openless-all/app" do
+      # Install frontend dependencies
+      system "npm", "ci"
+
+      # Build Tauri app with ad-hoc signing (no Developer ID required)
+      ENV["APPLE_SIGNING_IDENTITY"] = "-"
+      system "npm", "run", "tauri", "--", "build"
+
+      # Install the .app bundle
+      prefix.install "src-tauri/target/release/bundle/macos/OpenLess.app"
+    end
+
+    # Symlink binary for command-line access
+    bin.install_symlink prefix/"OpenLess.app/Contents/MacOS/openless"
+  end
+
+  def caveats
+    <<~EOS
+      OpenLess.app has been installed to:
+        #{prefix}/OpenLess.app
+
+      To use it, link it into /Applications:
+        ln -sf #{opt_prefix}/OpenLess.app /Applications/OpenLess.app
+
+      Or launch it directly:
+        open #{opt_prefix}/OpenLess.app
+
+      First-time setup:
+        - Grant Accessibility permission when prompted
+        - Grant Microphone permission when prompted
+
+      If Gatekeeper blocks the app (ad-hoc signed), run:
+        xattr -cr /Applications/OpenLess.app
+    EOS
+  end
+
+  test do
+    assert_path_exists prefix/"OpenLess.app"
+    assert_predicate prefix/"OpenLess.app/Contents/MacOS/openless", :executable?
+  end
+end

--- a/README.md
+++ b/README.md
@@ -148,6 +148,15 @@ OpenLess does one thing: **turn speech into usable written text (especially AI p
 Go to [Releases](../../releases) and download:
 - **macOS**: `OpenLess_<version>_aarch64.dmg` — open, drag to `/Applications`
 - **Windows**: `OpenLess_<version>_x64-setup.exe` — run the installer
+- **macOS(brew install)**:
+```bash
+brew tap appergb/openless https://github.com/appergb/openless
+brew install --cask openless
+xattr -cr /Applications/OpenLess.app
+
+# Upgrade to the latest version
+brew update && brew upgrade openless
+```
 
 On first launch, grant the permissions the app requests:
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -146,8 +146,17 @@ OpenLess 只做一件事：**把语音变成可用的书面文字（尤其是 AI
 ## 下载与安装（普通用户）
 
 到 [Releases](../../releases) 下载对应平台的安装包：
-- **macOS**：`OpenLess_<版本>_aarch64.dmg` — 打开后拖入「应用程序」
 - **Windows**：`OpenLess_<版本>_x64-setup.exe` — 运行安装程序
+- **macOS**：`OpenLess_<版本>_aarch64.dmg` — 打开后拖入「应用程序」
+- **macOS(brew install)**:
+```bash
+brew tap appergb/openless https://github.com/appergb/openless
+brew install --cask openless
+xattr -cr /Applications/OpenLess.app
+
+# Upgrade to the latest version
+brew update && brew upgrade openless
+```
 
 首次启动需要授予权限：
 


### PR DESCRIPTION
### **User description**
## 摘要

Close issues #254 #5

- 添加了brew install --cask的支持
- 对相关文档进行了更新
- 添加了github ci支持自动更新

## 注意事项

- 含有Formula安装脚本。但是经测试，Tauri 的 DMG bundler 需要调用 macOS 的系统工具（如 hdiutil、create-dmg），在 Homebrew 的沙盒构建环境中这些工具的权限和路径受限，导致打包失败。可以在merge的时候考虑删掉。
- zap的范围参考pearcleaner的范围
- 不太熟悉github ci，虽然检查过了，但是没有进行测试，需要review一下

## 测试计划

已经在本地进行测试，成功安装、使用、卸载


___

### **PR Type**
Enhancement, Documentation


___

### **Description**
- Added `Casks/openless.rb` Homebrew Cask for easy macOS installation and updates

- Created `.github/workflows/update-cask.yml` to auto-update Cask version and checksums on release

- Added `Formula/openless.rb` for building from source (experimental, may require review)

- Updated English and Chinese READMEs with `brew tap`/`install --cask` instructions


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Casks/openless.rb\n(Homebrew Cask)"] --> B["brew install --cask openless"]
  C["Release trigger"] --> D["CI workflow (update-cask.yml)\nauto-updates Cask"]
  D --> A
  E["README.md & README.zh.md\nadd install docs"] --> B
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>update-cask.yml</strong><dd><code>Automate Cask version and SHA256 updates on release</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/update-cask.yml

<ul><li>Triggers on published releases matching <code>v*-tauri</code> tags<br> <li> Extracts version and fetches SHA256 for arm64 and x64 DMG assets<br> <li> Replaces version and sha256 in <code>Casks/openless.rb</code><br> <li> Commits and pushes the updated Cask file automatically</ul>


</details>


  </td>
  <td><a href="https://github.com/appergb/openless/pull/322/files#diff-835138847c261225d480f9d1230632d003628890a34fe43205c6d6b62dea3cb2">+83/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>openless.rb</strong><dd><code>Add Homebrew Cask definition for OpenLess</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Casks/openless.rb

<ul><li>Defines <code>openless</code> Cask with arm64 and x64 DMG download URLs<br> <li> Hardcodes current version <code>1.2.22</code> and matching SHA256 checksums<br> <li> Sets <code>auto_updates true</code> and declares <code>zap</code> paths for user data cleanup<br> <li> Includes <code>livecheck</code> block for future version detection</ul>


</details>


  </td>
  <td><a href="https://github.com/appergb/openless/pull/322/files#diff-e7c9f13357bfa65862250bdbdb0d2af908f271746881dd0f40af443a5099daa4">+29/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>openless.rb</strong><dd><code>Add Homebrew Formula for building from source</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Formula/openless.rb

<ul><li>Defines <code>Openless</code> Formula building Tauri app from source<br> <li> Downloads <code>qwen-asr</code> submodule as a resource for local ASR<br> <li> Builds with ad-hoc signing (<code>APPLE_SIGNING_IDENTITY=-</code>) and installs <br>.app bundle<br> <li> Provides caveats for linking to /Applications and granting permissions</ul>


</details>


  </td>
  <td><a href="https://github.com/appergb/openless/pull/322/files#diff-3d1f0c60f52d2478141ea093d63999df53723bb2ce647fde7d1f55449dc3f2df">+67/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Document Homebrew installation in English README</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

<ul><li>Adds new subsection for macOS brew installation<br> <li> Documents <code>brew tap</code>, <code>brew install --cask openless</code>, and upgrade commands<br> <li> Includes <code>xattr -cr</code> step for ad-hoc signed app</ul>


</details>


  </td>
  <td><a href="https://github.com/appergb/openless/pull/322/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>README.zh.md</strong><dd><code>Document Homebrew installation in Chinese README</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.zh.md

<ul><li>Reorders platform list; adds Chinese brew install subsection<br> <li> Mirrors the English installation steps in Chinese</ul>


</details>


  </td>
  <td><a href="https://github.com/appergb/openless/pull/322/files#diff-b024066e6d6250813a9bc9284332cc3b84edc264857d6a671b7513f2c7ef90a8">+10/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

