### PR TITLE
chore: bump version to 1.2.24-2 (Beta-2)

### DIFF
--- a/openless-all/app/package-lock.json
+++ b/openless-all/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openless-app",
-  "version": "1.2.24-1",
+  "version": "1.2.24-2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openless-app",
-      "version": "1.2.24-1",
+      "version": "1.2.24-2",
       "dependencies": {
         "@tauri-apps/api": "^2.1.1",
         "@tauri-apps/plugin-autostart": "^2.5.1",

--- a/openless-all/app/package.json
+++ b/openless-all/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openless-app",
   "private": true,
-  "version": "1.2.24-1",
+  "version": "1.2.24-2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/openless-all/app/src-tauri/Cargo.lock
+++ b/openless-all/app/src-tauri/Cargo.lock
@@ -3751,7 +3751,7 @@ dependencies = [
 
 [[package]]
 name = "openless"
-version = "1.2.24-1"
+version = "1.2.24-2"
 dependencies = [
  "anyhow",
  "arboard",

--- a/openless-all/app/src-tauri/Cargo.toml
+++ b/openless-all/app/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openless"
-version = "1.2.24-1"
+version = "1.2.24-2"
 description = "OpenLess — local voice input that types where your cursor is"
 authors = ["OpenLess"]
 edition = "2021"

--- a/openless-all/app/src-tauri/tauri.conf.json
+++ b/openless-all/app/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "OpenLess",
-  "version": "1.2.24-1",
+  "version": "1.2.24-2",
   "identifier": "com.openless.app",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
### **User description**
## What

Beta 第 2 次发布。版本号从 \`1.2.24-1\` → \`1.2.24-2\`。

5 文件 6 处版本号同步，CI version-sync 本地预检通过，cargo check 干净。

## 与 Beta-1 (v1.2.24-1) 的代码差异

合入后 \`v1.2.24-2-beta-tauri\` tag 的 release 会自动包含：
- PR #344 的 Beta manifest URL fix（manifest.url 现在用 \`releases/download/<tag>/<asset>\` 而不是 \`releases/latest/...\`）—— 之前 Beta-1 的 manifest URL 是 dormant bug，这次实测可见
- 其他 beta 分支上的常规改动（自上次 Beta tag 以来）

## Tag

合入后维护者推 \`v1.2.24-2-beta-tauri\` 触发 release-tauri.yml。


___

### **PR Type**
Other


___

### **Description**
- Bump app version to `1.2.24-2`

- Sync Tauri and package metadata

- Keep release configuration aligned


___

### Diagram Walkthrough


```mermaid
flowchart LR
  pkg["package.json version"] --> sync["Version sync"]
  cargo["Cargo.toml version"] --> sync
  tauri["tauri.conf.json version"] --> sync
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>package.json</strong><dd><code>Bump app package version</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/package.json

- Updates the app version from `1.2.24-1` to `1.2.24-2`


</details>


  </td>
  <td><a href="https://github.com/appergb/openless/pull/345/files#diff-2650f8aa2f7ec97aa8af47f1f8a7c9ae4677fb69754b20d554e1d542507cf4ea">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Cargo.toml</strong><dd><code>Sync Tauri package version</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src-tauri/Cargo.toml

- Updates the Rust package version from `1.2.24-1` to `1.2.24-2`


</details>


  </td>
  <td><a href="https://github.com/appergb/openless/pull/345/files#diff-334952ba03e62939865bbf0351f0916ea88c6457f8ea1259336e73ee4e2f088b">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>tauri.conf.json</strong><dd><code>Align Tauri config version</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src-tauri/tauri.conf.json

- Updates the Tauri app version from `1.2.24-1` to `1.2.24-2`


</details>


  </td>
  <td><a href="https://github.com/appergb/openless/pull/345/files#diff-e9c2f15638ea988f61c82aeb2257147fb9cc96d7bda8709e8bad6b6517f5369c">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

