### PR TITLE
fix(coordinator): post-audit logic-review hotfixes

### DIFF
--- a/openless-all/app/src-tauri/src/coordinator.rs
+++ b/openless-all/app/src-tauri/src/coordinator.rs
@@ -2310,7 +2310,7 @@ async fn begin_qa_session(inner: &Arc<Inner>) -> Result<(), String> {
 
     let microphone_device_name = selected_microphone_device_name(inner);
     stop_microphone_preview_monitor(inner, "QA recorder");
-    acquire_recording_mute(inner, "qa");
+    acquire_recording_mute(inner, "qa").await;
     match Recorder::start(microphone_device_name, consumer, level_handler) {
         Ok((rec, runtime_errors)) => {
             *inner.qa_recorder.lock() = Some(rec);

--- a/openless-all/app/src-tauri/src/coordinator/dictation.rs
+++ b/openless-all/app/src-tauri/src/coordinator/dictation.rs
@@ -845,7 +845,15 @@ pub(super) async fn end_session(inner: &Arc<Inner>) -> Result<(), String> {
     if inner.state.lock().cancelled {
         log::info!("[coord] cancel detected after ASR — discarding transcript");
         restore_prepared_windows_ime_session(inner, current_session_id);
-        inner.state.lock().phase = SessionPhase::Idle;
+        // PR #387 的「cancel 后清 focus_target」契约要在 Processing 路径上也成立。
+        // cancel_session 在 Processing 阶段故意跳过 finish_cancel_session_state（让
+        // 这里收尾），但此前的 end_session 没把 focus_target 清掉。logic-review
+        // 2026-05-10 P3 (🚩) 把这条补完。
+        {
+            let mut state = inner.state.lock();
+            state.phase = SessionPhase::Idle;
+            state.focus_target = None;
+        }
         return Ok(());
     }
 


### PR DESCRIPTION
### **User description**
## Summary

Two real bugs surfaced by the 2026-05-10 end-to-end logic review of beta after the 8-PR audit-fix wave landed (full report at \`docs/logic-review-2026-05-10.md\`, kept local).

### Bug 1: \`coordinator.rs:2313\` — QA path missing \`.await\`
PR #391 (\`6171df61\`) made \`acquire_recording_mute\` \`async fn\` and updated the dictation call site (\`coordinator/dictation.rs:451\`), but the QA call site was missed.

**Effect**: when \`mute_during_recording = true\` and the user triggers QA, the returned Future was dropped on the next line, \`spawn_blocking\` was never scheduled, \`holders\` never incremented, system audio was NOT muted (YouTube/etc. kept playing into the QA recording). Both matching \`release_recording_mute(inner, \"qa\")\` calls became no-ops (early return at \`holders == 0\`). The Rust compiler was emitting \`unused_must_use\` for this exact line.

**Fix**: \`+ .await\`. Compiler warning gone.

### Bug 2: \`coordinator/dictation.rs:843-849\` — \`focus_target\` not cleared on cancel during Processing
PR #387 (\`ce82fcd9\`) was framed as \"clear focus_target on cancel regardless of phase\", but the unconditional clear only landed in \`finish_cancel_session_state\`. \`cancel_session\` deliberately **skips** that helper for the \`Processing\` branch (so \`end_session\` drives its own teardown), and \`end_session\`'s \"ASR-finished, cancelled\" exit set \`phase = Idle\` but never touched \`focus_target\`.

**Effect**: cancel-during-Processing leaves a stale \`usize\` focus slot in \`state.focus_target\` until the next \`begin_session_state\` overwrites it. Today bounded (no documented reader on that interval), but violates PR #387's stated contract and is a silent footgun for future readers.

**Fix**: in the cancelled-after-ASR exit branch, take \`state.lock()\` once and clear both \`phase\` and \`focus_target\` together.

## Test plan
- [x] \`cargo test --lib\` 185/185 pass.
- [x] \`cargo check\` clean. \`unused_must_use\` warning at coordinator.rs:2313 disappears.
- [ ] CI Linux/Windows/macOS to verify.
- [ ] **Manual** for Bug 1: enable mute_during_recording, play YouTube, open QA panel, press Right Option — audio should mute and \`[audio-mute] acquired by qa; holders=1\` appear in \`openless.log\`.
- [ ] **Manual** for Bug 2: start dictation → release → during ~1s ASR await window press Esc; inspect logs / state. \`focus_target\` should be \`None\` immediately after cancel-during-Processing (was: stale until next session).


___

### **PR Type**
Bug fix


___

### **Description**
- Add missing `.await` on `acquire_recording_mute` in QA path

- Clear `focus_target` on Processing‑phase cancel in `end_session`


___

### Diagram Walkthrough


```mermaid
flowchart LR
  QA["begin_qa_session"] -- ".await" --> Mute["acquire_recording_mute('qa') (mute engages)"]
  Cancel["end_session (cancel after ASR)"] -- "clear focus_target" --> Focus["state.focus_target = None (no stale handle)"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>coordinator.rs</strong><dd><code>Await QA audio mute call</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src-tauri/src/coordinator.rs

<ul><li>Add <code>.await</code> to <code>acquire_recording_mute(inner, "qa")</code> to prevent dropped <br>future</ul>


</details>


  </td>
  <td><a href="https://github.com/appergb/openless/pull/393/files#diff-73d8c004670b27293f74f0f3991b9a6fc28f0ff0b883214de2b078b1e09797ca">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>dictation.rs</strong><dd><code>Clear focus_target on Processing cancel</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src-tauri/src/coordinator/dictation.rs

<ul><li>Clear <code>focus_target</code> when cancelling during Processing phase to prevent <br>stale handle<br> <li> Use single lock acquisition to set both phase and focus_target</ul>


</details>


  </td>
  <td><a href="https://github.com/appergb/openless/pull/393/files#diff-4cf79887f41f4811eb2b1ef682c62ee34c14a0ab969362a9ba1046de59c8578b">+9/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

