### PR TITLE
fix(release): use tagged URL in beta manifest, not releases/latest

### DIFF
--- a/.github/workflows/release-tauri.yml
+++ b/.github/workflows/release-tauri.yml
@@ -379,6 +379,11 @@ jobs:
           OPENLESS_UPDATE_MIRROR_BASE_URL: https://fastgit.cc/https://github.com
           # beta 渠道时输出 latest-{tgt}-{arch}-beta.json，stable 沿用旧文件名。
           OPENLESS_RELEASE_CHANNEL: ${{ env.OPENLESS_RELEASE_CHANNEL }}
+          # Beta 渠道里脚本要把 manifest.url 写成 releases/download/<tag>/...
+          # 而不是 releases/latest（后者永远 = Stable，Beta 用户按 url 下载会拉到错文件）。
+          # workflow_dispatch 时 github.ref_name 不是 tag——但那种情况下 channel=stable，
+          # 脚本不会读这个字段，安全。
+          OPENLESS_RELEASE_TAG: ${{ github.ref_name }}
         run: node scripts/write-updater-manifest.mjs
 
       # ── 收集产物 ──

--- a/openless-all/app/scripts/write-updater-manifest.mjs
+++ b/openless-all/app/scripts/write-updater-manifest.mjs
@@ -15,6 +15,14 @@ if (rawChannel !== 'stable' && rawChannel !== 'beta') {
   throw new Error(`Invalid OPENLESS_RELEASE_CHANNEL: "${rawChannel}" (expected "stable" or "beta")`);
 }
 const channelSuffix = rawChannel === 'beta' ? '-beta' : '';
