### PR TITLE
fix: sync Windows tray style selection

### DIFF
--- a/openless-all/app/src-tauri/src/commands.rs
+++ b/openless-all/app/src-tauri/src/commands.rs
@@ -923,11 +923,18 @@ pub async fn repolish(
 #[tauri::command]
 pub fn set_default_polish_mode(
     coord: CoordinatorState<'_>,
+    app: AppHandle,
     mode: PolishMode,
 ) -> Result<(), String> {
     let mut prefs = coord.prefs().get();
     prefs.default_mode = mode;
-    coord.prefs().set(prefs).map_err(|e| e.to_string())
+    coord.prefs().set(prefs.clone()).map_err(|e| e.to_string())?;
+    if let Err(err) = crate::refresh_tray_microphone_menu(&app) {
+        log::warn!("[tray] refresh style menu after polish mode IPC change failed: {err}");
+    }
+    let _ = app.emit("prefs:changed", &prefs);
+    let _ = app.emit_to("main", "prefs:changed", &prefs);
+    Ok(())
 }
 
 #[tauri::command]

--- a/openless-all/app/src-tauri/src/lib.rs
+++ b/openless-all/app/src-tauri/src/lib.rs
@@ -49,6 +49,8 @@ use tauri::menu::{
 use tauri::tray::{MouseButton, TrayIconBuilder, TrayIconEvent};
 use tauri::{AppHandle, Emitter, LogicalPosition, LogicalSize, Manager, RunEvent, Runtime};
 
+use crate::types::PolishMode;
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     let foundry_local_runtime = Arc::new(asr::local::FoundryLocalRuntime::new());
@@ -192,7 +194,12 @@ pub fn run() {
                     .on_menu_event(move |app, event| match event.id.as_ref() {
                         "toggle" => show_main_window(app),
                         "quit" => app.exit(0),
-                        id => handle_microphone_tray_menu_event(app, id),
+                        id => {
+                            if handle_style_tray_menu_event(app, id) {
+                                return;
+                            }
+                            handle_microphone_tray_menu_event(app, id);
+                        }
                     })
                     .on_tray_icon_event(move |tray, event| match event {
                         TrayIconEvent::Enter { .. } => {
@@ -355,9 +362,52 @@ struct MicrophoneTrayMenu {
     items: Vec<commands::TrayMicrophoneMenuItem>,
 }
 
+struct StyleTrayMenu {
+    submenu: Submenu<tauri::Wry>,
+}
+
 struct TrayMenu {
     menu: Menu<tauri::Wry>,
     microphone_items: Vec<commands::TrayMicrophoneMenuItem>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct TrayPolishModeMenuEntry {
+    id: String,
+    label: &'static str,
+    mode: PolishMode,
+    checked: bool,
+}
+
+fn tray_style_menu_enabled() -> bool {
+    cfg!(target_os = "windows")
+}
+
+fn tray_polish_mode_menu_entries(selected: PolishMode) -> Vec<TrayPolishModeMenuEntry> {
+    [
+        (PolishMode::Raw, "style-raw"),
+        (PolishMode::Light, "style-light"),
+        (PolishMode::Structured, "style-structured"),
+        (PolishMode::Formal, "style-formal"),
+    ]
+    .into_iter()
+    .map(|(mode, id)| TrayPolishModeMenuEntry {
+        id: id.to_string(),
+        label: mode.display_name(),
+        mode,
+        checked: mode == selected,
+    })
+    .collect()
+}
+
+fn parse_tray_polish_mode_id(id: &str) -> Option<PolishMode> {
+    match id {
+        "style-raw" => Some(PolishMode::Raw),
+        "style-light" => Some(PolishMode::Light),
+        "style-structured" => Some(PolishMode::Structured),
+        "style-formal" => Some(PolishMode::Formal),
+        _ => None,
+    }
 }
 
 fn build_tray_menu<M: Manager<tauri::Wry>>(
@@ -367,12 +417,38 @@ fn build_tray_menu<M: Manager<tauri::Wry>>(
     let toggle = MenuItemBuilder::with_id("toggle", "显示主窗口").build(app)?;
     let microphone_menu = build_microphone_tray_menu(app, coordinator)?;
     let quit = MenuItemBuilder::with_id("quit", "退出 OpenLess").build(app)?;
-    let menu = MenuBuilder::new(app)
+    let mut builder = MenuBuilder::new(app);
+    let style_menu = if tray_style_menu_enabled() {
+        Some(build_style_tray_menu(app, coordinator)?)
+    } else {
+        None
+    };
+    if let Some(style_menu) = &style_menu {
+        builder = builder.item(&style_menu.submenu);
+    }
+    let menu = builder
         .items(&[&toggle, &microphone_menu.submenu, &quit])
         .build()?;
     Ok(TrayMenu {
         menu,
         microphone_items: microphone_menu.items,
+    })
+}
+
+fn build_style_tray_menu<M: Manager<tauri::Wry>>(
+    app: &M,
+    coordinator: &Arc<coordinator::Coordinator>,
+) -> tauri::Result<StyleTrayMenu> {
+    let selected = coordinator.prefs().get().default_mode;
+    let mut submenu = SubmenuBuilder::with_id(app, "style", "输出风格");
+    for entry in tray_polish_mode_menu_entries(selected) {
+        let item = CheckMenuItemBuilder::with_id(&entry.id, entry.label)
+            .checked(entry.checked)
+            .build(app)?;
+        submenu = submenu.item(&item);
+    }
+    Ok(StyleTrayMenu {
+        submenu: submenu.build()?,
     })
 }
 
@@ -510,6 +586,25 @@ fn handle_microphone_tray_menu_event(app: &AppHandle, id: &str) {
     let _ = app.emit("prefs:changed", &prefs);
 
     commands::sync_tray_microphone_selection(&items, &selected.device_name);
+}
+
+fn handle_style_tray_menu_event(app: &AppHandle, id: &str) -> bool {
+    let Some(mode) = parse_tray_polish_mode_id(id) else {
+        return false;
+    };
+    let coord = app.state::<Arc<coordinator::Coordinator>>();
+    let mut prefs = coord.prefs().get();
+    prefs.default_mode = mode;
+    if let Err(err) = coord.prefs().set(prefs.clone()) {
+        log::warn!("[tray] save polish mode preference failed: {err}");
+        return true;
+    }
+    let _ = app.emit("prefs:changed", &prefs);
+    let _ = app.emit_to("main", "prefs:changed", &prefs);
+    if let Err(err) = refresh_tray_microphone_menu(app) {
+        log::warn!("[tray] refresh style menu after polish mode change failed: {err}");
+    }
+    true
 }
 
 #[cfg(target_os = "windows")]
@@ -1066,9 +1161,54 @@ fn capsule_height_for_qa() -> f64 {
 mod tests {
     use super::{
         capsule_height_for_qa, capsule_visual_height, capsule_window_bounds,
-        rotate_log_if_too_large, LOG_ROTATE_LIMIT_BYTES,
+        parse_tray_polish_mode_id, rotate_log_if_too_large, tray_polish_mode_menu_entries,
+        tray_style_menu_enabled, LOG_ROTATE_LIMIT_BYTES,
     };
+    use crate::types::PolishMode;
     use std::io::Write;
+
+    #[test]
+    fn tray_style_menu_is_windows_only() {
+        #[cfg(target_os = "windows")]
+        assert!(tray_style_menu_enabled());
+
+        #[cfg(not(target_os = "windows"))]
+        assert!(!tray_style_menu_enabled());
+    }
+
+    #[test]
+    fn tray_style_menu_lists_builtin_modes_in_expected_order() {
+        let entries = tray_polish_mode_menu_entries(PolishMode::Structured);
+
+        assert_eq!(
+            entries
+                .iter()
+                .map(|entry| (entry.id.as_str(), entry.label, entry.mode, entry.checked))
+                .collect::<Vec<_>>(),
+            vec![
+                ("style-raw", "原文", PolishMode::Raw, false),
+                ("style-light", "轻度润色", PolishMode::Light, false),
+                ("style-structured", "清晰结构", PolishMode::Structured, true),
+                ("style-formal", "正式表达", PolishMode::Formal, false),
+            ]
+        );
+    }
+
+    #[test]
+    fn tray_style_menu_id_parsing_accepts_only_style_items() {
+        assert_eq!(parse_tray_polish_mode_id("style-raw"), Some(PolishMode::Raw));
+        assert_eq!(parse_tray_polish_mode_id("style-light"), Some(PolishMode::Light));
+        assert_eq!(
+            parse_tray_polish_mode_id("style-structured"),
+            Some(PolishMode::Structured)
+        );
+        assert_eq!(
+            parse_tray_polish_mode_id("style-formal"),
+            Some(PolishMode::Formal)
+        );
+        assert_eq!(parse_tray_polish_mode_id("toggle"), None);
+        assert_eq!(parse_tray_polish_mode_id("mic-default"), None);
+    }
 
     #[test]
     fn capsule_window_bounds_leave_room_for_windows_shadow() {

--- a/openless-all/app/src/lib/stylePrefs.test.ts
+++ b/openless-all/app/src/lib/stylePrefs.test.ts
@@ -1,4 +1,5 @@
 import {
+  applyStylePreferencesNotification,
   persistStylePreferenceChange,
   rollbackStyleEnabledChange,
   rollbackWholeStylePreferences,
@@ -105,3 +106,11 @@ assert(
   currentPrefs?.enabledModes.includes('structured') === false,
   'failed light toggle should preserve newer structured edit',
 );
+
+const notifiedPrefs: UserPreferences = {
+  ...previousPrefs,
+  defaultMode: 'formal',
+  enabledModes: ['raw', 'formal'],
+};
+const syncedPrefs = applyStylePreferencesNotification(previousPrefs, notifiedPrefs);
+assert(syncedPrefs === notifiedPrefs, 'prefs notification should replace stale style page prefs');

--- a/openless-all/app/src/lib/stylePrefs.ts
+++ b/openless-all/app/src/lib/stylePrefs.ts
@@ -28,6 +28,13 @@ export async function persistStylePreferenceChange(
   }
 }
 
+export function applyStylePreferencesNotification(
+  _current: UserPreferences | null,
+  incoming: UserPreferences,
+): UserPreferences {
+  return incoming;
+}
+
 export function rollbackDefaultModeChange(
   previousPrefs: UserPreferences,
   nextPrefs: UserPreferences,

--- a/openless-all/app/src/pages/Style.tsx
+++ b/openless-all/app/src/pages/Style.tsx
@@ -6,12 +6,14 @@ import { useTranslation } from 'react-i18next';
 import { getSettings, setDefaultPolishMode, setStyleEnabled, setSettings } from '../lib/ipc';
 import type { PolishMode, UserPreferences } from '../lib/types';
 import {
+  applyStylePreferencesNotification,
   persistStylePreferenceChange,
   rollbackDefaultModeChange,
   rollbackStyleEnabledChange,
   rollbackWholeStylePreferences,
 } from '../lib/stylePrefs';
 import { PageHeader, Pill } from './_atoms';
+import { useHotkeySettings } from '../state/HotkeySettingsContext';
 
 interface StyleDef {
   id: PolishMode;
@@ -25,6 +27,7 @@ type StyleSaveErrorTarget = PolishMode | 'master';
 
 export function Style() {
   const { t } = useTranslation();
+  const { prefs: sharedPrefs } = useHotkeySettings();
   const STYLES: StyleDef[] = STYLE_IDS.map(id => ({
     id,
     name: t(`style.modes.${id}.name`),
@@ -36,6 +39,33 @@ export function Style() {
 
   useEffect(() => {
     getSettings().then(setPrefs);
+  }, []);
+
+  useEffect(() => {
+    if (!sharedPrefs) return;
+    setPrefs(current => applyStylePreferencesNotification(current, sharedPrefs));
+    setSaveError(null);
+  }, [sharedPrefs]);
+
+  useEffect(() => {
+    let unlisten: (() => void) | undefined;
+    let cancelled = false;
+    (async () => {
+      try {
+        const { listen } = await import('@tauri-apps/api/event');
+        unlisten = await listen<UserPreferences>('prefs:changed', event => {
+          setPrefs(current => applyStylePreferencesNotification(current, event.payload));
+          setSaveError(null);
+        });
+        if (cancelled && unlisten) unlisten();
+      } catch (error) {
+        console.warn('[style] prefs:changed listener setup failed', error);
+      }
+    })();
+    return () => {
+      cancelled = true;
+      if (unlisten) unlisten();
+    };
   }, []);
 
   const showSaveError = (target: StyleSaveErrorTarget, error: string) => {


### PR DESCRIPTION
### **User description**
## Summary
- 在 Windows 托盘菜单顶部添加“输出风格”子菜单，可直接切换原文、轻度润色、清晰结构、正式表达。
- 托盘切换和设置页切换都会刷新托盘勾选状态，并广播 `prefs:changed`。
- 输出风格页面打开时会响应偏好通知，同步更新当前选中的风格。

## Verification
- `npx.cmd --cache .\.npm-cache tsx src/lib/stylePrefs.test.ts`
- `cargo check --manifest-path openless-all/app/src-tauri/Cargo.toml`
- `npm.cmd run build`
- Windows 实机验证：打开输出风格页面后，通过托盘菜单切到“轻度润色”，页面选中态立即同步更新。


___

### **PR Type**
Enhancement


___

### **Description**
- Add Windows tray output style submenu for polish mode switching

- Sync tray selection with settings page via prefs:changed event and React context

- Emit prefs:changed globally on style change from IPC or tray

- Add tests for tray menu entries and frontend notification logic


___

### Diagram Walkthrough


```mermaid
flowchart LR
  TrayEvent["Tray style menu click"] -- parse id --> Handler["handle_style_tray_menu_event"]
  Handler -- update --> Coordinator["Coordinator preferences"]
  Coordinator -- emit --> Broadcast["prefs:changed event"]
  Broadcast -- notify --> StylePage["Style.tsx"]
  Broadcast -- refresh --> TrayMenu["Rebuild tray menu"]
  StylePage -- reads --> Broadcast
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Event handling</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>commands.rs</strong><dd><code>Broadcast prefs:changed and refresh tray on mode set</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src-tauri/src/commands.rs

<ul><li>Add <code>app: AppHandle</code> parameter to <code>set_default_polish_mode</code><br> <li> Refresh tray microphone menu after setting preferences<br> <li> Emit <code>prefs:changed</code> to all windows and to "main" window</ul>


</details>


  </td>
  <td><a href="https://github.com/appergb/openless/pull/371/files#diff-8215873d09604b1dbb99088131ba7fc2fd6c537e67588cba5bd9160c2138b035">+8/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>lib.rs</strong><dd><code>Build Windows style tray submenu and handle selection</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src-tauri/src/lib.rs

<ul><li>Import <code>PolishMode</code> and add <code>StyleTrayMenu</code> struct<br> <li> Build output style submenu for Windows with checked state<br> <li> Route tray menu events to style handler before microphone handler<br> <li> Update preferences, emit <code>prefs:changed</code>, and refresh tray on style <br>selection<br> <li> Add unit tests for <code>tray_style_menu_enabled</code>, <br><code>tray_polish_mode_menu_entries</code>, and <code>parse_tray_polish_mode_id</code></ul>


</details>


  </td>
  <td><a href="https://github.com/appergb/openless/pull/371/files#diff-6b8eb1bbf8e378bab914f1a12962f7add5cc4ba9e013c37c9921a1032fa5e110">+143/-3</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>stylePrefs.ts</strong><dd><code>Add helper to apply incoming preference notification</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src/lib/stylePrefs.ts

<ul><li>Export new <code>applyStylePreferencesNotification</code> function that returns <br>incoming prefs</ul>


</details>


  </td>
  <td><a href="https://github.com/appergb/openless/pull/371/files#diff-574feee70bd2fc4415577c34ae7db1234f3e85ca99381ad69b8cd336066ce008">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Style.tsx</strong><dd><code>Sync style page with external preference changes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src/pages/Style.tsx

<ul><li>React to <code>sharedPrefs</code> from <code>useHotkeySettings</code> context<br> <li> Listen to <code>prefs:changed</code> Tauri event and update local prefs<br> <li> Clear save error on external preference change</ul>


</details>


  </td>
  <td><a href="https://github.com/appergb/openless/pull/371/files#diff-2a8b23751b06c84556f211a25b45e26ce57cb3dcd3e22e4552e0dc84b975b21d">+30/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>stylePrefs.test.ts</strong><dd><code>Test preference notification replaces stale prefs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src/lib/stylePrefs.test.ts

<ul><li>Add test for <code>applyStylePreferencesNotification</code> verifying incoming <br>preferences replace current</ul>


</details>


  </td>
  <td><a href="https://github.com/appergb/openless/pull/371/files#diff-a7ecf2d0594dfdd3e282c0af9077186eef74b9dc386643e32826345bab3c4c99">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

