### PR TITLE
docs: introduce Beta/Stable two-channel branching workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,9 +8,9 @@ name: CI
 
 on:
   push:
-    branches: [main, dev]
+    branches: [main, beta]
   pull_request:
-    branches: [main, dev]
+    branches: [main, beta]
 
 jobs:
   cross-platform:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,6 +105,28 @@ Push a `v*-tauri` tag → `.github/workflows/release-tauri.yml` builds macOS arm
 
 When bumping versions, update **both** `version` fields: `openless-all/app/package.json` and `openless-all/app/src-tauri/tauri.conf.json` (and `Cargo.toml`).
 
+### Branch & release-channel workflow
+
+Two-channel branching. **Branch name = release channel.**
+
+- **`beta`** — **Beta channel** (开发版). Default branch, integration buffer. **All PRs target `beta`** (never `main`). Beta builds may exist but are not pushed to general users — only opt-in users on the Beta channel see them.
+- **`main`** — **Stable channel** (正式版). Always-releasable. Updated only by `beta → main` merges performed by maintainers after a two-platform smoke build. Release tags `v<version>-tauri` are pushed on `main` and trigger `release-tauri.yml` (tag-driven; unaffected by branch renames).
+
+Per-PR contract:
+
+- Run the change locally on your target platform before opening the PR (build green + manual verification of the affected feature).
+- `pr-agent.yml` runs one AI review pass per PR — treat it as advisory, do not iterate on it.
+- Keep AI rework rounds tight (1–2). If a fix resists, escalate to a human or restart with fresh context.
+- `ci.yml` runs on push/PR for both `main` and `beta`; no extra wiring needed when adding new branches off `beta`.
+
+For maintainers:
+
+- Merge `beta → main` only after the two-platform (macOS + Windows) smoke build passes. **Beta work must not leak to Stable** — that gate exists for a reason.
+- Tag `v<version>-tauri` **on `main`**, not on `beta`. The release workflow keys off the tag, but tagging on `main` keeps the release commit linear with the always-releasable line.
+- Avoid direct pushes to `main` outside the `beta → main` merge — it bypasses the smoke-test gate.
+
+Channel distribution (in progress): per-channel updater endpoints + a Settings toggle for "join Beta channel" are tracked as a separate change. Until that lands, every release reaches every user; treat all `v*-tauri` tags as Stable-grade for now and avoid tagging anything from `beta` directly.
+
 ## Repo conventions
 
 - **Comments, log messages, user-facing strings, and most docs are in Simplified Chinese.** UI strings additionally route through `react-i18next` (`src/i18n/{zh-CN,en}.ts`) so we ship English alongside; `zh-CN.ts` is source of truth.

