### PR TITLE
让 Windows CI 真正运行 Rust 后端单测

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,10 +49,6 @@ jobs:
           cache-dependency-path: openless-all/app/package-lock.json
 
       - uses: dtolnay/rust-toolchain@stable
-        if: runner.os != 'Windows'
-
-      - uses: dtolnay/rust-toolchain@1.77.0
-        if: runner.os == 'Windows'
 
       - name: Install Linux check dependencies
         if: runner.os == 'Linux'
@@ -77,6 +73,11 @@ jobs:
         if: matrix.preflight
         shell: pwsh
         run: ./scripts/windows-preflight.ps1 -Toolchain msvc
+
+      - name: Install Windows unit-test target
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: rustup target add x86_64-win7-windows-msvc
 
       - name: Check PowerShell scripts
         if: matrix.preflight
@@ -107,12 +108,13 @@ jobs:
         run: |
           # 产品默认构建仍通过 cargo check 覆盖 Foundry 链接形态，单测门禁
           # 用无 Foundry native 链接的构建来真正执行 Windows 后端测试。
-          # Windows 测试固定到 Cargo.toml 声明的 MSRV 1.77，避开 rustc
-          # 1.78+ test harness 在 GitHub runner 上触发的 WaitOnAddress
-          # API-set loader 问题。
+          # Windows 单测使用 win7 target，让 std 走兼容路径，避开
+          # GitHub runner 上 Rust test harness 直接导入 WaitOnAddress 的
+          # API-set loader 问题；默认 Windows target 仍由 cargo check 覆盖。
           $env:CARGO_TARGET_DIR = Join-Path (Get-Location) "src-tauri\target\windows-unit-tests"
           cargo test `
             --manifest-path src-tauri/Cargo.toml `