+// Beta 渠道里 manifest.url 必须指向具体 tag 路径，不能用 releases/latest——后者
+// 永远是最新非-prerelease（即 Stable），Beta 用户按 url 下载会拉到 Stable 包，
+// 文件名碰巧重名时下载错版本，文件名带版本号时直接 404。
+// Stable 渠道沿用 releases/latest，没问题。
+const releaseTag = process.env.OPENLESS_RELEASE_TAG || '';
+if (rawChannel === 'beta' && !releaseTag) {
+  throw new Error('OPENLESS_RELEASE_TAG is required when OPENLESS_RELEASE_CHANNEL=beta');
+}
 
 if (!target || !arch) {
   throw new Error('OPENLESS_UPDATE_TARGET and OPENLESS_UPDATE_ARCH are required');
@@ -64,8 +72,13 @@ if (!existsSync(signaturePath)) {
 const assetName = basename(artifact);
 const manifestName = `latest-${target}-${arch}${channelSuffix}.json`;
 const mirrorManifestName = `latest-${target}-${arch}${channelSuffix}-mirror.json`;
-const githubAssetUrl = `https://github.com/${repo}/releases/latest/download/${assetName}`;
-const mirrorAssetUrl = `${mirrorBaseUrl.replace(/\/$/, '')}/${repo}/releases/latest/download/${assetName}`;
+// Stable: releases/latest/download/<asset>（GitHub 自动重定向到最新非-prerelease）
+// Beta:   releases/download/<tag>/<asset>（指定具体 tag，不被 prerelease 折叠影响）
+const downloadPath = rawChannel === 'beta'
+  ? `releases/download/${releaseTag}/${assetName}`
+  : `releases/latest/download/${assetName}`;
+const githubAssetUrl = `https://github.com/${repo}/${downloadPath}`;
+const mirrorAssetUrl = `${mirrorBaseUrl.replace(/\/$/, '')}/${repo}/${downloadPath}`;
 const manifest = {
   version: packageJson.version,
   pub_date: new Date().toISOString(),


### PR DESCRIPTION
### **User description**
## What

修复 \`v1.2.24-1-beta-tauri\` 跑 release verification checklist 时发现的 latent bug：Beta manifest 里 \`url\` 字段指向 \`releases/latest/download/<asset>\`，**但 \`releases/latest\` 永远是最新非-prerelease（即 Stable），不是 Beta**。

实测当前 Beta manifest 内容：
\`\`\`
darwin-aarch64-beta.json
  version: 1.2.24-1
  url:     .../releases/latest/download/OpenLess_aarch64.app.tar.gz   ← 重定向到 Stable v1.2.23
  
linux-x86_64-beta.json
  version: 1.2.24-1
  url:     .../releases/latest/download/OpenLess_1.2.24-1_amd64.AppImage   ← 路径下不存在 → 404
\`\`\`

## Why latent

当前走 **Path A 手动下载式 opt-in**——前端 \`fetch_latest_beta_release\` 拿 GitHub Release 页 \`html_url\`，用户点"前往下载"跳浏览器手动选包，**不消费 manifest.url 字段**。所以这个 bug 不影响今天的用户体验。

但如果后续从 Path A 升到真正的 auto-update Beta（plugin endpoints 切换或自实现 fetch+install），broken url 立刻变 user-facing 故障：macOS 用户装到错版本、Windows/Linux 用户 404。

## Fix

### \`scripts/write-updater-manifest.mjs\`

- 多读一个 \`OPENLESS_RELEASE_TAG\` env
- channel=beta 时 url 拼成 \`releases/download/<tag>/<asset>\`（指定具体 tag）
- channel=stable 沿用 \`releases/latest/download/<asset>\`（不变）
- channel=beta 但缺 \`OPENLESS_RELEASE_TAG\` → fail-fast，避免静默生成错 url

### \`.github/workflows/release-tauri.yml\`

manifest step 的 env 多一行：
\`\`\`yaml
OPENLESS_RELEASE_TAG: \${{ github.ref_name }}
\`\`\`

## 已发布的 v1.2.24-1 release 怎么办

**不重发**。当前 Path A 不消费 manifest.url，已发布版的 dormant bug 不影响用户。下一轮 Beta tag（如 \`v1.2.24-2-beta-tauri\` 或 stable cut 后再做的 Beta）会用修复后的脚本产出正确 URL。

## 本地 smoke test

\`\`\`
channel=beta + 缺 TAG  → fail-fast: "OPENLESS_RELEASE_TAG is required when ..."
channel=beta + 有 TAG  → env 检查通过，进入 artifact 解析
channel=stable + 无 TAG → 维持原行为
python yaml.safe_load() → release-tauri.yml 解析通过
\`\`\`

## Test plan

- [ ] 合并后下次 Beta tag 推送时，manifest.url 实测应是 \`https://github.com/.../releases/download/v<v>-beta-tauri/<asset>\`，curl 该 url 应返回真实文件而不是 404 / 重定向到 Stable


___

### **PR Type**
Bug fix


___

### **Description**
- Pass release tag into beta manifest generation

- Build beta download URLs from tagged releases

- Keep stable manifests on `releases/latest`

- Fail fast when beta tag is missing


___

### Diagram Walkthrough


```mermaid
flowchart LR
  wf["release-tauri.yml workflow"] -- "sets `OPENLESS_RELEASE_TAG`" --> script["write-updater-manifest.mjs"]
  script -- "beta uses `releases/download/<tag>/...`" --> beta["Beta manifest URL"]
  script -- "stable uses `releases/latest/download/...`" --> stable["Stable manifest URL"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>release-tauri.yml</strong><dd><code>Inject release tag for beta manifests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/release-tauri.yml

<ul><li>Adds <code>OPENLESS_RELEASE_TAG</code> to manifest-generation env<br> <li> Uses <code>github.ref_name</code> as the release tag source<br> <li> Documents why beta needs a tagged download path<br> <li> Notes stable releases remain unchanged</ul>


</details>


  </td>
  <td><a href="https://github.com/appergb/openless/pull/344/files#diff-cac78cd4d340dc05703d65bee14ea766337499de655e15553ceb8181eef097cb">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>write-updater-manifest.mjs</strong><dd><code>Generate beta URLs from tagged releases</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/scripts/write-updater-manifest.mjs

<ul><li>Reads <code>OPENLESS_RELEASE_TAG</code> from the environment<br> <li> Fails fast when beta runs without a tag<br> <li> Switches beta URLs to <code>releases/download/<tag>/...</code><br> <li> Keeps stable URLs on <code>releases/latest/download/...</code></ul>


</details>


  </td>
  <td><a href="https://github.com/appergb/openless/pull/344/files#diff-f177f84545804ad96174bee0eb1cf8f690ccba062130a6483bce7189e43ab417">+15/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

