### PR TITLE
fix(types): align TS UserPreferences with Rust update_channel

### DIFF
--- a/openless-all/app/src/lib/ipc.ts
+++ b/openless-all/app/src/lib/ipc.ts
@@ -14,10 +14,12 @@ import type {
   PolishMode,
   QaHotkeyBinding,
   ShortcutBinding,
+  UpdateChannel,
   UserPreferences,
   WindowsImeStatus,
   VocabPresetStore,
 } from './types';
+export type { UpdateChannel } from './types';
 import { OL_DATA } from './mockData';
 import { defaultAppShortcutModifiers, defaultQaShortcut, formatComboLabel } from './hotkey';
 
@@ -76,6 +78,7 @@ const mockSettings: UserPreferences = {
   historyRetentionDays: 7,
   polishContextWindowMinutes: 5,
   startMinimized: false,
+  updateChannel: 'stable',
 };
 
 const mockHotkeyCapability: HotkeyCapability = {
@@ -159,7 +162,8 @@ export function setSettings(prefs: UserPreferences): Promise<void> {
 // ── Release channel (Beta opt-in) ──────────────────────────────────────
 // 渠道偏好与 fetch_latest_beta_release 实际效果只在 Tauri runtime 内有意义；
 // 浏览器开发模式下走 mock，避免设置页因 invoke 抛错而白屏。
-export type UpdateChannel = 'stable' | 'beta';
+// UpdateChannel 类型搬到 types.ts（UserPreferences.updateChannel 字段使用），
+// 这里 re-export 保持外部模块（SettingsModal 等）import 路径不变。
 
 export interface LatestBetaRelease {
   tagName: string;

--- a/openless-all/app/src/lib/stylePrefs.test.ts
+++ b/openless-all/app/src/lib/stylePrefs.test.ts
@@ -48,6 +48,7 @@ const previousPrefs: UserPreferences = {
   historyRetentionDays: 7,
   polishContextWindowMinutes: 5,
   startMinimized: false,
+  updateChannel: 'stable',
 };
 
 const nextPrefs: UserPreferences = {

--- a/openless-all/app/src/lib/types.ts
+++ b/openless-all/app/src/lib/types.ts
@@ -115,6 +115,10 @@ export interface WindowsImeStatus {
   dllPath: string | null;
 }
 
+/** Auto-update 渠道偏好。stable = 跟正式版（默认）；beta = Settings 里多一个
+ *  手动下载 Beta 的入口。不影响 plugin-updater 的自动检查路径。 */
+export type UpdateChannel = 'stable' | 'beta';
+
 export interface UserPreferences {
   hotkey: HotkeyBinding;
   dictationHotkey: ShortcutBinding;
@@ -174,6 +178,9 @@ export interface UserPreferences {
   /** 启动时静默运行（不弹主窗口）。Windows 开机自启场景常用——只想要后台 + 托盘，
    *  不想被主窗口打扰。开后所有启动路径都不弹窗，从菜单栏 / 托盘进入主窗口。默认 false。 */
   startMinimized: boolean;
+  /** 自动更新渠道。'stable'（默认）= plugin-updater 仅检查正式版；
+   *  'beta' = Settings → About 出现手动下载 Beta 的入口。 */
+  updateChannel: UpdateChannel;
 }
 
 export interface MicrophoneDevice {


### PR DESCRIPTION
### **User description**
## Summary

Rust `types.rs` declares `pub update_channel: UpdateChannel` on `UserPreferences`, but the TS interface in `src/lib/types.ts` and `mockSettings` in `src/lib/ipc.ts` both omitted it. `setSettings()` round-trips were lossless only because Rust's `serde(default)` refilled the field, so today's behavior is unaffected — but TS consumers that destructure `UserPreferences` silently miss the field, and the type was lying about what the backend serializes.

## Changes

- Move `UpdateChannel` type from `ipc.ts` to `types.ts` (avoids `ipc <-> types` circular import).
- `ipc.ts` re-exports `UpdateChannel` for backward compat — `SettingsModal.tsx` and any other module still imports from `ipc.ts` unchanged.
- Add `updateChannel: UpdateChannel` to `UserPreferences` interface.
- Add `updateChannel: 'stable'` to `mockSettings` and to the `stylePrefs.test.ts` fixture (otherwise tsc fails).

## Audit linkage

Audit ID **2.2.1** of the 2026-05-10 audit set (CONFIRMED). See `docs/audit-2026-05-10-validated.md` (local, not in repo) for the full validation context.

## Test plan

- [x] `npx tsc --noEmit` clean (was failing on `stylePrefs.test.ts` for missing field — now fixed)
- [ ] `npm run build` — to be verified in CI
- [ ] Settings → About → Beta channel toggle still reads/writes via `getUpdateChannel`/`setUpdateChannel` IPC (unchanged)

Awaiting manual verification: this is a TS-only change; Rust round-trip behavior is identical.


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Add `updateChannel` field to TS `UserPreferences` to match Rust backend

- Move `UpdateChannel` type from `ipc.ts` to `types.ts` to avoid circular imports

- Update `mockSettings` and test fixture with new required field

- Re-export `UpdateChannel` from `ipc.ts` for backward compatibility


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Rust UserPreferences includes update_channel: UpdateChannel"] -- "missing in TypeScript" --> B["TS types.ts now defines UpdateChannel and adds updateChannel to UserPreferences"]
  B --> C["ipc.ts imports and re-exports UpdateChannel, adds field to mockSettings"]
  B --> D["stylePrefs.test.ts adds field to test fixture"]
  C --> E["SettingsModal and other imports remain unchanged"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>types.ts</strong><dd><code>Define UpdateChannel type and add updateChannel to UserPreferences</code></dd></summary>
<hr>

openless-all/app/src/lib/types.ts

<ul><li>Added <code>UpdateChannel</code> type definition (moved from ipc.ts)<br> <li> Added <code>updateChannel: UpdateChannel</code> property to <code>UserPreferences</code> <br>interface</ul>


</details>


  </td>
  <td><a href="https://github.com/appergb/openless/pull/386/files#diff-f22942a2f6ef50f13345f6b2781790a4a99e38a1a39702ce4bca3b2b2eb95e5a">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ipc.ts</strong><dd><code>Refactor UpdateChannel import and update mockSettings</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src/lib/ipc.ts

<ul><li>Imported <code>UpdateChannel</code> from <code>./types</code> instead of defining inline<br> <li> Re-exported <code>UpdateChannel</code> for backward compatibility<br> <li> Added <code>updateChannel: 'stable'</code> to <code>mockSettings</code> fixture<br> <li> Removed old inline type definition and updated comments</ul>


</details>


  </td>
  <td><a href="https://github.com/appergb/openless/pull/386/files#diff-ef5ae5193f0c45b487cbf9b509e52f941a85d5bffc201561a2fa1394a5ff160a">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>stylePrefs.test.ts</strong><dd><code>Add updateChannel to test fixture</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src/lib/stylePrefs.test.ts

<ul><li>Added <code>updateChannel: 'stable'</code> to <code>previousPrefs</code> test fixture to match <br>new interface requirement</ul>


</details>


  </td>
  <td><a href="https://github.com/appergb/openless/pull/386/files#diff-a7ecf2d0594dfdd3e282c0af9077186eef74b9dc386643e32826345bab3c4c99">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