+            --target x86_64-win7-windows-msvc `
             --lib `
             --no-default-features `
             --features custom-protocol

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,20 +126,27 @@ jobs:
         if: runner.os != 'Windows'
         run: cargo test --manifest-path src-tauri/Cargo.toml --lib
 
+      - name: Install nightly Rust source for Windows unit tests
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: rustup toolchain install nightly --profile minimal --component rust-src --no-self-update
+
       - name: Run Rust backend unit tests (Windows)
         if: runner.os == 'Windows'
         shell: pwsh
         run: |
           # 产品默认构建仍通过 cargo check 覆盖 Foundry 链接形态，单测门禁
           # 用无 Foundry native 链接的构建来真正执行 Windows 后端测试。
-          # GitHub runner 的普通 PATH 会先命中 Git 自带的 link.exe；
-          # 单测链接与执行都显式进入 VS DevCmd，确保走 MSVC 链接环境。
+          # 默认 Windows target 的 stable test harness 会在 runner 上因
+          # WaitOnAddress API-set 入口缺失而进程启动失败。单测执行改用
+          # nightly build-std 构建 win7 target 的 std 兼容路径；默认 Windows
+          # target 仍由上面的 stable cargo check 覆盖。
           $env:CARGO_TARGET_DIR = Join-Path (Get-Location) "src-tauri\target\windows-unit-tests"
           $vswhere = Join-Path ${env:ProgramFiles(x86)} "Microsoft Visual Studio\Installer\vswhere.exe"
           $vsInstall = & $vswhere -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath
           $vsDevCmd = Join-Path $vsInstall "Common7\Tools\VsDevCmd.bat"
           $targetDir = $env:CARGO_TARGET_DIR
-          $command = "call `"$vsDevCmd`" -arch=x64 -host_arch=x64 && set `"CARGO_TARGET_DIR=$targetDir`" && cargo test --manifest-path src-tauri/Cargo.toml --lib --no-default-features --features custom-protocol"
+          $command = "call `"$vsDevCmd`" -arch=x64 -host_arch=x64 && set `"CARGO_TARGET_DIR=$targetDir`" && cargo +nightly test -Z build-std=std,panic_unwind --target x86_64-win7-windows-msvc --manifest-path src-tauri/Cargo.toml --lib --no-default-features --features custom-protocol"
           & cmd.exe /d /s /c $command
           if ($LASTEXITCODE -ne 0) {
             exit $LASTEXITCODE

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,10 @@ jobs:
           - os: macos-latest
             label: macOS
             preflight: false
-          - os: windows-latest
+          # windows-latest 当前指向 Windows Server 2025；Rust lib test harness
+          # 在该镜像启动时会遇到 STATUS_ENTRYPOINT_NOT_FOUND。CI 先固定到
+          # Windows Server 2022，确保真正执行后端单测，而不是退回 --no-run。
+          - os: windows-2022
             label: Windows
             preflight: true
           - os: ubuntu-latest
@@ -95,12 +98,34 @@ jobs:
         if: runner.os != 'Windows'
         run: cargo test --manifest-path src-tauri/Cargo.toml --lib
 
-      - name: Compile Rust backend unit tests (Windows)
-        # Windows runner 能链接 lib test binary，但干净镜像缺少可选 native runtime
-        # DLL entrypoint 时，进程会在 test harness 启动前退出。这里保留 cfg/link
-        # 覆盖；共享单测在 macOS / Linux 上实际执行。
+      - name: Run Rust backend unit tests (Windows)
         if: runner.os == 'Windows'
-        run: cargo test --manifest-path src-tauri/Cargo.toml --lib --no-run
+        run: |
+          # Foundry/WinML SDK 在 GitHub Windows Server runner 上会让 test
+          # harness 启动前因 native entrypoint 退出；产品默认构建仍通过
+          # cargo check 覆盖该链接形态，单测门禁用无 native Foundry 链接的
+          # 构建来真正执行 Windows 后端测试。
+          cargo test --manifest-path src-tauri/Cargo.toml --lib --no-default-features --features custom-protocol
+          $testExit = $LASTEXITCODE
+          if ($testExit -ne 0) {
+            $testExe = Get-ChildItem -Path "src-tauri\target\debug\deps" -Filter "openless_lib-*.exe" |
+              Sort-Object LastWriteTime -Descending |
+              Select-Object -First 1
+            if ($testExe) {
+              Write-Host "[ci] failed test exe: $($testExe.FullName)"
+              $vswhere = Join-Path ${env:ProgramFiles(x86)} "Microsoft Visual Studio\Installer\vswhere.exe"
+              if (Test-Path $vswhere) {
+                $dumpbin = & $vswhere -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -find "VC\Tools\MSVC\**\bin\Hostx64\x64\dumpbin.exe" 2>$null | Select-Object -First 1
+                if ($dumpbin -and (Test-Path $dumpbin)) {
+                  Write-Host "[ci] dumpbin dependents"
+                  & $dumpbin /dependents $testExe.FullName
+                  Write-Host "[ci] dumpbin imports summary"
+                  & $dumpbin /imports $testExe.FullName | Select-String -Pattern "DLL Name|api-ms|VCRUNTIME|WebView2|Foundry|onnx|Mdd|WaitOnAddress|GetThreadDescription|LocalFree"
+                }
+              }
+            }
+            exit $testExit
+          }
 
       - name: Verify version sync across all 5 files
         # 两个平台都跑这个校验：Windows runner 自带 git-bash，跨 shell 表现一致。

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,7 +119,8 @@ jobs:
           # api-ms-win-core-synch-l1-2-0.dll。GitHub runner 上该 API-set
           # 解析缺 entrypoint 时，测试进程会在任何单测运行前退出。这里先
           # no-run 产出测试 exe，再把该 import 指向 Server 2022 自带且导出
-          # WaitOnAddress 的 KernelBase.dll，最后仍然执行 cargo test。
+          # WaitOnAddress 的 KernelBase.dll，然后直接执行已修补的 test
+          # harness；避免再次 cargo test 触发重新链接并覆盖补丁。
           cargo test @testArgs --no-run
           if ($LASTEXITCODE -ne 0) {
             exit $LASTEXITCODE
@@ -133,7 +134,7 @@ jobs:
           $replacement = New-Object byte[] $needle.Length
           $replacementBytes = $encoding.GetBytes($replacementText)
           [Array]::Copy($replacementBytes, $replacement, $replacementBytes.Length)
-          $patchedAny = $false
+          $patchedExes = @()
           Get-ChildItem -Path $depsDir -Filter "openless_lib-*.exe" | ForEach-Object {
             $bytes = [System.IO.File]::ReadAllBytes($_.FullName)
             $text = $encoding.GetString($bytes)
@@ -142,19 +143,29 @@ jobs:
             while ($offset -ge 0) {
               [Array]::Copy($replacement, 0, $bytes, $offset, $replacement.Length)
               $patchedThis = $true
-              $patchedAny = $true
               $offset = $text.IndexOf($needleText, $offset + $needle.Length, [System.StringComparison]::Ordinal)
             }
             if ($patchedThis) {
               [System.IO.File]::WriteAllBytes($_.FullName, $bytes)
+              $patchedExes += $_.FullName
               Write-Host "[ci] Patched Windows Rust test import to KernelBase.dll: $($_.FullName)"
             }
           }
-          if (-not $patchedAny) {
+          if ($patchedExes.Count -eq 0) {
             throw "api-ms-win-core-synch-l1-2-0.dll import not found in Windows Rust test executable."
           }
 
-          cargo test @testArgs
+          foreach ($testExe in $patchedExes) {
+            $patchedText = $encoding.GetString([System.IO.File]::ReadAllBytes($testExe))
+            if ($patchedText.Contains($needleText)) {
+              throw "Windows Rust test executable still imports api-ms-win-core-synch-l1-2-0.dll: $testExe"
+            }
+            Write-Host "[ci] Running patched Windows Rust test executable: $testExe"
+            & $testExe
+            if ($LASTEXITCODE -ne 0) {
+              exit $LASTEXITCODE
+            }
+          }
 
       - name: Verify version sync across all 5 files
         # 两个平台都跑这个校验：Windows runner 自带 git-bash，跨 shell 表现一致。

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,14 +105,19 @@ jobs:
           # harness 启动前因 native entrypoint 退出；产品默认构建仍通过
           # cargo check 覆盖该链接形态，单测门禁用无 native Foundry 链接的
           # 构建来真正执行 Windows 后端测试。
+          # 单测使用独立 target 目录，避免前面的默认特性 cargo check 产物
+          # 影响无 Foundry native 链接的测试进程 DLL 搜索路径。
+          $env:CARGO_TARGET_DIR = Join-Path (Get-Location) "src-tauri\target\windows-unit-tests"
           cargo test --manifest-path src-tauri/Cargo.toml --lib --no-default-features --features custom-protocol
           $testExit = $LASTEXITCODE
           if ($testExit -ne 0) {
-            $testExe = Get-ChildItem -Path "src-tauri\target\debug\deps" -Filter "openless_lib-*.exe" |
+            $testExe = Get-ChildItem -Path (Join-Path $env:CARGO_TARGET_DIR "debug\deps") -Filter "openless_lib-*.exe" |
               Sort-Object LastWriteTime -Descending |
               Select-Object -First 1
             if ($testExe) {
               Write-Host "[ci] failed test exe: $($testExe.FullName)"
+              Write-Host "[ci] dlls beside failed test exe"
+              Get-ChildItem -Path $testExe.DirectoryName -Filter "*.dll" | Select-Object Name,Length | Format-Table -AutoSize
               $vswhere = Join-Path ${env:ProgramFiles(x86)} "Microsoft Visual Studio\Installer\vswhere.exe"
               if (Test-Path $vswhere) {
                 $dumpbin = & $vswhere -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -find "VC\Tools\MSVC\**\bin\Hostx64\x64\dumpbin.exe" 2>$null | Select-Object -First 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,15 +23,20 @@ jobs:
           - os: macos-latest
             label: macOS
             preflight: false
+            rust: stable
           # windows-latest 当前指向 Windows Server 2025；Rust lib test harness
           # 在该镜像启动时会遇到 STATUS_ENTRYPOINT_NOT_FOUND。CI 先固定到
           # Windows Server 2022，确保真正执行后端单测，而不是退回 --no-run。
           - os: windows-2022
             label: Windows
             preflight: true
+            # 1.88 是当前锁文件依赖的最高 MSRV；避免 newest stable
+            # 生成的 test harness 在 Windows runner 上导入缺失 entrypoint。
+            rust: 1.88.0
           - os: ubuntu-latest
             label: Linux
             preflight: false
+            rust: stable
     runs-on: ${{ matrix.os }}
     defaults:
       run:
@@ -50,6 +55,10 @@ jobs:
           cache-dependency-path: openless-all/app/package-lock.json
 
       - uses: dtolnay/rust-toolchain@stable
+        if: matrix.rust == 'stable'
+
+      - uses: dtolnay/rust-toolchain@1.88.0
+        if: matrix.rust == '1.88.0'
 
       - name: Install Linux check dependencies
         if: runner.os == 'Linux'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,10 @@ jobs:
           cache-dependency-path: openless-all/app/package-lock.json
 
       - uses: dtolnay/rust-toolchain@stable
+        if: runner.os != 'Windows'
+
+      - uses: dtolnay/rust-toolchain@1.77.0
+        if: runner.os == 'Windows'
 
       - name: Install Linux check dependencies
         if: runner.os == 'Linux'
@@ -101,71 +105,17 @@ jobs:
         if: runner.os == 'Windows'
         shell: pwsh
         run: |
-          # Foundry/WinML SDK 以及 Rust 1.78+ 的 Windows test harness 在
-          # GitHub runner 上都可能让进程启动前因 native entrypoint 退出。
           # 产品默认构建仍通过 cargo check 覆盖 Foundry 链接形态，单测门禁
           # 用无 Foundry native 链接的构建来真正执行 Windows 后端测试。
-          # 单测使用独立 target 目录，避免前面的默认特性 cargo check 产物
-          # 影响无 Foundry native 链接的测试进程 DLL 搜索路径。
+          # Windows 测试固定到 Cargo.toml 声明的 MSRV 1.77，避开 rustc
+          # 1.78+ test harness 在 GitHub runner 上触发的 WaitOnAddress
+          # API-set loader 问题。
           $env:CARGO_TARGET_DIR = Join-Path (Get-Location) "src-tauri\target\windows-unit-tests"
-          $testArgs = @(
-            "--manifest-path", "src-tauri/Cargo.toml",
-            "--lib",
-            "--no-default-features",
-            "--features", "custom-protocol"
-          )
-
-          # rustc 1.78+ 生成的 Windows 二进制会导入 WaitOnAddress 所在的
-          # api-ms-win-core-synch-l1-2-0.dll。GitHub runner 上该 API-set
-          # 解析缺 entrypoint 时，测试进程会在任何单测运行前退出。这里先
-          # no-run 产出测试 exe，再把该 import 指向 Server 2022 自带且导出
-          # WaitOnAddress 的 KernelBase.dll，然后直接执行已修补的 test
-          # harness；避免再次 cargo test 触发重新链接并覆盖补丁。
-          cargo test @testArgs --no-run
-          if ($LASTEXITCODE -ne 0) {
-            exit $LASTEXITCODE
-          }
-
-          $depsDir = Join-Path $env:CARGO_TARGET_DIR "debug\deps"
-          $needleText = "api-ms-win-core-synch-l1-2-0.dll" + [char]0
-          $replacementText = "kernelbase.dll" + [char]0
-          $encoding = [System.Text.Encoding]::GetEncoding("iso-8859-1")
-          $needle = $encoding.GetBytes($needleText)
-          $replacement = New-Object byte[] $needle.Length
-          $replacementBytes = $encoding.GetBytes($replacementText)
-          [Array]::Copy($replacementBytes, $replacement, $replacementBytes.Length)
-          $patchedExes = @()
-          Get-ChildItem -Path $depsDir -Filter "openless_lib-*.exe" | ForEach-Object {
-            $bytes = [System.IO.File]::ReadAllBytes($_.FullName)
-            $text = $encoding.GetString($bytes)
-            $offset = $text.IndexOf($needleText, [System.StringComparison]::Ordinal)
-            $patchedThis = $false
-            while ($offset -ge 0) {
-              [Array]::Copy($replacement, 0, $bytes, $offset, $replacement.Length)
-              $patchedThis = $true
-              $offset = $text.IndexOf($needleText, $offset + $needle.Length, [System.StringComparison]::Ordinal)
-            }
-            if ($patchedThis) {
-              [System.IO.File]::WriteAllBytes($_.FullName, $bytes)
-              $patchedExes += $_.FullName
-              Write-Host "[ci] Patched Windows Rust test import to KernelBase.dll: $($_.FullName)"
-            }
-          }
-          if ($patchedExes.Count -eq 0) {
-            throw "api-ms-win-core-synch-l1-2-0.dll import not found in Windows Rust test executable."
-          }
-
-          foreach ($testExe in $patchedExes) {
-            $patchedText = $encoding.GetString([System.IO.File]::ReadAllBytes($testExe))
-            if ($patchedText.Contains($needleText)) {
-              throw "Windows Rust test executable still imports api-ms-win-core-synch-l1-2-0.dll: $testExe"
-            }
-            Write-Host "[ci] Running patched Windows Rust test executable: $testExe"
-            & $testExe
-            if ($LASTEXITCODE -ne 0) {
-              exit $LASTEXITCODE
-            }
-          }
+          cargo test `
+            --manifest-path src-tauri/Cargo.toml `
+            --lib `
+            --no-default-features `
+            --features custom-protocol
 
       - name: Verify version sync across all 5 files
         # 两个平台都跑这个校验：Windows runner 自带 git-bash，跨 shell 表现一致。

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,8 +24,7 @@ jobs:
             label: macOS
             preflight: false
           # Rust 1.78+ 生成的 Windows 测试运行器会使用 WaitOnAddress。
-          # 先避开 windows-latest/Server 2025 的 runner 变量，固定到
-          # Server 2022，验证能否真正执行后端单测。
+          # 固定 Server 2022，减少 windows-latest/Server 2025 的镜像变量。
           - os: windows-2022
             label: Windows
             preflight: true
@@ -100,7 +99,115 @@ jobs:
 
       - name: Run Rust backend unit tests (Windows)
         if: runner.os == 'Windows'
-        run: cargo test --manifest-path src-tauri/Cargo.toml --lib --no-default-features --features custom-protocol
+        shell: pwsh
+        run: |
+          # Foundry/WinML SDK 以及 Rust 1.78+ 的 Windows test harness 在
+          # GitHub runner 上都可能让进程启动前因 native entrypoint 退出。
+          # 产品默认构建仍通过 cargo check 覆盖 Foundry 链接形态，单测门禁
+          # 用无 Foundry native 链接的构建来真正执行 Windows 后端测试。
+          # 单测使用独立 target 目录，避免前面的默认特性 cargo check 产物
+          # 影响无 Foundry native 链接的测试进程 DLL 搜索路径。
+          $env:CARGO_TARGET_DIR = Join-Path (Get-Location) "src-tauri\target\windows-unit-tests"
+          $testArgs = @(
+            "--manifest-path", "src-tauri/Cargo.toml",
+            "--lib",
+            "--no-default-features",
+            "--features", "custom-protocol"
+          )
+
+          # rustc 1.78+ 生成的 Windows 二进制会导入 WaitOnAddress 所在的
+          # api-ms-win-core-synch-l1-2-0.dll。GitHub runner 上该 API-set
+          # 解析缺 entrypoint 时，测试进程会在任何单测运行前退出。这里先
+          # no-run 产出测试 exe，再放置一个只转发 WaitOnAddress/WakeByAddress*
+          # 到 KernelBase/kernel32 的测试目录 shim，最后仍然执行 cargo test。
+          cargo test @testArgs --no-run
+          if ($LASTEXITCODE -ne 0) {
+            exit $LASTEXITCODE
+          }
+
+          $depsDir = Join-Path $env:CARGO_TARGET_DIR "debug\deps"
+          $shimSource = Join-Path $env:RUNNER_TEMP "openless-waitonaddress-shim.c"
+          @'
+          #define WIN32_LEAN_AND_MEAN
+          #define WaitOnAddress OpenLessShimHeaderWaitOnAddress
+          #define WakeByAddressSingle OpenLessShimHeaderWakeByAddressSingle
+          #define WakeByAddressAll OpenLessShimHeaderWakeByAddressAll
+          #include <windows.h>
+          #undef WaitOnAddress
+          #undef WakeByAddressSingle
+          #undef WakeByAddressAll
+
+          typedef BOOL (WINAPI *WaitOnAddressFn)(volatile VOID *, PVOID, SIZE_T, DWORD);
+          typedef VOID (WINAPI *WakeByAddressFn)(PVOID);
+
+          static FARPROC resolve_export(const char *name) {
+              const wchar_t *modules[] = { L"KernelBase.dll", L"kernel32.dll" };
+              for (int i = 0; i < 2; ++i) {
+                  HMODULE module = GetModuleHandleW(modules[i]);
+                  if (!module) {
+                      module = LoadLibraryW(modules[i]);
+                  }
+                  if (module) {
+                      FARPROC proc = GetProcAddress(module, name);
+                      if (proc) {
+                          return proc;
+                      }
+                  }
+              }
+              return NULL;
+          }
+
+          __declspec(dllexport) BOOL WINAPI WaitOnAddress(
+              volatile VOID *Address,
+              PVOID CompareAddress,
+              SIZE_T AddressSize,
+              DWORD dwMilliseconds
+          ) {
+              WaitOnAddressFn fn = (WaitOnAddressFn)resolve_export("WaitOnAddress");
+              if (!fn) {
+                  SetLastError(ERROR_CALL_NOT_IMPLEMENTED);
+                  return FALSE;
+              }
+              return fn(Address, CompareAddress, AddressSize, dwMilliseconds);
+          }
+
+          __declspec(dllexport) VOID WINAPI WakeByAddressSingle(PVOID Address) {
+              WakeByAddressFn fn = (WakeByAddressFn)resolve_export("WakeByAddressSingle");
+              if (fn) {
+                  fn(Address);
+              }
+          }
+
+          __declspec(dllexport) VOID WINAPI WakeByAddressAll(PVOID Address) {
+              WakeByAddressFn fn = (WakeByAddressFn)resolve_export("WakeByAddressAll");
+              if (fn) {
+                  fn(Address);
+              }
+          }
+          '@ | Set-Content -Path $shimSource -Encoding ASCII
+
+          $vswhere = Join-Path ${env:ProgramFiles(x86)} "Microsoft Visual Studio\Installer\vswhere.exe"
+          $vsDevCmd = $null
+          if (Test-Path $vswhere) {
+            $installPath = & $vswhere -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath 2>$null
+            if (-not [string]::IsNullOrWhiteSpace($installPath)) {
+              $vsDevCmd = Join-Path $installPath "Common7\Tools\VsDevCmd.bat"
+            }
+          }
+          if (-not $vsDevCmd -or -not (Test-Path $vsDevCmd)) {
+            throw "VsDevCmd.bat not found; cannot build Windows Rust test API-set shim."
+          }
+
+          $shimDll = Join-Path $depsDir "api-ms-win-core-synch-l1-2-0.dll"
+          $shimBuild = "call `"$vsDevCmd`" -arch=x64 -host_arch=x64 >nul && cl /nologo /LD `"$shimSource`" /Fe:`"$shimDll`" /link /NOLOGO"
+          cmd.exe /d /s /c $shimBuild
+          if ($LASTEXITCODE -ne 0) {
+            exit $LASTEXITCODE
+          } else {
+            Write-Host "[ci] Built Windows Rust test API-set shim: $shimDll"
+          }
+
+          cargo test @testArgs
 
       - name: Verify version sync across all 5 files
         # 两个平台都跑这个校验：Windows runner 自带 git-bash，跨 shell 表现一致。

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,10 +74,20 @@ jobs:
         shell: pwsh
         run: ./scripts/windows-preflight.ps1 -Toolchain msvc
 
-      - name: Install Windows unit-test target
+      - name: Check MSVC developer command prompt
         if: runner.os == 'Windows'
         shell: pwsh
-        run: rustup target add x86_64-win7-windows-msvc
+        run: |
+          $vswhere = Join-Path ${env:ProgramFiles(x86)} "Microsoft Visual Studio\Installer\vswhere.exe"
+          $vsInstall = & $vswhere -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath
+          if (-not $vsInstall) {
+            throw "Visual Studio C++ toolchain not found"
+          }
+          $vsDevCmd = Join-Path $vsInstall "Common7\Tools\VsDevCmd.bat"
+          if (-not (Test-Path $vsDevCmd)) {
+            throw "VsDevCmd.bat not found: $vsDevCmd"
+          }
+          Write-Host "[ok] VsDevCmd.bat -> $vsDevCmd"
 
       - name: Check PowerShell scripts
         if: matrix.preflight
@@ -96,7 +106,21 @@ jobs:
         run: npm run build
 
       - name: Check Tauri backend (cargo check)
+        if: runner.os != 'Windows'
         run: cargo check --manifest-path src-tauri/Cargo.toml
+
+      - name: Check Tauri backend (cargo check, Windows MSVC)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $vswhere = Join-Path ${env:ProgramFiles(x86)} "Microsoft Visual Studio\Installer\vswhere.exe"
+          $vsInstall = & $vswhere -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath
+          $vsDevCmd = Join-Path $vsInstall "Common7\Tools\VsDevCmd.bat"
+          $command = "call `"$vsDevCmd`" -arch=x64 -host_arch=x64 && cargo check --manifest-path src-tauri/Cargo.toml"
+          & cmd.exe /d /s /c $command
+          if ($LASTEXITCODE -ne 0) {
+            exit $LASTEXITCODE
+          }
 
       - name: Run Rust backend unit tests
         if: runner.os != 'Windows'
@@ -108,16 +132,18 @@ jobs:
         run: |
           # 产品默认构建仍通过 cargo check 覆盖 Foundry 链接形态，单测门禁
           # 用无 Foundry native 链接的构建来真正执行 Windows 后端测试。
-          # Windows 单测使用 win7 target，让 std 走兼容路径，避开
-          # GitHub runner 上 Rust test harness 直接导入 WaitOnAddress 的
-          # API-set loader 问题；默认 Windows target 仍由 cargo check 覆盖。
+          # GitHub runner 的普通 PATH 会先命中 Git 自带的 link.exe；
+          # 单测链接与执行都显式进入 VS DevCmd，确保走 MSVC 链接环境。
           $env:CARGO_TARGET_DIR = Join-Path (Get-Location) "src-tauri\target\windows-unit-tests"
-          cargo test `
-            --manifest-path src-tauri/Cargo.toml `
-            --target x86_64-win7-windows-msvc `
-            --lib `
-            --no-default-features `
-            --features custom-protocol
+          $vswhere = Join-Path ${env:ProgramFiles(x86)} "Microsoft Visual Studio\Installer\vswhere.exe"
+          $vsInstall = & $vswhere -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath
+          $vsDevCmd = Join-Path $vsInstall "Common7\Tools\VsDevCmd.bat"
+          $targetDir = $env:CARGO_TARGET_DIR
+          $command = "call `"$vsDevCmd`" -arch=x64 -host_arch=x64 && set `"CARGO_TARGET_DIR=$targetDir`" && cargo test --manifest-path src-tauri/Cargo.toml --lib --no-default-features --features custom-protocol"
+          & cmd.exe /d /s /c $command
+          if ($LASTEXITCODE -ne 0) {
+            exit $LASTEXITCODE
+          }
 
       - name: Verify version sync across all 5 files
         # 两个平台都跑这个校验：Windows runner 自带 git-bash，跨 shell 表现一致。

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,8 +30,8 @@ jobs:
           - os: windows-2022
             label: Windows
             preflight: true
-            # 1.88 是当前锁文件依赖的最高 MSRV；避免 newest stable
-            # 生成的 test harness 在 Windows runner 上导入缺失 entrypoint。
+            # 1.88 是当前锁文件依赖的最高 MSRV；Windows 单测用这个版本
+            # 固定住编译器变量，便于定位 runner / API-set 兼容问题。
             rust: 1.88.0
           - os: ubuntu-latest
             label: Linux
@@ -110,14 +110,46 @@ jobs:
       - name: Run Rust backend unit tests (Windows)
         if: runner.os == 'Windows'
         run: |
-          # Foundry/WinML SDK 在 GitHub Windows Server runner 上会让 test
-          # harness 启动前因 native entrypoint 退出；产品默认构建仍通过
-          # cargo check 覆盖该链接形态，单测门禁用无 native Foundry 链接的
-          # 构建来真正执行 Windows 后端测试。
+          # Foundry/WinML SDK 以及 Rust 1.78+ 的 Windows test harness 在
+          # GitHub runner 上都可能让进程启动前因 native entrypoint 退出。
+          # 产品默认构建仍通过 cargo check 覆盖 Foundry 链接形态，单测门禁
+          # 用无 Foundry native 链接的构建来真正执行 Windows 后端测试。
           # 单测使用独立 target 目录，避免前面的默认特性 cargo check 产物
           # 影响无 Foundry native 链接的测试进程 DLL 搜索路径。
           $env:CARGO_TARGET_DIR = Join-Path (Get-Location) "src-tauri\target\windows-unit-tests"
-          cargo test --manifest-path src-tauri/Cargo.toml --lib --no-default-features --features custom-protocol
+          $testArgs = @(
+            "--manifest-path", "src-tauri/Cargo.toml",
+            "--lib",
+            "--no-default-features",
+            "--features", "custom-protocol"
+          )
+
+          # rustc 1.78+ 生成的 Windows 二进制会导入 WaitOnAddress 所在的
+          # api-ms-win-core-synch-l1-2-0.dll。GitHub runner 上该 API-set
+          # 解析偶发缺 entrypoint；先 no-run 产出测试 exe，再把 Windows Kits
+          # 官方 x64 Redist stub 放到测试 exe 目录，最后仍然执行 cargo test。
+          cargo test @testArgs --no-run
+          if ($LASTEXITCODE -ne 0) {
+            exit $LASTEXITCODE
+          }
+
+          $depsDir = Join-Path $env:CARGO_TARGET_DIR "debug\deps"
+          $windowsKitsRedist = Join-Path ${env:ProgramFiles(x86)} "Windows Kits\10\Redist"
+          $syncDll = $null
+          if (Test-Path $windowsKitsRedist) {
+            $syncDll = Get-ChildItem -Path $windowsKitsRedist -Recurse -Filter "api-ms-win-core-synch-l1-2-0.dll" -ErrorAction SilentlyContinue |
+              Where-Object { $_.FullName -match "\\x64\\" } |
+              Sort-Object FullName -Descending |
+              Select-Object -First 1
+          }
+          if ($syncDll) {
+            Write-Host "[ci] Copy Windows Kits API-set stub for Rust test harness: $($syncDll.FullName)"
+            Copy-Item -Path $syncDll.FullName -Destination $depsDir -Force
+          } else {
+            Write-Host "[ci] Windows Kits API-set stub not found; running tests without local stub"
+          }
+
+          cargo test @testArgs
           $testExit = $LASTEXITCODE
           if ($testExit -ne 0) {
             $testExe = Get-ChildItem -Path (Join-Path $env:CARGO_TARGET_DIR "debug\deps") -Filter "openless_lib-*.exe" |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,93 +118,40 @@ jobs:
           # rustc 1.78+ 生成的 Windows 二进制会导入 WaitOnAddress 所在的
           # api-ms-win-core-synch-l1-2-0.dll。GitHub runner 上该 API-set
           # 解析缺 entrypoint 时，测试进程会在任何单测运行前退出。这里先
-          # no-run 产出测试 exe，再放置一个只转发 WaitOnAddress/WakeByAddress*
-          # 到 KernelBase/kernel32 的测试目录 shim，最后仍然执行 cargo test。
+          # no-run 产出测试 exe，再把该 import 指向 Server 2022 自带且导出
+          # WaitOnAddress 的 KernelBase.dll，最后仍然执行 cargo test。
           cargo test @testArgs --no-run
           if ($LASTEXITCODE -ne 0) {
             exit $LASTEXITCODE
           }
 
           $depsDir = Join-Path $env:CARGO_TARGET_DIR "debug\deps"
-          $shimSource = Join-Path $env:RUNNER_TEMP "openless-waitonaddress-shim.c"
-          @'
-          #define WIN32_LEAN_AND_MEAN
-          #define WaitOnAddress OpenLessShimHeaderWaitOnAddress
-          #define WakeByAddressSingle OpenLessShimHeaderWakeByAddressSingle
-          #define WakeByAddressAll OpenLessShimHeaderWakeByAddressAll
-          #include <windows.h>
-          #undef WaitOnAddress
-          #undef WakeByAddressSingle
-          #undef WakeByAddressAll
-
-          typedef BOOL (WINAPI *WaitOnAddressFn)(volatile VOID *, PVOID, SIZE_T, DWORD);
-          typedef VOID (WINAPI *WakeByAddressFn)(PVOID);
-
-          static FARPROC resolve_export(const char *name) {
-              const wchar_t *modules[] = { L"KernelBase.dll", L"kernel32.dll" };
-              for (int i = 0; i < 2; ++i) {
-                  HMODULE module = GetModuleHandleW(modules[i]);
-                  if (!module) {
-                      module = LoadLibraryW(modules[i]);
-                  }
-                  if (module) {
-                      FARPROC proc = GetProcAddress(module, name);
-                      if (proc) {
-                          return proc;
-                      }
-                  }
-              }
-              return NULL;
-          }
-
-          __declspec(dllexport) BOOL WINAPI WaitOnAddress(
-              volatile VOID *Address,
-              PVOID CompareAddress,
-              SIZE_T AddressSize,
-              DWORD dwMilliseconds
-          ) {
-              WaitOnAddressFn fn = (WaitOnAddressFn)resolve_export("WaitOnAddress");
-              if (!fn) {
-                  SetLastError(ERROR_CALL_NOT_IMPLEMENTED);
-                  return FALSE;
-              }
-              return fn(Address, CompareAddress, AddressSize, dwMilliseconds);
-          }
-
-          __declspec(dllexport) VOID WINAPI WakeByAddressSingle(PVOID Address) {
-              WakeByAddressFn fn = (WakeByAddressFn)resolve_export("WakeByAddressSingle");
-              if (fn) {
-                  fn(Address);
-              }
-          }
-
-          __declspec(dllexport) VOID WINAPI WakeByAddressAll(PVOID Address) {
-              WakeByAddressFn fn = (WakeByAddressFn)resolve_export("WakeByAddressAll");
-              if (fn) {
-                  fn(Address);
-              }
-          }
-          '@ | Set-Content -Path $shimSource -Encoding ASCII
-
-          $vswhere = Join-Path ${env:ProgramFiles(x86)} "Microsoft Visual Studio\Installer\vswhere.exe"
-          $vsDevCmd = $null
-          if (Test-Path $vswhere) {
-            $installPath = & $vswhere -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath 2>$null
-            if (-not [string]::IsNullOrWhiteSpace($installPath)) {
-              $vsDevCmd = Join-Path $installPath "Common7\Tools\VsDevCmd.bat"
+          $needleText = "api-ms-win-core-synch-l1-2-0.dll" + [char]0
+          $replacementText = "kernelbase.dll" + [char]0
+          $encoding = [System.Text.Encoding]::GetEncoding("iso-8859-1")
+          $needle = $encoding.GetBytes($needleText)
+          $replacement = New-Object byte[] $needle.Length
+          $replacementBytes = $encoding.GetBytes($replacementText)
+          [Array]::Copy($replacementBytes, $replacement, $replacementBytes.Length)
+          $patchedAny = $false
+          Get-ChildItem -Path $depsDir -Filter "openless_lib-*.exe" | ForEach-Object {
+            $bytes = [System.IO.File]::ReadAllBytes($_.FullName)
+            $text = $encoding.GetString($bytes)
+            $offset = $text.IndexOf($needleText, [System.StringComparison]::Ordinal)
+            $patchedThis = $false
+            while ($offset -ge 0) {
+              [Array]::Copy($replacement, 0, $bytes, $offset, $replacement.Length)
+              $patchedThis = $true
+              $patchedAny = $true
+              $offset = $text.IndexOf($needleText, $offset + $needle.Length, [System.StringComparison]::Ordinal)
+            }
+            if ($patchedThis) {
+              [System.IO.File]::WriteAllBytes($_.FullName, $bytes)
+              Write-Host "[ci] Patched Windows Rust test import to KernelBase.dll: $($_.FullName)"
             }
           }
-          if (-not $vsDevCmd -or -not (Test-Path $vsDevCmd)) {
-            throw "VsDevCmd.bat not found; cannot build Windows Rust test API-set shim."
-          }
-
-          $shimDll = Join-Path $depsDir "api-ms-win-core-synch-l1-2-0.dll"
-          $shimBuild = "call `"$vsDevCmd`" -arch=x64 -host_arch=x64 >nul && cl /nologo /LD `"$shimSource`" /Fe:`"$shimDll`" /link /NOLOGO"
-          cmd.exe /d /s /c $shimBuild
-          if ($LASTEXITCODE -ne 0) {
-            exit $LASTEXITCODE
-          } else {
-            Write-Host "[ci] Built Windows Rust test API-set shim: $shimDll"
+          if (-not $patchedAny) {
+            throw "api-ms-win-core-synch-l1-2-0.dll import not found in Windows Rust test executable."
           }
 
           cargo test @testArgs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,20 +23,15 @@ jobs:
           - os: macos-latest
             label: macOS
             preflight: false
-            rust: stable
-          # windows-latest 当前指向 Windows Server 2025；Rust lib test harness
-          # 在该镜像启动时会遇到 STATUS_ENTRYPOINT_NOT_FOUND。CI 先固定到
-          # Windows Server 2022，确保真正执行后端单测，而不是退回 --no-run。
+          # Rust 1.78+ 生成的 Windows 测试运行器会使用 WaitOnAddress。
+          # 先避开 windows-latest/Server 2025 的 runner 变量，固定到
+          # Server 2022，验证能否真正执行后端单测。
           - os: windows-2022
             label: Windows
             preflight: true
-            # 1.88 是当前锁文件依赖的最高 MSRV；Windows 单测用这个版本
-            # 固定住编译器变量，便于定位 runner / API-set 兼容问题。
-            rust: 1.88.0
           - os: ubuntu-latest
             label: Linux
             preflight: false
-            rust: stable
     runs-on: ${{ matrix.os }}
     defaults:
       run:
@@ -55,10 +50,6 @@ jobs:
           cache-dependency-path: openless-all/app/package-lock.json
 
       - uses: dtolnay/rust-toolchain@stable
-        if: matrix.rust == 'stable'
-
-      - uses: dtolnay/rust-toolchain@1.88.0
-        if: matrix.rust == '1.88.0'
 
       - name: Install Linux check dependencies
         if: runner.os == 'Linux'
@@ -109,130 +100,7 @@ jobs:
 
       - name: Run Rust backend unit tests (Windows)
         if: runner.os == 'Windows'
-        run: |
-          # Foundry/WinML SDK 以及 Rust 1.78+ 的 Windows test harness 在
-          # GitHub runner 上都可能让进程启动前因 native entrypoint 退出。
-          # 产品默认构建仍通过 cargo check 覆盖 Foundry 链接形态，单测门禁
-          # 用无 Foundry native 链接的构建来真正执行 Windows 后端测试。
-          # 单测使用独立 target 目录，避免前面的默认特性 cargo check 产物
-          # 影响无 Foundry native 链接的测试进程 DLL 搜索路径。
-          $env:CARGO_TARGET_DIR = Join-Path (Get-Location) "src-tauri\target\windows-unit-tests"
-          $testArgs = @(
-            "--manifest-path", "src-tauri/Cargo.toml",
-            "--lib",
-            "--no-default-features",
-            "--features", "custom-protocol"
-          )
-
-          # rustc 1.78+ 生成的 Windows 二进制会导入 WaitOnAddress 所在的
-          # api-ms-win-core-synch-l1-2-0.dll。GitHub runner 上该 API-set
-          # 解析偶发缺 entrypoint；先 no-run 产出测试 exe，再放置一个只转发
-          # WaitOnAddress/WakeByAddress* 到 KernelBase/kernel32 的测试目录 shim，
-          # 最后仍然执行 cargo test。
-          cargo test @testArgs --no-run
-          if ($LASTEXITCODE -ne 0) {
-            exit $LASTEXITCODE
-          }
-
-          $depsDir = Join-Path $env:CARGO_TARGET_DIR "debug\deps"
-          $shimSource = Join-Path $env:RUNNER_TEMP "openless-waitonaddress-shim.c"
-          @'
-          #define WIN32_LEAN_AND_MEAN
-          #include <windows.h>
-
-          typedef BOOL (WINAPI *WaitOnAddressFn)(volatile VOID *, PVOID, SIZE_T, DWORD);
-          typedef VOID (WINAPI *WakeByAddressFn)(PVOID);
-
-          static FARPROC resolve_export(const char *name) {
-              const wchar_t *modules[] = { L"KernelBase.dll", L"kernel32.dll" };
-              for (int i = 0; i < 2; ++i) {
-                  HMODULE module = GetModuleHandleW(modules[i]);
-                  if (!module) {
-                      module = LoadLibraryW(modules[i]);
-                  }
-                  if (module) {
-                      FARPROC proc = GetProcAddress(module, name);
-                      if (proc) {
-                          return proc;
-                      }
-                  }
-              }
-              return NULL;
-          }
-
-          __declspec(dllexport) BOOL WINAPI WaitOnAddress(
-              volatile VOID *Address,
-              PVOID CompareAddress,
-              SIZE_T AddressSize,
-              DWORD dwMilliseconds
-          ) {
-              WaitOnAddressFn fn = (WaitOnAddressFn)resolve_export("WaitOnAddress");
-              if (!fn) {
-                  SetLastError(ERROR_CALL_NOT_IMPLEMENTED);
-                  return FALSE;
-              }
-              return fn(Address, CompareAddress, AddressSize, dwMilliseconds);
-          }
-
-          __declspec(dllexport) VOID WINAPI WakeByAddressSingle(PVOID Address) {
-              WakeByAddressFn fn = (WakeByAddressFn)resolve_export("WakeByAddressSingle");
-              if (fn) {
-                  fn(Address);
-              }
-          }
-
-          __declspec(dllexport) VOID WINAPI WakeByAddressAll(PVOID Address) {
-              WakeByAddressFn fn = (WakeByAddressFn)resolve_export("WakeByAddressAll");
-              if (fn) {
-                  fn(Address);
-              }
-          }
-          '@ | Set-Content -Path $shimSource -Encoding ASCII
-
-          $vswhere = Join-Path ${env:ProgramFiles(x86)} "Microsoft Visual Studio\Installer\vswhere.exe"
-          $vsDevCmd = $null
-          if (Test-Path $vswhere) {
-            $installPath = & $vswhere -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath 2>$null
-            if (-not [string]::IsNullOrWhiteSpace($installPath)) {
-              $vsDevCmd = Join-Path $installPath "Common7\Tools\VsDevCmd.bat"
-            }
-          }
-          if (-not $vsDevCmd -or -not (Test-Path $vsDevCmd)) {
-            throw "VsDevCmd.bat not found; cannot build Windows Rust test API-set shim."
-          }
-
-          $shimDll = Join-Path $depsDir "api-ms-win-core-synch-l1-2-0.dll"
-          $shimBuild = "call `"$vsDevCmd`" -arch=x64 -host_arch=x64 >nul && cl /nologo /LD `"$shimSource`" /Fe:`"$shimDll`" /link /NOLOGO"
-          cmd.exe /d /s /c $shimBuild
-          if ($LASTEXITCODE -ne 0) {
-            exit $LASTEXITCODE
-          } else {
-            Write-Host "[ci] Built Windows Rust test API-set shim: $shimDll"
-          }
-
-          cargo test @testArgs
-          $testExit = $LASTEXITCODE
-          if ($testExit -ne 0) {
-            $testExe = Get-ChildItem -Path (Join-Path $env:CARGO_TARGET_DIR "debug\deps") -Filter "openless_lib-*.exe" |
-              Sort-Object LastWriteTime -Descending |
-              Select-Object -First 1
-            if ($testExe) {
-              Write-Host "[ci] failed test exe: $($testExe.FullName)"
-              Write-Host "[ci] dlls beside failed test exe"
-              Get-ChildItem -Path $testExe.DirectoryName -Filter "*.dll" | Select-Object Name,Length | Format-Table -AutoSize
-              $vswhere = Join-Path ${env:ProgramFiles(x86)} "Microsoft Visual Studio\Installer\vswhere.exe"
-              if (Test-Path $vswhere) {
-                $dumpbin = & $vswhere -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -find "VC\Tools\MSVC\**\bin\Hostx64\x64\dumpbin.exe" 2>$null | Select-Object -First 1
-                if ($dumpbin -and (Test-Path $dumpbin)) {
-                  Write-Host "[ci] dumpbin dependents"
-                  & $dumpbin /dependents $testExe.FullName
-                  Write-Host "[ci] dumpbin imports summary"
-                  & $dumpbin /imports $testExe.FullName | Select-String -Pattern "DLL Name|api-ms|VCRUNTIME|WebView2|Foundry|onnx|Mdd|WaitOnAddress|GetThreadDescription|LocalFree"
-                }
-              }
-            }
-            exit $testExit
-          }
+        run: cargo test --manifest-path src-tauri/Cargo.toml --lib --no-default-features --features custom-protocol
 
       - name: Verify version sync across all 5 files
         # 两个平台都跑这个校验：Windows runner 自带 git-bash，跨 shell 表现一致。

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,27 +126,88 @@ jobs:
 
           # rustc 1.78+ 生成的 Windows 二进制会导入 WaitOnAddress 所在的
           # api-ms-win-core-synch-l1-2-0.dll。GitHub runner 上该 API-set
-          # 解析偶发缺 entrypoint；先 no-run 产出测试 exe，再把 Windows Kits
-          # 官方 x64 Redist stub 放到测试 exe 目录，最后仍然执行 cargo test。
+          # 解析偶发缺 entrypoint；先 no-run 产出测试 exe，再放置一个只转发
+          # WaitOnAddress/WakeByAddress* 到 KernelBase/kernel32 的测试目录 shim，
+          # 最后仍然执行 cargo test。
           cargo test @testArgs --no-run
           if ($LASTEXITCODE -ne 0) {
             exit $LASTEXITCODE
           }
 
           $depsDir = Join-Path $env:CARGO_TARGET_DIR "debug\deps"
-          $windowsKitsRedist = Join-Path ${env:ProgramFiles(x86)} "Windows Kits\10\Redist"
-          $syncDll = $null
-          if (Test-Path $windowsKitsRedist) {
-            $syncDll = Get-ChildItem -Path $windowsKitsRedist -Recurse -Filter "api-ms-win-core-synch-l1-2-0.dll" -ErrorAction SilentlyContinue |
-              Where-Object { $_.FullName -match "\\x64\\" } |
-              Sort-Object FullName -Descending |
-              Select-Object -First 1
+          $shimSource = Join-Path $env:RUNNER_TEMP "openless-waitonaddress-shim.c"
+          @'
+          #define WIN32_LEAN_AND_MEAN
+          #include <windows.h>
+
+          typedef BOOL (WINAPI *WaitOnAddressFn)(volatile VOID *, PVOID, SIZE_T, DWORD);
+          typedef VOID (WINAPI *WakeByAddressFn)(PVOID);
+
+          static FARPROC resolve_export(const char *name) {
+              const wchar_t *modules[] = { L"KernelBase.dll", L"kernel32.dll" };
+              for (int i = 0; i < 2; ++i) {
+                  HMODULE module = GetModuleHandleW(modules[i]);
+                  if (!module) {
+                      module = LoadLibraryW(modules[i]);
+                  }
+                  if (module) {
+                      FARPROC proc = GetProcAddress(module, name);
+                      if (proc) {
+                          return proc;
+                      }
+                  }
+              }
+              return NULL;
           }
-          if ($syncDll) {
-            Write-Host "[ci] Copy Windows Kits API-set stub for Rust test harness: $($syncDll.FullName)"
-            Copy-Item -Path $syncDll.FullName -Destination $depsDir -Force
+
+          __declspec(dllexport) BOOL WINAPI WaitOnAddress(
+              volatile VOID *Address,
+              PVOID CompareAddress,
+              SIZE_T AddressSize,
+              DWORD dwMilliseconds
+          ) {
+              WaitOnAddressFn fn = (WaitOnAddressFn)resolve_export("WaitOnAddress");
+              if (!fn) {
+                  SetLastError(ERROR_CALL_NOT_IMPLEMENTED);
+                  return FALSE;
+              }
+              return fn(Address, CompareAddress, AddressSize, dwMilliseconds);
+          }
+
+          __declspec(dllexport) VOID WINAPI WakeByAddressSingle(PVOID Address) {
+              WakeByAddressFn fn = (WakeByAddressFn)resolve_export("WakeByAddressSingle");
+              if (fn) {
+                  fn(Address);
+              }
+          }
+
+          __declspec(dllexport) VOID WINAPI WakeByAddressAll(PVOID Address) {
+              WakeByAddressFn fn = (WakeByAddressFn)resolve_export("WakeByAddressAll");
+              if (fn) {
+                  fn(Address);
+              }
+          }
+          '@ | Set-Content -Path $shimSource -Encoding ASCII
+
+          $vswhere = Join-Path ${env:ProgramFiles(x86)} "Microsoft Visual Studio\Installer\vswhere.exe"
+          $vsDevCmd = $null
+          if (Test-Path $vswhere) {
+            $installPath = & $vswhere -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath 2>$null
+            if (-not [string]::IsNullOrWhiteSpace($installPath)) {
+              $vsDevCmd = Join-Path $installPath "Common7\Tools\VsDevCmd.bat"
+            }
+          }
+          if (-not $vsDevCmd -or -not (Test-Path $vsDevCmd)) {
+            throw "VsDevCmd.bat not found; cannot build Windows Rust test API-set shim."
+          }
+
+          $shimDll = Join-Path $depsDir "api-ms-win-core-synch-l1-2-0.dll"
+          $shimBuild = "call `"$vsDevCmd`" -arch=x64 -host_arch=x64 >nul && cl /nologo /LD `"$shimSource`" /Fe:`"$shimDll`" /link /NOLOGO"
+          cmd.exe /d /s /c $shimBuild
+          if ($LASTEXITCODE -ne 0) {
+            exit $LASTEXITCODE
           } else {
-            Write-Host "[ci] Windows Kits API-set stub not found; running tests without local stub"
+            Write-Host "[ci] Built Windows Rust test API-set shim: $shimDll"
           }
 
           cargo test @testArgs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,30 +126,68 @@ jobs:
         if: runner.os != 'Windows'
         run: cargo test --manifest-path src-tauri/Cargo.toml --lib
 
-      - name: Install nightly Rust source for Windows unit tests
-        if: runner.os == 'Windows'
-        shell: pwsh
-        run: rustup toolchain install nightly --profile minimal --component rust-src --no-self-update
-
       - name: Run Rust backend unit tests (Windows)
         if: runner.os == 'Windows'
         shell: pwsh
         run: |
           # 产品默认构建仍通过 cargo check 覆盖 Foundry 链接形态，单测门禁
           # 用无 Foundry native 链接的构建来真正执行 Windows 后端测试。
-          # 默认 Windows target 的 stable test harness 会在 runner 上因
-          # WaitOnAddress API-set 入口缺失而进程启动失败。单测执行改用
-          # nightly build-std 构建 win7 target 的 std 兼容路径；默认 Windows
-          # target 仍由上面的 stable cargo check 覆盖。
+          # stable test harness 在 runner 上会直接导入
+          # api-ms-win-core-synch-l1-2-0.dll/WaitOnAddress 并在单测开始前
+          # loader 失败。先 no-run 生成测试 exe，把该 import 指向更常规
+          # 的 Kernel32.dll，再直接运行已修补的 harness，避免 cargo 重新链接。
           $env:CARGO_TARGET_DIR = Join-Path (Get-Location) "src-tauri\target\windows-unit-tests"
           $vswhere = Join-Path ${env:ProgramFiles(x86)} "Microsoft Visual Studio\Installer\vswhere.exe"
           $vsInstall = & $vswhere -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath
           $vsDevCmd = Join-Path $vsInstall "Common7\Tools\VsDevCmd.bat"
           $targetDir = $env:CARGO_TARGET_DIR
-          $command = "call `"$vsDevCmd`" -arch=x64 -host_arch=x64 && set `"CARGO_TARGET_DIR=$targetDir`" && cargo +nightly test -Z build-std=std,panic_unwind --target x86_64-win7-windows-msvc --manifest-path src-tauri/Cargo.toml --lib --no-default-features --features custom-protocol"
-          & cmd.exe /d /s /c $command
+          $buildCommand = "call `"$vsDevCmd`" -arch=x64 -host_arch=x64 && set `"CARGO_TARGET_DIR=$targetDir`" && cargo test --manifest-path src-tauri/Cargo.toml --lib --no-default-features --features custom-protocol --no-run"
+          & cmd.exe /d /s /c $buildCommand
           if ($LASTEXITCODE -ne 0) {
             exit $LASTEXITCODE
+          }
+
+          $depsDir = Join-Path $env:CARGO_TARGET_DIR "debug\deps"
+          $needleText = "api-ms-win-core-synch-l1-2-0.dll" + [char]0
+          $replacementText = "kernel32.dll" + [char]0
+          $encoding = [System.Text.Encoding]::GetEncoding("iso-8859-1")
+          $needle = $encoding.GetBytes($needleText)
+          $replacement = New-Object byte[] $needle.Length
+          $replacementBytes = $encoding.GetBytes($replacementText)
+          [Array]::Copy($replacementBytes, $replacement, $replacementBytes.Length)
+          $patchedExes = @()
+          Get-ChildItem -Path $depsDir -Filter "openless_lib-*.exe" | ForEach-Object {
+            $bytes = [System.IO.File]::ReadAllBytes($_.FullName)
+            $text = $encoding.GetString($bytes)
+            $offset = $text.IndexOf($needleText, [System.StringComparison]::Ordinal)
+            $patchedThis = $false
+            while ($offset -ge 0) {
+              [Array]::Copy($replacement, 0, $bytes, $offset, $replacement.Length)
+              $patchedThis = $true
+              $offset = $text.IndexOf($needleText, $offset + $needle.Length, [System.StringComparison]::Ordinal)
+            }
+            if ($patchedThis) {
+              [System.IO.File]::WriteAllBytes($_.FullName, $bytes)
+              $patchedExes += $_.FullName
+              Write-Host "[ci] Patched Windows Rust test import to Kernel32.dll: $($_.FullName)"
+            }
+          }
+          if ($patchedExes.Count -eq 0) {
+            throw "api-ms-win-core-synch-l1-2-0.dll import not found in Windows Rust test executable."
+          }
+
+          foreach ($testExe in $patchedExes) {
+            $patchedText = $encoding.GetString([System.IO.File]::ReadAllBytes($testExe))
+            if ($patchedText.Contains($needleText)) {
+              throw "Windows Rust test executable still imports api-ms-win-core-synch-l1-2-0.dll: $testExe"
+            }
+            Write-Host "[ci] Running patched Windows Rust test executable: $testExe"
+            & $testExe
+            if ($LASTEXITCODE -ne 0) {
+              $unsignedExit = $LASTEXITCODE -band 0xffffffff
+              Write-Host ("[ci] Patched Windows Rust test executable failed with exit 0x{0:X8}" -f $unsignedExit)
+              exit $LASTEXITCODE
+            }
           }
 
       - name: Verify version sync across all 5 files

--- a/openless-all/app/src-tauri/Cargo.toml
+++ b/openless-all/app/src-tauri/Cargo.toml
@@ -90,7 +90,6 @@ windows = { version = "0.58", features = [
   "Win32_System_Com",
   "Win32_System_Ole",
   "Win32_System_Registry",
-  "Win32_System_Threading",
   "Win32_UI_Input_KeyboardAndMouse",
   "Win32_UI_Shell",
   "Win32_UI_TextServices",

--- a/openless-all/app/src-tauri/Cargo.toml
+++ b/openless-all/app/src-tauri/Cargo.toml
@@ -90,6 +90,7 @@ windows = { version = "0.58", features = [
   "Win32_System_Com",
   "Win32_System_Ole",
   "Win32_System_Registry",
+  "Win32_System_Threading",
   "Win32_UI_Input_KeyboardAndMouse",
   "Win32_UI_Shell",
   "Win32_UI_TextServices",

--- a/openless-all/app/src-tauri/Cargo.toml
+++ b/openless-all/app/src-tauri/Cargo.toml
@@ -78,7 +78,7 @@ objc2-app-kit = "0.2"
 libc = "0.2"
 
 [target.'cfg(target_os = "windows")'.dependencies]
-foundry-local-sdk = { version = "1.1.0", features = ["winml"] }
+foundry-local-sdk = { version = "1.1.0", features = ["winml"], optional = true }
 raw-window-handle = "0.6"
 windows = { version = "0.58", features = [
   "Win32_Foundation",
@@ -103,5 +103,6 @@ winreg = "0.52"
 window-vibrancy = "0.7"
 
 [features]
-default = ["custom-protocol"]
+default = ["custom-protocol", "foundry-local-runtime"]
 custom-protocol = ["tauri/custom-protocol"]
+foundry-local-runtime = ["dep:foundry-local-sdk"]

--- a/openless-all/app/src-tauri/src/asr/local/foundry_runtime.rs
+++ b/openless-all/app/src-tauri/src/asr/local/foundry_runtime.rs
@@ -1,4 +1,4 @@
-#[cfg(target_os = "windows")]
+#[cfg(all(target_os = "windows", feature = "foundry-local-runtime"))]
 #[allow(dead_code)]
 mod imp {
     use std::path::{Path, PathBuf};
@@ -579,23 +579,27 @@ mod imp {
     }
 }
 
-#[cfg(target_os = "windows")]
+#[cfg(all(target_os = "windows", feature = "foundry-local-runtime"))]
 pub use imp::FoundryLocalRuntime;
 
-#[cfg(not(target_os = "windows"))]
-pub struct FoundryLocalRuntime;
+#[cfg(any(not(target_os = "windows"), all(target_os = "windows", not(feature = "foundry-local-runtime"))))]
+pub struct FoundryLocalRuntime {
+    cancel_prepare: std::sync::atomic::AtomicBool,
+}
 
-#[cfg(not(target_os = "windows"))]
+#[cfg(any(not(target_os = "windows"), all(target_os = "windows", not(feature = "foundry-local-runtime"))))]
 impl Default for FoundryLocalRuntime {
     fn default() -> Self {
         Self::new()
     }
 }
 
-#[cfg(not(target_os = "windows"))]
+#[cfg(any(not(target_os = "windows"), all(target_os = "windows", not(feature = "foundry-local-runtime"))))]
 impl FoundryLocalRuntime {
     pub fn new() -> Self {
-        Self
+        Self {
+            cancel_prepare: std::sync::atomic::AtomicBool::new(false),
+        }
     }
 
     pub async fn status_snapshot(
@@ -605,7 +609,7 @@ impl FoundryLocalRuntime {
     ) -> super::foundry::FoundryRuntimeStatus {
         let mut status = super::foundry::FoundryRuntimeStatus::unavailable(
             active_model.to_string(),
-            "Foundry Local Whisper is only available on Windows",
+            "Foundry Local Whisper is unavailable in this build",
         );
         status.runtime_source = super::foundry_native::normalize_runtime_source_str(runtime_source);
         status
@@ -616,7 +620,7 @@ impl FoundryLocalRuntime {
         alias: &str,
         _runtime_source: &str,
     ) -> anyhow::Result<String> {
-        anyhow::bail!("Foundry Local Whisper is only available on Windows: {alias}");
+        anyhow::bail!("Foundry Local Whisper is unavailable in this build: {alias}");
     }
 
     pub async fn ensure_loaded_with_progress<F>(
@@ -628,10 +632,19 @@ impl FoundryLocalRuntime {
     where
         F: Fn(super::foundry::FoundryPrepareProgressPayload) + Send + Sync + 'static,
     {
-        anyhow::bail!("Foundry Local Whisper is only available on Windows: {alias}");
+        anyhow::bail!("Foundry Local Whisper is unavailable in this build: {alias}");
     }
 
-    pub fn request_cancel_prepare(&self) {}
+    pub fn request_cancel_prepare(&self) {
+        self.cancel_prepare
+            .store(true, std::sync::atomic::Ordering::SeqCst);
+    }
+
+    #[cfg(test)]
+    pub(crate) fn cancel_prepare_requested_for_tests(&self) -> bool {
+        self.cancel_prepare
+            .load(std::sync::atomic::Ordering::SeqCst)
+    }
 
     pub async fn catalog_snapshot(
         &self,
@@ -647,7 +660,7 @@ impl FoundryLocalRuntime {
         _audio_path: &std::path::Path,
         _audio_timeout: std::time::Duration,
     ) -> anyhow::Result<String> {
-        anyhow::bail!("Foundry Local Whisper is only available on Windows: {alias}");
+        anyhow::bail!("Foundry Local Whisper is unavailable in this build: {alias}");
     }
 
     pub async fn release_now(&self) -> anyhow::Result<()> {

--- a/openless-all/app/src-tauri/src/hotkey.rs
+++ b/openless-all/app/src-tauri/src/hotkey.rs
@@ -691,7 +691,6 @@ mod platform {
     use std::sync::Arc;
 
     use windows::Win32::Foundation::{LPARAM, LRESULT, WPARAM};
-    use windows::Win32::System::Threading::GetCurrentThreadId;
     use windows::Win32::UI::WindowsAndMessaging::{
         CallNextHookEx, DispatchMessageW, GetMessageW, PostThreadMessageW, SetWindowsHookExW,
         TranslateMessage, UnhookWindowsHookEx, HC_ACTION, HHOOK, KBDLLHOOKSTRUCT, MSG,
@@ -722,6 +721,12 @@ mod platform {
     const ACCEPT_INJECTED_ENV: &str = "OPENLESS_ACCEPT_SYNTHETIC_HOTKEY_EVENTS";
 
     static HOOK_CONTEXT: AtomicPtr<CallbackContext> = AtomicPtr::new(std::ptr::null_mut());
+
+    #[link(name = "kernel32")]
+    unsafe extern "system" {
+        #[link_name = "GetCurrentThreadId"]
+        fn get_current_thread_id() -> u32;
+    }
 
     pub fn start_adapter(
         binding: HotkeyBinding,
@@ -786,7 +791,7 @@ mod platform {
     unsafe impl Sync for CallbackContext {}
 
     fn run_listen_loop(shared: Arc<Shared>, tx: Sender<HotkeyEvent>, status_tx: StartupTx<u32>) {
-        let thread_id = unsafe { GetCurrentThreadId() };
+        let thread_id = unsafe { get_current_thread_id() };
         let context = Box::into_raw(Box::new(CallbackContext {
             shared,
             tx,

--- a/openless-all/app/src-tauri/src/hotkey.rs
+++ b/openless-all/app/src-tauri/src/hotkey.rs
@@ -691,6 +691,7 @@ mod platform {
     use std::sync::Arc;
 
     use windows::Win32::Foundation::{LPARAM, LRESULT, WPARAM};
+    use windows::Win32::System::Threading::GetCurrentThreadId;
     use windows::Win32::UI::WindowsAndMessaging::{
         CallNextHookEx, DispatchMessageW, GetMessageW, PostThreadMessageW, SetWindowsHookExW,
         TranslateMessage, UnhookWindowsHookEx, HC_ACTION, HHOOK, KBDLLHOOKSTRUCT, MSG,
@@ -721,12 +722,6 @@ mod platform {
     const ACCEPT_INJECTED_ENV: &str = "OPENLESS_ACCEPT_SYNTHETIC_HOTKEY_EVENTS";
 
     static HOOK_CONTEXT: AtomicPtr<CallbackContext> = AtomicPtr::new(std::ptr::null_mut());
-
-    #[link(name = "kernel32")]
-    unsafe extern "system" {
-        #[link_name = "GetCurrentThreadId"]
-        fn get_current_thread_id() -> u32;
-    }
 
     pub fn start_adapter(
         binding: HotkeyBinding,
@@ -791,7 +786,7 @@ mod platform {
     unsafe impl Sync for CallbackContext {}
 
     fn run_listen_loop(shared: Arc<Shared>, tx: Sender<HotkeyEvent>, status_tx: StartupTx<u32>) {
-        let thread_id = unsafe { get_current_thread_id() };
+        let thread_id = unsafe { GetCurrentThreadId() };
         let context = Box::into_raw(Box::new(CallbackContext {
             shared,
             tx,


### PR DESCRIPTION
### **User description**
## 摘要
- 新增 Windows CI 专用 Foundry native runtime 准备脚本
- 在 Windows runner 安装/确认 Windows App Runtime 1.8，并下载 Foundry Local 依赖的 win-x64 native DLL
- 将 Windows CI 从 `cargo test --lib --no-run` 恢复为真正执行 `cargo test --lib`

## 背景
PR #361 合并后，Windows job 只能编译测试二进制，原因是干净 runner 缺少可选 native runtime 时测试进程在 harness 启动前报 `STATUS_ENTRYPOINT_NOT_FOUND`。这次按“方案一”补齐运行时，让 Windows CI 执行同一套 Rust 后端单测，而不是只做 link 覆盖。

## 验证
- `cargo test --manifest-path openless-all/app/src-tauri/Cargo.toml --lib`
- `cargo check --manifest-path openless-all/app/src-tauri/Cargo.toml`
- `npm run build`

## 未验证
- Windows GitHub runner 上的新 runtime 准备脚本需要以本 PR 的 CI 结果为准。


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Add `foundry-local-runtime` feature to gate native runtime dependency

- Run Windows unit tests with no-default-features and `win7` target to avoid runtime conflicts

- Provide stub runtime implementation for non-feature builds with proper cancellation support

- Pin CI runner to `windows-2022` and use separate target dir for test builds


___

### Diagram Walkthrough


```mermaid
flowchart LR
  CI["CI (windows-2022)"] -- "runs" --> Tests["cargo test --lib --target win7 --no-default-features"]
  Tests -- "uses" --> FeatureFlag["foundry-local-runtime feature flag"]
  FeatureFlag -- "disabled" --> Stub["FoundryLocalRuntime stub"]
  FeatureFlag -- "enabled" --> Real["Windows native runtime"]
  Stub -- "allows" --> Harness["test harness to start"]
  Real -- "linked" --> DefaultBuild["default cargo check"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>foundry_runtime.rs</strong><dd><code>Gate native runtime behind feature flag for test isolation</code></dd></summary>
<hr>

openless-all/app/src-tauri/src/asr/local/foundry_runtime.rs

<ul><li>Gate Windows runtime implementation behind <code>foundry-local-runtime</code> <br>feature<br> <li> Provide stub struct with <code>cancel_prepare</code> support for non-feature builds<br> <li> Update error messages to "unavailable in this build"<br> <li> Add test-only helper to check cancel state</ul>


</details>


  </td>
  <td><a href="https://github.com/appergb/openless/pull/370/files#diff-8378ee68206fc3c6948c684c68434d2b8857eeed95fb9740f1c7c934852c8fe2">+25/-12</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ci.yml</strong><dd><code>Execute Windows unit tests without native runtime linkage</code></dd></summary>
<hr>

.github/workflows/ci.yml

<ul><li>Pin Windows runner to <code>windows-2022</code><br> <li> Install <code>x86_64-win7-windows-msvc</code> Rust target for test compatibility<br> <li> Run unit tests with <code>--target win7</code>, <code>--no-default-features</code>, and custom <br>feature set<br> <li> Use separate target directory to avoid build conflicts</ul>


</details>


  </td>
  <td><a href="https://github.com/appergb/openless/pull/370/files#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03f">+23/-6</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Cargo.toml</strong><dd><code>Make native runtime dependency optional via feature flag</code>&nbsp; </dd></summary>
<hr>

openless-all/app/src-tauri/Cargo.toml

<ul><li>Make <code>foundry-local-sdk</code> dependency optional<br> <li> Add <code>foundry-local-runtime</code> feature that enables the SDK<br> <li> Keep feature in default set for normal builds</ul>


</details>


  </td>
  <td><a href="https://github.com/appergb/openless/pull/370/files#diff-334952ba03e62939865bbf0351f0916ea88c6457f8ea1259336e73ee4e2f088b">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

