### PR TITLE
docs(release): make macOS xattr workaround discoverable

### DIFF
--- a/.github/workflows/release-tauri.yml
+++ b/.github/workflows/release-tauri.yml
@@ -484,6 +484,26 @@ jobs:
           # 普通用户看不到；同时只上传 latest-*-beta.json，正式版用户的
           # endpoint（latest-*.json）永远不会被覆盖，保证 Beta 不溢出正式版。
           prerelease: ${{ env.OPENLESS_RELEASE_CHANNEL == 'beta' }}
+          # body 在 generated notes 之前 prepend——所有 matrix job 设同一份字符串，
+          # 多次调用 action 时内容一致、idempotent。提示 macOS Gatekeeper 绕过指令 +
+          # 渠道说明，每个 release 自动带上，用户不用回项目 README 翻就能看到。
+          body: |
+            ### macOS 用户首次安装提示
+
+            下载 DMG 拖入 `/Applications` 后，**必须**在终端运行：
+
+            ```bash
+            xattr -cr /Applications/OpenLess.app
+            ```
+
+            否则 Gatekeeper 会提示「OpenLess 已损坏」——这是因为当前 build 用 ad-hoc 签名、没做 Apple 公证。
+
+            ### 渠道说明
+
+            - 以 `-tauri` 结尾的 tag 是**正式版**（自动推送给所有 in-app 检查更新的用户）。
+            - 以 `-beta-tauri` 结尾的 tag 是 **Beta 版**（GitHub 标 pre-release，**不**通过 in-app updater 推送给正式版用户；只对在「设置 → 关于 → 加入 Beta 渠道」开关切到 Beta 的用户可见，且需要手动从此页面下载安装）。
+
+          append_body: true
           # Matrix jobs all upload assets to the same release. Generate notes once
           # so macOS, Windows, and Linux jobs do not duplicate the release body.
           generate_release_notes: ${{ matrix.updater-target == 'darwin' && matrix.updater-arch == 'aarch64' }}

