### PR TITLE
feat(release): split updater manifest by channel from tag suffix

### DIFF
--- a/.github/workflows/release-tauri.yml
+++ b/.github/workflows/release-tauri.yml
@@ -24,6 +24,14 @@ jobs:
   build:
     permissions:
       contents: write
+    # 渠道由 tag 后缀决定：
+    #   v<v>-beta-tauri  → beta 渠道（GitHub Release 标 prerelease，
+    #                      manifest 文件名带 -beta 后缀，正式版用户的 endpoint 拿不到）
+    #   v<v>-tauri       → stable 渠道（正式版，文件名沿用旧约定，向后兼容）
+    # workflow_dispatch / 非 tag 触发时 github.ref_name 不是 tag 字符串，
+    # endsWith 返回 false，回退为 stable，不改变现有 dispatch 行为。
+    env:
+      OPENLESS_RELEASE_CHANNEL: ${{ endsWith(github.ref_name, '-beta-tauri') && 'beta' || 'stable' }}
     strategy:
       fail-fast: false
       matrix:
@@ -370,6 +378,8 @@ jobs:
           OPENLESS_UPDATE_ARCH: ${{ matrix.updater-arch }}
           OPENLESS_UPDATE_REPO: appergb/openless
           OPENLESS_UPDATE_MIRROR_BASE_URL: https://fastgit.cc/https://github.com
+          # beta 渠道时输出 latest-{tgt}-{arch}-beta.json，stable 沿用旧文件名。
+          OPENLESS_RELEASE_CHANNEL: ${{ env.OPENLESS_RELEASE_CHANNEL }}
         run: node scripts/write-updater-manifest.mjs
 
       # ── 收集产物 ──
