### PR TITLE
fix(coordinator): clear focus_target on cancel regardless of phase

### DIFF
--- a/openless-all/app/src-tauri/src/coordinator_state.rs
+++ b/openless-all/app/src-tauri/src/coordinator_state.rs
@@ -164,11 +164,14 @@ pub(crate) fn begin_cancel_session_state(state: &mut SessionState) -> Option<Can
     })
 }
 
-/// cancel_session 外部资源清理后的锁内收尾。Processing 交给 end_session 自己收尾。
+/// cancel_session 外部资源清理后的锁内收尾。Processing 阶段把 phase 留给 end_session
+/// 自己收尾（防止与 polish/insert 路径竞争），但 focus_target 是当前 session 的窗口
+/// 资源句柄，cancel 之后无论处于哪个 phase 都应当释放，避免下一个 session 之前的
+/// 空档期被旧值污染。详见 audit 3.3.5。
 pub(crate) fn finish_cancel_session_state(state: &mut SessionState, decision: CancelDecision) {
+    state.focus_target = None;
     if decision.phase != SessionPhase::Processing {
         state.phase = SessionPhase::Idle;
-        state.focus_target = None;
     }
 }
 
@@ -367,8 +370,19 @@ mod tests {
 
             assert_eq!(state.phase, expected_phase, "initial={initial:?}");
             assert_eq!(state.cancelled, expected_cancelled, "initial={initial:?}");
-            if matches!(initial, SessionPhase::Starting | SessionPhase::Listening) {
-                assert!(state.focus_target.is_none(), "initial={initial:?}");
+            // 任何被 begin_cancel_session_state 接受的 phase（即非 Idle/Inserting）
+            // 都应当清掉 focus_target，包括 Processing —— 这是 audit 3.3.5 的回归卡。
+            if expected_cancelled {
+                assert!(
+                    state.focus_target.is_none(),
+                    "focus_target should clear after cancel, initial={initial:?}"
+                );
+            } else {
+                assert_eq!(
+                    state.focus_target,
+                    Some(1),
+                    "rejected cancel must not touch focus_target, initial={initial:?}"
+                );
             }
         }
     }


### PR DESCRIPTION
### **User description**
## Summary

\`finish_cancel_session_state\` only cleared \`state.focus_target\` when the cancelled phase was **not** \`Processing\`. A Processing-phase cancel therefore left the stale window-resource handle in place until the next \`begin_session_state\` overwrote it. Between cancel and the next \`begin_session\`, any reader of \`focus_target\` sees a value belonging to a session that is about to be torn down.

## Why this matters

Today the leak is bounded — \`begin_session_state\` always overwrites \`focus_target\` (\`coordinator_state.rs:80\`), and there is no documented reader that races with that interval. So this isn't user-visible **today**. But the asymmetry is a footgun: anyone wiring a new code path that consults \`focus_target\` between cancel and next session would silently inherit the stale handle.

## Change

Move \`state.focus_target = None\` ahead of the phase check so it always fires when the cancel was accepted (i.e. not rejected for \`Idle\` / \`Inserting\` phases). Phase transition stays conditional on the original non-Processing branch — \`end_session\` must still own the \`Processing → Idle\` collapse to avoid racing with the polish/insert tail of \`Processing\`.

## Audit linkage

Audit ID **3.3.5** (CONFIRMED). See \`docs/audit-2026-05-10-validated.md\` (local) for full validation context.

## Test plan

- [x] \`cargo test --manifest-path openless-all/app/src-tauri/Cargo.toml --lib coordinator_state\` — 9/9 passing.
- [x] Tightened \`cancel_session_state_machine_is_table_driven\` to assert \`focus_target\` clears for every accepted phase (including Processing) and stays untouched on rejected cancels (Idle / Inserting). Test fails on the old code (regression-guard).
- [ ] CI build — to be verified

Pure state-machine bookkeeping fix; no runtime behavior change in any documented path. Awaiting manual verification of cancel-during-polish on a real build.


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Move focus_target clearing before phase check

- Retain conditional phase transition for Processing

- Assert focus_target cleared after accepted cancels

- Assert focus_target unchanged after rejected cancels


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["begin_cancel_session_state"] --> B{"Phase accepted?"}
  B -- "No (Idle/Inserting)" --> C["Return None"]
  B -- "Yes" --> D["finish_cancel_session_state"]
  D --> E["Clear focus_target"]
  E --> F{"Phase != Processing?"}
  F -- "Yes" --> G["Set phase to Idle"]
  F -- "No" --> H["Leave phase for end_session"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>coordinator_state.rs</strong><dd><code>Clear focus_target on cancel in all phases</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src-tauri/src/coordinator_state.rs

<ul><li>Move <code>state.focus_target = None</code> before the phase check so it clears on <br>every accepted cancel (including Processing)<br> <li> Update doc comment to explain why <code>focus_target</code> must always be <br>released, referencing audit 3.3.5<br> <li> Enhance <code>cancel_session_state_machine_is_table_driven</code> test to assert <br><code>focus_target</code> is <code>None</code> after any accepted cancel and remains untouched <br>on rejected cancels</ul>


</details>


  </td>
  <td><a href="https://github.com/appergb/openless/pull/387/files#diff-af1e9e773b048436908ed48a1535c23c9033bde451a0a781d52fedaa9aff4bf2">+18/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

