### PR TITLE
fix(coordinator): add shutdown flag to supervisor + dispatcher loops [中]

### DIFF
--- a/openless-all/app/src-tauri/src/coordinator.rs
+++ b/openless-all/app/src-tauri/src/coordinator.rs
@@ -139,6 +139,11 @@ struct Inner {
     /// polish::chat_completion_history_streaming 的 loop 每帧检查，true 时 break loop
     /// 避免取消后 LLM 仍 drain HTTP body 烧 token。详见 issue #161。
     qa_stream_cancelled: Arc<AtomicBool>,
+    /// Coordinator 退出信号。各 hotkey supervisor loop 在每轮重试 sleep 之前会检查
+    /// 此 flag；为 true 时 loop 立刻 return。生产场景里 process exit 一并 reap 所有
+    /// supervisor 线程，但 integration test 和未来 RunEvent::Exit 钩子需要这条
+    /// 显式退出路径。审计 3.1.2。
+    shutdown: AtomicBool,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -197,6 +202,7 @@ impl Coordinator {
                     qa_recorder: Mutex::new(None),
                     qa_stream_cancelled: Arc::new(AtomicBool::new(false)),
                     local_asr_cache: Arc::new(crate::asr::local::LocalAsrCache::new()),
+                    shutdown: AtomicBool::new(false),
                 }),
             }
         }
@@ -241,6 +247,7 @@ impl Coordinator {
                 qa_stream_cancelled: Arc::new(AtomicBool::new(false)),
                 local_asr_cache: Arc::new(crate::asr::local::LocalAsrCache::new()),
                 foundry_local_runtime,
+                shutdown: AtomicBool::new(false),
             }),
         }
     }
