### PR TITLE
chore: bump version to 1.2.24-7 (Beta-7)

### DIFF
--- a/openless-all/app/package-lock.json
+++ b/openless-all/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openless-app",
-  "version": "1.2.24-6",
+  "version": "1.2.24-7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openless-app",
-      "version": "1.2.24-6",
+      "version": "1.2.24-7",
       "dependencies": {
         "@tauri-apps/api": "^2.1.1",
         "@tauri-apps/plugin-autostart": "^2.5.1",

--- a/openless-all/app/package.json
+++ b/openless-all/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openless-app",
   "private": true,
-  "version": "1.2.24-6",
+  "version": "1.2.24-7",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/openless-all/app/src-tauri/Cargo.lock
+++ b/openless-all/app/src-tauri/Cargo.lock
@@ -3751,7 +3751,7 @@ dependencies = [
 
 [[package]]
 name = "openless"
-version = "1.2.24-6"
+version = "1.2.24-7"
 dependencies = [
  "anyhow",
  "arboard",

--- a/openless-all/app/src-tauri/Cargo.toml
+++ b/openless-all/app/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openless"
-version = "1.2.24-6"
+version = "1.2.24-7"
 description = "OpenLess — local voice input that types where your cursor is"
 authors = ["OpenLess"]
 edition = "2021"

--- a/openless-all/app/src-tauri/tauri.conf.json
+++ b/openless-all/app/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "OpenLess",
-  "version": "1.2.24-6",
+  "version": "1.2.24-7",
   "identifier": "com.openless.app",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
### **User description**
## Summary
Cut Beta-7. 10 PRs landed on \`beta\` this cycle:

| PR | 严重度 | What |
|----|--------|------|
| #377 | — | Paste shortcut configurable for kitty/alacritty (issue #360) |
| #386 | 中 | TS \`UserPreferences.updateChannel\` alignment |
| #387 | 低 | \`focus_target\` leak on Processing-phase cancel |
| #388 | **严重** | \`MacHotkeyAdapter::shutdown\` stops \`CFRunLoop\` + tap |
| #389 | 高 | \`emit_capsule\` window ops off audio callback thread |
| #390 | 高 | QA / dictation hotkey routing race + capsule clobber |
| #391 | 中 | \`audio-mute\` shellouts via \`spawn_blocking\` |
| #392 | 中 | Hotkey supervisor + global dispatcher exit signal |
| #393 | 中 | Post-audit logic-review hotfixes (QA \`acquire_recording_mute\` missing \`.await\` + \`focus_target\` Processing branch) |
| #394 | 高 | In-process \`CREDENTIALS_CACHE\` kills repeated Keychain prompts |

## Files bumped
- \`openless-all/app/package.json\`
- \`openless-all/app/src-tauri/tauri.conf.json\`
- \`openless-all/app/src-tauri/Cargo.toml\`
- \`openless-all/app/src-tauri/Cargo.lock\` (auto-refreshed by \`cargo check\`)

## Test plan
- [x] \`cargo check --lib\` clean
- [ ] CI on Linux/Windows/macOS
- [ ] pr_agent review
- [ ] Local rebuild already verified for cdhash \`d871ab69c7bbf427117f252b19caaa3a288e4698\` (this dev machine)
- [ ] After merge: tag \`v1.2.24-7-beta-tauri\` on \`beta\` to trigger \`release-tauri.yml\` Beta channel build (macOS arm64 \`.dmg\` + Windows x64 \`.msi\`, prerelease=true, manifests \`latest-{tgt}-{arch}-beta.json\`)


___

### **PR Type**
Other


___

### **Description**
- Bump version to 1.2.24-7 (Beta-7) across package.json, Cargo.toml, and tauri.conf.json


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Version 1.2.24-6"] -- "Bump to" --> B["Version 1.2.24-7"]
  B --> C["package.json"]
  B --> D["Cargo.toml"]
  B --> E["tauri.conf.json"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>package.json</strong><dd><code>Bump version in package.json</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/package.json

- Update version from 1.2.24-6 to 1.2.24-7


</details>


  </td>
  <td><a href="https://github.com/appergb/openless/pull/395/files#diff-2650f8aa2f7ec97aa8af47f1f8a7c9ae4677fb69754b20d554e1d542507cf4ea">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Cargo.toml</strong><dd><code>Bump version in Cargo.toml</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src-tauri/Cargo.toml

- Update version from 1.2.24-6 to 1.2.24-7


</details>


  </td>
  <td><a href="https://github.com/appergb/openless/pull/395/files#diff-334952ba03e62939865bbf0351f0916ea88c6457f8ea1259336e73ee4e2f088b">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>tauri.conf.json</strong><dd><code>Bump version in tauri.conf.json</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src-tauri/tauri.conf.json

- Update version from 1.2.24-6 to 1.2.24-7


</details>


  </td>
  <td><a href="https://github.com/appergb/openless/pull/395/files#diff-e9c2f15638ea988f61c82aeb2257147fb9cc96d7bda8709e8bad6b6517f5369c">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

