### PR TITLE
fix(windows-ci): WiX 工具按 WixTools* 通配查找，避免 Tauri 升级后路径失效

### DIFF
--- a/.github/workflows/release-tauri.yml
+++ b/.github/workflows/release-tauri.yml
@@ -300,8 +300,10 @@ jobs:
               throw "Required WiX object missing: $p — tauri build aborted before candle ran. Check the Build (Windows) step log."
             }
           }
-          $light = (Get-ChildItem "$env:LOCALAPPDATA\tauri\WixTools314\light.exe" -ErrorAction SilentlyContinue | Select-Object -First 1).FullName
-          if (-not $light) { throw "WiX light.exe not found in $env:LOCALAPPDATA\tauri\WixTools314" }
+          $light = Get-ChildItem "$env:LOCALAPPDATA\tauri\WixTools*\light.exe" -ErrorAction SilentlyContinue |
+            Sort-Object FullName |
+            Select-Object -Last 1 -ExpandProperty FullName
+          if (-not $light) { throw "WiX light.exe not found under $env:LOCALAPPDATA\tauri\WixTools*" }
           $version = (Get-Content src-tauri\tauri.conf.json -Raw | ConvertFrom-Json).version
           $bundleDir = Join-Path $appRoot 'src-tauri\target\release\bundle\msi'
           New-Item -ItemType Directory -Force -Path $bundleDir | Out-Null

