### PR TITLE
修复 Style 总开关关闭后的兜底风格

### DIFF
--- a/openless-all/app/src/lib/stylePrefs.test.ts
+++ b/openless-all/app/src/lib/stylePrefs.test.ts
@@ -1,8 +1,11 @@
 import {
   applyStylePreferencesNotification,
+  isStyleMasterEnabled,
   persistStylePreferenceChange,
   rollbackStyleEnabledChange,
   rollbackWholeStylePreferences,
+  styleMasterFallbackModes,
+  styleMasterOffPreferences,
 } from './stylePrefs';
 import type { UserPreferences } from './types';
 
@@ -114,3 +117,28 @@ const notifiedPrefs: UserPreferences = {
 };
 const syncedPrefs = applyStylePreferencesNotification(previousPrefs, notifiedPrefs);
 assert(syncedPrefs === notifiedPrefs, 'prefs notification should replace stale style page prefs');
+
+const masterOffPrefs = styleMasterOffPreferences(previousPrefs);
+assert(
+  masterOffPrefs.enabledModes.join(',') === 'raw,light',
+  `master toggle off should persist raw and current default, got ${masterOffPrefs.enabledModes.join(',')}`,
+);
+
+const masterFallback = styleMasterFallbackModes('light');
+assert(
+  masterFallback.join(',') === 'raw,light',
+  `master toggle off should preserve raw and current default, got ${masterFallback.join(',')}`,
+);
+assert(
+  isStyleMasterEnabled({ ...previousPrefs, enabledModes: masterFallback }) === false,
+  'master toggle should render off when only raw and default remain enabled',
+);
+assert(
+  isStyleMasterEnabled(previousPrefs) === true,
+  'master toggle should render on when extra styles remain enabled',
+);
+const rawFallback = styleMasterFallbackModes('raw');
+assert(
+  rawFallback.join(',') === 'raw',
+  `raw default fallback should not duplicate raw, got ${rawFallback.join(',')}`,
+);

--- a/openless-all/app/src/lib/stylePrefs.test.ts
+++ b/openless-all/app/src/lib/stylePrefs.test.ts
@@ -1,9 +1,11 @@
 import {
   applyStylePreferencesNotification,
   isStyleMasterEnabled,
+  rollbackDefaultAndEnabledChange,
   persistStylePreferenceChange,
   rollbackStyleEnabledChange,
   rollbackWholeStylePreferences,
+  styleDefaultModePreferences,
   styleMasterFallbackModes,
   styleMasterOffPreferences,
 } from './stylePrefs';
@@ -141,4 +143,29 @@ const rawFallback = styleMasterFallbackModes('raw');
 assert(
   rawFallback.join(',') === 'raw',
   `raw default fallback should not duplicate raw, got ${rawFallback.join(',')}`,
+);
+
+
+const defaultAfterMasterOff = styleDefaultModePreferences(
+  { ...previousPrefs, enabledModes: ['raw', 'light'] },
+  'formal',
+);
+assert(
+  defaultAfterMasterOff.defaultMode === 'formal' && defaultAfterMasterOff.enabledModes.join(',') === 'raw,formal',
+  `default change while master is off should refresh fallback modes, got ${defaultAfterMasterOff.defaultMode}/${defaultAfterMasterOff.enabledModes.join(',')}`,
+);
+assert(
+  isStyleMasterEnabled(defaultAfterMasterOff) === false,
+  'master toggle should stay off after changing default while off',
+);
+
+let rolledBackDefaultAndEnabled: UserPreferences | null = defaultAfterMasterOff;
+const rollbackDefaultAndEnabled = rollbackDefaultAndEnabledChange(
+  { ...previousPrefs, enabledModes: ['raw', 'light'] },
+  defaultAfterMasterOff,
+);
+rolledBackDefaultAndEnabled = rollbackDefaultAndEnabled(rolledBackDefaultAndEnabled);
+assert(
+  rolledBackDefaultAndEnabled?.defaultMode === 'light' && rolledBackDefaultAndEnabled.enabledModes.join(',') === 'raw,light',
+  'failed off-state default save should roll back both default mode and enabled modes',
 );

--- a/openless-all/app/src/lib/stylePrefs.ts
+++ b/openless-all/app/src/lib/stylePrefs.ts
@@ -35,6 +35,18 @@ export function applyStylePreferencesNotification(
   return incoming;
 }
 
