### PR TITLE
fix(commands): wrap tray refresh in run_on_main_thread to avoid macOS UI freeze

### DIFF
--- a/openless-all/app/src-tauri/src/commands.rs
+++ b/openless-all/app/src-tauri/src/commands.rs
@@ -150,10 +150,22 @@ pub fn set_settings(
     // 没有 HotkeySettingsContext，必须靠事件感知录音键变化，否则面板可见时
     // 用户改键会让浮窗里的 "{recordHotkey}" 文案一直停留在旧值。
     persist_settings(&*coord, prefs.clone())?;
-    if let Err(err) = crate::refresh_tray_microphone_menu(&app) {
-        log::warn!("[tray] refresh microphone menu after settings save failed: {err}");
-        sync_tray_microphone_selection(&tray_microphones.lock(), &prefs.microphone_device_name);
-    }
+    // refresh_tray_microphone_menu 内部会调用 NSStatusItem.set_menu，必须在主线程上跑。
+    // set_settings 本身是同步 Tauri command，在 IPC handler 线程上执行；从这里直接调
+    // 会触发 macOS 主线程断言或在 dispatch 队列上死锁，导致整个 UI 无响应（用户改
+    // 偏好后所有按键都没反应即此根因）。dispatch 到主线程后立即返回，IPC 线程不阻塞。
+    let app_for_main = app.clone();
+    let prefs_for_main = prefs.clone();
+    let _ = app.run_on_main_thread(move || {
+        if let Err(err) = crate::refresh_tray_microphone_menu(&app_for_main) {
+            log::warn!("[tray] refresh microphone menu after settings save failed: {err}");
+            let tray_state = app_for_main.state::<TrayMicrophoneMenuState>();
+            sync_tray_microphone_selection(&tray_state.lock(), &prefs_for_main.microphone_device_name);
+        }
+    });
+    // 抑制 unused 警告：tray_microphones 现在改在闭包里通过 app.state 取，
+    // 但函数签名保留 State 入参，以便 Tauri 在调用前注入。
+    let _ = tray_microphones;
     let _ = app.emit("prefs:changed", &prefs);
     Ok(())
 }
@@ -929,9 +941,14 @@ pub fn set_default_polish_mode(
     let mut prefs = coord.prefs().get();
     prefs.default_mode = mode;
     coord.prefs().set(prefs.clone()).map_err(|e| e.to_string())?;
-    if let Err(err) = crate::refresh_tray_microphone_menu(&app) {
-        log::warn!("[tray] refresh style menu after polish mode IPC change failed: {err}");
-    }
+    // 跟 set_settings 同样：refresh_tray_microphone_menu 里 tray.set_menu 改 NSStatusItem，
+    // 必须主线程；这里是同步 Tauri command 跑在 IPC 线程，直调会让 macOS 死锁。
+    let app_for_main = app.clone();
+    let _ = app.run_on_main_thread(move || {
+        if let Err(err) = crate::refresh_tray_microphone_menu(&app_for_main) {
+            log::warn!("[tray] refresh style menu after polish mode IPC change failed: {err}");
+        }
+    });
     let _ = app.emit("prefs:changed", &prefs);
     let _ = app.emit_to("main", "prefs:changed", &prefs);
     Ok(())


### PR DESCRIPTION
### **User description**
## Summary

`set_settings` 和 `set_default_polish_mode` 是同步 Tauri commands，跑在 IPC handler 线程。它们直接调 `refresh_tray_microphone_menu`，里面 `tray.set_menu(...)` 改 macOS NSStatusItem 必须主线程；从 IPC 线程直调会触发 macOS dispatch queue 死锁，导致用户改任何偏好开关（包括 ASR 配置、划词追问历史保存、默认风格切换）后整个 UI 永久卡死、所有按键无响应。

修复：把两处 tray 刷新都包到 `app.run_on_main_thread(move || ...)` dispatch 到主线程，IPC 线程立即返回不阻塞。这跟 `lib.rs:558` 里 `start_tray_microphone_watcher` 已经在用的 pattern 完全一致（参考 issue #169）。

## Root cause

PR #306（feat: microphone device selection）第一次在 `set_settings` 加这个调用，没意识到主线程隔离；`set_default_polish_mode` 后续也有同样模式。两处都修。

## Defensive sweep

整个项目里 `tray.set_menu()` 只在 `refresh_tray_microphone_menu`（lib.rs:518）一处出现，所有 5 个调用点已确认安全：

| 位置 | 状态 |
| --- | --- |
| lib.rs:207 tray hover event | tray 事件本身在主线程 ✓ |
| lib.rs:559 麦克风设备 watcher | 已包 run_on_main_thread ✓ |
| lib.rs:605 tray 菜单事件 | 主线程 ✓ |
| commands.rs:160 set_settings | **本提交修复** |
| commands.rs:944 set_default_polish_mode | **本提交修复** |

其它 sync IPC commands（set_dictation/qa/translation/switch_style/open_app_hotkey）通过 `coord.refresh_*_hotkey()` 间接刷新，那些函数内部已包了 run_on_main_thread；不碰 AppKit 的 commands 安全。Rust 后端无更多隐患。

## Test plan

- [ ] 反复 toggle 划词追问"历史保存"开关，UI 不应卡死
- [ ] 切换默认风格（Style 页 / 托盘菜单），UI 不应卡死
- [ ] 改 ASR 麦克风设备，托盘菜单同步更新且 UI 不卡
- [ ] cargo check 通过（已验证）


___

### **PR Type**
Bug fix


___

### **Description**
- Wrap tray refresh in `run_on_main_thread` in `set_settings`

- Same fix in `set_default_polish_mode`

- Prevent UI freeze from IPC threads calling NSStatusItem


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["IPC thread (set_settings)"] -- "run_on_main_thread" --> B["Main thread"]
  B -- "refresh_tray_microphone_menu" --> C["Update NSStatusItem menu"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>commands.rs</strong><dd><code>Dispatch tray menu refresh to main thread in settings commands</code></dd></summary>
<hr>

openless-all/app/src-tauri/src/commands.rs

<ul><li>Wrapped <code>refresh_tray_microphone_menu</code> call in <code>set_settings</code> with <br><code>app.run_on_main_thread</code> to dispatch to main thread.<br> <li> Similarly wrapped in <code>set_default_polish_mode</code>.<br> <li> Removed direct use of <code>tray_microphones</code> state parameter; now accessed <br>via <code>app.state</code> inside the closure.</ul>


</details>


  </td>
  <td><a href="https://github.com/appergb/openless/pull/380/files#diff-8215873d09604b1dbb99088131ba7fc2fd6c537e67588cba5bd9160c2138b035">+24/-7</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