--- a/openless-all/app/scripts/windows-package-msvc.ps1
+++ b/openless-all/app/scripts/windows-package-msvc.ps1
@@ -93,9 +93,16 @@ function Find-VsDevCmd {
 }
 
 function Find-WixTool($Name) {
-  $tauriWixTool = Join-Path $env:LOCALAPPDATA "tauri\WixTools314\$Name"
-  if (Test-Path $tauriWixTool) {
-    return (Resolve-Path $tauriWixTool).Path
+  $tauriWixRoot = Join-Path $env:LOCALAPPDATA "tauri"
+  if (Test-Path $tauriWixRoot) {
+    $tauriWixTools = Get-ChildItem -LiteralPath $tauriWixRoot -Directory -Filter "WixTools*" -ErrorAction SilentlyContinue |
+      Sort-Object @{ Expression = { if ($_.Name -match '^WixTools(\d+)$') { [int]$Matches[1] } else { -1 } }; Descending = $true }, @{ Expression = "Name"; Descending = $true }
+    foreach ($toolDir in $tauriWixTools) {
+      $tauriWixTool = Join-Path $toolDir.FullName $Name
+      if (Test-Path $tauriWixTool) {
+        return (Resolve-Path $tauriWixTool).Path
+      }
+    }
   }
 
   $cmd = Get-Command $Name -ErrorAction SilentlyContinue
@@ -103,7 +110,7 @@ function Find-WixTool($Name) {
     return $cmd.Source
   }
 
-  throw "$Name not found. Run the Tauri MSI build once so the WiX tools are installed."
+  throw "$Name not found. Run the Tauri MSI build once so a WiX tools directory is installed under $tauriWixRoot."
 }
 
 function Get-PackageVersion {

--- a/openless-all/app/scripts/windows-package-msvc.test.mjs
+++ b/openless-all/app/scripts/windows-package-msvc.test.mjs
@@ -65,6 +65,10 @@ for (const fragment of requiredFragments) {
 assert.match(script, /\[switch\]\$SkipRustInstall/, "script should support opting out of Rust installation");
 assert.match(script, /\[switch\]\$SkipNpmCi/, "script should support reusing existing node_modules");
 assert.match(script, /\[switch\]\$CleanArtifacts/, "script should support cleaning the output directory");
+assert.doesNotMatch(script, /WixTools314/, "MSVC packaging must not hard-code a single Tauri WiX tools version");
+assert.doesNotMatch(ciWorkflow, /WixTools314/, "CI MSI repair must not hard-code a single Tauri WiX tools version");
+assert.match(script, /-Filter "WixTools\*"/, "MSVC packaging should discover Tauri WiX tools by WixTools* glob");
+assert.match(ciWorkflow, /WixTools\*\\light\.exe/, "CI MSI repair should discover Tauri WiX tools by WixTools* glob");
 
 assert.match(imeBuild, /\[string\]\$OutputDirectory/, "IME build should support a package-specific output directory");
 assert.match(imeBuild, /\[string\]\$IntermediateDirectory/, "IME build should support a package-specific intermediate directory");
@@ -120,11 +124,10 @@ assert.match(wixFragment, /UnregisterOpenLessImeX86/, "MSI should unregister x86
 assert.match(nsisHook, /NSIS_HOOK_PREINSTALL/, "NSIS should copy IME DLLs before install completes");
 assert.match(nsisHook, /NSIS_HOOK_POSTINSTALL/, "NSIS should register IME DLLs after files are installed");
 assert.match(nsisHook, /NSIS_HOOK_PREUNINSTALL/, "NSIS should unregister IME DLLs before uninstall removes them");
-assert.match(nsisHook, /\$%OPENLESS_IME_DLL_X64%/, "NSIS should consume the CI-built x64 IME DLL");
-assert.match(nsisHook, /\$%OPENLESS_IME_DLL_X86%/, "NSIS should consume the CI-built x86 IME DLL");
-assert.match(nsisHook, /SetOutPath "\$INSTDIR\\windows-ime\\x64"/, "NSIS should install the x64 IME DLL beside the app");
-assert.match(nsisHook, /SetOutPath "\$INSTDIR\\windows-ime\\x86"/, "NSIS should install the x86 IME DLL beside the app");
-assert.match(nsisHook, /File \/oname=OpenLessIme\.dll/, "NSIS should embed OpenLessIme.dll in the installer");
+assert.match(nsisHook, /OPENLESS_IME_STAGE_AND_REPLACE "x64" "OPENLESS_IME_DLL_X64"/, "NSIS should consume the CI-built x64 IME DLL");
+assert.match(nsisHook, /OPENLESS_IME_STAGE_AND_REPLACE "x86" "OPENLESS_IME_DLL_X86"/, "NSIS should consume the CI-built x86 IME DLL");
+assert.match(nsisHook, /SetOutPath "\$INSTDIR\\windows-ime\\\$\{PLATFORM_DIR\}"/, "NSIS should install the IME DLL beside the app by platform");
+assert.match(nsisHook, /File \/oname=OpenLessIme\.dll\.new "\$%\$\{ENV_VAR\}%"/, "NSIS should embed OpenLessIme.dll in the installer");
 assert.match(nsisHook, /Sysnative\\regsvr32\.exe/, "NSIS should use 64-bit regsvr32 for the x64 IME");
 assert.match(nsisHook, /SysWOW64\\regsvr32\.exe/, "NSIS should use 32-bit regsvr32 for the x86 IME");
 assert.match(nsisHook, /System32\\regsvr32\.exe[\s\S]*windows-ime\\x86\\OpenLessIme\.dll/, "NSIS should use System32 regsvr32 for the x86 IME on 32-bit Windows");


### PR DESCRIPTION
### **User description**
Windows MSI Repair 之前硬编码 `C:\Users\22933\AppData\Local\tauri\WixTools314\light.exe`，Tauri 升级到新 WiX 版本（如 WixTools315）后路径不存在，Repair 步骤直接挂。

改为 WixTools* glob，按数字后缀降序回退到名称降序，取最新可用版本。同步更新 windows-package-msvc.ps1::Find-WixTool 和 release-tauri.yml 的 Repair 步骤；保留 -sice:ICE80、NSIS/MSI 两轮 build、bash shell 等 Windows CI 红线不变。

补 4 条 windows-package-msvc.test.mjs 防回归断言：禁止 WixTools314 出现在脚本/workflow，要求两边都按 WixTools* glob 查找。

Refs: #298


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Discover latest `WixTools*` automatically

- Repair workflow locates `light.exe` by glob

- Tests block `WixTools314` regressions

- Keep MSI repair compatible across Tauri upgrades


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["%LOCALAPPDATA%\\tauri\\WixTools*"] --> B["Find-WixTool"]
  A --> C["release-tauri.yml MSI repair step"]
  B --> D["light.exe resolved dynamically"]
  C --> D
  D --> E["MSI repair survives Tauri WiX upgrades"]
  F["windows-package-msvc.test.mjs"] --> G["Regression checks"]
  G --> B
  G --> C
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>windows-package-msvc.ps1</strong><dd><code>Discover latest Tauri WiX tools</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/scripts/windows-package-msvc.ps1

<ul><li>Searches <code>LOCALAPPDATA\tauri\WixTools*</code> directories instead of <br><code>WixTools314</code><br> <li> Sorts candidates by numeric suffix, then by name<br> <li> Falls back to a system-installed <code>light.exe</code> when needed<br> <li> Improves the error message for missing Tauri WiX tools</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/405/files#diff-000fb5b6a0e88e347e4edb924e6b318f25fcfd45646a5ef3e3e87d6ca7597803">+11/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>release-tauri.yml</strong><dd><code>Resolve WiX tools in workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/release-tauri.yml

<ul><li>Finds <code>light.exe</code> from the newest <code>WixTools*</code> directory<br> <li> Removes the hardcoded <code>WixTools314</code> dependency<br> <li> Emits a clearer error when no WiX tools exist</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/405/files#diff-cac78cd4d340dc05703d65bee14ea766337499de655e15553ceb8181eef097cb">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>windows-package-msvc.test.mjs</strong><dd><code>Update WiX discovery regression tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/scripts/windows-package-msvc.test.mjs

<ul><li>Adds assertions that <code>WixTools314</code> never appears<br> <li> Verifies glob-based WiX discovery in script and workflow<br> <li> Updates NSIS hook expectations to match the new helpers<br> <li> Keeps coverage aligned with the packaging changes</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/405/files#diff-4a04249d55b337623336d4d8ad295ac9b6a73d8471d05454b934cd3fb60e3747">+8/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