+export function styleMasterFallbackModes(defaultMode: PolishMode): PolishMode[] {
+  return defaultMode === 'raw' ? ['raw'] : ['raw', defaultMode];
+}
+
+export function isStyleMasterEnabled(prefs: UserPreferences): boolean {
+  return !sameModeSet(prefs.enabledModes, styleMasterFallbackModes(prefs.defaultMode));
+}
+
+export function styleMasterOffPreferences(prefs: UserPreferences): UserPreferences {
+  return { ...prefs, enabledModes: styleMasterFallbackModes(prefs.defaultMode) };
+}
+
 export function rollbackDefaultModeChange(
   previousPrefs: UserPreferences,
   nextPrefs: UserPreferences,
@@ -69,6 +81,12 @@ export function rollbackWholeStylePreferences(
     if (!current || !sameModes(current.enabledModes, nextPrefs.enabledModes)) return current;
     return { ...current, enabledModes: previousPrefs.enabledModes };
   };
+}
+
+function sameModeSet(left: PolishMode[], right: PolishMode[]): boolean {
+  if (left.length !== right.length) return false;
+  const rightSet = new Set(right);
+  return left.every(mode => rightSet.has(mode));
 }
 
 function sameModes(left: PolishMode[], right: PolishMode[]): boolean {

--- a/openless-all/app/src/lib/stylePrefs.ts
+++ b/openless-all/app/src/lib/stylePrefs.ts
@@ -47,6 +47,11 @@ export function styleMasterOffPreferences(prefs: UserPreferences): UserPreferenc
   return { ...prefs, enabledModes: styleMasterFallbackModes(prefs.defaultMode) };
 }
 
