### PR TITLE
chore: bump version to 1.2.24-beta.1

### DIFF
--- a/openless-all/app/package-lock.json
+++ b/openless-all/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openless-app",
-  "version": "1.2.23",
+  "version": "1.2.24-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openless-app",
-      "version": "1.2.23",
+      "version": "1.2.24-beta.1",
       "dependencies": {
         "@tauri-apps/api": "^2.1.1",
         "@tauri-apps/plugin-autostart": "^2.5.1",

--- a/openless-all/app/package.json
+++ b/openless-all/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openless-app",
   "private": true,
-  "version": "1.2.23",
+  "version": "1.2.24-beta.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/openless-all/app/src-tauri/Cargo.lock
+++ b/openless-all/app/src-tauri/Cargo.lock
@@ -3751,7 +3751,7 @@ dependencies = [
 
 [[package]]
 name = "openless"
-version = "1.2.23"
+version = "1.2.24-beta.1"
 dependencies = [
  "anyhow",
  "arboard",

--- a/openless-all/app/src-tauri/Cargo.toml
+++ b/openless-all/app/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openless"
-version = "1.2.23"
+version = "1.2.24-beta.1"
 description = "OpenLess — local voice input that types where your cursor is"
 authors = ["OpenLess"]
 edition = "2021"

--- a/openless-all/app/src-tauri/tauri.conf.json
+++ b/openless-all/app/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "OpenLess",
-  "version": "1.2.23",
+  "version": "1.2.24-beta.1",
   "identifier": "com.openless.app",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
### **User description**
## Summary

把 beta 分支版本号从 \`1.2.23\` bump 到 \`1.2.24-beta.1\`，准备发第一个 Beta release。

## 5 处版本号同步更新

\`\`\`
package.json                       1.2.23 → 1.2.24-beta.1
package-lock.json (root)           1.2.23 → 1.2.24-beta.1
package-lock.json (packages."")    1.2.23 → 1.2.24-beta.1
src-tauri/tauri.conf.json          1.2.23 → 1.2.24-beta.1
src-tauri/Cargo.toml               1.2.23 → 1.2.24-beta.1
src-tauri/Cargo.lock (openless)    1.2.23 → 1.2.24-beta.1
\`\`\`

本地跑 CI 用的同一段 shell 校验通过：\`OK 全部一致\`。\`cargo check\` 干净。

## semver 关系

\`1.2.23 < 1.2.24-beta.1 < 1.2.24\`

- 当前 Stable v1.2.23-tauri 不变（main 仍 1.2.23）
- 下一个 Stable 计划是 \`1.2.24\`，会 supersede 此 Beta
- Tag 命名：\`v1.2.24-beta.1-beta-tauri\`，由 release-tauri.yml 检测到 \`-beta-tauri\` 后缀 → \`prerelease=true\` + 上传 \`latest-{tgt}-{arch}-beta.json\`

## Merge 后的下一步

合并后由维护者本地推 tag：

\`\`\`bash
git checkout beta && git pull --ff-only origin beta
git tag v1.2.24-beta.1-beta-tauri
git push origin v1.2.24-beta.1-beta-tauri
\`\`\`

→ 触发 release-tauri.yml，约 15-20 分钟后产出第一个 Beta release。


___

### **PR Type**
Other


___

### **Description**
- Bump version from 1.2.23 to 1.2.24-beta.1

- Sync version across package.json, Cargo.toml, tauri.conf.json


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>package.json</strong><dd><code>Bump version in package.json</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/package.json

- Update version field from "1.2.23" to "1.2.24-beta.1"


</details>


  </td>
  <td><a href="https://github.com/appergb/openless/pull/334/files#diff-2650f8aa2f7ec97aa8af47f1f8a7c9ae4677fb69754b20d554e1d542507cf4ea">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Cargo.toml</strong><dd><code>Bump version in Cargo.toml</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src-tauri/Cargo.toml

- Update package version from "1.2.23" to "1.2.24-beta.1"


</details>


  </td>
  <td><a href="https://github.com/appergb/openless/pull/334/files#diff-334952ba03e62939865bbf0351f0916ea88c6457f8ea1259336e73ee4e2f088b">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>tauri.conf.json</strong><dd><code>Bump version in tauri.conf.json</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src-tauri/tauri.conf.json

- Update version field from "1.2.23" to "1.2.24-beta.1"


</details>


  </td>
  <td><a href="https://github.com/appergb/openless/pull/334/files#diff-e9c2f15638ea988f61c82aeb2257147fb9cc96d7bda8709e8bad6b6517f5369c">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