--- a/README.md
+++ b/README.md
@@ -157,17 +157,20 @@ OpenLess does one thing: **turn speech into usable written text (especially AI p
 ## Download & install (end users)
 
 Go to [Releases](../../releases) and download:
-- **macOS**: `OpenLess_<version>_aarch64.dmg` — open, drag to `/Applications`
+- **macOS**: `OpenLess_<version>_aarch64.dmg` (Apple Silicon) or `OpenLess_<version>_x64.dmg` (Intel) — open, drag to `/Applications`, **then run this once in Terminal to bypass Gatekeeper "damaged" warning** (the build is ad-hoc signed, not Apple-notarized):
+  ```bash
+  xattr -cr /Applications/OpenLess.app
+  ```
 - **Windows**: `OpenLess_<version>_x64-setup.exe` — run the installer
-- **macOS(brew install)**:
-```bash
-brew tap appergb/openless https://github.com/appergb/openless
-brew install --cask openless
-xattr -cr /Applications/OpenLess.app
+- **macOS (Homebrew)**:
+  ```bash
+  brew tap appergb/openless https://github.com/appergb/openless
+  brew install --cask openless
+  xattr -cr /Applications/OpenLess.app
 
-# Upgrade to the latest version
-brew update && brew upgrade openless
-```
+  # Upgrade to the latest version
+  brew update && brew upgrade openless
+  ```
 
 On first launch, grant the permissions the app requests:
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -158,16 +158,19 @@ OpenLess 只做一件事：**把语音变成可用的书面文字（尤其是 AI
 
 到 [Releases](../../releases) 下载对应平台的安装包：
 - **Windows**：`OpenLess_<版本>_x64-setup.exe` — 运行安装程序
-- **macOS**：`OpenLess_<版本>_aarch64.dmg` — 打开后拖入「应用程序」
-- **macOS(brew install)**:
-```bash
-brew tap appergb/openless https://github.com/appergb/openless
-brew install --cask openless
-xattr -cr /Applications/OpenLess.app
+- **macOS**：`OpenLess_<版本>_aarch64.dmg`（Apple Silicon）或 `OpenLess_<版本>_x64.dmg`（Intel）— 打开后拖入「应用程序」，**然后必须在终端跑这一行绕过 Gatekeeper 的"已损坏"提示**（当前包是 ad-hoc 签名、未做 Apple 公证）：
+  ```bash
+  xattr -cr /Applications/OpenLess.app
+  ```
+- **macOS（Homebrew）**：
+  ```bash
+  brew tap appergb/openless https://github.com/appergb/openless
+  brew install --cask openless
+  xattr -cr /Applications/OpenLess.app
 
-# Upgrade to the latest version
-brew update && brew upgrade openless
-```
+  # 升级到最新版本
+  brew update && brew upgrade openless
+  ```
 
 首次启动需要授予权限：
 


### PR DESCRIPTION
### **User description**
## Why

v1.2.23 Stable 和 v1.2.24-1 Beta 的 macOS DMG 都是 ad-hoc 签名 + 未经 Apple 公证（仓库没配 secrets）。Gatekeeper 14+ 弹「OpenLess 已损坏」，用户必须手工 \`xattr -cr\` 才能跑。

\`build-mac.sh:40-41\` 项目作者自己已经注释承认这是已知限制：

> 这只能保证 CI/本机构建产物本身干净；浏览器下载仍可能重新加 quarantine。  
> 用户免手工 xattr 的根本方案是 Developer ID 签名 + Apple notarization。

之前 README 只在 brew install 段写过 xattr 指令，**DMG 直装路径没有同等提示**。用户装 Beta-1 时没看到提示就踩坑（"无法扫描到 Beta 版本的安装"= Gatekeeper 拒签）。

## What

1. \`README.md\` / \`README.zh.md\`：DMG 直装段加 \`xattr -cr\` 指令 + 一句解释
2. \`release-tauri.yml\`：Create release step 加 \`body:\` 模板，每个 release 自动 prepend 一段提示——含 macOS xattr 指令 + Beta/Stable 渠道说明。\`append_body: true\` 让它放在 generated notes 之前。本机 \`yaml.safe_load\` 解析通过

## Out of scope

配 Apple Developer 证书 + secrets——那是根治方案。需要 $99/年 Apple Developer 账号，用户决定要不要走

## Effect

- 合入后下次 push v\\*-tauri 或 v\\*-beta-tauri tag，release body 自动带上 xattr 指令
- README 改动立刻生效——DMG 直装路径有了显式 xattr 指令
- v1.2.24-2 release（已发布）我会用 \`gh release edit\` 立即手工 patch body


___

### **PR Type**
Documentation, Enhancement


___

### **Description**
- Add `xattr -cr` bypass command to DMG install steps in README.md and README.zh.md

- Automatically prepend macOS Gatekeeper bypass note to each GitHub release via workflow template

- Clarify separate Apple Silicon and Intel DMG download options

- Improve code block formatting for Homebrew install sections


___

### Diagram Walkthrough


```mermaid
flowchart LR
    A["Update README files"] -- "add xattr command for DMG" --> B["Documentation improved"]
    C["Update release-tauri.yml"] -- "add body template with append_body" --> D["Release notes include xattr hint"]
    B --> E["Users see bypass instructions"]
    D --> E
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>release-tauri.yml</strong><dd><code>Automate macOS Gatekeeper workaround in release notes</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/release-tauri.yml

<ul><li>Add release body template with macOS xattr bypass command and channel <br>explanation<br> <li> Set <code>append_body: true</code> to prepend template before generated notes<br> <li> Ensure idempotent body content across all matrix jobs</ul>


</details>


  </td>
  <td><a href="https://github.com/appergb/openless/pull/347/files#diff-cac78cd4d340dc05703d65bee14ea766337499de655e15553ceb8181eef097cb">+20/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Document xattr workaround for macOS DMG users</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

<ul><li>Add <code>xattr -cr</code> bypass command to DMG install step with explanation <br>about ad-hoc signing<br> <li> List separate Apple Silicon and Intel DMG download variants<br> <li> Reformat Homebrew installation code block with proper indentation</ul>


</details>


  </td>
  <td><a href="https://github.com/appergb/openless/pull/347/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+13/-10</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>README.zh.md</strong><dd><code>Chinese README update with xattr instruction</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.zh.md

<ul><li>Add <code>xattr -cr</code> bypass command to Chinese DMG install step with <br>explanation<br> <li> List separate Apple Silicon and Intel DMG download variants<br> <li> Reformat Homebrew installation code block with proper indentation</ul>


</details>


  </td>
  <td><a href="https://github.com/appergb/openless/pull/347/files#diff-b024066e6d6250813a9bc9284332cc3b84edc264857d6a671b7513f2c7ef90a8">+13/-10</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

