### PR TITLE
fix(hotkey): MacHotkeyAdapter::shutdown stops CFRunLoop + tap [严重]

### DIFF
--- a/openless-all/app/src-tauri/src/hotkey.rs
+++ b/openless-all/app/src-tauri/src/hotkey.rs
@@ -292,14 +292,32 @@ mod platform {
             "hotkey hook 启动超时",
             run_listen_loop,
         )?;
-        listener.startup;
         Ok(Box::new(MacHotkeyAdapter {
             shared: listener.shared,
+            handles: listener.startup,
         }))
     }
 
+    /// Refs needed to stop the Mac CFRunLoop / CGEventTap from outside the listener
+    /// thread. Filled in by `run_listen_loop` once the tap is created and the runloop
+    /// reference is captured; consumed by `MacHotkeyAdapter::shutdown` when the
+    /// monitor is dropped (so a binding swap or app shutdown doesn't leak the
+    /// listener thread + tap). Cf. audit 3.1.1.
+    struct MacShutdownHandles {
+        tap: std::sync::Mutex<Option<CfMachPortRef>>,
+        runloop: std::sync::Mutex<Option<CfRunLoopRef>>,
+    }
+
+    // SAFETY: CfMachPortRef / CfRunLoopRef are CoreFoundation handles; the only
+    // operations we perform on them across threads are CGEventTapEnable and
+    // CFRunLoopStop, both of which Apple documents as safe to call from any
+    // thread.
+    unsafe impl Send for MacShutdownHandles {}
+    unsafe impl Sync for MacShutdownHandles {}
+
     struct MacHotkeyAdapter {
         shared: Arc<Shared>,
+        handles: Arc<MacShutdownHandles>,
     }
 
     impl HotkeyAdapter for MacHotkeyAdapter {
@@ -321,6 +339,19 @@ mod platform {
 
         fn reset_held_state(&self) {
             reset_shared_held_state(&self.shared);
+        }
+
+        fn shutdown(&self) {
+            // 顺序：先 disable tap 让 OS 不再向我们派发事件，然后 stop runloop
+            // 让 listener 线程从 CFRunLoopRun() 返回退出。take() 保证幂等。
+            let tap = self.handles.tap.lock().ok().and_then(|mut g| g.take());
+            if let Some(tap) = tap {
+                unsafe { CGEventTapEnable(tap, false) };
+            }
+            let runloop = self.handles.runloop.lock().ok().and_then(|mut g| g.take());
+            if let Some(rl) = runloop {
+                unsafe { CFRunLoopStop(rl) };
+            }
         }
     }
 
@@ -404,24 +435,35 @@ mod platform {
         fn CFRunLoopGetCurrent() -> CfRunLoopRef;
         fn CFRunLoopAddSource(rl: CfRunLoopRef, source: CfRunLoopSourceRef, mode: CfStringRef);
         fn CFRunLoopRun();
+        fn CFRunLoopStop(rl: CfRunLoopRef);
         static kCFRunLoopCommonModes: CfStringRef;
     }
 
     struct CallbackContext {
         shared: Arc<Shared>,
         tx: Sender<HotkeyEvent>,
-        tap: std::sync::Mutex<Option<CfMachPortRef>>,
+        /// 与 MacHotkeyAdapter 共享的 (tap, runloop) refs。tap re-enable on
+        /// TAP_DISABLED_BY_TIMEOUT 走 handles.tap；adapter shutdown 也走这两个 lock。
+        handles: Arc<MacShutdownHandles>,
     }
 
     unsafe impl Send for CallbackContext {}
     unsafe impl Sync for CallbackContext {}
 
-    fn run_listen_loop(shared: Arc<Shared>, tx: Sender<HotkeyEvent>, status_tx: StartupTx<()>) {
+    fn run_listen_loop(
+        shared: Arc<Shared>,
+        tx: Sender<HotkeyEvent>,
+        status_tx: StartupTx<Arc<MacShutdownHandles>>,
+    ) {
         let mask: CgEventMask = (1u64 << FLAGS_CHANGED) | (1u64 << KEY_DOWN);
+        let handles = Arc::new(MacShutdownHandles {
+            tap: std::sync::Mutex::new(None),
+            runloop: std::sync::Mutex::new(None),
+        });
         let context = Box::into_raw(Box::new(CallbackContext {
             shared,
             tx,
-            tap: std::sync::Mutex::new(None),
+            handles: Arc::clone(&handles),
         }));
 
         unsafe {
@@ -444,16 +486,20 @@ mod platform {
                 )));
                 return;
             }
-            *(*context).tap.lock().unwrap() = Some(tap);
+            *handles.tap.lock().unwrap() = Some(tap);
 
             let source = CFMachPortCreateRunLoopSource(std::ptr::null(), tap, 0);
             let runloop = CFRunLoopGetCurrent();
+            *handles.runloop.lock().unwrap() = Some(runloop);
             CFRunLoopAddSource(runloop, source, kCFRunLoopCommonModes);
             CGEventTapEnable(tap, true);
 
             log::info!("[hotkey] CGEventTap 已启动");
-            let _ = status_tx.send(Ok(()));
+            let _ = status_tx.send(Ok(handles));
+            // CFRunLoopRun 阻塞直到 CFRunLoopStop 被调用（由 MacHotkeyAdapter::shutdown
+            // 触发）。返回后 listener 线程清理 context 并自然退出。
             CFRunLoopRun();
+            let _ = Box::from_raw(context);
         }
     }
 