--- a/README.md
+++ b/README.md
@@ -208,6 +208,37 @@ Logs: `~/Library/Logs/OpenLess/openless.log` (macOS) / `%LOCALAPPDATA%\OpenLess\
 
 **Windows build** — see [`openless-all/README.md`](openless-all/README.md) for MSVC vs GNU/MinGW routes.
 
+## Contributing workflow
+
+OpenLess uses a two-channel branching model.
+
+- **`beta`** — the **Beta channel**. Default branch and integration buffer; all in-progress development lands here. Beta builds may exist but are **not pushed to regular users** — they only reach people who explicitly opt into the Beta channel.
+- **`main`** — the **Stable channel (正式版)**. Always-releasable. The build everyone gets by default.
+
+```text
+your fork / topic branch
+        │  (test locally on your target platform first)
+        ▼
+   PR → beta  ← AI review (one pass, advisory only)
+        │     ← maintainer lightweight glance (scope, cross-module impact)
+        ▼
+       merged into beta
+        │  (periodically, after a two-platform smoke build)
+        ▼
+       merged into main  →  tag `v<version>-tauri`  →  release CI → Stable users
+```
+
+Rules of thumb:
+
+- **Open PRs against `beta`, never against `main`.** GitHub already defaults the base branch to `beta` for new PRs.
+- **Verify the change on your target platform before opening the PR** — build green is necessary, manual verification is required.
+- **AI review runs once per PR and is advisory.** Don't loop on it. Apply your judgment.
+- **Keep AI rework rounds tight (1–2).** If a fix resists, ask a human or restart with fresh context — multi-round AI back-and-forth tends to do more harm than good here.
+- **Beta work must not leak to Stable.** `main` only receives merges from `beta`, performed by maintainers after a successful two-platform smoke build. No direct pushes to `main`.
+- **Stable releases are cut from `main`** by pushing a `v<version>-tauri` tag — see the maintainer release checklist below.
+
+Beta release distribution (opt-in, not yet wired): Beta builds are intended for users who consciously join the Beta channel; the in-app updater currently treats every release as Stable, and a follow-up change will introduce per-channel updater endpoints + a Settings toggle.
+
 ## Credentials
 
 Credentials live in the OS credential vault (service = `com.openless.app`): macOS Keychain, Windows Credential Manager, or Linux keyring. A legacy plaintext JSON file is read only as a migration source and removed after a successful vault write:

--- a/README.zh.md
+++ b/README.zh.md
@@ -211,6 +211,37 @@ npm run build
 
 **Windows 构建** — MSVC 和 GNU/MinGW 两种路线详见 [`openless-all/README.md`](openless-all/README.md)。
 
+## 贡献流程
+
+OpenLess 采用 **Beta / 正式版** 双渠道分支模型。
+
+- **`beta`** —— **Beta 渠道（开发版）**。默认分支，也是日常集成缓冲区；所有进行中的开发都先落到这里。Beta 渠道可以直接出包，但**不会推送给普通用户**——只有主动切换到 Beta 渠道的用户才会拿到 Beta 包。
+- **`main`** —— **正式版渠道（Stable）**。始终保持可发布状态，普通用户默认拿到的就是这条线上的版本。
+
+```text
+你的 fork / topic 分支
+        │  （先在目标平台本地自测通过）
+        ▼
+   PR → beta   ← AI Review（一次性，仅供参考）
+        │     ← 维护者轻量过一眼（范围、跨模块影响）
+        ▼
+       合入 beta
+        │  （定期或里程碑节点，跑双端冒烟测试）
+        ▼
+       合入 main  →  打 tag `v<版本>-tauri`  →  Release CI → 推给正式版用户
+```
+
+核心规则：
+
+- **PR 一律打到 `beta`，不要直接打到 `main`。** GitHub 上新建 PR 的 base 已默认是 `beta`。
+- **开 PR 前先在目标平台跑通功能** —— build 绿是底线，必须做人工验证。
+- **AI Review 每个 PR 只跑一轮，结果仅供参考。** 不要围绕它反复改，最终判断权在贡献者和维护者手里。
+- **AI 改 Review 意见控制在 1–2 轮。** 卡住了直接换人工或重开对话上下文，避免多轮 AI 越改越乱。
+- **Beta 不能溢出到正式版。** `main` 只接收来自 `beta` 的合并，由维护者在双端冒烟测试通过后执行；任何人不要直接 push `main`。
+- **正式版 Release 从 `main` 切出**，通过推送 `v<版本>-tauri` tag 触发，详见下方"维护者：发布检查"。
+
+Beta 包的分发（opt-in，尚未接入）：Beta 包面向主动加入 Beta 渠道的用户；当前 App 内 updater 把所有 release 都当作正式版处理，后续会在设置页加入"加入 Beta 渠道"开关，并把 updater endpoint 按渠道拆开。
+
 ## 凭据
 
 凭据保存在系统凭据库（service = `com.openless.app`）：macOS Keychain、Windows Credential Manager 或 Linux keyring。旧版明文 JSON 只作为迁移来源读取，成功写入系统凭据库后会被删除：


### PR DESCRIPTION
### **User description**
## Summary

把分支模型从「dev/main」改为「Beta/正式版」双渠道，渠道语义由分支名直接承载。

### 仓库侧动作（已完成，PR 之外）

- 远端 `dev` 重命名为 `beta`（`git push origin dev:beta` + 删旧 dev）
- GitHub 仓库默认分支切到 `beta`，新建 PR 默认 base 是 beta
- 本 PR 的 base 已从 dev 重新指向 beta
- `release-tauri.yml` 用 `v*-tauri` tag 触发，跟分支无关，**发版机制不受影响**

### 渠道定义

- **`beta`** — **Beta 渠道（开发版）**：默认分支 + 集成缓冲区。Beta 包**不会**推到普通用户，只对主动加入 Beta 渠道的用户可见。
- **`main`** — **正式版渠道（Stable）**：始终可发布。普通用户默认拿到的就是这条线。

### 工作流核心约定

\`\`\`text
fork / topic
   │ (本地双端自测)
   ▼
PR → beta   ← AI Review (一次性，仅供参考)
   │       ← 维护者轻量过一眼
   ▼
合入 beta
   │ (定期，双端冒烟通过)
   ▼
合入 main → 打 v*-tauri tag → release CI → 推给正式版用户
\`\`\`

- 所有 PR 打到 `beta`，`main` 只接 `beta → main` 合并
- **Beta 工作不能溢出到正式版** —— 双端冒烟闸门为此而设
- AI Review 一次性辅助，rework 控制 1–2 轮
- 正式版 release 仍从 main 切，tag 打在 main 上

### 文档 / CI 改动

- `README.md` / `README.zh.md`：贡献流程章节改写为 Beta/正式版双渠道
- `CLAUDE.md`：`### Branch & release-channel workflow` 明确「分支名 = 渠道名」
- `.github/workflows/ci.yml`：触发分支 `[main, dev]` → `[main, beta]`

