### PR TITLE
fix(coordinator): marshal capsule show/hide to main thread [高]

### DIFF
--- a/openless-all/app/src-tauri/src/coordinator.rs
+++ b/openless-all/app/src-tauri/src/coordinator.rs
@@ -3666,19 +3666,26 @@ fn emit_capsule(
         translation,
     };
 
-    let show_capsule = inner.prefs.get().show_capsule;
+    // visible / translation 是「这一帧 capsule:state event 的 payload」内容 ——
+    // 必须在 call-site（即音频线程触发 emit_capsule 时）就算定，否则 main thread
+    // 闭包里读到的将是「下一帧」的 state，跟实际下发给 JS 的 payload 不一致。
     let visible = !matches!(state, CapsuleState::Idle);
 
     // emit_capsule 会被 cpal process_callback（音频回调线程）调用 ~30 Hz —— 在该
     // 线程上调用 NSWindow / HWND API 会撞 macOS dispatch_assert_queue_fail SIGTRAP
     // 或者 Win32 SendMessage 死锁。把 window.show/hide + 位置调整 marshal 到主线程；
     // app.emit_to 走 Tauri 内部事件总线，本身线程安全，保留同步调用。详见 audit 3.2.2。
+    //
+    // show_capsule（用户偏好）在主线程执行时再读 —— 用户可以在录音过程中改设置，
+    // 闭包入队到真正跑之间窗口上限是一两帧（~16-33ms），用最新值消除 stale-pref
+    // 闪烁。pr_agent 关注点 — 见 audit follow-up。
     let inner_for_main = Arc::clone(inner);
     let app_for_main = app.clone();
     let _ = app.run_on_main_thread(move || {
         let Some(window) = app_for_main.get_webview_window("capsule") else {
             return;
         };
+        let show_capsule = inner_for_main.prefs.get().show_capsule;
         // 三平台统一：Done / Cancelled / Error 状态保留 ~1.5s toast
         // （schedule_capsule_idle 之后会回 Idle 隐藏）。
         // Windows 上 linger 的真实问题（截图选中 / 死区 / 拖拽卡顿）由 #140 加的

--- a/openless-all/app/src-tauri/src/coordinator.rs
+++ b/openless-all/app/src-tauri/src/coordinator.rs
@@ -3656,37 +3656,48 @@ fn emit_capsule(
 ) {
     let app_opt = inner.app.lock().clone();
     let Some(app) = app_opt else { return };
+    let translation = inner.translation_modifier_seen.load(Ordering::SeqCst);
     let payload = CapsulePayload {
         state,
         level,
         elapsed_ms,
         message,
         inserted_chars,
-        translation: inner.translation_modifier_seen.load(Ordering::SeqCst),
+        translation,
     };
 
     let show_capsule = inner.prefs.get().show_capsule;
-    if let Some(window) = app.get_webview_window("capsule") {
+    let visible = !matches!(state, CapsuleState::Idle);
+
+    // emit_capsule 会被 cpal process_callback（音频回调线程）调用 ~30 Hz —— 在该
+    // 线程上调用 NSWindow / HWND API 会撞 macOS dispatch_assert_queue_fail SIGTRAP
+    // 或者 Win32 SendMessage 死锁。把 window.show/hide + 位置调整 marshal 到主线程；
+    // app.emit_to 走 Tauri 内部事件总线，本身线程安全，保留同步调用。详见 audit 3.2.2。
+    let inner_for_main = Arc::clone(inner);
+    let app_for_main = app.clone();
+    let _ = app.run_on_main_thread(move || {
+        let Some(window) = app_for_main.get_webview_window("capsule") else {
+            return;
+        };
         // 三平台统一：Done / Cancelled / Error 状态保留 ~1.5s toast
         // （schedule_capsule_idle 之后会回 Idle 隐藏）。
         // Windows 上 linger 的真实问题（截图选中 / 死区 / 拖拽卡顿）由 #140 加的
         // `hide_capsule_window_if_present()` Win32 hard-hide 在 visible=false 分支
         // 处理，不依赖把 Done/Cancelled/Error 打成 invisible。详见 PR #140 评论。
-        let visible = !matches!(state, CapsuleState::Idle);
-        maybe_position_capsule_bottom_center(inner, &window, payload.translation);
+        maybe_position_capsule_bottom_center(&inner_for_main, &window, translation);
         if show_capsule && visible {
-            if !show_capsule_window_no_activate(&app, &window) {
+            if !show_capsule_window_no_activate(&app_for_main, &window) {
                 let _ = window.show();
             }
             // macOS/Windows 优先走 no-activate show，避免录音胶囊抢走主窗口点击焦点。
             // 若 fallback 到 show()，OpenLess 已是前台 app 时再把 key window 还给 main。
             #[cfg(target_os = "macos")]
-            crate::restore_main_window_key_if_active(&app);
+            crate::restore_main_window_key_if_active(&app_for_main);
         } else {
             hide_capsule_window_if_present();
             let _ = window.hide();
         }
-    }
+    });
 
     let _ = app.emit_to("capsule", "capsule:state", payload);
 }


### PR DESCRIPTION
### **User description**
## Summary

\`emit_capsule\` runs window state changes (\`show()\` / \`hide()\` / position helpers) inline on whichever thread invoked it. The level handler in \`coordinator/dictation.rs\` invokes \`emit_capsule\` at ~30 Hz from inside cpal's \`process_callback\` — i.e. the **audio callback thread**. NSWindow / HWND APIs expect the main thread; calling them from the audio thread risks:

- macOS: \`dispatch_assert_queue_fail\` SIGTRAP if the AppKit runloop assertion fires
- Windows: \`SendMessage\` deadlock against the GUI thread
- Either platform: the audio callback misses its deadline and triggers \`kAudioUnitErr_TooManyFramesToProcess\` (macOS) / dropped frames (Windows)

The 30 Hz throttle bounds frequency but doesn't change per-call risk.

## Change

Wrap the window-touching half of \`emit_capsule\` in \`app.run_on_main_thread\`:
- \`window.show\` / \`window.hide\`
- \`maybe_position_capsule_bottom_center\`
- \`show_capsule_window_no_activate\`
- \`restore_main_window_key_if_active\` (macOS-only)

\`app.emit_to\` stays inline since Tauri's event bus is thread-safe. Closure captures \`Arc<Inner>\` clone + \`AppHandle\` clone + Copy primitives (\`translation\`, \`show_capsule\`, \`visible\`) — no \`CapsulePayload\` clone needed.

The pattern is already established in this file — see \`stop_qa_hotkey_listener\` (line 326) for the same reasoning around Carbon hotkey drop running off the AppKit thread.

## Why this is safe

- emit_to and run_on_main_thread are independent — the JS frontend processes the event asynchronously regardless, so the existing happens-before between \"frontend hears event\" and \"OS window visible\" is preserved (both were already async from JS's perspective).
- run_on_main_thread is fire-and-forget; emit_capsule's existing semantics (returns immediately, no result) are unchanged.
- Window state changes for begin/end/cancel paths still run — just slightly later (one main-runloop turn). At human time scales (<16 ms) this is invisible.

## Audit linkage

Audit ID **3.2.2** (CONFIRMED 高). See \`docs/audit-2026-05-10-validated.md\` (local).

## Test plan

- [x] \`cargo test --lib\` — 31/31 pass.
- [x] \`cargo check --lib\` clean.
- [ ] CI build — to be verified.
- [ ] **Manual functional verification**: dictate for ≥30 s on macOS while watching for SIGTRAP / Console.app crash logs; verify capsule still appears at session start. To be done after merge.


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Marshal window ops to main thread to avoid audio-thread crash

- Read `show_capsule` pref inside main-thread closure

- Capture visible/translation at call site for frame consistency

- Keep `emit_to` synchronous on calling thread


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["emit_capsule (audio thread)"] --> B["compute visible, capture translation"]
  B --> C["run_on_main_thread closure"]
  C --> D["read latest show_capsule pref"]
  D --> E["maybe_position, show/hide capsule window"]
  B --> F["app.emit_to (inline, thread-safe)"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>coordinator.rs</strong><dd><code>Thread-safe capsule window ops and fresh preference reading</code></dd></summary>
<hr>

openless-all/app/src-tauri/src/coordinator.rs

<ul><li>Wraps capsule window show/hide/positioning calls in <br><code>app.run_on_main_thread</code> to prevent main-thread-only API violations from <br>the audio callback thread.<br> <li> Moves the <code>show_capsule</code> preference read inside the main-thread closure <br>so the latest user setting is always used, eliminating stale-pref <br>flashes.<br> <li> Computes <code>visible</code> and loads <code>translation</code> before spawning the closure, <br>aligning window state with the actual capsule payload for the current <br>frame.<br> <li> Preserves the synchronous <code>app.emit_to</code> call on the calling thread <br>(Tauri event bus is thread-safe), maintaining the existing <br>happens‑before order between event delivery and window visibility.</ul>


</details>


  </td>
  <td><a href="https://github.com/appergb/openless/pull/389/files#diff-73d8c004670b27293f74f0f3991b9a6fc28f0ff0b883214de2b078b1e09797ca">+26/-8</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

