### PR TITLE
fix(recorder): watchdog 在 sleep 醒来后重检 stop_flag，消除停采误报

### DIFF
--- a/openless-all/app/src-tauri/src/recorder.rs
+++ b/openless-all/app/src-tauri/src/recorder.rs
@@ -192,6 +192,23 @@ fn run_audio_thread(
             while !stop_flag_for_watchdog.load(Ordering::SeqCst) {
                 thread::sleep(std::time::Duration::from_millis(WATCHDOG_CHECK_INTERVAL_MS));
 
+                // 关键：sleep 醒来后必须重新检查 stop_flag，再去看 elapsed。
+                //
+                // 否则会与 hotkey-release 停采路径产生竞态：
+                //   1. 用户松开 hotkey → end_session 调 rec.stop() → 设置 stop_flag
+                //      → audio 线程 pause 了 cpal Stream → 回调真的静默
+                //   2. 但 watchdog 此时正卡在上面的 1 秒 sleep 里
+                //   3. sleep 结束后，若不重新检查 stop_flag，
+                //      就会读到 last_callback_time 已经"老 4 秒"，
+                //      把"我们主动停掉的录音"错报成 EngineFailed("录音回调静默停止 N 秒")，
+                //      coordinator 收到错误后会终止 session、胶囊弹错。
+                //
+                // 修复方式是 sleep 后立即再 load 一次：进入 stop 流程后 watchdog 静默退出，
+                // 不影响 watchdog 在真正活动期捕获 CoreAudio 设备掉线等真故障。
+                if stop_flag_for_watchdog.load(Ordering::SeqCst) {
+                    break;
+                }
+
                 let last_callback = *state_for_watchdog.last_callback_time.lock();
                 match last_callback {
                     Some(last_time) => {


### PR DESCRIPTION
### **User description**
## 问题

Listening → Processing 转移期间，recorder 的 liveness watchdog 会把"用户主动停采"误报为 EngineFailed，导致 coordinator 终止 session、胶囊弹出 \`audio engine failed\` 错误。

## 复现日志

\`~/Library/Logs/OpenLess/openless.log\`：

\`\`\`
27.011  [recorder] cb#4250 ...                  <- 最后一次回调
27.054  [asr] server JSON ...                   <- ASR 仍在收尾
~27.5   用户松开 hotkey → end_session 调 rec.stop() → stop_flag=true + pause cpal
31.667  [ERROR] [recorder] watchdog: 录音回调已停止 4 秒，触发错误恢复
31.667  [ERROR] [coord] recorder runtime error: audio engine failed
36.244  [ERROR] [asr] error frame code=45000081 [Timeout waiting next packet]
\`\`\`

同一日志里 05:51:33 有同样模式，每次都恰好在用户停止说话后 4–5 秒。

## Root cause（race）

watchdog 循环原结构：

\`\`\`rust
while !stop_flag.load(...) {        // 顶检
    thread::sleep(1s);              // 长 sleep
    let last = state.last_callback_time.lock();  // 不再 check stop_flag
    if elapsed > 3s { fire EngineFailed; break; }
}
\`\`\`

竞态时序：

1. 用户松开 hotkey → \`end_session\` → \`rec.stop()\`：先 \`stop_flag.store(true)\`，再 \`handle.join()\`
2. audio 线程从 50ms sleep 醒来 → 看到 stop_flag → \`stream.pause()\`（cpal callback 停止递送）
3. **此时 watchdog 还卡在 1s sleep 里**
4. watchdog 醒来：旧逻辑不重检 stop_flag，直接读 \`last_callback_time\`，发现已 >3 秒未更新（因为 cpal 已 pause）→ 误报 EngineFailed

\`Recorder::stop\` 在 \`end_session\` 第 3 步就被调，并不是慢，但 watchdog 1s 的 sleep + 3s 的容忍阈值天然就给 race 留了 ~4s 的窗口。

## 修复

watchdog sleep 醒来后立即再 load 一次 stop_flag，置位则直接 break：

\`\`\`rust
while !stop_flag.load(...) {
    thread::sleep(1s);

    // 关键：sleep 醒来后必须重新检查 stop_flag
    if stop_flag.load(...) { break; }

    // ...原有的 elapsed 判定
}
\`\`\`

注释里写了 18 行 root cause 解释，防止后续重构时被无意识回退。

## 行为对比

| 场景 | 修复前 | 修复后 |
|---|---|---|
| 用户主动停采（hotkey-release / cancel） | watchdog 误报 EngineFailed | watchdog 静默退出 |
| 真故障（CoreAudio 设备掉线、OS 音频复位） | 触发 EngineFailed | 触发 EngineFailed（不变） |
| 慢启动设备（首次回调超时） | 触发首次回调超时 | 触发首次回调超时（不变） |

修复保留 watchdog 在活动期捕获真故障的能力——只在 stop 流程里让它静默退出。

## Test plan

- [x] \`cargo check --manifest-path openless-all/app/src-tauri/Cargo.toml\` 通过
- [x] \`cargo test --manifest-path openless-all/app/src-tauri/Cargo.toml --lib recorder::\` 8/8 通过（已有的 recorder 单元测试）
- [ ] 实机验证：在 macOS 上短按 hotkey → 说话 → 松开 hotkey；多重复几次，观察 \`~/Library/Logs/OpenLess/openless.log\` 不再出现 \`watchdog: 录音回调已停止 N 秒\` 日志，胶囊不再弹 \`audio engine failed\`
- [ ] 实机验证：拔掉/切换麦克风设备触发真故障路径，确认 watchdog 仍能正常报 EngineFailed


___

### **PR Type**
Bug fix


___

### **Description**
- Recheck `stop_flag` after watchdog sleep

- Prevent false `EngineFailed` on manual stop

- Preserve real audio failure detection

- Add race-condition explanation comments


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["hotkey release / stop"] -- "sets" --> B["stop_flag = true"]
  C["watchdog sleep"] -- "wake up" --> D["recheck stop_flag"]
  D -- "true" --> E["exit silently"]
  D -- "false" --> F["check last callback time"]
  F -- "silent too long" --> G["EngineFailed"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>recorder.rs</strong><dd><code>Guard watchdog against stop-race false alarms</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src-tauri/src/recorder.rs

<ul><li>Added an immediate <code>stop_flag</code> recheck after each watchdog sleep.<br> <li> Prevented the watchdog from misclassifying intentional stops as engine <br>failures.<br> <li> Kept the existing silence-based failure path for real audio issues.<br> <li> Documented the race condition with detailed inline comments.</ul>


</details>


  </td>
  <td><a href="https://github.com/appergb/openless/pull/379/files#diff-3a3bff2e6caa233c7088fe47b82b922594ff82333dc4b57032612ffbabb6a006">+17/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

