### PR TITLE
fix(vault): cache CredsRoot in process to stop repeated Keychain prompts

### DIFF
--- a/openless-all/app/src-tauri/src/persistence.rs
+++ b/openless-all/app/src-tauri/src/persistence.rs
@@ -47,6 +47,41 @@ fn credentials_lock() -> &'static Mutex<()> {
     CREDENTIALS_LOCK.get_or_init(|| Mutex::new(()))
 }
 
+/// Process-wide credentials cache.
+///
+/// Without this cache every `CredentialsVault::get_*` / `snapshot` call hits
+/// `load_credentials()` → `load_keyring_credentials()` which reads the
+/// manifest entry plus every chunk entry from the OS keyring. On macOS each
+/// distinct keychain entry has its own ACL — so an ad-hoc-signed binary (or
+/// any binary whose ACL grants haven't been set up yet) prompts on every read
+/// of every entry. A single dictation cycle reads credentials 5–10 times,
+/// times (1 manifest + N chunks) entries → tens of "OpenLess wants to use
+/// the keychain" prompts per recording.
+///
+/// With this cache the first read populates `Some(CredsRoot)` and every
+/// subsequent read in the same process is silent. `save_credentials` keeps
+/// the cache in sync after writes so Settings → Recording credential edits
+/// take effect immediately.
+///
+/// Cross-process changes (e.g. user edits via `security` CLI, or another
+/// instance of the app — single-instance is enforced but defense in depth)
+/// will be invisible until the next process launch. Acceptable trade-off
+/// per the credential vault contract: the keyring is owned by this app.
+static CREDENTIALS_CACHE: OnceLock<Mutex<Option<CredsRoot>>> = OnceLock::new();
+
+fn credentials_cache() -> &'static Mutex<Option<CredsRoot>> {
+    CREDENTIALS_CACHE.get_or_init(|| Mutex::new(None))
+}
+
+fn store_credentials_cache(root: &CredsRoot) {
+    *credentials_cache().lock() = Some(root.clone());
+}
+
+#[cfg(test)]
+fn reset_credentials_cache_for_tests() {
+    *credentials_cache().lock() = None;
+}
+
 // ───────────────────────── path helpers ─────────────────────────
 
 fn data_dir() -> Result<PathBuf> {
@@ -533,7 +568,10 @@ fn migrate_legacy_sources_for_update() -> Result<CredsRoot> {
 }
 
 fn load_credentials() -> CredsRoot {
-    match load_keyring_credentials() {
+    if let Some(cached) = credentials_cache().lock().as_ref().cloned() {
+        return cached;
+    }
+    let root = match load_keyring_credentials() {
         Ok(Some(root)) => {
             // 不在这里调 remove_legacy_keyring_credentials() —— 它内部对每个
             // 旧 account 各做一次 keyring delete，每次 delete 在 macOS Keychain
@@ -549,20 +587,27 @@ fn load_credentials() -> CredsRoot {
             log::warn!("[vault] system credential read failed: {e}");
             load_legacy_sources_without_migration()
         }
-    }
+    };
+    store_credentials_cache(&root);
+    root
 }
 
 fn load_credentials_for_update() -> Result<CredsRoot> {
-    match load_keyring_credentials() {
+    if let Some(cached) = credentials_cache().lock().as_ref().cloned() {
+        return Ok(cached);
+    }
+    let root = match load_keyring_credentials() {
         Ok(Some(root)) => {
             // 同 load_credentials：不再每次 update 都尝试 delete legacy keyring
             // entries，避免反复触发 macOS Keychain ACL 弹窗。
             remove_legacy_credentials_file_best_effort();
-            Ok(root)
+            root
         }
-        Ok(None) => migrate_legacy_sources_for_update(),
-        Err(e) => Err(e),
-    }
+        Ok(None) => migrate_legacy_sources_for_update()?,
+        Err(e) => return Err(e),
+    };
+    store_credentials_cache(&root);
+    Ok(root)
 }
 
 fn save_credentials(root: &CredsRoot) -> Result<()> {
@@ -616,6 +661,9 @@ fn save_credentials(root: &CredsRoot) -> Result<()> {
     }
 
     remove_legacy_credentials_file_best_effort();
+    // 写完成功后立刻刷新 process cache —— 同进程后续读不再回 Keychain。
+    // 见 CREDENTIALS_CACHE 的 doc。
+    store_credentials_cache(&cleaned);
     Ok(())
 }
 

--- a/openless-all/app/src-tauri/src/persistence.rs
+++ b/openless-all/app/src-tauri/src/persistence.rs
@@ -571,7 +571,7 @@ fn load_credentials() -> CredsRoot {
     if let Some(cached) = credentials_cache().lock().as_ref().cloned() {
         return cached;
     }
-    let root = match load_keyring_credentials() {
+    match load_keyring_credentials() {
         Ok(Some(root)) => {
             // 不在这里调 remove_legacy_keyring_credentials() —— 它内部对每个
             // 旧 account 各做一次 keyring delete，每次 delete 在 macOS Keychain
@@ -580,34 +580,52 @@ fn load_credentials() -> CredsRoot {
             // 只会反复弹「OpenLess 想删除 X」十几次。文件 legacy（plaintext
             // JSON）不需要 ACL，可继续 best-effort 删除。
             remove_legacy_credentials_file_best_effort();
+            store_credentials_cache(&root);
             root
         }
-        Ok(None) => migrate_legacy_sources(),
+        Ok(None) => {
+            // 没有现成 chunked manifest —— 走 migrate（如果有 legacy 则写入并返回写后的 root）。
+            // migrate_legacy_sources 内部 save_credentials 已经会刷 cache，这里再补一次
+            // 是为了「无 legacy 也无 manifest」走默认 root 的路径也能进 cache。
+            let root = migrate_legacy_sources();
+            store_credentials_cache(&root);
+            root
+        }
         Err(e) => {
+            // **不缓存 keyring 错误路径下的 fallback**。Keychain 可能只是临时不可读
+            // （用户尚未在第一次弹窗里点同意 / DataProtection 错误 / login keychain
+            // 还没 unlock）；如果在这里把 legacy fallback 写进 cache，等用户授权后
+            // 我们就再也不会重读 keyring，整个进程生命周期里都拿 stale 数据。下次
+            // 调用让它再尝试一次 keyring。pr_agent feedback on PR #394。
             log::warn!("[vault] system credential read failed: {e}");
             load_legacy_sources_without_migration()
         }
-    };
-    store_credentials_cache(&root);
-    root
+    }
 }
 
 fn load_credentials_for_update() -> Result<CredsRoot> {
     if let Some(cached) = credentials_cache().lock().as_ref().cloned() {
         return Ok(cached);
     }
-    let root = match load_keyring_credentials() {
+    match load_keyring_credentials() {
         Ok(Some(root)) => {
             // 同 load_credentials：不再每次 update 都尝试 delete legacy keyring
             // entries，避免反复触发 macOS Keychain ACL 弹窗。
             remove_legacy_credentials_file_best_effort();
-            root
+            store_credentials_cache(&root);
+            Ok(root)
         }
-        Ok(None) => migrate_legacy_sources_for_update()?,
-        Err(e) => return Err(e),
-    };
-    store_credentials_cache(&root);
-    Ok(root)
+        Ok(None) => {
+            // migrate_legacy_sources_for_update 内部如果实际 migrate 会调
+            // save_credentials，cache 会被刷新；如果只返回 default root（没 legacy），
+            // 我们这里再显式 cache 一次防御性补一下。
+            let root = migrate_legacy_sources_for_update()?;
+            store_credentials_cache(&root);
+            Ok(root)
+        }
+        // 错误路径不缓存 —— 同 load_credentials 注释；让下次读重试 keyring。
+        Err(e) => Err(e),
+    }
 }
 
 fn save_credentials(root: &CredsRoot) -> Result<()> {


### PR DESCRIPTION
### **User description**
## Symptom
User reports macOS keychain prompts firing repeatedly during normal use, even after granting "Always Allow". Previously this was 2 prompts on first launch then silent; now it's many prompts per recording.

## Root cause analysis
Two independent issues compound:

1. **No in-process cache** — \`load_credentials()\` re-reads from OS keyring on every \`CredentialsVault::get_*\` / \`snapshot\` call. The credentials are stored as a manifest entry + N chunks, each with its own macOS Keychain ACL. A single dictation reads credentials ~5-10 times → ~5-10 × (1 + N) prompts if ACL hasn't been granted yet.

2. **Ad-hoc signing instability** (out of scope for this PR) — every fresh build produces a new \`cdhash\`, so previous "Always Allow" grants don't bind to the new binary. Stable Apple Developer ID signing fixes this; the cache fix mitigates per-session impact but can't restore cross-build "Always Allow" persistence.

## Fix (this PR)
Add a process-wide cache via \`static CREDENTIALS_CACHE: OnceLock<Mutex<Option<CredsRoot>>>\`:

- \`load_credentials\` / \`load_credentials_for_update\` consult the cache first. First read in a process: populates cache (still triggers ACL prompts). Subsequent reads: silent cache hit.
- \`save_credentials\` refreshes the cache with the cleaned root after successful Keychain write — Settings → Recording credential edits are visible immediately.
- \`migrate_legacy_sources{,_for_update}\` call \`save_credentials\` internally → migration paths inherit cache update.

## Trade-off
Cross-process credential changes (user editing via \`security\` CLI, or another instance) are invisible until next app launch. Acceptable: the keyring is owned by this app, single-instance enforced.

## Test plan
- [x] \`cargo check --lib\` clean.
- [x] \`cargo test --lib\` 185/185 pass.
- [ ] CI three platforms.
- [ ] **Manual verification**: launch the rebuilt app, observe initial round of Keychain prompts (manifest + N chunks), grant "Always Allow" each time. Trigger 3 dictations + 1 QA. Should see **zero additional Keychain prompts** during those 4 sessions.
- [ ] Settings → Recording: change ASR endpoint to a different URL, save. Trigger a dictation. New endpoint should be used immediately (cache invalidated by save_credentials).


___

### **PR Type**
Bug fix


___

### **Description**
- Add process-wide credentials cache

- Reuse cached creds for reads

- Refresh cache after successful saves

- Avoid caching keyring error fallbacks


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Keychain read"] -- "first load" --> B["Populate CREDENTIALS_CACHE"]
  B -- "subsequent reads" --> C["Return cached CredsRoot"]
  D["Credential save"] -- "after write" --> B
  E["Keychain read error"] -- "fallback only" --> F["Skip cache update"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>persistence.rs</strong><dd><code>Add in-process credentials caching</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src-tauri/src/persistence.rs

<ul><li>Introduces <code>CREDENTIALS_CACHE</code> as a <code>OnceLock<Mutex<Option<CredsRoot>>></code>.<br> <li> Returns cached credentials from <code>load_credentials</code> and <br><code>load_credentials_for_update</code> before hitting Keychain.<br> <li> Updates the cache after successful credential loads and saves.<br> <li> Avoids caching fallback data on keyring read errors to prevent stale <br>credentials.</ul>


</details>


  </td>
  <td><a href="https://github.com/appergb/openless/pull/394/files#diff-fe150b5c0806f2cac2827075208fe552ab2b17590ad3dddfbdbdc240084e1adb">+68/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

