### PR TITLE
chore: bump version to 1.2.24-1 (Tauri MSI prerelease constraint)

### DIFF
--- a/openless-all/app/package-lock.json
+++ b/openless-all/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openless-app",
-  "version": "1.2.24-beta.1",
+  "version": "1.2.24-1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openless-app",
-      "version": "1.2.24-beta.1",
+      "version": "1.2.24-1",
       "dependencies": {
         "@tauri-apps/api": "^2.1.1",
         "@tauri-apps/plugin-autostart": "^2.5.1",

--- a/openless-all/app/package.json
+++ b/openless-all/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openless-app",
   "private": true,
-  "version": "1.2.24-beta.1",
+  "version": "1.2.24-1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/openless-all/app/src-tauri/Cargo.lock
+++ b/openless-all/app/src-tauri/Cargo.lock
@@ -3751,7 +3751,7 @@ dependencies = [
 
 [[package]]
 name = "openless"
-version = "1.2.24-beta.1"
+version = "1.2.24-1"
 dependencies = [
  "anyhow",
  "arboard",

--- a/openless-all/app/src-tauri/Cargo.toml
+++ b/openless-all/app/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openless"
-version = "1.2.24-beta.1"
+version = "1.2.24-1"
 description = "OpenLess — local voice input that types where your cursor is"
 authors = ["OpenLess"]
 edition = "2021"

--- a/openless-all/app/src-tauri/tauri.conf.json
+++ b/openless-all/app/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "OpenLess",
-  "version": "1.2.24-beta.1",
+  "version": "1.2.24-1",
   "identifier": "com.openless.app",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
### **User description**
## What

把 Beta 版本号从 \`1.2.24-beta.1\` 改成 \`1.2.24-1\`。

## Why — Tauri MSI 的 prerelease 限制

上次推 \`v1.2.24-beta.1-beta-tauri\` tag 触发的 CI run [25501471895](https://github.com/appergb/openless/actions/runs/25501239092) 在 Windows job 报：

\`\`\`
failed to bundle project: optional pre-release identifier in app version 
must be numeric-only and cannot be greater than 65535 for msi target
\`\`\`

**Tauri MSI bundler 比 npm/Cargo 更严**：prerelease 段必须是单一**纯数字**且 ≤ 65535。\`beta.1\` 含字母 + 多段，直接 reject。macOS DMG / Linux AppImage/deb/rpm 没这个限制，所以那 3 个平台 build 成功，只有 Windows 失败。

\`1.2.24-1\` 满足约束：
- npm semver / Cargo: 合法 prerelease
- Tauri MSI: 接受
- 排序：\`1.2.23 < 1.2.24-1 < 1.2.24\` ✓
- 后续 Beta 迭代：\`1.2.24-2\`、\`1.2.24-3\`、…
- Beta 渠道身份**不**靠版本号字面，靠 tag 后缀 \`-beta-tauri\`（\`release-tauri.yml\` 用 \`endsWith\` 判定）

## 已做的清理

- 删除残缺的 GitHub Release \`v1.2.24-beta.1-beta-tauri\`（macOS/Linux 资产已上传但缺 Windows）
- 删除远端 tag \`v1.2.24-beta.1-beta-tauri\`

## Diff

5 个文件 6 处版本号同步：\`package.json\`、\`package-lock.json\` (root + nested)、\`tauri.conf.json\`、\`Cargo.toml\`、\`Cargo.lock\`。CI 用的同一段 \`Verify version sync\` 本地实测 \`OK 全部一致\`。\`cargo check\` 干净。

## Next

合并后我会立刻推 \`v1.2.24-1-beta-tauri\` tag，4 平台预期全部 success。


___

### **PR Type**
Bug fix


___

### **Description**
- Replace version `1.2.24-beta.1` with `1.2.24-1` across three config files

- Ensure prerelease identifier is numeric-only for Tauri MSI bundler

- Fix Windows MSI build failure caused by non-numeric prerelease


___

### Diagram Walkthrough


```mermaid
flowchart LR
  old["1.2.24-beta.1 (non-numeric prerelease)"]
  new["1.2.24-1 (numeric prerelease)"]
  old -- "Replace in 3 config files" --> new
  new -- "Satisfies Tauri MSI constraint" --> win["Windows MSI build"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>package.json</strong><dd><code>Bump version in package.json</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/package.json

- Bump version from `1.2.24-beta.1` to `1.2.24-1`


</details>


  </td>
  <td><a href="https://github.com/appergb/openless/pull/337/files#diff-2650f8aa2f7ec97aa8af47f1f8a7c9ae4677fb69754b20d554e1d542507cf4ea">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Cargo.toml</strong><dd><code>Bump version in Cargo manifest</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src-tauri/Cargo.toml

- Bump version from `1.2.24-beta.1` to `1.2.24-1`


</details>


  </td>
  <td><a href="https://github.com/appergb/openless/pull/337/files#diff-334952ba03e62939865bbf0351f0916ea88c6457f8ea1259336e73ee4e2f088b">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>tauri.conf.json</strong><dd><code>Bump version in Tauri configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src-tauri/tauri.conf.json

- Bump version from `1.2.24-beta.1` to `1.2.24-1`


</details>


  </td>
  <td><a href="https://github.com/appergb/openless/pull/337/files#diff-e9c2f15638ea988f61c82aeb2257147fb9cc96d7bda8709e8bad6b6517f5369c">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

