### PR TITLE
fix(coordinator): block QA edge routing while dictation runs [高]

### DIFF
--- a/openless-all/app/src-tauri/src/coordinator/dictation.rs
+++ b/openless-all/app/src-tauri/src/coordinator/dictation.rs
@@ -12,8 +12,14 @@ pub(super) async fn handle_pressed_edge(inner: &Arc<Inner>) {
     let was_held = inner.hotkey_trigger_held.swap(true, Ordering::SeqCst);
     if !was_held {
         // 路由：QA 浮窗可见时，rightOption 边沿走 QA；否则走主听写。详见 issue #118 v2。
+        // 例外：dictation session 已经在跑（Starting / Listening / Processing / Inserting），
+        // 即使 QA 浮窗被打开了，这条边沿也必须先走 dictation。否则 begin_qa_session 会
+        // 第二次抢同一个麦克风 device —— 在 Linux/PipeWire 上甚至会成功打开两路捕获，
+        // dictation 的 recorder 没人停；在 macOS/Windows 上 cpal 会拒绝第二次 build_input_stream
+        // 但 dictation session 仍在跑、用户找不到从 QA 面板停掉它的入口。审计 3.3.1。
+        let dictation_active = !matches!(inner.state.lock().phase, SessionPhase::Idle);
         let panel_visible = inner.qa_state.lock().panel_visible;
-        if panel_visible {
+        if panel_visible && !dictation_active {
             handle_qa_option_edge(inner).await;
         } else {
             handle_pressed(inner).await;
@@ -48,8 +54,12 @@ pub(super) async fn handle_released_edge(inner: &Arc<Inner>) {
     let was_held = inner.hotkey_trigger_held.swap(false, Ordering::SeqCst);
     if was_held {
         // QA 浮窗可见时，Option 行为是 press-toggle（不分 hold/release），release 边沿忽略。
+        // 与 handle_pressed_edge 的路由对称：dictation session 在跑时 Pressed 已经被路由到
+        // dictation，那 Released 必须也路由到 dictation —— 否则 Hold 模式松开热键时
+        // end_session 不会触发，dictation 永远停不下来。审计 3.3.1。
+        let dictation_active = !matches!(inner.state.lock().phase, SessionPhase::Idle);
         let panel_visible = inner.qa_state.lock().panel_visible;
-        if panel_visible {
+        if panel_visible && !dictation_active {
             return;
         }
         handle_released(inner).await;

--- a/openless-all/app/src-tauri/src/coordinator/qa.rs
+++ b/openless-all/app/src-tauri/src/coordinator/qa.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use tauri::Emitter;
 
-use crate::coordinator_state::{initial_session_id, SessionId};
+use crate::coordinator_state::{initial_session_id, SessionId, SessionPhase};
 use crate::selection::SelectionContext;
 use crate::types::CapsuleState;
 
@@ -86,9 +86,16 @@ pub(super) fn open_qa_panel(inner: &Arc<Inner>) {
         state.selection = None;
         state.front_app = capture_frontmost_app();
     }
-    // 先把胶囊清干净，避免主听写上一次 Done 状态残留的 message/insertedChars
-    // 在 QA Done 阶段被 capsule UI 错误复用（"已之一粘贴这个 0" 那种）。
-    emit_capsule(inner, CapsuleState::Idle, 0.0, 0, None, None);
+    // 主听写 phase 是 Idle 才需要 sweep capsule —— 这里的语义是清掉「上一次 dictation
+    // Done 状态残留」的 message / insertedChars，让 QA 自己的 capsule 状态从干净起跑
+    // （否则 capsule UI 会出现 "已粘贴这个 0" 之类把上一次 inserted_chars 错误复用的
+    // 显示）。但如果 dictation 当前正处于 Recording / Polishing / Inserting / Done toast
+    // 显示中，强行 emit Idle 会把用户没看完的反馈抹掉、或者把 Polishing 中的进度条
+    // 卡死。审计 3.3.4。
+    let dictation_idle = matches!(inner.state.lock().phase, SessionPhase::Idle);
+    if dictation_idle {
+        emit_capsule(inner, CapsuleState::Idle, 0.0, 0, None, None);
+    }
     if let Some(app) = inner.app.lock().clone() {
         crate::show_qa_window(&app, "idle");
         let _ = app.emit_to(


### PR DESCRIPTION
### **User description**
## Summary

Two related state-machine race fixes between dictation and the Q&A panel.

### 3.3.1 — Hotkey edge routing race

\`handle_pressed_edge\` routed the dictation hotkey edge to the QA panel whenever \`qa_state.panel_visible\` was true, regardless of whether a main dictation session was already running. If the user opened the QA panel mid-dictation, the next dictation-hotkey edge was routed into \`begin_qa_session\`, which calls \`Recorder::start\` a second time on the same mic device.

- macOS / Windows: cpal usually rejects the second \`build_input_stream\`, but the original dictation session keeps running with no UX path to stop it from the QA panel.
- Linux / PipeWire: the second open can succeed; two concurrent capture streams compete for the device.

Symmetrically, \`handle_released_edge\` swallowed Released whenever the panel was visible — fine when QA owned the press, but if dictation owned the press, Hold-mode dictation could never end because the Released edge was eaten.

**Fix**: read \`inner.state.phase\` alongside \`panel_visible\`. If a dictation session is non-Idle, both edges go to dictation regardless of \`panel_visible\`. QA panel stays open, just doesn't capture this hotkey.

### 3.3.4 — open_qa_panel clobbers in-flight capsule

\`open_qa_panel\` always emitted \`CapsuleState::Idle\` to sweep stale \"已粘贴 N 字\" Done residue. But if dictation was mid-flight (Recording bar / Polishing progress / Done toast still visible inside the ~1.5s auto-hide window), the sweep clobbered live UI.

**Fix**: guard the sweep on dictation phase == Idle. The original Done-residue sweep semantic still applies the common case (dictation finished, capsule auto-hid, user opens QA later) since by then phase is Idle.

## Why one PR

Both fixes are about the same logical seam — \"QA panel ↔ dictation session interaction\" — and touch the two adjacent files (\`coordinator/dictation.rs\` + \`coordinator/qa.rs\`). Splitting them across PRs would just create a merge conflict on the same code review boundary.

## Audit linkage

Audit IDs **3.3.1** + **3.3.4** (both CONFIRMED, 高 + 中). See \`docs/audit-2026-05-10-validated.md\` (local).

## Test plan

- [x] \`cargo test --lib\` — 183/183 pass.
- [ ] CI build — to be verified.
- [ ] **Manual verification**: (a) open QA panel during dictation, press dictation hotkey → should stop dictation, not begin QA recording; (b) Hold-mode dictation with QA panel open → release should still end the session; (c) finish dictation, see Done toast, immediately open QA panel → toast should not be wiped. To be done after merge.


___

### **PR Type**
Bug fix


___

### **Description**
- Prevent QA hotkey routing during active dictation

- Fix Hold-mode stuck by proper release edge routing

- Conditionally clear capsule to protect in-flight UI


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Hotkey Edge"] --> B{"dictation active?"}
  B -- "Yes" --> C["Route to Dictation"]
  B -- "No, QA visible?" --> D["Route to QA"]
  E["open_qa_panel"] --> F{"dictation idle?"}
  F -- "Yes" --> G["Emit Idle Capsule"]
  F -- "No" --> H["Keep Current Capsule"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>dictation.rs</strong><dd><code>Guard hotkey routing with dictation phase check</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src-tauri/src/coordinator/dictation.rs

<ul><li>Added <code>dictation_active</code> guard in <code>handle_pressed_edge</code> to route to <br>dictation when session is non-Idle, even if QA panel is visible.<br> <li> Added same guard in <code>handle_released_edge</code> to allow release to stop <br>dictation when session is active.<br> <li> Updated inline comments documenting the race condition and fix.</ul>


</details>


  </td>
  <td><a href="https://github.com/appergb/openless/pull/390/files#diff-4cf79887f41f4811eb2b1ef682c62ee34c14a0ab969362a9ba1046de59c8578b">+12/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>qa.rs</strong><dd><code>Conditional capsule reset on QA panel open</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src-tauri/src/coordinator/qa.rs

<ul><li>In <code>open_qa_panel</code>, emit <code>CapsuleState::Idle</code> only when dictation is Idle, <br>preventing capsule overwrite of in-progress UI.<br> <li> Imported <code>SessionPhase</code> to perform the state check.<br> <li> Updated comment explaining the conditional capsule sweep logic.</ul>


</details>


  </td>
  <td><a href="https://github.com/appergb/openless/pull/390/files#diff-2922c03737a3ebf22ac1e18c7bcb8f9ed46603817f9081647791d30542d8003e">+11/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