+export function styleDefaultModePreferences(prefs: UserPreferences, mode: PolishMode): UserPreferences {
+  const nextPrefs = { ...prefs, defaultMode: mode };
+  return isStyleMasterEnabled(prefs) ? nextPrefs : styleMasterOffPreferences(nextPrefs);
+}
+
 export function rollbackDefaultModeChange(
   previousPrefs: UserPreferences,
   nextPrefs: UserPreferences,
@@ -80,6 +85,26 @@ export function rollbackWholeStylePreferences(
   return current => {
     if (!current || !sameModes(current.enabledModes, nextPrefs.enabledModes)) return current;
     return { ...current, enabledModes: previousPrefs.enabledModes };
+  };
+}
+
+export function rollbackDefaultAndEnabledChange(
+  previousPrefs: UserPreferences,
+  nextPrefs: UserPreferences,
+): StylePrefsRollback {
+  return current => {
+    if (
+      !current ||
+      current.defaultMode !== nextPrefs.defaultMode ||
+      !sameModes(current.enabledModes, nextPrefs.enabledModes)
+    ) {
+      return current;
+    }
+    return {
+      ...current,
+      defaultMode: previousPrefs.defaultMode,
+      enabledModes: previousPrefs.enabledModes,
+    };
   };
 }
 

--- a/openless-all/app/src/pages/Style.tsx
+++ b/openless-all/app/src/pages/Style.tsx
@@ -9,9 +9,11 @@ import {
   applyStylePreferencesNotification,
   isStyleMasterEnabled,
   persistStylePreferenceChange,
+  rollbackDefaultAndEnabledChange,
   rollbackDefaultModeChange,
   rollbackStyleEnabledChange,
   rollbackWholeStylePreferences,
+  styleDefaultModePreferences,
   styleMasterOffPreferences,
 } from '../lib/stylePrefs';
 import { PageHeader, Pill } from './_atoms';
@@ -76,13 +78,16 @@ export function Style() {
 
   const onPickDefault = async (mode: PolishMode) => {
     if (!prefs) return;
-    const next = { ...prefs, defaultMode: mode };
+    const masterWasEnabled = isStyleMasterEnabled(prefs);
+    const next = styleDefaultModePreferences(prefs, mode);
     const saved = await persistStylePreferenceChange(
       next,
-      () => setDefaultPolishMode(mode),
+      () => (masterWasEnabled ? setDefaultPolishMode(mode) : setSettings(next)),
       setPrefs,
       error => showSaveError(mode, error),
-      rollbackDefaultModeChange(prefs, next),
+      masterWasEnabled
+        ? rollbackDefaultModeChange(prefs, next)
+        : rollbackDefaultAndEnabledChange(prefs, next),
     );
     if (saved) setSaveError(null);
   };

--- a/openless-all/app/src/pages/Style.tsx
+++ b/openless-all/app/src/pages/Style.tsx
@@ -7,10 +7,12 @@ import { getSettings, setDefaultPolishMode, setStyleEnabled, setSettings } from 
 import type { PolishMode, UserPreferences } from '../lib/types';
 import {
   applyStylePreferencesNotification,
+  isStyleMasterEnabled,
   persistStylePreferenceChange,
   rollbackDefaultModeChange,
   rollbackStyleEnabledChange,
   rollbackWholeStylePreferences,
+  styleMasterOffPreferences,
 } from '../lib/stylePrefs';
 import { PageHeader, Pill } from './_atoms';
 import { useHotkeySettings } from '../state/HotkeySettingsContext';
@@ -112,13 +114,13 @@ export function Style() {
     );
   }
 
-  const masterEnabled = prefs.enabledModes.length > 0;
+  const masterEnabled = isStyleMasterEnabled(prefs);
 
   const onMasterToggle = async () => {
     if (!prefs) return;
     if (masterEnabled) {
-      // 全部关闭 → 留 raw 和当前 default 兜底
-      const next = { ...prefs, enabledModes: [] as PolishMode[] };
+      // 全部关闭 → 留 raw 和当前 default 兜底，避免持久化空集合。
+      const next = styleMasterOffPreferences(prefs);
       const saved = await persistStylePreferenceChange(
         next,
         () => setSettings(next),


### PR DESCRIPTION
### **User description**
## 摘要

- 选择 #312 中的方案 A：Style 页总开关关闭时保留 `raw` 和当前 `defaultMode`，不再持久化空的 `enabledModes`。
- 将 master toggle 的兜底风格与开关显示判定集中到 `stylePrefs`，避免 UI 状态和保存值再次分叉。
- 补充手写回归测试，覆盖 master toggle off 后的最终 `enabledModes`。

Closes #312

## 验证

- `cd openless-all/app && npx tsx src/lib/stylePrefs.test.ts`
- `cd openless-all/app && npm run build`

## 备注

`coordinator.rs` 中 `enabled_modes` 目前用于切换风格热键过滤；听写主流程仍读取 `default_mode`。因此本修复避免空集合让风格热键无可选项，同时保持主听写路径行为稳定。


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Preserve raw/default fallback modes

- Keep master-off state stable

- Recompute saved modes after default changes

- Add regression coverage for toggle and rollback


___

### Diagram Walkthrough


```mermaid
flowchart LR
  StylePage["Style page"]
  StylePrefs["stylePrefs helpers"]
  IPC["Settings IPC"]
  Tests["Regression tests"]

  StylePage -- "toggle default / master" --> StylePrefs
  StylePrefs -- "persist fallback modes" --> IPC
  Tests -- "verify master-off semantics" --> StylePrefs
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>stylePrefs.ts</strong><dd><code>Centralize style master fallback and rollback logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src/lib/stylePrefs.ts

<ul><li>Adds <code>styleMasterFallbackModes</code> to derive <code>raw</code> plus the current default <br>mode.<br> <li> Introduces <code>isStyleMasterEnabled</code> and <code>styleMasterOffPreferences</code> to <br>centralize master-toggle state.<br> <li> Updates default-mode changes to recompute fallback modes when the <br>master switch is off.<br> <li> Adds <code>rollbackDefaultAndEnabledChange</code> plus a set-comparison helper for <br>off-state rollbacks.</ul>


</details>


  </td>
  <td><a href="https://github.com/appergb/openless/pull/383/files#diff-574feee70bd2fc4415577c34ae7db1234f3e85ca99381ad69b8cd336066ce008">+43/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Style.tsx</strong><dd><code>Use shared helpers for Style page state</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src/pages/Style.tsx

<ul><li>Switches master-toggle and default-selection logic to shared style <br>preference helpers.<br> <li> Persists full settings when default mode changes while master is off, <br>keeping <code>enabledModes</code> in sync.<br> <li> Replaces direct <code>enabledModes.length</code> checks with semantic <br>master-enabled detection.<br> <li> Updates the master-off save path to keep <code>raw</code> and the current default <br>mode.</ul>


</details>


  </td>
  <td><a href="https://github.com/appergb/openless/pull/383/files#diff-2a8b23751b06c84556f211a25b45e26ce57cb3dcd3e22e4552e0dc84b975b21d">+13/-6</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>stylePrefs.test.ts</strong><dd><code>Extend style preference regression tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src/lib/stylePrefs.test.ts

<ul><li>Adds assertions for master-off fallback modes and master-enabled <br>detection.<br> <li> Covers the <code>raw</code> default edge case so fallback mode lists are not <br>duplicated.<br> <li> Verifies default changes while master is off recompute <code>enabledModes</code> <br>correctly.<br> <li> Adds rollback coverage for failed off-state default updates.</ul>


</details>


  </td>
  <td><a href="https://github.com/appergb/openless/pull/383/files#diff-a7ecf2d0594dfdd3e282c0af9077186eef74b9dc386643e32826345bab3c4c99">+55/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

