### PR TITLE
Improve capsule recording feedback

### DIFF
--- a/openless-all/app/src-tauri/src/coordinator/dictation.rs
+++ b/openless-all/app/src-tauri/src/coordinator/dictation.rs
@@ -1048,6 +1048,8 @@ pub(super) async fn end_session(inner: &Arc<Inner>) -> Result<(), String> {
         return Ok(());
     }
 
+    emit_capsule(inner, CapsuleState::Inserting, 0.0, elapsed, None, None);
+
     let focus_target = inner.state.lock().focus_target;
     let focus_ready_for_paste = restore_focus_target_if_possible(focus_target);
     let prefs = inner.prefs.get();
@@ -1142,15 +1144,15 @@ pub(super) async fn end_session(inner: &Arc<Inner>) -> Result<(), String> {
         Some("TSF 未上屏，已禁止非 TSF 兜底".to_string())
     } else if polish_error.is_some() {
         // polish 失败优先告知用户，即使 insert 成功也要让用户知道这版是原文
-        Some("润色失败，已插入原文".to_string())
+        Some(format!("润色失败，已插入识别文本 {inserted_chars} 字"))
     } else {
         match status {
-            InsertStatus::Inserted => None,
-            InsertStatus::PasteSent => Some("已尝试粘贴".to_string()),
+            InsertStatus::Inserted => Some(format!("已润色并插入 {inserted_chars} 字")),
+            InsertStatus::PasteSent => Some(format!("已润色，尝试插入 {inserted_chars} 字")),
             InsertStatus::CopiedFallback => Some(if cfg!(target_os = "windows") {
-                "已复制，请 Ctrl+V".to_string()
+                format!("已润色并复制 {inserted_chars} 字，请 Ctrl+V")
             } else {
-                "已复制，请粘贴".to_string()
+                format!("已润色并复制 {inserted_chars} 字，请粘贴")
             }),
             InsertStatus::Failed => Some("插入失败".to_string()),
         }

--- a/openless-all/app/src-tauri/src/types.rs
+++ b/openless-all/app/src-tauri/src/types.rs
@@ -1104,6 +1104,7 @@ pub enum CapsuleState {
     Recording,
     Transcribing,
     Polishing,
+    Inserting,
     Done,
     Cancelled,
     Error,

--- a/openless-all/app/src/components/Capsule.tsx
+++ b/openless-all/app/src/components/Capsule.tsx
@@ -76,6 +76,13 @@ function ProcessingDots() {
   );
 }
 
+function formatElapsed(ms: number) {
+  const totalSeconds = Math.max(0, Math.floor(ms / 1000));
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return `${String(minutes).padStart(2, '0')}:${String(seconds).padStart(2, '0')}`;
+}
+
 interface CenterTextProps {
   os: OS;
   kind: 'default' | 'processing' | 'error';
@@ -164,13 +171,14 @@ interface PillProps {
   os: OS;
   state: CapsuleState;
   level: number;
+  elapsedMs: number;
   insertedChars: number;
   message?: string;
   onCancel: () => void;
   onConfirm: () => void;
 }
 
-function Pill({ os, state, level, insertedChars, message, onCancel, onConfirm }: PillProps) {
+function Pill({ os, state, level, elapsedMs, insertedChars, message, onCancel, onConfirm }: PillProps) {
   const { t } = useTranslation();
   const metrics = getCapsulePillMetrics(os);
   const processingLayout = getCapsuleMessageLayout(os, 'processing');
@@ -179,10 +187,42 @@ function Pill({ os, state, level, insertedChars, message, onCancel, onConfirm }:
   let center: JSX.Element;
   switch (state) {
     case 'recording':
-      center = <AudioBars level={level} />;
+      center = (
+        <div
+          style={{
+            display: 'inline-flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            gap: 7,
+            width: '100%',
+            maxWidth: metrics.textWidth,
+            minWidth: 0,
+          }}
+        >
+          <AudioBars level={level} />
+          <span
+            style={{
+              fontSize: 10.5,
+              fontWeight: 600,
+              color: 'var(--ol-ink-2)',
+              whiteSpace: 'nowrap',
+              fontVariantNumeric: 'tabular-nums',
+            }}
+          >
+            {t('capsule.recordingElapsed', { time: formatElapsed(elapsedMs) })}
+          </span>
+        </div>
+      );
       break;
     case 'transcribing':
     case 'polishing':
+    case 'inserting': {
+      const processingText =
+        state === 'transcribing'
+          ? t('capsule.transcribing')
+          : state === 'polishing'
+            ? t('capsule.polishing')
+            : t('capsule.inserting');
       center = (
         <div
           style={{
@@ -213,11 +253,12 @@ function Pill({ os, state, level, insertedChars, message, onCancel, onConfirm }:
               WebkitLineClamp: processingLayout.lineClamp,
             }}
           >
-            {t('capsule.thinking')}
+            {processingText}
           </span>
         </div>
       );
       break;
+    }
     case 'done':
       center = <CenterText os={os} kind="default" text={message || t('capsule.inserted', { count: insertedChars })} />;
       break;
@@ -278,6 +319,7 @@ export function Capsule() {
   const metrics = getCapsulePillMetrics(os);
   const [state, setState] = useState<CapsuleState>(isTauri ? 'idle' : 'recording');
   const [level, setLevel] = useState<number>(isTauri ? 0 : 0.6);
+  const [elapsedMs, setElapsedMs] = useState<number>(0);
   const [insertedChars, setInsertedChars] = useState<number>(0);
   const [message, setMessage] = useState<string | undefined>();
   const [translation, setTranslation] = useState<boolean>(false);
@@ -294,6 +336,7 @@ export function Capsule() {
         const p = event.payload;
         setState(p.state);
         setLevel(p.level ?? 0);
+        setElapsedMs(p.elapsedMs ?? 0);
         setMessage(p.message ?? undefined);
         if (p.insertedChars != null) setInsertedChars(p.insertedChars);
         setTranslation(p.translation === true);
@@ -390,6 +433,7 @@ export function Capsule() {
         os={os}
         state={state}
         level={level}
+        elapsedMs={elapsedMs}
         insertedChars={insertedChars}
         message={message}
         onCancel={onCancel}

--- a/openless-all/app/src/i18n/en.ts
+++ b/openless-all/app/src/i18n/en.ts
@@ -31,9 +31,13 @@ export const en: typeof zhCN = {
   },
   capsule: {
     thinking: 'Thinking…',
+    recordingElapsed: 'Recording {{time}}',
+    transcribing: 'Transcribing…',
+    polishing: 'Polishing…',
+    inserting: 'Inserting…',
     cancelled: 'Cancelled',
     error: 'Something went wrong',
-    inserted: 'Inserted {{count}}',
+    inserted: 'Inserted {{count}} chars',
     translating: 'Translating',
   },
   qa: {

--- a/openless-all/app/src/i18n/ja.ts
+++ b/openless-all/app/src/i18n/ja.ts
@@ -33,6 +33,10 @@ export const ja: typeof zhCN = {
   },
   capsule: {
     thinking: '考えています',
+    recordingElapsed: '録音中 {{time}}',
+    transcribing: '文字起こし中…',
+    polishing: '整えています…',
+    inserting: '入力中…',
     cancelled: 'キャンセルしました',
     error: 'エラーが発生しました',
     inserted: '{{count}} 文字を入力しました',

--- a/openless-all/app/src/i18n/ko.ts
+++ b/openless-all/app/src/i18n/ko.ts
@@ -33,6 +33,10 @@ export const ko: typeof zhCN = {
   },
   capsule: {
     thinking: '생각 중',
+    recordingElapsed: '녹음 중 {{time}}',
+    transcribing: '인식 중…',
+    polishing: '다듬는 중…',
+    inserting: '입력 중…',
     cancelled: '취소됨',
     error: '오류 발생',
     inserted: '{{count}}자 입력됨',

--- a/openless-all/app/src/i18n/zh-CN.ts
+++ b/openless-all/app/src/i18n/zh-CN.ts
@@ -29,9 +29,13 @@ export const zhCN = {
   },
   capsule: {
     thinking: '正在思考中',
+    recordingElapsed: '录音中 {{time}}',
+    transcribing: '正在识别…',
+    polishing: '正在润色…',
+    inserting: '正在插入…',
     cancelled: '已取消',
     error: '出错了',
-    inserted: '已插入 {{count}}',
+    inserted: '已插入 {{count}} 字',
     translating: '正在翻译',
   },
   qa: {

--- a/openless-all/app/src/i18n/zh-TW.ts
+++ b/openless-all/app/src/i18n/zh-TW.ts
@@ -31,9 +31,13 @@ export const zhTW: typeof zhCN = {
   },
   capsule: {
     thinking: '正在思考中',
+    recordingElapsed: '錄音中 {{time}}',
+    transcribing: '正在識別…',
+    polishing: '正在潤色…',
+    inserting: '正在插入…',
     cancelled: '已取消',
     error: '出錯了',
-    inserted: '已插入 {{count}}',
+    inserted: '已插入 {{count}} 字',
     translating: '正在翻譯',
   },
   qa: {

--- a/openless-all/app/src/lib/types.ts
+++ b/openless-all/app/src/lib/types.ts
@@ -263,6 +263,7 @@ export type CapsuleState =
   | 'recording'
   | 'transcribing'
   | 'polishing'
+  | 'inserting'
   | 'done'
   | 'cancelled'
   | 'error';


### PR DESCRIPTION
### **User description**
## Summary

This PR improves the dictation capsule feedback during recording and processing.

Changes:
- Show elapsed recording time in the capsule, e.g. `Recording 00:08`.
- Split processing feedback into clearer states:
  - Transcribing
  - Polishing
  - Inserting
- Emit an explicit `inserting` capsule state before text insertion.
- Show clearer completion messages, including inserted character count.
- Add i18n strings for zh-CN, zh-TW, en, ja, and ko.

## Why

Previously the capsule mainly showed generic thinking/inserted feedback, so users could not tell whether the app was recording, transcribing, polishing, or inserting. This makes the voice input flow easier to understand and reduces the feeling that the app is stuck.

## Verification

- Ran `npm run build` successfully.
- Built and manually tested the macOS app locally.
- Verified that the capsule shows elapsed recording time and processing states.


___

### **PR Type**
Enhancement


___

### **Description**
- Show elapsed recording time

- Add explicit inserting progress state

- Clarify completion messages with counts

- Update capsule translations and types


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Dictation end_session"] -- "emit inserting state" --> B["Capsule progress state"]
  B -- "render elapsed time and status" --> C["Capsule UI"]
  A -- "richer completion messages" --> D["Insert feedback"]
  E["Type definitions"] -- "add inserting value" --> B
  F["i18n translations"] -- "localized labels" --> C
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>9 files</summary><table>
<tr>
  <td><strong>dictation.rs</strong><dd><code>Emit inserting state and richer completion text</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/406/files#diff-4cf79887f41f4811eb2b1ef682c62ee34c14a0ab969362a9ba1046de59c8578b">+7/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>types.rs</strong><dd><code>Add inserting capsule state enum value</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/406/files#diff-702c533512690147fd6f9342d29f6258530afc2c9ada765f4af3bd082080c952">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>Capsule.tsx</strong><dd><code>Show elapsed time and inserting status</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/406/files#diff-864fa6eaba61a50b436891d4a11265927947abf4d5447192368d26b12e9eaa67">+47/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>en.ts</strong><dd><code>Add capsule progress strings in English</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/406/files#diff-bb2f4fa05787923f8aeb23b6f11ad8705e02d9ff03a45790f9181e4615c79d83">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ja.ts</strong><dd><code>Add capsule progress strings in Japanese</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/406/files#diff-be57f0090cf34e3ff924cfa35f13d5d9e6514d3af5a1ebfdeb92bd7d36ed9cf4">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ko.ts</strong><dd><code>Add capsule progress strings in Korean</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/406/files#diff-daf35bcb6a2f8a31565b83d119cb59b69c1dededbabfccfd0d56693fdb3726ca">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>zh-CN.ts</strong><dd><code>Add capsule progress strings in Simplified Chinese</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/406/files#diff-571576f3c7b6c4a78ae0f91accdccc5da5cbed00409955c9914c046fee6c80ea">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>zh-TW.ts</strong><dd><code>Add capsule progress strings in Traditional Chinese</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/406/files#diff-a8d5953f9c76bc3c90ec583270be04c852bd7540297500e6ff3260760fc61ea4">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>types.ts</strong><dd><code>Extend capsule state type with inserting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/406/files#diff-f22942a2f6ef50f13345f6b2781790a4a99e38a1a39702ce4bca3b2b2eb95e5a">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