@@ -297,6 +304,15 @@ impl Coordinator {
 
     pub fn bind_app(&self, handle: AppHandle) {
         *self.inner.app.lock() = Some(handle);
+    }
+
+    /// 让所有 hotkey supervisor loop（dictation / qa / combo / translation /
+    /// switch_style / open_app）在下一轮 sleep / poll 后退出。生产场景下进程退出
+    /// 一并 reap 所有线程，但 integration test 和未来 RunEvent::Exit 钩子需要
+    /// 显式退出路径。审计 3.1.2。
+    #[allow(dead_code)]
+    pub fn request_shutdown(&self) {
+        self.inner.shutdown.store(true, Ordering::SeqCst);
     }
 
     pub fn start_hotkey_listener(&self) {
@@ -768,6 +784,9 @@ fn hotkey_supervisor_loop(inner: Arc<Inner>) {
     let mut attempts: u32 = 0;
     let capability = HotkeyMonitor::capability();
     loop {
+        if inner.shutdown.load(Ordering::SeqCst) {
+            return;
+        }
         let prefs = inner.prefs.get();
 
         if inner.hotkey.lock().is_some() {
@@ -838,6 +857,9 @@ fn hotkey_supervisor_loop(inner: Arc<Inner>) {
 fn qa_hotkey_supervisor_loop(inner: Arc<Inner>) {
     let mut attempts: u32 = 0;
     loop {
+        if inner.shutdown.load(Ordering::SeqCst) {
+            return;
+        }
         // 用户已经把 QA 关掉就睡着等 prefs 改动；改动通过 update_qa_hotkey_binding 唤醒。
         let binding = match inner.prefs.get().qa_hotkey.clone() {
             Some(b) => b,
@@ -945,6 +967,9 @@ fn qa_hotkey_bridge_loop(inner: Arc<Inner>, rx: mpsc::Receiver<QaHotkeyEvent>) {
 fn combo_hotkey_supervisor_loop(inner: Arc<Inner>) {
     let mut attempts: u32 = 0;
     loop {
+        if inner.shutdown.load(Ordering::SeqCst) {
+            return;
+        }
         // 读当前 prefs
         let prefs = inner.prefs.get();
         if crate::shortcut_binding::legacy_modifier_trigger(&prefs.dictation_hotkey).is_some() {
@@ -1043,6 +1068,9 @@ fn combo_hotkey_bridge_loop(inner: Arc<Inner>, rx: mpsc::Receiver<ComboHotkeyEve
 fn translation_hotkey_supervisor_loop(inner: Arc<Inner>) {
     let mut attempts: u32 = 0;
     loop {
+        if inner.shutdown.load(Ordering::SeqCst) {
+            return;
+        }
         let binding = inner.prefs.get().translation_hotkey;
         if is_builtin_translation_shift(&binding)
             || crate::shortcut_binding::legacy_modifier_trigger(&binding).is_some()
@@ -1142,6 +1170,9 @@ fn translation_hotkey_bridge_loop(inner: Arc<Inner>, rx: mpsc::Receiver<ComboHot
 fn action_hotkey_supervisor_loop(inner: Arc<Inner>, kind: ActionHotkeyKind) {
     let mut attempts: u32 = 0;
     loop {
+        if inner.shutdown.load(Ordering::SeqCst) {
+            return;
+        }
         let binding = action_hotkey_binding(&inner, kind);
         if is_modifier_only_shortcut(&binding) {
             take_action_hotkey_on_main_thread(&inner, kind);

--- a/openless-all/app/src-tauri/src/global_hotkey_runtime.rs
+++ b/openless-all/app/src-tauri/src/global_hotkey_runtime.rs
@@ -6,6 +6,7 @@
 //! and one dispatcher instead of racing on `GlobalHotKeyEvent::receiver()`.
 
 use std::collections::HashMap;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc::{self, Receiver, Sender};
 use std::sync::Arc;
 use std::time::Duration;
@@ -20,6 +21,10 @@ static RUNTIME: OnceCell<Arc<GlobalHotkeyRuntime>> = OnceCell::new();
 pub struct GlobalHotkeyRuntime {
     manager: GlobalHotKeyManager,
     routes: Mutex<HashMap<u32, Sender<GlobalHotKeyEvent>>>,
+    /// 用于 dispatcher loop 的退出信号。process-singleton 在生产路径里不会被
+    /// drop，但 integration test / future RunEvent::Exit 钩子可以调用
+    /// `request_shutdown` 让 dispatcher 退出。审计 3.4.4。
+    shutdown: AtomicBool,
 }
 
 // global-hotkey 0.6 does not mark its manager Send/Sync on all platforms even
@@ -41,11 +46,20 @@ impl GlobalHotkeyRuntime {
                 let runtime = Arc::new(Self {
                     manager,
                     routes: Mutex::new(HashMap::new()),
+                    shutdown: AtomicBool::new(false),
                 });
                 start_dispatcher(Arc::clone(&runtime));
                 Ok(runtime)
             })
             .cloned()
+    }
+
+    /// Signal the dispatcher loop to exit at its next 250 ms tick. Idempotent.
+    /// Currently called only from tests; production app shutdown lets the OS
+    /// reap the process. Audit 3.4.4.
+    #[allow(dead_code)]
+    pub fn request_shutdown(&self) {
+        self.shutdown.store(true, Ordering::SeqCst);
     }
 
     pub fn register(
@@ -97,6 +111,9 @@ fn start_dispatcher(runtime: Arc<GlobalHotkeyRuntime>) {
         .spawn(move || {
             let receiver = GlobalHotKeyEvent::receiver();
             loop {
+                if runtime.shutdown.load(Ordering::SeqCst) {
+                    return;
+                }
                 match receiver.recv_timeout(Duration::from_millis(250)) {
                     Ok(event) => runtime.dispatch(event),
                     Err(_) => continue,


### PR DESCRIPTION
### **User description**
## Summary

Five hotkey supervisor loops in \`coordinator.rs\` (dictation / qa / combo / translation / action) and the global-hotkey dispatcher loop in \`global_hotkey_runtime.rs\` run as \`loop { ... sleep N }\` with no exit signal.

In production the OS reaps these threads at process exit, so this isn't a user-visible bug today. But:

- Integration tests can't drive Coordinator up/down without leaking threads across test runs.
- Future \`RunEvent::Exit\` cleanup work has nowhere to plug in.
- A panicked listener thread leaves the supervisor spinning forever with no way to surface the failure.

## Change

- **\`Inner\`** gains an \`AtomicBool shutdown\` field. Each supervisor loop reads it at the top of each iteration (before any work / sleep) and \`return\`s when set.
- **\`GlobalHotkeyRuntime\`** gains a parallel \`AtomicBool shutdown\`; the dispatcher loop checks it before each 250 ms \`recv_timeout\`.
- Public methods \`Coordinator::request_shutdown\` and \`GlobalHotkeyRuntime::request_shutdown\` set the respective flags. \`#[allow(dead_code)]\` until the \`RunEvent::Exit\` wiring lands — this PR is infrastructure-only.

## Why this is safe

The change is **passive**: nothing in the production binary sets the flags, so behavior is unchanged. Tests that want bounded teardown can now call \`request_shutdown\` explicitly. The check is a single \`load(SeqCst)\` per iteration — overhead is unmeasurable.

## Audit linkage

Audit IDs **3.1.2** (loop exit signal, 中) + **3.4.4** (dispatcher loop, 低). Both CONFIRMED. \`3.1.3\` (JoinHandle storage) is deferred — without a supervisor consumer for \`is_finished()\` liveness checks, storing the handle is a no-op. See \`docs/audit-2026-05-10-validated.md\` (local).

## Test plan

- [x] \`cargo test --lib\` — 183/183 pass.
- [x] \`cargo check --lib\` clean.
- [ ] CI build — to be verified.
- [ ] **Future**: wire \`Coordinator::request_shutdown\` + \`GlobalHotkeyRuntime::request_shutdown\` from \`RunEvent::Exit\` in \`lib.rs\` so app-quit teardown is bounded. Out of scope for this PR.


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Add shutdown AtomicBool to Inner struct and supervisor loops

- Add shutdown AtomicBool to GlobalHotkeyRuntime and dispatcher loop

- Expose request_shutdown methods for integration tests and future Exit hook


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Coordinator::request_shutdown()"] --> B["Inner::shutdown"]
  B --> C["hotkey supervisor loops (dictation, qa, combo, translation, action)"]
  D["GlobalHotkeyRuntime::request_shutdown()"] --> E["GlobalHotkeyRuntime::shutdown"]
  E --> F["global hotkey dispatcher loop"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>coordinator.rs</strong><dd><code>Add shutdown flag to coordinator's hotkey supervisor loops</code></dd></summary>
<hr>

openless-all/app/src-tauri/src/coordinator.rs

<ul><li>Added <code>shutdown: AtomicBool</code> field to <code>Inner</code> struct<br> <li> Initialized <code>shutdown</code> to false in both constructor variants<br> <li> Added public <code>request_shutdown</code> method to set the flag<br> <li> Checked shutdown flag at top of each supervisor loop<br> <li> Marked <code>request_shutdown</code> as <code>#[allow(dead_code)]</code></ul>


</details>


  </td>
  <td><a href="https://github.com/appergb/openless/pull/392/files#diff-73d8c004670b27293f74f0f3991b9a6fc28f0ff0b883214de2b078b1e09797ca">+31/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>global_hotkey_runtime.rs</strong><dd><code>Add shutdown flag to global hotkey dispatcher loop</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src-tauri/src/global_hotkey_runtime.rs

<ul><li>Added <code>shutdown: AtomicBool</code> field to <code>GlobalHotkeyRuntime</code><br> <li> Imported <code>AtomicBool</code> and <code>Ordering</code><br> <li> Initialized <code>shutdown</code> to false in <code>shared()</code> constructor<br> <li> Added public <code>request_shutdown</code> method<br> <li> Dispatcher loop checks <code>shutdown</code> before each <code>recv_timeout</code></ul>


</details>


  </td>
  <td><a href="https://github.com/appergb/openless/pull/392/files#diff-42de00c25f6901aca7b70ced51cc4379538696bf0d0d042da6cc4b5a7fc2058d">+17/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

