### PR TITLE
修复热键设置加载失败后永久 loading

### DIFF
--- a/openless-all/app/src/i18n/en.ts
+++ b/openless-all/app/src/i18n/en.ts
@@ -10,6 +10,8 @@ export const en: typeof zhCN = {
   },
   common: {
     loading: 'Loading…',
+    retry: 'Retry',
+    settingsLoadFailed: 'Settings load failed',
     refresh: 'Refresh',
     clear: 'Clear',
     copy: 'Copy',

--- a/openless-all/app/src/i18n/ja.ts
+++ b/openless-all/app/src/i18n/ja.ts
@@ -12,6 +12,8 @@ export const ja: typeof zhCN = {
   },
   common: {
     loading: '読み込み中…',
+    retry: '再試行',
+    settingsLoadFailed: '設定の読み込みに失敗しました',
     refresh: '更新',
     clear: 'クリア',
     copy: 'コピー',

--- a/openless-all/app/src/i18n/ko.ts
+++ b/openless-all/app/src/i18n/ko.ts
@@ -12,6 +12,8 @@ export const ko: typeof zhCN = {
   },
   common: {
     loading: '로딩 중…',
+    retry: '다시 시도',
+    settingsLoadFailed: '설정 로드 실패',
     refresh: '새로고침',
     clear: '지우기',
     copy: '복사',

--- a/openless-all/app/src/i18n/zh-CN.ts
+++ b/openless-all/app/src/i18n/zh-CN.ts
@@ -8,6 +8,8 @@ export const zhCN = {
   },
   common: {
     loading: '加载中…',
+    retry: '重试',
+    settingsLoadFailed: '设置加载失败',
     refresh: '刷新',
     clear: '清空',
     copy: '复制',

--- a/openless-all/app/src/i18n/zh-TW.ts
+++ b/openless-all/app/src/i18n/zh-TW.ts
@@ -10,6 +10,8 @@ export const zhTW: typeof zhCN = {
   },
   common: {
     loading: '加載中…',
+    retry: '重試',
+    settingsLoadFailed: '設置加載失敗',
     refresh: '刷新',
     clear: '清空',
     copy: '複製',

--- a/openless-all/app/src/pages/Translation.tsx
+++ b/openless-all/app/src/pages/Translation.tsx
@@ -18,7 +18,7 @@ type SaveState = 'idle' | 'saving' | 'saved' | 'failed';
 
 export function Translation() {
   const { t } = useTranslation();
-  const { prefs, refresh, updatePrefs: savePrefs } = useHotkeySettings();
+  const { prefs, loading, error, refresh, updatePrefs: savePrefs } = useHotkeySettings();
   const [saveState, setSaveState] = useState<SaveState>('idle');
   const [saveMessage, setSaveMessage] = useState('');
   const statusTimer = useRef<number | null>(null);
@@ -69,7 +69,34 @@ export function Translation() {
           desc={t('translation.desc')}
         />
         <Card>
-          <div style={{ fontSize: 12, color: 'var(--ol-ink-4)' }}>{t('common.loading')}</div>
+          {error ? (
+            <div role="alert" style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
+              <div style={{ fontSize: 12, color: 'var(--ol-red, #ef4444)', lineHeight: 1.5 }}>
+                {t('common.settingsLoadFailed')}：{error}
+              </div>
+              <button
+                type="button"
+                onClick={() => { void refresh(); }}
+                disabled={loading}
+                style={{
+                  alignSelf: 'flex-start',
+                  padding: '6px 12px',
+                  borderRadius: 999,
+                  border: 0,
+                  background: 'var(--ol-blue)',
+                  color: '#fff',
+                  fontSize: 12,
+                  fontWeight: 600,
+                  cursor: loading ? 'not-allowed' : 'default',
+                  opacity: loading ? 0.64 : 1,
+                }}
+              >
+                {loading ? t('common.loading') : t('common.retry')}
+              </button>
+            </div>
+          ) : (
+            <div style={{ fontSize: 12, color: 'var(--ol-ink-4)' }}>{t('common.loading')}</div>
+          )}
         </Card>
       </>
     );
@@ -121,6 +148,46 @@ export function Translation() {
       />
 
       <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+        {error && (
+          <div
+            role="alert"
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'space-between',
+              gap: 10,
+              padding: '8px 12px',
+              borderRadius: 10,
+              border: '0.5px solid rgba(239,68,68,0.22)',
+              background: 'rgba(239,68,68,0.07)',
+              color: 'var(--ol-red, #ef4444)',
+              fontSize: 11.5,
+              lineHeight: 1.5,
+            }}
+          >
+            <span>{t('common.settingsLoadFailed')}：{error}</span>
+            <button
+              type="button"
+              onClick={() => { void refresh(); }}
+              disabled={loading}
+              style={{
+                flex: '0 0 auto',
+                border: 0,
+                borderRadius: 999,
+                background: 'rgba(239,68,68,0.12)',
+                color: 'inherit',
+                padding: '4px 10px',
+                fontSize: 11,
+                fontWeight: 600,
+                cursor: loading ? 'not-allowed' : 'default',
+                opacity: loading ? 0.64 : 1,
+              }}
+            >
+              {loading ? t('common.loading') : t('common.retry')}
+            </button>
+          </div>
+        )}
+
         {saveState !== 'idle' && (
           <div
             role={saveState === 'failed' ? 'alert' : 'status'}

--- a/openless-all/app/src/state/HotkeySettingsContext.tsx
+++ b/openless-all/app/src/state/HotkeySettingsContext.tsx
@@ -17,6 +17,7 @@ interface HotkeySettingsContextValue {
   hotkey: HotkeyBinding | null;
   capability: HotkeyCapability | null;
   loading: boolean;
+  error: string | null;
   refresh: () => Promise<void>;
   updatePrefs: (
     next: UserPreferences | ((current: UserPreferences) => UserPreferences),
@@ -25,18 +26,45 @@ interface HotkeySettingsContextValue {
 
 const HotkeySettingsContext = createContext<HotkeySettingsContextValue | null>(null);
 
+const errorMessage = (error: unknown) =>
+  String(error instanceof Error ? error.message : error);
+
 export function HotkeySettingsProvider({ children }: { children: ReactNode }) {
   const [prefs, setPrefs] = useState<UserPreferences | null>(null);
   const [capability, setCapability] = useState<HotkeyCapability | null>(null);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
   const persistQueueRef = useRef<Promise<void>>(Promise.resolve());
   const latestPrefsRef = useRef<UserPreferences | null>(null);
 
   const refresh = useCallback(async () => {
-    const [nextPrefs, nextCapability] = await Promise.all([getSettings(), getHotkeyCapability()]);
-    setPrefs(nextPrefs);
-    setCapability(nextCapability);
-    setLoading(false);
+    setLoading(true);
+    setError(null);
+    try {
+      const [prefsResult, capabilityResult] = await Promise.allSettled([
+        getSettings(),
+        getHotkeyCapability(),
+      ]);
+      let nextError: string | null = null;
+      if (prefsResult.status === 'fulfilled') {
+        setPrefs(prefsResult.value);
+      } else {
+        console.error('[hotkey-settings] failed to load preferences', prefsResult.reason);
+        nextError = errorMessage(prefsResult.reason);
+      }
+      if (capabilityResult.status === 'fulfilled') {
+        setCapability(capabilityResult.value);
+      } else {
+        console.error('[hotkey-settings] failed to load hotkey capability', capabilityResult.reason);
+        nextError = errorMessage(capabilityResult.reason);
+      }
+      setError(nextError);
+    } catch (error) {
+      console.error('[hotkey-settings] failed to refresh hotkey settings', error);
+      setError(errorMessage(error));
+    } finally {
+      setLoading(false);
+    }
   }, []);
 
   const queueSetSettings = useCallback((resolveNext: (current: UserPreferences) => UserPreferences) => {
@@ -137,10 +165,11 @@ export function HotkeySettingsProvider({ children }: { children: ReactNode }) {
       hotkey: prefs?.hotkey ?? null,
       capability,
       loading,
+      error,
       refresh,
       updatePrefs,
     }),
-    [capability, loading, prefs, refresh, updatePrefs],
+    [capability, error, loading, prefs, refresh, updatePrefs],
   );
 
   return <HotkeySettingsContext.Provider value={value}>{children}</HotkeySettingsContext.Provider>;


### PR DESCRIPTION
### **User description**
## 变更内容
- 修复 `HotkeySettingsContext.refresh()` 任一 IPC 失败后 `loading` 永远不释放的问题。
- 新增 context 级 `error`，`refresh()` 使用 `finally` 保证退出 loading，并保留成功返回的 prefs/capability 半边状态。
- 在翻译页展示“设置加载失败”错误和重试按钮，避免用户只看到永久加载态。
- 补齐新增错误/重试文案的简中、繁中、英文、日文、韩文翻译。

## 验证
- `git diff --check`
- `cd openless-all/app && npm run build`
- `cd openless-all/app && cargo check --manifest-path src-tauri/Cargo.toml`（仅既有 warning）

Closes #316


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fix permanent loading state on IPC failure using `Promise.allSettled` and `finally`
  - Always release loading even when one call rejects
  - Keep partially successful data (prefs or capability)

- Add `error` state to HotkeySettingsContext for consumers

- Show localized error alert and retry button in Translation page

- Add `retry` and `settingsLoadFailed` keys to all five locales


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["HotkeySettingsProvider.refresh()"] --> B["Promise.allSettled(getSettings, getHotkeyCapability)"]
  B -- "fulfilled" --> C["setPrefs / setCapability (partial success)"]
  B -- "rejected" --> D["setError(reason)"]
  C --> E["finally { setLoading(false) }"]
  D --> E
  E --> F["Context value updated with error"]
  F --> G["Translation page shows alert + retry button"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>en.ts</strong><dd><code>Add retry and load failure i18n keys</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/appergb/openless/pull/351/files#diff-bb2f4fa05787923f8aeb23b6f11ad8705e02d9ff03a45790f9181e4615c79d83">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ja.ts</strong><dd><code>Add retry and load failure i18n keys</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/appergb/openless/pull/351/files#diff-be57f0090cf34e3ff924cfa35f13d5d9e6514d3af5a1ebfdeb92bd7d36ed9cf4">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ko.ts</strong><dd><code>Add retry and load failure i18n keys</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/appergb/openless/pull/351/files#diff-daf35bcb6a2f8a31565b83d119cb59b69c1dededbabfccfd0d56693fdb3726ca">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>zh-CN.ts</strong><dd><code>Add retry and load failure i18n keys</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/appergb/openless/pull/351/files#diff-571576f3c7b6c4a78ae0f91accdccc5da5cbed00409955c9914c046fee6c80ea">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>zh-TW.ts</strong><dd><code>Add retry and load failure i18n keys</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/appergb/openless/pull/351/files#diff-a8d5953f9c76bc3c90ec583270be04c852bd7540297500e6ff3260760fc61ea4">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>Translation.tsx</strong><dd><code>Display error alert and retry on load failure</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/appergb/openless/pull/351/files#diff-ac2243e818f550360a2beccf9a687f0e6c42d75fe8736a09d8823d15d20bc761">+69/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>HotkeySettingsContext.tsx</strong><dd><code>Handle IPC failures with error state and finally</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/appergb/openless/pull/351/files#diff-e62674662a221b573ac2fb80bbe6aa101479533cce21f3d9414ad6c08642d614">+34/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

