### PR TITLE
fix(hotkey): 250ms debounce on pressed-edge dispatch

### DIFF
--- a/openless-all/app/src-tauri/src/coordinator.rs
+++ b/openless-all/app/src-tauri/src/coordinator.rs
@@ -119,6 +119,11 @@ struct Inner {
     hotkey: Mutex<Option<HotkeyMonitor>>,
     hotkey_status: Mutex<HotkeyStatus>,
     hotkey_trigger_held: AtomicBool,
+    /// 防抖时间戳：handle_pressed_edge 入口检查与本字段的距离，< 250ms 的边沿直接
+    /// 丢弃（误触双击 / 微动开关回弹 / 用户连点过快造成的空转写报错）。
+    /// 与 `hotkey_trigger_held` 互补 —— held 防 press-without-release，本字段防
+    /// press-release-press 三连过快。
+    last_hotkey_dispatch_at: Mutex<Option<std::time::Instant>>,
     shortcut_recording_active: AtomicBool,
     /// 自定义组合键监听器（global-hotkey crate）。当 `prefs.hotkey.trigger == Custom` 时
     /// 代替 modifier-only 的 hotkey monitor。`None` 表示不使用自定义组合键或还没成功安装。
@@ -199,6 +204,7 @@ impl Coordinator {
                     hotkey: Mutex::new(None),
                     hotkey_status: Mutex::new(HotkeyStatus::default()),
                     hotkey_trigger_held: AtomicBool::new(false),
+                    last_hotkey_dispatch_at: Mutex::new(None),
                     shortcut_recording_active: AtomicBool::new(false),
                     combo_hotkey: Mutex::new(None),
                     translation_hotkey: Mutex::new(None),
@@ -245,6 +251,7 @@ impl Coordinator {
                 hotkey: Mutex::new(None),
                 hotkey_status: Mutex::new(HotkeyStatus::default()),
                 hotkey_trigger_held: AtomicBool::new(false),
+                last_hotkey_dispatch_at: Mutex::new(None),
                 shortcut_recording_active: AtomicBool::new(false),
                 combo_hotkey: Mutex::new(None),
                 translation_hotkey: Mutex::new(None),

--- a/openless-all/app/src-tauri/src/coordinator/dictation.rs
+++ b/openless-all/app/src-tauri/src/coordinator/dictation.rs
@@ -9,9 +9,33 @@ use super::qa::handle_qa_option_edge;
 use super::resources::*;
 use super::*;
 
+/// 同一个 hotkey 边沿之间的最小间隔。低于此阈值的连按整体作为误触丢弃 ——
+/// 避免微动开关回弹 / 用户手抖双击造成的空转写报错和 ASR session 抢资源。
+const HOTKEY_DEBOUNCE: std::time::Duration = std::time::Duration::from_millis(250);
+
 pub(super) async fn handle_pressed_edge(inner: &Arc<Inner>) {
     let was_held = inner.hotkey_trigger_held.swap(true, Ordering::SeqCst);
     if !was_held {
+        // 防抖：相邻 < HOTKEY_DEBOUNCE 的边沿直接丢弃，记到 log 方便排查。
+        // 与 `hotkey_trigger_held` 互补：held 防 press-without-release，本检查防
+        // press-release-press 三连过快。每个有效边沿都会更新时间戳。
+        let now = std::time::Instant::now();
+        let too_soon = {
+            let mut last = inner.last_hotkey_dispatch_at.lock();
+            let drop = matches!(*last, Some(t) if now.duration_since(t) < HOTKEY_DEBOUNCE);
+            if !drop {
+                *last = Some(now);
+            }
+            drop
+        };
+        if too_soon {
+            log::info!(
+                "[coord] hotkey pressed edge debounced (< {} ms since last dispatch)",
+                HOTKEY_DEBOUNCE.as_millis()
+            );
+            return;
+        }
+
         // 路由：QA 浮窗可见时，rightOption 边沿走 QA；否则走主听写。详见 issue #118 v2。
         // 例外：dictation session 已经在跑（Starting / Listening / Processing / Inserting），
         // 即使 QA 浮窗被打开了，这条边沿也必须先走 dictation。否则 begin_qa_session 会


### PR DESCRIPTION
### **User description**
## Summary
- 相邻 < 250ms 的 hotkey press 边沿直接丢弃，记 log 方便排查
- 解决：微动开关回弹 / 用户手抖双击 / 用户连点过快 → 空转写报错 + ASR session 抢资源

## 主要改动
- \`coordinator.rs::Inner\` 新增 \`last_hotkey_dispatch_at: Mutex<Option<Instant>>\` 字段（2 个构造点同步初始化）
- \`coordinator/dictation.rs\` 加 \`HOTKEY_DEBOUNCE = 250ms\` 常量，\`handle_pressed_edge\` 入口检查时间戳

与 \`hotkey_trigger_held\` 互补：held 防 press-without-release，本检查防 press-release-press 三连过快。用户正常使用（不会快于 4 次/秒）不会触发。

## Test plan
- [x] \`cargo check --manifest-path src-tauri/Cargo.toml\` pass
- [ ] CI 三平台 cargo check pass
- [ ] 真机：正常切换式录音不受影响（每按一次都生效）
- [ ] 真机：故意 50ms 内连按两次，第二下应被 log \"debounced\" 丢弃


___

### **PR Type**
Bug fix


___

### **Description**
- Add 250ms pressed-edge debounce

- Drop rapid hotkey repeats

- Initialize dispatch timestamp state


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Pressed hotkey edge"] --> B["250ms debounce check"]
  B -- "too soon" --> C["Log and drop"]
  B -- "accepted" --> D["Route to dictation or QA"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>coordinator.rs</strong><dd><code>Track last hotkey dispatch timestamp</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src-tauri/src/coordinator.rs

<ul><li>Add <code>last_hotkey_dispatch_at</code> to <code>Inner</code><br> <li> Document the debounce purpose and scope<br> <li> Initialize the new mutex in both constructors</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/409/files#diff-73d8c004670b27293f74f0f3991b9a6fc28f0ff0b883214de2b078b1e09797ca">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>dictation.rs</strong><dd><code>Debounce rapid hotkey press edges</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src-tauri/src/coordinator/dictation.rs

<ul><li>Define a 250ms <code>HOTKEY_DEBOUNCE</code> constant<br> <li> Check elapsed time before handling pressed edges<br> <li> Update the timestamp only for accepted edges<br> <li> Log debounced presses for easier debugging</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/409/files#diff-4cf79887f41f4811eb2b1ef682c62ee34c14a0ab969362a9ba1046de59c8578b">+24/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

