### PR TITLE
fix(release): backport YAML duplicate env fix into main

### DIFF
--- a/.github/workflows/release-tauri.yml
+++ b/.github/workflows/release-tauri.yml
@@ -24,14 +24,6 @@ jobs:
   build:
     permissions:
       contents: write
-    # 渠道由 tag 后缀决定：
-    #   v<v>-beta-tauri  → beta 渠道（GitHub Release 标 prerelease，
-    #                      manifest 文件名带 -beta 后缀，正式版用户的 endpoint 拿不到）
-    #   v<v>-tauri       → stable 渠道（正式版，文件名沿用旧约定，向后兼容）
-    # workflow_dispatch / 非 tag 触发时 github.ref_name 不是 tag 字符串，
-    # endsWith 返回 false，回退为 stable，不改变现有 dispatch 行为。
-    env:
-      OPENLESS_RELEASE_CHANNEL: ${{ endsWith(github.ref_name, '-beta-tauri') && 'beta' || 'stable' }}
     strategy:
       fail-fast: false
       matrix:
@@ -56,6 +48,13 @@ jobs:
     env:
       TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
       TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+      # 渠道由 tag 后缀决定：
+      #   v<v>-beta-tauri  → beta 渠道（GitHub Release 标 prerelease，manifest 文件名带 -beta 后缀，
+      #                      正式版用户的 endpoint 拿不到）
+      #   v<v>-tauri       → stable 渠道（正式版，文件名沿用旧约定，向后兼容）
+      # workflow_dispatch / 非 tag 触发时 github.ref_name 不是 tag 字符串，
+      # endsWith 返回 false，回退为 stable，不改变现有 dispatch 行为。
+      OPENLESS_RELEASE_CHANNEL: ${{ endsWith(github.ref_name, '-beta-tauri') && 'beta' || 'stable' }}
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Why

PR #335 已经把这个 \`release-tauri.yml\` 的 YAML \`jobs.build.env\` duplicate-key 启动失败 bug 在 \`beta\` 上修了。但 \`main\` 上这份文件没动——下次从 main 打 \`v<v>-tauri\` stable tag 会重踩同样的坑（CI 在 \"workflow file issue\" 阶段直接 fail）。

这个 PR 是把 #335 的同 patch cherry-pick 到 main，保持 main 的 release pipeline 也是干净的。

## What

cherry-pick \`2246d8f6\`（#335 squash commit），单文件 \`-8/+7\`：把 PR-B-1 在 \`jobs.build\` 顶层多加的 \`OPENLESS_RELEASE_CHANNEL\` 那个 \`env:\` 块并入下方原有的 \`TAURI_SIGNING_PRIVATE_KEY\` 那个 \`env:\` 块。

## 为什么不全量 sync beta → main

beta 还有一个 \`chore: bump version to 1.2.24-beta.1 (#334)\` commit——那是 Beta 渠道的故意版本号分叉，不应该进 main（main 应保持 stable 版本号 1.2.23 直到下次 stable cut）。所以本 PR 只 cherry-pick CI 修复一项。

## Test plan

- [ ] 合入后 \`python -c "yaml.safe_load(...)"\` 解析 main 上的 release-tauri.yml 通过
- [ ] 下次从 main 打 \`v*-tauri\` stable tag，CI 不再因 workflow file issue startup-fail