### PR TITLE
fix(release): merge duplicate jobs.build.env block in release-tauri.yml

### DIFF
--- a/.github/workflows/release-tauri.yml
+++ b/.github/workflows/release-tauri.yml
@@ -24,14 +24,6 @@ jobs:
   build:
     permissions:
       contents: write
-    # 渠道由 tag 后缀决定：
-    #   v<v>-beta-tauri  → beta 渠道（GitHub Release 标 prerelease，
-    #                      manifest 文件名带 -beta 后缀，正式版用户的 endpoint 拿不到）
-    #   v<v>-tauri       → stable 渠道（正式版，文件名沿用旧约定，向后兼容）
-    # workflow_dispatch / 非 tag 触发时 github.ref_name 不是 tag 字符串，
-    # endsWith 返回 false，回退为 stable，不改变现有 dispatch 行为。
-    env:
-      OPENLESS_RELEASE_CHANNEL: ${{ endsWith(github.ref_name, '-beta-tauri') && 'beta' || 'stable' }}
     strategy:
       fail-fast: false
       matrix:
@@ -56,6 +48,13 @@ jobs:
     env:
       TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
       TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+      # 渠道由 tag 后缀决定：
+      #   v<v>-beta-tauri  → beta 渠道（GitHub Release 标 prerelease，manifest 文件名带 -beta 后缀，
+      #                      正式版用户的 endpoint 拿不到）
+      #   v<v>-tauri       → stable 渠道（正式版，文件名沿用旧约定，向后兼容）
+      # workflow_dispatch / 非 tag 触发时 github.ref_name 不是 tag 字符串，
+      # endsWith 返回 false，回退为 stable，不改变现有 dispatch 行为。
+      OPENLESS_RELEASE_CHANNEL: ${{ endsWith(github.ref_name, '-beta-tauri') && 'beta' || 'stable' }}
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## What

PR #330 引入的 release-tauri.yml 在 \`jobs.build\` 顶层创建了第 2 个 \`env:\` 块（用来定义 \`OPENLESS_RELEASE_CHANNEL\`），但 \`runs-on\` 之后已有一个旧的 \`env:\` 块（\`TAURI_SIGNING_PRIVATE_KEY\` 等）。YAML map 不允许重复 key —— GitHub Actions 解析直接 fail。

## Why we caught it now

PR-B-1 merge 后 release-tauri.yml 没立刻被跑（它是 tag-triggered）。今天推 \`v1.2.24-beta.1-beta-tauri\` tag 时第一次执行，立刻 \"workflow file issue\" 启动失败：[run 25501239092](https://github.com/appergb/openless/actions/runs/25501239092)。

## Fix

把 \`OPENLESS_RELEASE_CHANNEL\` 并入下方唯一的 \`env:\` 块，注释保留。文件 diff: -8 / +7。

## 验证

\`python -c \"yaml.safe_load(...)\"\` parse 成功，\`jobs.build.env\` 现在有 3 个 key：\`OPENLESS_RELEASE_CHANNEL\`、\`TAURI_SIGNING_PRIVATE_KEY\`、\`TAURI_SIGNING_PRIVATE_KEY_PASSWORD\`。

## Next

合入后删旧 tag \`v1.2.24-beta.1-beta-tauri\` 并在新 beta HEAD 上重打、重推。