### 后续（独立 PR）

Beta 包的 **opt-in 分发机制**——per-channel updater endpoint + 设置页"加入 Beta 渠道"开关——将在新 PR 中接入。在那之前，所有 \`v*-tauri\` tag 都按正式版对待，**不要从 beta 分支直接打 tag**。

## Test plan

- [ ] 合并后访问 https://github.com/appergb/openless 主页，README 上「Contributing workflow」段落能看到 Beta/Stable 双渠道说明
- [ ] 中文 README 可以看到「贡献流程」段落，含 Beta 渠道（开发版）/ 正式版渠道术语
- [ ] 新建 PR 时 base 默认是 \`beta\`
- [ ] 合到 beta 后 \`ci.yml\` 在 beta 分支正常触发
- [ ] 维护者 \`beta → main\` 合并后，在 main 上打 \`v*-tauri\` tag，\`release-tauri.yml\` 正常触发


___

### **PR Type**
Documentation, Enhancement


___

### **Description**
- Route CI to `beta` and `main`

- Rewrite contribution docs for two channels

- Clarify maintainer release and tagging rules

- Note beta distribution is pending


___

### Diagram Walkthrough


```mermaid
flowchart LR
  fork["Your fork / topic branch"]
  pr["PR to beta"]
  beta["beta branch"]
  main["main branch"]
  tag["v<version>-tauri tag"]
  ci["Release CI"]
  users["Stable users"]

  fork -- "test locally" --> pr
  pr -- "review and merge" --> beta
  beta -- "smoke build" --> main
  main -- "push tag" --> tag
  tag -- "triggers" --> ci
  ci -- "ship" --> users
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ci.yml</strong><dd><code>Run CI on beta and main</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/ci.yml

<ul><li>Updated <code>push</code> triggers to <code>main</code> and <code>beta</code>.<br> <li> Updated <code>pull_request</code> triggers to <code>main</code> and <code>beta</code>.</ul>


</details>


  </td>
  <td><a href="https://github.com/appergb/openless/pull/327/files#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03f">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CLAUDE.md</strong><dd><code>Add branch and release-channel guidance</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CLAUDE.md

<ul><li>Added <code>beta</code> and <code>main</code> channel definitions.<br> <li> Documented PR, maintainer, and tagging rules.<br> <li> Noted beta distribution work is still pending.</ul>


</details>


  </td>
  <td><a href="https://github.com/appergb/openless/pull/327/files#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7">+22/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Rewrite contributing flow for two channels</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

<ul><li>Added a new <code>Contributing workflow</code> section.<br> <li> Included branch flow diagram and core rules.<br> <li> Clarified stable releases come from <code>main</code>.<br> <li> Mentioned beta opt-in distribution is pending.</ul>


</details>


  </td>
  <td><a href="https://github.com/appergb/openless/pull/327/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+31/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>README.zh.md</strong><dd><code>Update Chinese docs for branching workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.zh.md

<ul><li>Added a new <code>贡献流程</code> section.<br> <li> Included the Beta/Stable flow diagram.<br> <li> Clarified release and PR rules in Chinese.<br> <li> Mentioned beta distribution is not yet wired.</ul>


</details>


  </td>
  <td><a href="https://github.com/appergb/openless/pull/327/files#diff-b024066e6d6250813a9bc9284332cc3b84edc264857d6a671b7513f2c7ef90a8">+31/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