@@ -470,7 +516,7 @@ mod platform {
 
         match event_type {
             TAP_DISABLED_BY_TIMEOUT | TAP_DISABLED_BY_USER_INPUT => {
-                if let Some(tap) = *ctx.tap.lock().unwrap() {
+                if let Some(tap) = *ctx.handles.tap.lock().unwrap() {
                     unsafe { CGEventTapEnable(tap, true) };
                 }
                 return event;
@@ -622,7 +668,10 @@ mod platform {
                 CallbackContext {
                     shared,
                     tx,
-                    tap: std::sync::Mutex::new(None),
+                    handles: Arc::new(MacShutdownHandles {
+                        tap: std::sync::Mutex::new(None),
+                        runloop: std::sync::Mutex::new(None),
+                    }),
                 },
                 rx,
             )


### PR DESCRIPTION
### **User description**
## Summary

\`MacHotkeyAdapter\` did not override \`HotkeyAdapter::shutdown\` — it inherited the empty default. The mac listener's \`run_listen_loop\` calls \`CFRunLoopRun()\` which never returns absent \`CFRunLoopStop\`. So every \`HotkeyMonitor::drop\` (which fires on every preference-driven monitor swap, e.g. user changes hotkey binding) leaked the listener thread + the underlying CGEventTap. Long-running sessions that cycle bindings would steadily accumulate background threads.

The Windows adapter already does this correctly via \`PostThreadMessageW(WM_QUIT)\`; this PR mirrors that pattern on macOS.

## Change

- Add \`CFRunLoopStop\` FFI extern.
- New \`MacShutdownHandles { tap, runloop }\` shared via \`Arc\` between the listener thread (writes refs after \`CGEventTapCreate\` + \`CFRunLoopGetCurrent\`) and \`MacHotkeyAdapter\` (reads them in \`shutdown\`).
- \`MacHotkeyAdapter::shutdown\` — disables the tap first (so OS stops dispatching), then \`CFRunLoopStop\`. \`take()\` makes shutdown idempotent.
- \`run_listen_loop\` now does \`Box::from_raw(context)\` after \`CFRunLoopRun\` returns, so the listener thread releases the callback context before exiting.
- The TAP_DISABLED_BY_TIMEOUT re-enable path in \`tap_callback\` now reads through \`ctx.handles.tap\` (same lock that adapter shutdown takes from). Consistent ownership story.

## Safety / threading

\`CGEventTapEnable\` and \`CFRunLoopStop\` are documented by Apple as safe to call from any thread. Captured as a \`SAFETY\` comment on the \`unsafe Send/Sync impl for MacShutdownHandles\`. Mutex held only across the FFI call (already a no-syscall fast path), so no nested-lock hazards.

## Audit linkage

Audit ID **3.1.1** (CONFIRMED 严重). See \`docs/audit-2026-05-10-validated.md\` (local) for full validation context. **3.1.3** (JoinHandle storage) deferred to a separate supervisor PR — that fix is meaningless without a supervisor consuming the health signal.

## Test plan

- [x] \`cargo test --lib\` — all 31 hotkey/coordinator/types/commands tests pass.
- [x] Test fixture \`callback_context\` updated to construct \`MacShutdownHandles\` (was constructing \`tap\` field directly on \`CallbackContext\`).
- [x] \`cargo check --lib\` clean (warnings unrelated, pre-existing).
- [ ] CI build (mac + windows targets) — to be verified.
- [ ] **Manual functional verification on macOS**: swap hotkey binding 5+ times in Settings, watch \`ps -M\` / Activity Monitor for openless threads — count should stay flat (was: leaks one thread + one CGEventTap per swap). To be done after merge.


___

### **PR Type**
Bug fix


___

### **Description**
- `MacHotkeyAdapter::shutdown` stops CFRunLoop and tap

- Shares handles via `Arc<MacShutdownHandles>`

- Idempotent teardown using `take()` on lock

- Fixes thread/tap leak on monitor drop


___

### Diagram Walkthrough


```mermaid
flowchart LR
    listener["listener thread: CFRunLoopRun"]
    handles["Arc<MacShutdownHandles>"]
    adapter["MacHotkeyAdapter::shutdown"]
    disable["CGEventTapEnable(tap, false)"]
    stop["CFRunLoopStop(runloop)"]
    exit["cleanup context"]
    listener -- "stores tap/runloop" --> handles
    handles -- "shared with" --> adapter
    adapter -- "1. disable tap" --> disable
    adapter -- "2. stop runloop" --> stop
    stop -- "unblocks" --> listener
    listener -- "exits" --> exit
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>hotkey.rs</strong><dd><code>Implement MacHotkeyAdapter::shutdown for proper cleanup</code>&nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src-tauri/src/hotkey.rs

<ul><li>Add <code>MacShutdownHandles</code> with tap/runloop refs and Send/Sync impl<br> <li> Implement <code>MacHotkeyAdapter::shutdown</code> to disable tap and stop runloop<br> <li> Update <code>run_listen_loop</code> to share handles with adapter via <code>StartupTx</code><br> <li> Add <code>CFRunLoopStop</code> FFI and adjust callback context to use handles</ul>


</details>


  </td>
  <td><a href="https://github.com/appergb/openless/pull/388/files#diff-f37b55b08938663b38e59e53ba8da02d59954d3f07dfbfa3a6c84aa7a43a3148">+57/-8</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

