### PR TITLE
fix(installer): unregister TSF IME before replacing OpenLessIme.dll on upgrade (#321)

### DIFF
--- a/openless-all/app/package-lock.json
+++ b/openless-all/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openless-app",
-  "version": "1.2.24-4",
+  "version": "1.2.24-5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openless-app",
-      "version": "1.2.24-4",
+      "version": "1.2.24-5",
       "dependencies": {
         "@tauri-apps/api": "^2.1.1",
         "@tauri-apps/plugin-autostart": "^2.5.1",

--- a/openless-all/app/package.json
+++ b/openless-all/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openless-app",
   "private": true,
-  "version": "1.2.24-4",
+  "version": "1.2.24-5",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/openless-all/app/src-tauri/Cargo.lock
+++ b/openless-all/app/src-tauri/Cargo.lock
@@ -3751,7 +3751,7 @@ dependencies = [
 
 [[package]]
 name = "openless"
-version = "1.2.24-4"
+version = "1.2.24-5"
 dependencies = [
  "anyhow",
  "arboard",

--- a/openless-all/app/src-tauri/Cargo.toml
+++ b/openless-all/app/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openless"
-version = "1.2.24-4"
+version = "1.2.24-5"
 description = "OpenLess — local voice input that types where your cursor is"
 authors = ["OpenLess"]
 edition = "2021"

--- a/openless-all/app/src-tauri/nsis/openless-ime-hooks.nsh
+++ b/openless-all/app/src-tauri/nsis/openless-ime-hooks.nsh
@@ -56,12 +56,34 @@
   !insertmacro OPENLESS_IME_ABORT_IF_FAILED $0 "x86 registration"
 !macroend
 
-!macro NSIS_HOOK_PREINSTALL
-  SetOutPath "$INSTDIR\windows-ime\x64"
-  File /oname=OpenLessIme.dll "$%OPENLESS_IME_DLL_X64%"
+!macro OPENLESS_IME_STAGE_AND_REPLACE PLATFORM_DIR ENV_VAR
+  ; Write new bytes to OpenLessIme.dll.new, then atomically replace the old file.
+  ; If the old DLL is still mapped into TSF client processes (browsers, IDEs,
+  ; chat apps, ...) and Delete fails, queue the rename for next reboot via
+  ; PendingFileRenameOperations. Issue #321.
+  SetOutPath "$INSTDIR\windows-ime\${PLATFORM_DIR}"
+  File /oname=OpenLessIme.dll.new "$%${ENV_VAR}%"
+  ClearErrors
+  Delete "$INSTDIR\windows-ime\${PLATFORM_DIR}\OpenLessIme.dll"
+  ${If} ${Errors}
+    DetailPrint "OpenLessIme.dll (${PLATFORM_DIR}) is in use; queuing replacement at next reboot"
+    Rename /REBOOTOK "$INSTDIR\windows-ime\${PLATFORM_DIR}\OpenLessIme.dll.new" "$INSTDIR\windows-ime\${PLATFORM_DIR}\OpenLessIme.dll"
+    SetRebootFlag true
+  ${Else}
+    Rename "$INSTDIR\windows-ime\${PLATFORM_DIR}\OpenLessIme.dll.new" "$INSTDIR\windows-ime\${PLATFORM_DIR}\OpenLessIme.dll"
+  ${EndIf}
+!macroend
 
-  SetOutPath "$INSTDIR\windows-ime\x86"
-  File /oname=OpenLessIme.dll "$%OPENLESS_IME_DLL_X86%"
+!macro NSIS_HOOK_PREINSTALL
+  ; Upgrade path: release the COM/TSF registration so new client processes won't
+  ; bind to the old DLL while we replace it. Fresh install: regsvr32 /u against
+  ; a missing DLL is harmless — the existing UNREGISTER macros log the exit code
+  ; and continue without aborting.
+  !insertmacro OPENLESS_IME_UNREGISTER_X86
+  !insertmacro OPENLESS_IME_UNREGISTER_X64
+
+  !insertmacro OPENLESS_IME_STAGE_AND_REPLACE "x64" "OPENLESS_IME_DLL_X64"
+  !insertmacro OPENLESS_IME_STAGE_AND_REPLACE "x86" "OPENLESS_IME_DLL_X86"
 
   SetOutPath "$INSTDIR"
 !macroend

--- a/openless-all/app/src-tauri/tauri.conf.json
+++ b/openless-all/app/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "OpenLess",
-  "version": "1.2.24-4",
+  "version": "1.2.24-5",
   "identifier": "com.openless.app",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/openless-all/app/src-tauri/wix/openless-ime.wxs
+++ b/openless-all/app/src-tauri/wix/openless-ime.wxs
@@ -45,8 +45,13 @@
       Return="ignore" />
 
     <InstallExecuteSequence>
-      <Custom Action="UnregisterOpenLessImeX86" Before="RemoveFiles"><![CDATA[REMOVE="ALL"]]></Custom>
-      <Custom Action="UnregisterOpenLessImeX64" Before="UnregisterOpenLessImeX86"><![CDATA[REMOVE="ALL"]]></Custom>
+      <!-- Issue #321: unregister the old DLL before InstallFiles whenever a
+           previous version is installed, so Windows Installer can overwrite
+           OpenLessIme.dll instead of failing on a sharing violation. The
+           previous condition (REMOVE="ALL") only fired during dedicated
+           uninstall and skipped the auto-update / minor-upgrade path. -->
+      <Custom Action="UnregisterOpenLessImeX86" Before="InstallFiles"><![CDATA[Installed AND NOT REMOVE]]></Custom>
+      <Custom Action="UnregisterOpenLessImeX64" Before="UnregisterOpenLessImeX86"><![CDATA[Installed AND NOT REMOVE]]></Custom>
       <Custom Action="RegisterOpenLessImeX64" After="InstallFiles"><![CDATA[NOT REMOVE]]></Custom>
       <Custom Action="RegisterOpenLessImeX86" After="RegisterOpenLessImeX64"><![CDATA[NOT REMOVE]]></Custom>
     </InstallExecuteSequence>


### PR DESCRIPTION
### **User description**
## Summary

Closes #321 — Windows auto-update was failing with `OpenLessIme.dll` reported as locked / unwritable.

`OpenLessIme.dll` is the OpenLess TSF input method. After registration via `regsvr32`, Windows maps the DLL into **every** text-input client process — browsers, IDEs, chat apps, even Notepad. The previous installer hooks tried to overwrite the DLL directly during upgrade, hit a sharing violation, and aborted. Both the NSIS and WiX paths had the same gap: unregister-before-replace only ran on a dedicated uninstall, never on the upgrade / auto-update path.

## Changes

- **NSIS** (`src-tauri/nsis/openless-ime-hooks.nsh`)
  - `NSIS_HOOK_PREINSTALL` now calls the existing `OPENLESS_IME_UNREGISTER_X86/X64` macros first. Releasing COM/TSF registration prevents new client processes from binding to the old DLL while we replace it. Fresh install is a harmless no-op.
  - New helper `OPENLESS_IME_STAGE_AND_REPLACE` writes the new bytes to `OpenLessIme.dll.new`, deletes the old file, and renames in. If the old DLL is still locked, falls back to `Rename /REBOOTOK` + `SetRebootFlag true` — Windows queues the rename via `PendingFileRenameOperations` and the new bytes activate after the next reboot. The TSF registration path is preserved, so re-registering in `POSTINSTALL` remains valid across the reboot.

- **WiX** (`src-tauri/wix/openless-ime.wxs`)
  - `UnregisterOpenLessImeX86/X64` now also fire `Before="InstallFiles"` when `Installed AND NOT REMOVE`. The original `REMOVE="ALL"` + `Before="RemoveFiles"` condition only covered standalone uninstall and skipped the auto-update / minor-upgrade path entirely — same root cause as NSIS.

- **Version bump** → `1.2.24-5` (Beta-5) across `package.json`, `package-lock.json`, `tauri.conf.json`, `Cargo.toml`, `Cargo.lock`.

## Test plan

- [ ] Build NSIS bundle locally on a Windows host, install 1.2.24-4, exercise the IME (open Notepad, type with the OpenLess IME selected), then run the 1.2.24-5 installer in-place. Update should complete without the locked-DLL error.
- [ ] Same flow with WiX `.msi`.
- [ ] Confirm reboot-pending fallback: hold the IME open in a long-running process, run the upgrade, expect the installer to succeed, see "restart required" semantics, reboot, verify new DLL bytes load.
- [ ] Smoke test fresh install (no prior version) to verify the new `regsvr32 /u` no-op path doesn't abort the installer.

## Notes / caveats

- Cannot be verified on macOS CI; **needs a Windows host smoke test before merging beta → main**, per `CLAUDE.md`'s two-platform smoke gate.
- Old DLL ↔ new main-app IPC may be temporarily mismatched between the upgrade and the next reboot when the reboot-pending fallback is taken. If the protocol in `windows_ime_protocol.rs` changes incompatibly in a future release, the main app should detect version drift and degrade gracefully — not in scope here.


___

### **PR Type**
Bug fix


___

### **Description**
- NSIS installer: unregister TSF IME before replacing `OpenLessIme.dll` to prevent sharing violation

- New `OPENLESS_IME_STAGE_AND_REPLACE` macro atomically replaces DLL, with reboot fallback if file is in use

- WiX installer: unregister IME during upgrades (`Installed AND NOT REMOVE`) instead of only on full uninstall

- Version bump to 1.2.24-5 (Beta-5)


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["NSIS PREINSTALL"] -- "unregister x86 & x64" --> B["STAGE_AND_REPLACE macro"]
  B -- "write new DLL, delete old" --> C{"Delete OK?"}
  C -- "yes" --> D["Rename new -> old"]
  C -- "no (in use)" --> E["Queue rename on reboot"]
  F["WiX InstallExecuteSequence"] -- "UnregisterOpenLessIme before InstallFiles" --> G["InstallFiles overwrite"]
  G --> H["Register IME after InstallFiles"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>openless-ime-hooks.nsh</strong><dd><code>Add staged DLL replacement with reboot fallback for locked IME file</code></dd></summary>
<hr>

openless-all/app/src-tauri/nsis/openless-ime-hooks.nsh

<ul><li>Added <code>OPENLESS_IME_STAGE_AND_REPLACE</code> macro: writes new DLL as <code>.new</code>, <br>deletes old, renames atomically; if delete fails, queues rename on <br>reboot via <code>Rename /REBOOTOK</code> and sets reboot flag<br> <li> Modified <code>NSIS_HOOK_PREINSTALL</code> to call unregister macros for x86 and <br>x64 IME before calling <code>STAGE_AND_REPLACE</code> for each platform<br> <li> Fresh installs are unaffected as unregister macros are harmless no-ops <br>when the DLL is missing</ul>


</details>


  </td>
  <td><a href="https://github.com/appergb/openless/pull/369/files#diff-368c4067ed1d20a5d2a3b93128b13800eaf60fe1d616cd1e35310734457c0a53">+26/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>openless-ime.wxs</strong><dd><code>Trigger IME unregistration on upgrade to prevent sharing violation in </code><br><code>WiX</code></dd></summary>
<hr>

openless-all/app/src-tauri/wix/openless-ime.wxs

<ul><li>Changed <code>UnregisterOpenLessImeX86</code> and <code>UnregisterOpenLessImeX64</code> custom <br>action conditions from <code>REMOVE="ALL"</code> to <code>Installed AND NOT REMOVE</code><br> <li> Moved unregister actions to <code>Before="InstallFiles"</code> to release old DLL <br>before overwrite during upgrades<br> <li> Registration actions remain after <code>InstallFiles</code> to re-register the new <br>DLL</ul>


</details>


  </td>
  <td><a href="https://github.com/appergb/openless/pull/369/files#diff-985611b7c97c134e8b9b96c56b3ae223a35460cbe5da351cdbfa6fd1151b7f76">+7/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>package.json</strong><dd><code>Bump version to 1.2.24-5</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/package.json

- Bumped version from `1.2.24-4` to `1.2.24-5`


</details>


  </td>
  <td><a href="https://github.com/appergb/openless/pull/369/files#diff-2650f8aa2f7ec97aa8af47f1f8a7c9ae4677fb69754b20d554e1d542507cf4ea">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Cargo.toml</strong><dd><code>Bump version to 1.2.24-5</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src-tauri/Cargo.toml

- Bumped version from `1.2.24-4` to `1.2.24-5`


</details>


  </td>
  <td><a href="https://github.com/appergb/openless/pull/369/files#diff-334952ba03e62939865bbf0351f0916ea88c6457f8ea1259336e73ee4e2f088b">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>tauri.conf.json</strong><dd><code>Bump version to 1.2.24-5</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src-tauri/tauri.conf.json

- Bumped version from `1.2.24-4` to `1.2.24-5`


</details>


  </td>
  <td><a href="https://github.com/appergb/openless/pull/369/files#diff-e9c2f15638ea988f61c82aeb2257147fb9cc96d7bda8709e8bad6b6517f5369c">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

