### PR TITLE
chore: bump version to 1.2.24-4 (Beta-4)

### DIFF
--- a/openless-all/app/package-lock.json
+++ b/openless-all/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openless-app",
-  "version": "1.2.24-3",
+  "version": "1.2.24-4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openless-app",
-      "version": "1.2.24-3",
+      "version": "1.2.24-4",
       "dependencies": {
         "@tauri-apps/api": "^2.1.1",
         "@tauri-apps/plugin-autostart": "^2.5.1",

--- a/openless-all/app/package.json
+++ b/openless-all/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openless-app",
   "private": true,
-  "version": "1.2.24-3",
+  "version": "1.2.24-4",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/openless-all/app/src-tauri/Cargo.lock
+++ b/openless-all/app/src-tauri/Cargo.lock
@@ -3751,7 +3751,7 @@ dependencies = [
 
 [[package]]
 name = "openless"
-version = "1.2.24-3"
+version = "1.2.24-4"
 dependencies = [
  "anyhow",
  "arboard",

--- a/openless-all/app/src-tauri/Cargo.toml
+++ b/openless-all/app/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openless"
-version = "1.2.24-3"
+version = "1.2.24-4"
 description = "OpenLess — local voice input that types where your cursor is"
 authors = ["OpenLess"]
 edition = "2021"

--- a/openless-all/app/src-tauri/tauri.conf.json
+++ b/openless-all/app/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "OpenLess",
-  "version": "1.2.24-3",
+  "version": "1.2.24-4",
   "identifier": "com.openless.app",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
### **User description**
Beta 第 4 次发布。版本号 1.2.24-3 → 1.2.24-4。包含自 Beta-3 以来的合入：

- #340 Foundry Windows App Runtime prompt fix
- #355 history retention + conversation-aware polish (含 4 个 unit test 锁死"不复读上文"逻辑)
- #356 icon padding (修 #354 Dock 图标过大)
- #357 启动时静默运行开关

5 文件 6 处版本号同步，CI version-sync 本地预检通过；cargo check + cargo test --lib 139/139 + npm run build + 完整本地 release build 全部干净。


___

### **PR Type**
Other


___

### **Description**
- Bump version from 1.2.24-3 to 1.2.24-4

- Update version in package.json, Cargo.toml, and tauri.conf.json


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>package.json</strong><dd><code>Bump version in package.json</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/package.json

- Bump version from 1.2.24-3 to 1.2.24-4


</details>


  </td>
  <td><a href="https://github.com/appergb/openless/pull/358/files#diff-2650f8aa2f7ec97aa8af47f1f8a7c9ae4677fb69754b20d554e1d542507cf4ea">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Cargo.toml</strong><dd><code>Bump version in Cargo.toml</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src-tauri/Cargo.toml

- Bump version from 1.2.24-3 to 1.2.24-4


</details>


  </td>
  <td><a href="https://github.com/appergb/openless/pull/358/files#diff-334952ba03e62939865bbf0351f0916ea88c6457f8ea1259336e73ee4e2f088b">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>tauri.conf.json</strong><dd><code>Bump version in tauri.conf.json</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src-tauri/tauri.conf.json

- Bump version from 1.2.24-3 to 1.2.24-4


</details>


  </td>
  <td><a href="https://github.com/appergb/openless/pull/358/files#diff-e9c2f15638ea988f61c82aeb2257147fb9cc96d7bda8709e8bad6b6517f5369c">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