@@ -413,8 +423,7 @@ jobs:
           path: |
             openless-all/app/src-tauri/target/release/bundle/macos/*.app.tar.gz
             openless-all/app/src-tauri/target/release/bundle/macos/*.app.tar.gz.sig
-            openless-all/app/src-tauri/target/release/bundle/latest-darwin-${{ matrix.updater-arch }}.json
-            openless-all/app/src-tauri/target/release/bundle/latest-darwin-${{ matrix.updater-arch }}-mirror.json
+            openless-all/app/src-tauri/target/release/bundle/latest-darwin-${{ matrix.updater-arch }}*.json
           if-no-files-found: error
 
       - name: Upload Windows artifacts
@@ -435,8 +444,7 @@ jobs:
           path: |
             openless-all/app/src-tauri/target/release/bundle/nsis/*.exe.sig
             openless-all/app/src-tauri/target/release/bundle/msi/*.msi.sig
-            openless-all/app/src-tauri/target/release/bundle/latest-windows-x86_64.json
-            openless-all/app/src-tauri/target/release/bundle/latest-windows-x86_64-mirror.json
+            openless-all/app/src-tauri/target/release/bundle/latest-windows-x86_64*.json
           if-no-files-found: error
 
       - name: Upload Linux artifacts
@@ -457,8 +465,7 @@ jobs:
           name: openless-linux-x64-updater
           path: |
             openless-all/app/src-tauri/target/release/bundle/appimage/*.AppImage.sig
-            openless-all/app/src-tauri/target/release/bundle/latest-linux-x86_64.json
-            openless-all/app/src-tauri/target/release/bundle/latest-linux-x86_64-mirror.json
+            openless-all/app/src-tauri/target/release/bundle/latest-linux-x86_64*.json
           if-no-files-found: error
 
       # ── tag 推送时,同步上传到 GitHub Release ──
@@ -469,7 +476,10 @@ jobs:
           tag_name: ${{ github.ref_name }}
           name: 'OpenLess ${{ github.ref_name }}'
           draft: false
-          prerelease: false
+          # beta 渠道的 release 必须标 prerelease=true：GitHub UI 会折叠它，
+          # 普通用户看不到；同时只上传 latest-*-beta.json，正式版用户的
+          # endpoint（latest-*.json）永远不会被覆盖，保证 Beta 不溢出正式版。
+          prerelease: ${{ env.OPENLESS_RELEASE_CHANNEL == 'beta' }}
           # Matrix jobs all upload assets to the same release. Generate notes once
           # so macOS, Windows, and Linux jobs do not duplicate the release body.
           generate_release_notes: ${{ matrix.updater-target == 'darwin' && matrix.updater-arch == 'aarch64' }}

--- a/openless-all/app/scripts/write-updater-manifest.mjs
+++ b/openless-all/app/scripts/write-updater-manifest.mjs
@@ -8,6 +8,13 @@ const target = process.env.OPENLESS_UPDATE_TARGET;
 const arch = process.env.OPENLESS_UPDATE_ARCH;
 const repo = process.env.OPENLESS_UPDATE_REPO || 'appergb/openless';
 const mirrorBaseUrl = process.env.OPENLESS_UPDATE_MIRROR_BASE_URL || 'https://fastgit.cc/https://github.com';
+// 渠道决定 manifest 文件名后缀：stable → 旧文件名（向后兼容）；beta → 加 -beta 后缀，
+// 让 stable 用户的 endpoint 永远拿不到 beta 包。空 / 未设置 = stable。
+const rawChannel = (process.env.OPENLESS_RELEASE_CHANNEL || 'stable').toLowerCase();
+if (rawChannel !== 'stable' && rawChannel !== 'beta') {
+  throw new Error(`Invalid OPENLESS_RELEASE_CHANNEL: "${rawChannel}" (expected "stable" or "beta")`);
+}
+const channelSuffix = rawChannel === 'beta' ? '-beta' : '';
 
 if (!target || !arch) {
   throw new Error('OPENLESS_UPDATE_TARGET and OPENLESS_UPDATE_ARCH are required');
@@ -55,8 +62,8 @@ if (!existsSync(signaturePath)) {
 }
 
 const assetName = basename(artifact);
-const manifestName = `latest-${target}-${arch}.json`;
-const mirrorManifestName = `latest-${target}-${arch}-mirror.json`;
+const manifestName = `latest-${target}-${arch}${channelSuffix}.json`;
+const mirrorManifestName = `latest-${target}-${arch}${channelSuffix}-mirror.json`;
 const githubAssetUrl = `https://github.com/${repo}/releases/latest/download/${assetName}`;
 const mirrorAssetUrl = `${mirrorBaseUrl.replace(/\/$/, '')}/${repo}/releases/latest/download/${assetName}`;
 const manifest = {


### PR DESCRIPTION
### **User description**
## Summary

让 release pipeline 根据 tag 后缀区分 Beta / 正式版渠道。这是 opt-in Beta 机制的**服务端基础**——客户端按渠道选 endpoint 的代码在 PR-B-2 中接入。

### 约定（这套机制的全部行为都建立在这一行规则上）

| Tag pattern         | 渠道       | GitHub Release       | Manifest 文件名                            |
|---------------------|-----------|----------------------|-------------------------------------------|
| \`v<v>-tauri\`      | stable    | 正式（prerelease=false） | \`latest-{tgt}-{arch}.json\`（旧文件名，不变）  |
| \`v<v>-beta-tauri\` | beta      | prerelease=true       | \`latest-{tgt}-{arch}-beta.json\`（新增）     |

正式版用户的 endpoint 永远指向不带后缀的 \`latest-{tgt}-{arch}.json\`，**beta release 不会覆盖这个文件**——这是「Beta 不溢出正式版」的物理隔离基础。

## 改动

### \`.github/workflows/release-tauri.yml\`

- \`jobs.build\` 顶层加 \`OPENLESS_RELEASE_CHANNEL\` env，由 \`endsWith(github.ref_name, '-beta-tauri')\` 判定。workflow_dispatch / 非 tag 触发回退 stable，**现有 dispatch 行为不变**
- Write updater manifest step 把渠道透传给脚本
- Upload-artifact 的 manifest path 由两条具体文件名改成 \`latest-{tgt}-{arch}*.json\` glob，让 stable 和 beta 两种文件名（含 mirror 变体）都能被收集
- Create release 的 \`prerelease\` 从硬编码 \`false\` 改为 \`\${{ env.OPENLESS_RELEASE_CHANNEL == 'beta' }}\`

### \`openless-all/app/scripts/write-updater-manifest.mjs\`

- 读取 \`OPENLESS_RELEASE_CHANNEL\`（默认 stable）；非 \`stable\` / \`beta\` 时 fail-fast，避免拼错 env 静默走错路径
- beta 渠道时输出 \`latest-{tgt}-{arch}-beta.json\` + \`-beta-mirror.json\`；stable 沿用旧文件名

## 向后兼容

- 现有 \`v1.2.23-tauri\` 等 stable release 的所有行为**完全不变**（文件名、prerelease=false、上传清单都沿用旧逻辑）
- workflow_dispatch 不打 tag 时照常构建 + 不上传 release
- Tauri updater 的 endpoints（\`tauri.conf.json\` 里的 \`latest-{{target}}-{{arch}}.json\`）暂时不动，依然指向 stable manifest——这是 PR-B-2 才会调整的部分

## 本地烟囱测试

\`\`\`bash
# 不合法值：fail-fast
OPENLESS_UPDATE_TARGET=darwin OPENLESS_UPDATE_ARCH=aarch64 \\
  OPENLESS_RELEASE_CHANNEL=invalid \\
  node openless-all/app/scripts/write-updater-manifest.mjs
# → Error: Invalid OPENLESS_RELEASE_CHANNEL: "invalid" (expected "stable" or "beta")

# 合法值或不设：进入正常 artifact 解析路径（本地无 build artifact 时报 No updater artifact found，符合预期）
\`\`\`

## Test plan

- [ ] PR-A (#327) merge 后，本 PR 可独立 merge（两者无文件冲突）
- [ ] 与 PR-B-2 一并 merge 后，推一个 \`v<v>-beta-tauri\` tag：
  - GitHub Release 应标为 prerelease（页面标题旁有 "Pre-release" 标签）
  - Release assets 中**只**有 \`latest-{tgt}-{arch}-beta.json\` + \`-beta-mirror.json\`，**没有**不带后缀的 \`latest-*.json\`
- [ ] 反之推 \`v<v>-tauri\` stable tag：
  - 标为正式 release（无 Pre-release 标签）
  - Release assets 含 \`latest-{tgt}-{arch}.json\` + \`-mirror.json\`，**不**含 \`-beta\` 变体
- [ ] 现有 stable 用户的 in-app 「检查更新」行为不变（endpoint 指向旧文件名）


___

### **PR Type**
Enhancement


___

### **Description**
- Support beta channel releases via `-beta-tauri` tag suffix

- Generate `-beta` suffix in updater manifest filenames for beta

- Mark beta GitHub Releases as prerelease to hide from stable users

- Switch artifact upload paths to glob to capture both channel manifests


___

### Diagram Walkthrough


```mermaid
flowchart LR
  beta_tag["Tag v*-beta-tauri"] --> channel_beta["Channel: beta"]
  stable_tag["Tag v*-tauri"] --> channel_stable["Channel: stable"]
  channel_beta --> manifest_beta["Write manifest\nlatest-*-beta.json"]
  channel_stable --> manifest_stable["Write manifest\nlatest-*.json (unchanged)"]
  manifest_beta --> upload["Artifact glob: *.json"]
  manifest_stable --> upload
  upload --> release["Create Release\nprerelease=(channel==beta)"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>release-tauri.yml</strong><dd><code>Add beta channel support to release CI</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/release-tauri.yml

<ul><li>Added job-level env to derive channel from tag suffix<br> <li> Pass channel env to write-updater-manifest step<br> <li> Changed manifest artifact upload paths to glob to include beta files<br> <li> Set GitHub Release prerelease flag based on channel</ul>


</details>


  </td>
  <td><a href="https://github.com/appergb/openless/pull/330/files#diff-cac78cd4d340dc05703d65bee14ea766337499de655e15553ceb8181eef097cb">+17/-7</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>write-updater-manifest.mjs</strong><dd><code>Add beta channel suffix to updater manifest</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/scripts/write-updater-manifest.mjs

<ul><li>Read and validate OPENLESS_RELEASE_CHANNEL (stable/beta)<br> <li> Append -beta suffix to manifest filenames for beta channel<br> <li> Stable channel filenames remain unchanged for backward compatibility</ul>


</details>


  </td>
  <td><a href="https://github.com/appergb/openless/pull/330/files#diff-f177f84545804ad96174bee0eb1cf8f690ccba062130a6483bce7189e43ab417">+9/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

