### PR TITLE
feat(ui): drop sidebar version chip; show BETA tag only on beta builds

### DIFF
--- a/openless-all/app/src/components/FloatingShell.tsx
+++ b/openless-all/app/src/components/FloatingShell.tsx
@@ -17,7 +17,7 @@ import { Style } from '../pages/Style';
 import { Translation } from '../pages/Translation';
 import { SelectionAsk } from '../pages/SelectionAsk';
 import { LocalAsr } from '../pages/LocalAsr';
-import { APP_VERSION_LABEL } from '../lib/appVersion';
+import { APP_VERSION_LABEL, IS_BETA_BUILD } from '../lib/appVersion';
 import {
   HOTKEY_MODE_MIGRATION_ACK_KEY,
   HOTKEY_MODE_MIGRATION_DEFERRED_KEY,
@@ -219,11 +219,6 @@ function FloatingShellBody({ os, initialTab, initialSettings }: { os: OS; initia
               style={{ width: 22, height: 22, borderRadius: 5, boxShadow: '0 1px 2px rgba(0,0,0,.1), 0 0 0 0.5px rgba(0,0,0,.06)' }} />
 
             <div style={{ fontSize: 13.5, fontWeight: 600, letterSpacing: '-0.01em', color: 'var(--ol-ink)' }}>OpenLess</div>
-            <span style={{
-              marginLeft: 'auto', padding: '1px 6px', fontSize: 9.5, fontWeight: 600,
-              borderRadius: 4, background: 'rgba(0,0,0,0.06)', color: 'var(--ol-ink-3)',
-              letterSpacing: '0.04em',
-            }}>{APP_VERSION_LABEL}</span>
           </div>
 
           {/* nav */}
@@ -271,11 +266,14 @@ function FloatingShellBody({ os, initialTab, initialSettings }: { os: OS; initia
             </div>
           </div>
 
-          {/* BETA 区域 — 去掉描边和实色背景，让它和底部 footer 一起浮在磨砂玻璃上 */}
-          <div style={{ marginTop: 8, padding: '10px 10px 4px' }}>
-            <div style={{ fontSize: 10.5, fontWeight: 600, color: 'var(--ol-blue)', letterSpacing: '0.04em', textTransform: 'uppercase' }}>{t('shell.betaTag')}</div>
-            <div style={{ fontSize: 11.5, color: 'var(--ol-ink-2)', marginTop: 4, lineHeight: 1.5 }}>{t('shell.betaNote')}</div>
-          </div>
+          {/* BETA 区域 — 仅在 Beta build（version 含 semver prerelease 段，如 1.2.24-1）显示。
+              正式版 build 完全不渲染这块，避免普通用户误以为正式版是 Beta。 */}
+          {IS_BETA_BUILD && (
+            <div style={{ marginTop: 8, padding: '10px 10px 4px' }}>
+              <div style={{ fontSize: 10.5, fontWeight: 600, color: 'var(--ol-blue)', letterSpacing: '0.04em', textTransform: 'uppercase' }}>{t('shell.betaTag')}</div>
+              <div style={{ fontSize: 11.5, color: 'var(--ol-ink-2)', marginTop: 4, lineHeight: 1.5 }}>{t('shell.betaNote')}</div>
+            </div>
+          )}
         </aside>
 
         {/* Main content — inset white card sitting on the frosted backplate.

--- a/openless-all/app/src/lib/appVersion.ts
+++ b/openless-all/app/src/lib/appVersion.ts
@@ -2,3 +2,7 @@ import packageJson from '../../package.json';
 
 export const APP_VERSION = packageJson.version;
 export const APP_VERSION_LABEL = `v${APP_VERSION}`;
+// 当前 build 是不是 Beta 版？约定：semver prerelease 段（含 `-`）= Beta，
+// 例如 `1.2.24-1` / `1.2.24-2`；正式版没有 `-`，例如 `1.2.23` / `1.2.24`。
+// 用于 UI 条件渲染——Beta 标签只在 Beta build 出现。
+export const IS_BETA_BUILD = APP_VERSION.includes('-');


### PR DESCRIPTION
### **User description**
## What

两处侧栏 UI 修整，回应用户截图反馈（v1.2.24-2 chip 在窄侧栏被截断换行像 \"v1.2.24-/2\"）：

1. **删除左上 brand 行的 version chip** —— 保留 logo + \"OpenLess\" 文字。版本号在底部 footer (\`版本 v1.2.24-2 检查\`) 和「设置 → 关于」里都已经展示，不需要这第三处冗余
2. **BETA 标签条件渲染** —— 只在 Beta build 显示，正式版 build 直接不渲染。约定：\`APP_VERSION\` 含 \`-\`（semver prerelease）= Beta（\`1.2.24-1\` / \`1.2.24-2\`）；不含 \`-\` = 正式版（\`1.2.23\` / \`1.2.24\`）

## Why

- chip 在窄侧栏下断行变 \"v1.2.24-/2\"，视觉乱
- BETA 标签当前无条件渲染——正式版用户也看到，违反「Beta 不泄漏到正式版」整套渠道隔离的精神
- 用条件渲染让单一代码库 build 出的 Stable / Beta 两套包自动表现出对应身份，不用维护人手切

## Files

- \`appVersion.ts\`：新增 \`IS_BETA_BUILD\` 常量
- \`FloatingShell.tsx\`：
  - brand 行删 chip \`<span>\`
  - BETA 区域包 \`{IS_BETA_BUILD && (...)}\`

## 验证

- \`npm run build\` 干净通过
- 当前 beta 分支 \`APP_VERSION = '1.2.24-2'\` → \`IS_BETA_BUILD = true\` → 仍显示 BETA 标签
- 未来 main 分支 \`APP_VERSION = '1.2.24'\`（正式版）→ \`IS_BETA_BUILD = false\` → 不渲染 BETA 区域


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Remove redundant version chip from sidebar brand row (fixes line break "v1.2.24-/2" on narrow sidebar).

- Add `IS_BETA_BUILD` constant to detect beta builds (version contains `-` semver prerelease).

- Conditionally render BETA section only on beta builds, preventing stable users from seeing beta label.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["appVersion.ts: Add IS_BETA_BUILD constant"] --> B["FloatingShell.tsx: Import IS_BETA_BUILD"]
  B --> C["Remove version chip from brand row"]
  B --> D["Conditionally render BETA section"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>appVersion.ts</strong><dd><code>Add IS_BETA_BUILD constant for beta build detection</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src/lib/appVersion.ts

<ul><li>Added <code>IS_BETA_BUILD</code> constant to detect beta builds via <br><code>APP_VERSION.includes('-')</code>.<br> <li> Exported for use in UI components.</ul>


</details>


  </td>
  <td><a href="https://github.com/appergb/openless/pull/348/files#diff-2ffe0dc7eb0196aaf4cf971d19570298f524848451191d025751bbded4786ba4">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>FloatingShell.tsx</strong><dd><code>Remove version chip and conditionally render BETA tag</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src/components/FloatingShell.tsx

<ul><li>Removed the version chip (<code><span></code> with <code>APP_VERSION_LABEL</code>) from the sidebar <br>brand row.<br> <li> Imported <code>IS_BETA_BUILD</code> from <code>../lib/appVersion</code>.<br> <li> Wrapped the BETA section with <code>{IS_BETA_BUILD && (...)}</code> to render only <br>on beta builds.</ul>


</details>


  </td>
  <td><a href="https://github.com/appergb/openless/pull/348/files#diff-ef6d623d372a1cb87a4833f1435927fc2e2ceeedb75c18ea4064d45e1f44df38">+9/-11</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

