### PR TITLE
feat(asr): forward dictionary entries to Whisper prompt

### DIFF
--- a/openless-all/app/src-tauri/src/asr/whisper.rs
+++ b/openless-all/app/src-tauri/src/asr/whisper.rs
@@ -7,19 +7,39 @@ use parking_lot::Mutex;
 use crate::asr::wav::encode_wav_16k_mono;
 use crate::asr::RawTranscript;
 
+/// Whisper の `prompt` パラメータの安全側上限（文字数）。
+///
+/// OpenAI / Groq の Audio Transcriptions API は `prompt` を 244 トークンまで
+/// 受け付ける。トークナイザは BPE で言語によって 1 token あたりの文字数が
+/// 異なる：英語は ~4 chars/token、日本語・中国語は最悪 ~1 char/token。
+/// CJK ユーザーが安全に収まるよう、文字数で 240 を上限にする。
+pub const PROMPT_CHAR_BUDGET: usize = 240;
+
+/// 区切り文字（ASCII）。Whisper のトークナイザはどの言語でも安定して扱える。
+const PROMPT_SEPARATOR: &str = ", ";
+
 pub struct WhisperBatchASR {
     api_key: String,
     base_url: String,
     model: String,
+    /// 任意のプロンプト（語彙ヒント等）。空文字や空白のみは送信しない。
+    /// `None` ＝ プロンプト無し（既存挙動）。
+    prompt: Option<String>,
     buffer: Mutex<Vec<u8>>,
 }
 
 impl WhisperBatchASR {
-    pub fn new(api_key: String, base_url: String, model: String) -> Self {
+    pub fn new(
+        api_key: String,
+        base_url: String,
+        model: String,
+        prompt: Option<String>,
+    ) -> Self {
         Self {
             api_key,
             base_url,
             model,
+            prompt,
             buffer: Mutex::new(Vec::new()),
         }
     }
@@ -69,9 +89,19 @@ impl WhisperBatchASR {
             .file_name("audio.wav")
             .mime_str("audio/wav")
             .context("set MIME type")?;
-        let form = reqwest::multipart::Form::new()
+        let mut form = reqwest::multipart::Form::new()
             .part("file", wav_part)
             .text("model", self.model.clone());
+
+        // `prompt` は空文字を送らない：OpenAI 互換実装によっては空文字でエラーに
+        // なるリスクがある（Groq は許容するが防御的にスキップ）。`trim()` で
+        // 空白のみのケースも除外。
+        if let Some(prompt) = self.prompt.as_ref() {
+            let trimmed = prompt.trim();
+            if !trimmed.is_empty() {
+                form = form.text("prompt", trimmed.to_string());
+            }
+        }
 
         let client = reqwest::Client::new();
         let resp = client
@@ -102,5 +132,153 @@ impl WhisperBatchASR {
 impl crate::recorder::AudioConsumer for WhisperBatchASR {
     fn consume_pcm_chunk(&self, pcm: &[u8]) {
         self.buffer.lock().extend_from_slice(pcm);
+    }
+}
+
+/// 用户辞書の有効フレーズから Whisper の `prompt` パラメータを組み立てる。
+///
+/// Whisper は `prompt` で語彙ヒント / スタイル文脈を渡せる：固有名詞・専門
+/// 用語の表記揺れを抑え、ASR 段階で正しい綴り（漢字選択を含む）に偏らせる。
+/// 既存の dictionary 機能はこれまで Volcengine ASR と Polish LLM のみに渡って
+/// いて、Whisper 互換プロバイダ（whisper / siliconflow / zhipu / groq）には
+/// 流れていなかった。本関数で同じエントリを Whisper にも届ける。
+///
+/// # 仕様
+///
+/// - 空白のみのフレーズは除外
+/// - 区切りは `, `
+/// - 末尾に `.` を付与して「文の終わり」を Whisper に明示（モデルがプロンプト
+///   を続きと誤解して書き起こし冒頭に混入するのを抑える）
+/// - 文字数が `PROMPT_CHAR_BUDGET` を超えるエントリは**スキップ**して次に
+///   進む（途中で打ち切らない）。これにより「先頭に長文 1 件があると残りが
+///   全部捨てられる」現象を回避でき、登録順を保ちつつ収まるエントリを最大化
+///   できる。
+/// - 入力が空、または有効フレーズが 0 件の場合は `None` を返す。Optional に
+///   することで「プロンプト無し」と「空文字プロンプト」を呼び出し側で区別
+///   する必要をなくす。
+pub fn build_prompt_from_phrases(phrases: &[String]) -> Option<String> {
+    let mut included: Vec<&str> = Vec::new();
+    let mut total_chars: usize = 0;
+
+    for phrase in phrases {
+        let trimmed = phrase.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let phrase_chars = trimmed.chars().count();
+        let added = if included.is_empty() {
+            phrase_chars
+        } else {
+            PROMPT_SEPARATOR.chars().count() + phrase_chars
+        };
+        // 末尾の "." 1 文字も予約。
+        if total_chars + added + 1 > PROMPT_CHAR_BUDGET {
+            continue;
+        }
+        included.push(trimmed);
+        total_chars += added;
+    }
+
+    if included.is_empty() {
+        return None;
+    }
+    let mut s = included.join(PROMPT_SEPARATOR);
+    s.push('.');
+    Some(s)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn build_prompt_returns_none_for_empty_input() {
+        assert_eq!(build_prompt_from_phrases(&[]), None);
+    }
+
+    #[test]
+    fn build_prompt_returns_none_when_all_phrases_blank() {
+        let phrases = vec!["".to_string(), "   ".to_string(), "\t\n".to_string()];
+        assert_eq!(build_prompt_from_phrases(&phrases), None);
+    }
+
+    #[test]
+    fn build_prompt_single_phrase() {
+        let phrases = vec!["梁山泊".to_string()];
+        assert_eq!(build_prompt_from_phrases(&phrases), Some("梁山泊.".to_string()));
+    }
+
+    #[test]
+    fn build_prompt_joins_with_comma_and_appends_period() {
+        let phrases = vec![
+            "梁山泊".to_string(),
+            "片沼ほとり".to_string(),
+            "TRC".to_string(),
+        ];
+        assert_eq!(
+            build_prompt_from_phrases(&phrases),
+            Some("梁山泊, 片沼ほとり, TRC.".to_string())
+        );
+    }
+
+    #[test]
+    fn build_prompt_trims_each_phrase() {
+        let phrases = vec!["  梁山泊  ".to_string(), "\tTRC\n".to_string()];
+        assert_eq!(
+            build_prompt_from_phrases(&phrases),
+            Some("梁山泊, TRC.".to_string())
+        );
+    }
+
+    #[test]
+    fn build_prompt_skips_blank_entries_in_middle() {
+        let phrases = vec![
+            "alpha".to_string(),
+            "".to_string(),
+            "   ".to_string(),
+            "beta".to_string(),
+        ];
+        assert_eq!(
+            build_prompt_from_phrases(&phrases),
+            Some("alpha, beta.".to_string())
+        );
+    }
+
+    #[test]
+    fn build_prompt_truncates_overflow_but_keeps_short_entries_after_long_one() {
+        // 先頭に 250 文字の長文 → 単独で予算超過 → スキップ。続く短いエントリは
+        // 採用される。「途中で break しない」契約の検証。
+        let long = "あ".repeat(250);
+        let phrases = vec![long.clone(), "梁山泊".to_string(), "TRC".to_string()];
+        let prompt = build_prompt_from_phrases(&phrases).expect("non-empty");
+        assert!(!prompt.contains(&long), "long phrase must be dropped");
+        assert!(prompt.contains("梁山泊"));
+        assert!(prompt.contains("TRC"));
+        assert!(prompt.ends_with('.'));
+    }
+
+    #[test]
+    fn build_prompt_respects_char_budget() {
+        // 6 文字 × 50 件 = 300 文字（区切り込みでさらに増える）→ 予算超過分は捨てる。
+        let phrases: Vec<String> = (0..50).map(|i| format!("word{:02}", i)).collect();
+        let prompt = build_prompt_from_phrases(&phrases).expect("non-empty");
+        assert!(
+            prompt.chars().count() <= PROMPT_CHAR_BUDGET,
+            "prompt length {} exceeds budget {}",
+            prompt.chars().count(),
+            PROMPT_CHAR_BUDGET
+        );
+        assert!(prompt.ends_with('.'));
+    }
+
+    #[test]
+    fn build_prompt_includes_first_entries_when_truncating_in_order() {
+        // 順序保証：登録順の早いものから入る。後続が落ちる。
+        let phrases: Vec<String> = (0..100).map(|i| format!("entry{:03}", i)).collect();
+        let prompt = build_prompt_from_phrases(&phrases).expect("non-empty");
+        assert!(prompt.contains("entry000"));
+        assert!(prompt.contains("entry001"));
+        // 100 件 × 8 文字以上は確実に予算超過 → 末尾は入らない
+        assert!(!prompt.contains("entry099"));
     }
 }

--- a/openless-all/app/src-tauri/src/coordinator.rs
+++ b/openless-all/app/src-tauri/src/coordinator.rs
@@ -2094,7 +2094,21 @@ async fn begin_session(inner: &Arc<Inner>) -> Result<(), String> {
 
     if is_whisper_compatible_provider(&active_asr) {
         let (api_key, base_url, model) = read_whisper_credentials();
-        let whisper = Arc::new(WhisperBatchASR::new(api_key, base_url, model));
+        // 用户辞書の有効フレーズを Whisper の `prompt` に流し込む。固有名詞や
+        // 専門用語の同音・近形誤認識を ASR 段階で抑える。Polish LLM 側には
+        // 既に system prompt として注入済みだが、Whisper 出力が大きく崩れる
+        // と Polish でも救えない（特に CJK で顕著）。Volcengine ASR は元々
+        // hotword を受け取っており、UI 説明文も「ASR ホットワードと後処理
+        // モデルのコンテキスト両方に渡される」と明示しているので、Whisper
+        // 互換プロバイダにも揃えるのが筋。
+        let whisper_prompt =
+            crate::asr::whisper::build_prompt_from_phrases(&enabled_phrases(inner));
+        let whisper = Arc::new(WhisperBatchASR::new(
+            api_key,
+            base_url,
+            model,
+            whisper_prompt,
+        ));
         store_asr_for_session(
             inner,
             current_session_id,
@@ -4652,6 +4666,7 @@ mod tests {
             "key".to_string(),
             "http://localhost".to_string(),
             "model".to_string(),
+            None,
         ));
         *coordinator.inner.asr.lock() = Some(SessionResource::new(
             session_id(2),


### PR DESCRIPTION
### **User description**
## Why

The Vocabulary screen advertises that entries are passed to **both ASR hotword and post-processing model context**, and that contract is honored for Volcengine ASR (forwarded as hotwords) and the Polish LLM (concatenated into the system prompt). Whisper-compatible providers (`whisper` / `siliconflow` / `zhipu` / `groq`) were the gap: `WhisperBatchASR` never set the OpenAI `prompt` field, so the dictionary did not influence the STT stage at all.

That gap is most visible with proper nouns and CJK script choice. A user who registers `梁山泊` still receives variants like `両山泊` / `良山泊` / hiragana `りょうざんぱく` from Whisper, and the Polish LLM cannot always recover once the script has already drifted in the upstream transcription.

## What

- **`asr/whisper.rs`** — add `prompt: Option<String>` to `WhisperBatchASR`. Attach it as a `prompt` multipart field when non-blank. Blank/whitespace prompts are skipped defensively so they cannot trigger provider-specific 4xx responses on stricter OpenAI-compatible implementations.
- **`asr/whisper.rs`** — new pure helper `build_prompt_from_phrases(phrases: &[String]) -> Option<String>`:
  - joins enabled vocabulary entries with `\", \"` plus a trailing `.` (signals "complete sentence" so Whisper does not try to continue the prompt as transcription),
  - caps at **240 characters** (Whisper's documented `prompt` limit is 244 tokens; CJK is worst-case ~1 token/char, so 240 is the safe cap),
  - skips over-budget entries individually rather than truncating mid-list, which preserves registration order while letting short later entries still ride along when one earlier entry happens to be unusually long.
- **`coordinator.rs`** — at the existing Whisper-compatible branch (`is_whisper_compatible_provider`), feed `enabled_phrases(inner)` through the helper and pass the result into the new constructor. Mirrors how the Volcengine branch already builds its hotword list.

When the dictionary is empty, `build_prompt_from_phrases` returns `None`, the constructor stores `None`, and the request body is byte-for-byte identical to the previous behavior — no regression risk for users without registered vocabulary.

## Tests

`cargo test --lib asr::whisper` covers:

| case | expectation |
|---|---|
| empty slice | `None` |
| all whitespace entries | `None` |
| single phrase | `Some(\"phrase.\")` |
| multi phrase | joined with `\", \"`, trailing `.` |
| per-entry whitespace | trimmed |
| blank middle entries | skipped without breaking the join |
| 250-char single entry followed by short entries | long one dropped, short ones kept |
| 50× 6-char words | output ≤ 240 chars, ends with `.` |
| 100× 8-char entries | first entries kept, last entries truncated |

## No new dependencies; no breaking change to other call sites

Constructor signature gained one parameter; the only caller is in `coordinator.rs` and is updated in this PR. The existing test in `coordinator::tests::stale_startup_cleanup_keeps_newer_asr_resource` is updated to pass `None`.

## Out of scope

- DashScope / Qwen3-ASR-Flash uses a different protocol and is intentionally outside the Whisper-compatible branch (per existing comment at `is_whisper_compatible_provider`); not touched here.
- The Polish LLM hotword path is unchanged; this only fills in the previously-missing ASR side.


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Add optional prompt field to WhisperBatchASR

- Implement build_prompt_from_phrases with 240-char limit

- Inject vocabulary phrases as prompt in coordinator

- Add unit tests for prompt construction logic


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Enabled dictionary phrases"] --> B["build_prompt_from_phrases"]
  B --> C["Prompt String (comma-separated, period-terminated)"]
  C --> D["WhisperBatchASR prompt field"]
  D --> E["Multipart request with prompt"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>whisper.rs</strong><dd><code>Add prompt support and phrase construction in Whisper ASR</code></dd></summary>
<hr>

openless-all/app/src-tauri/src/asr/whisper.rs

<ul><li>Add PROMPT_CHAR_BUDGET constant and PROMPT_SEPARATOR<br> <li> Add optional prompt field to WhisperBatchASR and update constructor<br> <li> Include prompt in multipart request when non-blank<br> <li> Implement build_prompt_from_phrases with char budget, trimming, and <br>ordering<br> <li> Add unit tests covering empty, single, merging, budget, and truncation</ul>


</details>


  </td>
  <td><a href="https://github.com/appergb/openless/pull/375/files#diff-cf6696a6b96bc9f0fb12aeb6e3934ad2668e3595f06ad10652604887f9794d2b">+180/-2</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>coordinator.rs</strong><dd><code>Wire dictionary phrases to Whisper ASR prompt in coordinator</code></dd></summary>
<hr>

openless-all/app/src-tauri/src/coordinator.rs

<ul><li>Build whisper prompt from enabled phrases for Whisper-compatible <br>providers<br> <li> Pass prompt to WhisperBatchASR::new during session start<br> <li> Update existing test to supply None prompt</ul>


</details>


  </td>
  <td><a href="https://github.com/appergb/openless/pull/375/files#diff-73d8c004670b27293f74f0f3991b9a6fc28f0ff0b883214de2b078b1e09797ca">+16/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

