### PR TITLE
feat(capsule): animated thinking shine indicator

### DIFF
--- a/openless-all/app/src/components/Capsule.tsx
+++ b/openless-all/app/src/components/Capsule.tsx
@@ -56,26 +56,6 @@ function AudioBars({ level }: AudioBarsProps) {
   );
 }
 
-function ProcessingDots() {
-  return (
-    <div style={{ display: 'inline-flex', alignItems: 'center', gap: 4, width: 20 }}>
-      {[0, 1, 2].map(i => (
-        <span
-          key={i}
-          style={{
-            width: 4,
-            height: 4,
-            borderRadius: 999,
-            background: 'var(--ol-blue)',
-            opacity: 0.85,
-            animation: `cap-dot 0.9s var(--ol-motion-soft) ${i * 0.3}s infinite`,
-          }}
-        />
-      ))}
-    </div>
-  );
-}
-
 interface CenterTextProps {
   os: OS;
   kind: 'default' | 'processing' | 'error';
@@ -176,6 +156,20 @@ function Pill({ os, state, level, insertedChars, message, onCancel, onConfirm }:
   const processingLayout = getCapsuleMessageLayout(os, 'processing');
   const enabled = state === 'recording';
 
+  // "thinking" 扫光速度：进入 transcribing/polishing 的头 2 秒走快速（0.9s/cycle，提示
+  // 「流式刚开始」），之后切回慢速（2.4s）作为稳态。切回 idle / done / 其他 state 也复位
+  // 为 fast，下次进入时从头开始 burst。
+  const [shineFast, setShineFast] = useState(true);
+  useEffect(() => {
+    if (state === 'transcribing' || state === 'polishing') {
+      setShineFast(true);
+      const t = setTimeout(() => setShineFast(false), 2000);
+      return () => clearTimeout(t);
+    }
+    setShineFast(true);
+    return undefined;
+  }, [state]);
+
   let center: JSX.Element;
   switch (state) {
     case 'recording':
@@ -187,24 +181,43 @@ function Pill({ os, state, level, insertedChars, message, onCancel, onConfirm }:
         <div
           style={{
             display: 'inline-flex',
-            flexDirection: os === 'win' ? 'column' : 'row',
             alignItems: 'center',
-            gap: os === 'win' ? 4 : 6,
+            // 左右 4px 内边距 + 外层 gap 已经让 "thinking" ↔ ✗/✓ 视觉间距落在 ~4-5px。
+            padding: '0 4px',
             width: '100%',
             maxWidth: metrics.textWidth,
             minWidth: 0,
             justifyContent: 'center',
+            // state 进入动画 —— 用户从 recording 切到 polishing 时多一道淡入提示，
+            // 比纯切换 center 内容更容易被感知。
+            animation: 'cap-state-enter 220ms var(--ol-motion-soft) both',
           }}
         >
-          <ProcessingDots />
           <span
             style={{
-              fontSize: 10.5,
+              // 放大 11 → 14 让 thinking 在胶囊里更显眼。
+              fontSize: 14,
+              // 字重 500：用户反馈 700 太粗。500 是 medium 视觉重量，扫光更稳。
               fontWeight: 500,
+              letterSpacing: 0.5,
+              // 字号 14 + 字重 500 时小写 g/y/p 等下伸字符在 line-height: 1 下会被
+              // clip。给 line-height 一点冗余 + 上下 1px padding，descender 不再被切。
+              paddingBlock: 1,
+              // 扫光：渐变中段用更饱和的 ol-blue（不靠透明度），尾段保留 ink-3 作收尾，
+              // 整条 stripe 比之前更醒目（用户反馈"扫光不够明显"）。
               color: 'var(--ol-ink-2)',
+              backgroundImage:
+                'linear-gradient(100deg, var(--ol-ink-3) 0%, var(--ol-ink-3) 35%, var(--ol-blue) 50%, var(--ol-ink-3) 65%, var(--ol-ink-3) 100%)',
+              backgroundSize: '220% auto',
+              WebkitBackgroundClip: 'text',
+              backgroundClip: 'text',
+              WebkitTextFillColor: 'transparent',
+              // 进入流式的头 ~2 秒用 0.9s 高速扫光（视觉提示「刚开始」），之后 React 副作用
+              // 切到 2.4s 慢速。duration 变化时浏览器不重启动画，会平滑减速。
+              animation: `cap-shine ${shineFast ? '0.9s' : '2.4s'} linear infinite`,
               minWidth: 0,
               textAlign: 'center',
-              lineHeight: processingLayout.allowWrap ? 1.15 : 1,
+              lineHeight: processingLayout.allowWrap ? 1.3 : 1.25,
               whiteSpace: processingLayout.allowWrap ? 'normal' : 'nowrap',
               overflow: 'hidden',
               textOverflow: 'ellipsis',
@@ -242,7 +255,7 @@ function Pill({ os, state, level, insertedChars, message, onCancel, onConfirm }:
         display: 'inline-flex',
         alignItems: 'center',
         justifyContent: 'space-between',
-        gap: 8,
+        gap: 4,
         padding: '0 8px',
         width: metrics.width,
         height: metrics.height,
@@ -400,9 +413,13 @@ export function Capsule() {
           from { opacity: 0; transform: translateY(6px) scale(.96); }
           to   { opacity: 1; transform: translateY(0) scale(1); }
         }
-        @keyframes cap-dot {
-          0%, 100% { opacity: 0.3; transform: scale(0.8); }
-          50%      { opacity: 1.0; transform: scale(1.0); }
+        @keyframes cap-shine {
+          0%   { background-position: 200% center; }
+          100% { background-position: -200% center; }
+        }
+        @keyframes cap-state-enter {
+          from { opacity: 0; transform: translateY(2px); }
+          to   { opacity: 1; transform: translateY(0); }
         }
       `}</style>
     </div>

--- a/openless-all/app/src/i18n/en.ts
+++ b/openless-all/app/src/i18n/en.ts
@@ -30,7 +30,7 @@ export const en: typeof zhCN = {
     durationMinutes: '{{value}}m',
   },
   capsule: {
-    thinking: 'Thinking…',
+    thinking: 'thinking',
     cancelled: 'Cancelled',
     error: 'Something went wrong',
     inserted: 'Inserted {{count}}',

--- a/openless-all/app/src/i18n/ja.ts
+++ b/openless-all/app/src/i18n/ja.ts
@@ -32,7 +32,7 @@ export const ja: typeof zhCN = {
     durationMinutes: '{{value}} 分',
   },
   capsule: {
-    thinking: '考えています',
+    thinking: 'thinking',
     cancelled: 'キャンセルしました',
     error: 'エラーが発生しました',
     inserted: '{{count}} 文字を入力しました',

--- a/openless-all/app/src/i18n/ko.ts
+++ b/openless-all/app/src/i18n/ko.ts
@@ -32,7 +32,7 @@ export const ko: typeof zhCN = {
     durationMinutes: '{{value}}분',
   },
   capsule: {
-    thinking: '생각 중',
+    thinking: 'thinking',
     cancelled: '취소됨',
     error: '오류 발생',
     inserted: '{{count}}자 입력됨',

--- a/openless-all/app/src/i18n/zh-CN.ts
+++ b/openless-all/app/src/i18n/zh-CN.ts
@@ -28,7 +28,7 @@ export const zhCN = {
     durationMinutes: '{{value}} 分钟',
   },
   capsule: {
-    thinking: '正在思考中',
+    thinking: 'thinking',
     cancelled: '已取消',
     error: '出错了',
     inserted: '已插入 {{count}}',

--- a/openless-all/app/src/i18n/zh-TW.ts
+++ b/openless-all/app/src/i18n/zh-TW.ts
@@ -30,7 +30,7 @@ export const zhTW: typeof zhCN = {
     durationMinutes: '{{value}} 分鐘',
   },
   capsule: {
-    thinking: '正在思考中',
+    thinking: 'thinking',
     cancelled: '已取消',
     error: '出錯了',
     inserted: '已插入 {{count}}',


### PR DESCRIPTION
### **User description**
## Summary
- 把 transcribing / polishing 阶段的胶囊从 \"三个圆点 + 文案\" 换成扫光的 thinking 文字效果
- 字号 11 → 14，字重 500，linear-gradient + background-clip: text 实现扫光
- 进入流式头 2 秒走 0.9s 高速扫光（提示「刚开始」），之后切到 2.4s 稳态；duration 变化时浏览器不重启动画，会平滑减速
- 5 个 locale 的 \`capsule.thinking\` 文案统一为 'thinking'（小写英文），与扫光字面视觉一致

## Test plan
- [x] \`npm run build\` pass
- [ ] 真机验证：录音 → 转写 → 润色全程胶囊文字扫光动画顺滑，状态切换有淡入提示
- [ ] 中英日韩繁五种 locale 下扫光字面尺寸排版一致


___

### **PR Type**
Enhancement


___

### **Description**
- Replaced processing dots with thinking shine

- Added fast-then-slow shimmer timing

- Faded in state transitions

- Unified thinking text across locales


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Capsule processing state"] -- "renders" --> B["Shining thinking text"]
  B -- "uses" --> C["Fast burst then steady shimmer"]
  B -- "applies" --> D["State enter fade-in"]
  E["Locale strings"] -- "normalize to" --> F["thinking"]
  F -- "feeds" --> B
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Capsule.tsx</strong><dd><code>Replace dots with animated thinking shine</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src/components/Capsule.tsx

<ul><li>Removed the <code>ProcessingDots</code> indicator entirely.<br> <li> Rendered <code>thinking</code> as gradient-clipped animated text.<br> <li> Added a fast initial shimmer, then steady speed.<br> <li> Added a brief state-enter fade for transitions.</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/408/files#diff-864fa6eaba61a50b436891d4a11265927947abf4d5447192368d26b12e9eaa67">+46/-29</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Localization</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>en.ts</strong><dd><code>Normalize English thinking label</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src/i18n/en.ts

<ul><li>Changed <code>capsule.thinking</code> from <code>Thinking…</code> to <code>thinking</code>.<br> <li> Keeps the visual label aligned with the new shine effect.</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/408/files#diff-bb2f4fa05787923f8aeb23b6f11ad8705e02d9ff03a45790f9181e4615c79d83">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ja.ts</strong><dd><code>Normalize Japanese thinking label</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src/i18n/ja.ts

<ul><li>Changed <code>capsule.thinking</code> from Japanese text to <code>thinking</code>.<br> <li> Removes locale-length variance from the capsule layout.</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/408/files#diff-be57f0090cf34e3ff924cfa35f13d5d9e6514d3af5a1ebfdeb92bd7d36ed9cf4">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ko.ts</strong><dd><code>Normalize Korean thinking label</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src/i18n/ko.ts

<ul><li>Changed <code>capsule.thinking</code> from Korean text to <code>thinking</code>.<br> <li> Ensures consistent width for the animated text treatment.</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/408/files#diff-daf35bcb6a2f8a31565b83d119cb59b69c1dededbabfccfd0d56693fdb3726ca">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>zh-CN.ts</strong><dd><code>Normalize Simplified Chinese thinking label</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src/i18n/zh-CN.ts

<ul><li>Changed <code>capsule.thinking</code> from Chinese text to <code>thinking</code>.<br> <li> Aligns the displayed text with the new shimmer styling.</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/408/files#diff-571576f3c7b6c4a78ae0f91accdccc5da5cbed00409955c9914c046fee6c80ea">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>zh-TW.ts</strong><dd><code>Normalize Traditional Chinese thinking label</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src/i18n/zh-TW.ts

<ul><li>Changed <code>capsule.thinking</code> from Chinese text to <code>thinking</code>.<br> <li> Keeps the capsule label visually consistent across locales.</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/408/files#diff-a8d5953f9c76bc3c90ec583270be04c852bd7540297500e6ff3260760fc61ea4">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

