### PR TITLE
security: 为 Tauri WebView 启用最小 CSP

### DIFF
--- a/docs/tauri-csp.md
+++ b/docs/tauri-csp.md
@@ -1,0 +1,10 @@
+# Tauri CSP 边界
+
+OpenLess 的桌面 WebView 已在 `openless-all/app/src-tauri/tauri.conf.json` 启用最小 CSP。该策略只放开前端渲染和 Tauri IPC 必需的来源：
+
+- `script-src 'self'`：脚本只允许随应用打包的前端产物；Tauri 会在构建时为自身注入脚本补齐必要 nonce / hash。
+- `connect-src 'self' ipc: http://ipc.localhost http://localhost:1420 ws://localhost:1420`：允许同源连接、Tauri IPC，以及 Vite 开发模式的本机 HTTP / HMR 连接。
+- `style-src 'self' 'unsafe-inline' https://fonts.googleapis.com` 与 `font-src https://fonts.gstatic.com`：当前 React 页面大量使用 `style={{ ... }}` 保持设计稿像素对齐，因此短期保留 inline style；外部字体只允许 Google Fonts 相关域名。
+- `object-src 'none'`、`base-uri 'none'`、`form-action 'none'`、`frame-ancestors 'none'`：关闭插件对象、base URL、表单提交和嵌入入口。
+
+Provider 校验、ASR/LLM 请求、更新检查、本地 ASR 模型下载等网络访问都在 Rust / Tauri plugin 侧执行，不通过 WebView 的 `fetch` 直连外部服务，因此不在 WebView CSP 中放开 provider 域名。QA markdown 的 sanitizer 仍是第一道防线；CSP 只作为纵深防御。

--- a/openless-all/app/src-tauri/tauri.conf.json
+++ b/openless-all/app/src-tauri/tauri.conf.json
@@ -66,7 +66,18 @@
       }
     ],
     "security": {
-      "csp": null
+      "csp": {
+        "default-src": "'self' customprotocol: asset:",
+        "script-src": "'self'",
+        "style-src": "'self' 'unsafe-inline' https://fonts.googleapis.com",
+        "font-src": "'self' https://fonts.gstatic.com",
+        "img-src": "'self' asset: http://asset.localhost blob: data:",
+        "connect-src": "'self' ipc: http://ipc.localhost http://localhost:1420 ws://localhost:1420",
+        "object-src": "'none'",
+        "base-uri": "'none'",
+        "form-action": "'none'",
+        "frame-ancestors": "'none'"
+      }
     }
   },
   "bundle": {


### PR DESCRIPTION
### **User description**
## 概述

- 将 Tauri WebView 从 `csp: null` 改为最小 CSP，避免无说明地关闭纵深防御。
- 限制脚本、对象、base URL、表单提交和嵌入来源，只保留 Tauri IPC 与开发模式本机连接。
- 增加 `docs/tauri-csp.md` 记录 CSP 边界，说明 provider / updater / 模型下载走 Rust 侧，不在 WebView CSP 放开外部域名。

## 验证

- `npm run build`
- `npm run tauri -- info`
- `cargo check --manifest-path src-tauri/Cargo.toml`

Closes #226


___

### **PR Type**
Enhancement, Documentation


___

### **Description**
- Replaced null CSP with minimal Content Security Policy.

- Restricted script, object, base, form, frame sources.

- Allowed only IPC, local dev, and inline styles.

- Added `docs/tauri-csp.md` explaining boundaries and Rust networking.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Previous: WebView with csp: null"] -- "Enforce" --> B["Minimal CSP enabled"]
  B --> C["script-src: self-only"]
  B --> D["connect-src: IPC & local dev"]
  B --> E["object-src, base-uri, form-action: none"]
  B --> F["New doc: tauri-csp.md"]
  D -- "Keeps networking on Rust side" --> G["Provider/updater/model requests"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>tauri-csp.md</strong><dd><code>Document CSP boundaries and rationale</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/tauri-csp.md

<ul><li>Added documentation explaining the minimal CSP and its boundaries.<br> <li> Lists permitted sources for scripts, styles, fonts, and connections.<br> <li> Clarifies that provider/updater/model networking uses Rust, not <br>WebView fetch.<br> <li> Notes CSP is defense-in-depth; QA sanitizer remains primary XSS <br>defense.</ul>


</details>


  </td>
  <td><a href="https://github.com/appergb/openless/pull/359/files#diff-51c20b183c5cbbbe16618fff21592ab431c5f31374001643ba0a5409df079209">+10/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Security</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>tauri.conf.json</strong><dd><code>Enable minimal CSP in Tauri WebView config</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src-tauri/tauri.conf.json

<ul><li>Replaced <code>csp: null</code> with a minimal Content Security Policy.<br> <li> Set <code>script-src</code> to <code>'self'</code>, <code>object-src</code>/<code>base-uri</code>/<code>form-action</code> to <code>'none'</code>.<br> <li> Allowed <code>connect-src</code> only for <code>ipc:</code>, <code>localhost:1420</code>, and WebSocket HMR.<br> <li> Permitted inline styles and Google Fonts for current React UI <br>implementation.</ul>


</details>


  </td>
  <td><a href="https://github.com/appergb/openless/pull/359/files#diff-e9c2f15638ea988f61c82aeb2257147fb9cc96d7bda8709e8bad6b6517f5369c">+12/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

