### PR TITLE
修复流式 SSE UTF-8 切分与部分输入丢失

### DIFF
--- a/openless-all/app/src-tauri/src/coordinator/dictation.rs
+++ b/openless-all/app/src-tauri/src/coordinator/dictation.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 use crate::coordinator_state::request_stop_during_starting_state;
 use crate::correction::apply_correction_rules;
-use crate::types::HotkeyMode;
+use crate::types::{CorrectionRule, HotkeyMode};
 
 use super::qa::handle_qa_option_edge;
 use super::resources::*;
@@ -38,6 +38,50 @@ const HOTKEY_DEBOUNCE: std::time::Duration = std::time::Duration::from_millis(25
 /// **不在流式路径里做**：`apply_chinese_script_preference` / `apply_correction_rules`
 /// 这两步在 v1 跳过 —— 字符已经一边流一边落出去了，不好回退。需要的话只能关 toggle 走
 /// 一次性路径。
+fn append_typed_prefix(typed_text: &mut String, delta: &str, typed_chars: usize) {
+    typed_text.extend(delta.chars().take(typed_chars));
+}
+
+fn finalize_dictation_text(
+    mut text: String,
+    already_streamed: bool,
+    translation_active: bool,
+    mode: PolishMode,
+    polish_failed: bool,
+    chinese_script_preference: crate::types::ChineseScriptPreference,
+    correction_rules: &[CorrectionRule],
+) -> String {
+    if already_streamed {
+        return text;
+    }
+
+    // 仅在“ASR 直出文本”场景做强制简繁收敛，避免误伤成功的翻译/常规 LLM 输出：
+    // - 非翻译模式：mode=Raw（本来就不走润色）或润色失败回退 raw
+    // - 翻译模式：仅翻译失败回退 raw 时才收敛
+    let should_force_script = if translation_active {
+        polish_failed
+    } else {
+        mode == PolishMode::Raw || polish_failed
+    };
+    if should_force_script {
+        text = apply_chinese_script_preference(&text, chinese_script_preference);
+    }
+
+    if correction_rules.is_empty() {
+        return text;
+    }
+
+    let corrected = apply_correction_rules(&text, correction_rules);
+    if corrected != text {
+        log::info!(
+            "[coord] correction rules adjusted final text ({} → {} chars)",
+            text.chars().count(),
+            corrected.chars().count()
+        );
+    }
+    corrected
+}
+
 #[allow(clippy::too_many_arguments)]
 async fn run_streaming_polish(
     inner: &Arc<Inner>,
@@ -120,10 +164,12 @@ async fn run_streaming_polish(
                 continue;
             }
             match crate::unicode_keystroke::type_unicode_chunk(&delta) {
-                Ok(()) => {
-                    typed_text.push_str(&delta);
+                Ok(typed_chars) => {
+                    append_typed_prefix(&mut typed_text, &delta, typed_chars);
                 }
                 Err(e) => {
+                    let typed_chars = e.typed_chars();
+                    append_typed_prefix(&mut typed_text, &delta, typed_chars);
                     log::error!(
                         "[coord] streaming_insert: type_unicode_chunk failed at typed={} chars: {e}; \
                          dropping remaining deltas",
@@ -202,10 +248,7 @@ async fn run_streaming_polish(
             // pr-agent #412 反馈 \"Clipboard Mismatch\"：之前先写 text 到剪贴板再
             // 决定 typer 是否中途失败，导致 Cmd+V 粘出用户屏幕上没见过的内容。
             let (final_text, polish_err) = match typer_failure {
-                Some(e) => (
-                    typed_text,
-                    Some(format!("typing partially failed: {e}")),
-                ),
+                Some(e) => (typed_text, Some(format!("typing partially failed: {e}"))),
                 None => (text, None),
             };
             // 把 final_text 写回剪贴板（默认 on，可关）。一次性路径天然走剪贴板，
@@ -217,23 +260,23 @@ async fn run_streaming_polish(
                             "[coord] streaming_insert: final text written to clipboard ({} chars)",
                             final_text.chars().count()
                         ),
-                        Err(e) => log::warn!(
-                            "[coord] streaming_insert: clipboard set_text failed: {e}"
-                        ),
+                        Err(e) => {
+                            log::warn!("[coord] streaming_insert: clipboard set_text failed: {e}")
+                        }
                     },
-                    Err(e) => log::warn!(
-                        "[coord] streaming_insert: clipboard handle init failed: {e}"
-                    ),
+                    Err(e) => {
+                        log::warn!("[coord] streaming_insert: clipboard handle init failed: {e}")
+                    }
                 }
             } else {
-                log::info!(
-                    "[coord] streaming_insert: clipboard save skipped (pref off)"
-                );
+                log::info!("[coord] streaming_insert: clipboard save skipped (pref off)");
             }
             (final_text, polish_err, true)
         }
         super::StreamingPolishOutcome::UnsupportedFallback => {
-            log::info!("[coord] streaming_insert: dispatch reported unsupported, fall back to one-shot");
+            log::info!(
+                "[coord] streaming_insert: dispatch reported unsupported, fall back to one-shot"
+            );
             let (p, e) = polish_or_passthrough(
                 raw,
                 mode,
@@ -1304,32 +1347,15 @@ pub(super) async fn end_session(inner: &Arc<Inner>) -> Result<(), String> {
         (p, e, false)
     };
 
-    // 仅在“ASR 直出文本”场景做强制简繁收敛，避免误伤成功的翻译/常规 LLM 输出：
-    // - 非翻译模式：mode=Raw（本来就不走润色）或润色失败回退 raw
-    // - 翻译模式：仅翻译失败回退 raw 时才收敛
-    let should_force_script = if translation_active {
-        polish_error.is_some()
-    } else {
-        mode == PolishMode::Raw || polish_error.is_some()
-    };
-    let polished = if should_force_script {
-        apply_chinese_script_preference(&polished, chinese_script_preference)
-    } else {
-        polished
-    };
-    let polished = if correction_rules.is_empty() {
-        polished
-    } else {
-        let corrected = apply_correction_rules(&polished, &correction_rules);
-        if corrected != polished {
-            log::info!(
-                "[coord] correction rules adjusted final text ({} → {} chars)",
-                polished.chars().count(),
-                corrected.chars().count()
-            );
-        }
-        corrected
-    };
+    let polished = finalize_dictation_text(
+        polished,
+        already_streamed,
+        translation_active,
+        mode,
+        polish_error.is_some(),
+        chinese_script_preference,
+        &correction_rules,
+    );
 
     // 原子化最后一次 cancel 检查 + 转 Inserting：
     // 在同一 lock 内决定「丢弃」还是「进入 Inserting」。一旦设到 Inserting，
@@ -1539,4 +1565,70 @@ pub(super) fn cancel_session(inner: &Arc<Inner>) {
     emit_capsule(inner, CapsuleState::Cancelled, 0.0, 0, None, None);
     log::info!("[coord] session cancelled (was {:?})", decision.phase);
     schedule_capsule_idle(inner, CAPSULE_AUTO_HIDE_DELAY_MS);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{append_typed_prefix, finalize_dictation_text};
+    use crate::types::PolishMode;
+
+    #[test]
+    fn append_typed_prefix_truncates_by_chars_not_bytes() {
+        let mut typed = String::from("已");
+        append_typed_prefix(&mut typed, "你好🙂abc", 3);
+        assert_eq!(typed, "已你好🙂");
+    }
+
+    #[test]
+    fn append_typed_prefix_ignores_overlarge_count() {
+        let mut typed = String::new();
+        append_typed_prefix(&mut typed, "好", 99);
+        assert_eq!(typed, "好");
+    }
+
+    #[test]
+    fn streamed_text_skips_mutating_final_postprocess() {
+        let rules = vec![crate::types::CorrectionRule {
+            id: "r1".into(),
+            pattern: "错词".into(),
+            replacement: "正词".into(),
+            enabled: true,
+            created_at: "2026-01-01T00:00:00Z".into(),
+        }];
+
+        let text = finalize_dictation_text(
+            "錯詞".to_string(),
+            true,
+            false,
+            PolishMode::Raw,
+            true,
+            crate::types::ChineseScriptPreference::Simplified,
+            &rules,
+        );
+
+        assert_eq!(text, "錯詞");
+    }
+
+    #[test]
+    fn non_streamed_text_still_applies_final_postprocess() {
+        let rules = vec![crate::types::CorrectionRule {
+            id: "r1".into(),
+            pattern: "错词".into(),
+            replacement: "正词".into(),
+            enabled: true,
+            created_at: "2026-01-01T00:00:00Z".into(),
+        }];
+
+        let text = finalize_dictation_text(
+            "錯詞".to_string(),
+            false,
+            false,
+            PolishMode::Raw,
+            false,
+            crate::types::ChineseScriptPreference::Simplified,
+            &rules,
+        );
+
+        assert_eq!(text, "正词");
+    }
 }

--- a/openless-all/app/src-tauri/src/polish.rs
+++ b/openless-all/app/src-tauri/src/polish.rs
@@ -587,12 +587,15 @@ impl OpenAICompatibleLLMProvider {
         // 一个 chunk() 可能包含半帧或多帧；用 buffer 累积后再按 `\n\n` 切。
         let mut response = response;
         let mut buffer = String::new();
+        let mut utf8_pending: Vec<u8> = Vec::new();
         let mut full_text = String::new();
+        let mut cancelled = false;
         loop {
             // 取消旗标：用户取消 / 关浮窗时立即 break，不再 drain HTTP body。
             // 否则 reqwest 会读完整个流（包括 LLM 后续 token）烧 quota。详见 issue #161。
             if should_cancel() {
                 log::info!("[llm] stream cancelled by caller; breaking SSE loop");
+                cancelled = true;
                 break;
             }
             let chunk_opt = response
@@ -600,9 +603,7 @@ impl OpenAICompatibleLLMProvider {
                 .await
                 .map_err(|e| LLMError::Network(e.to_string()))?;
             let Some(chunk) = chunk_opt else { break };
-            let s = std::str::from_utf8(&chunk)
-                .map_err(|e| LLMError::Network(format!("non-utf8 SSE chunk: {e}")))?;
-            buffer.push_str(s);
+            append_utf8_sse_chunk(&mut buffer, &mut utf8_pending, &chunk)?;
 
             while let Some(idx) = buffer.find("\n\n") {
                 let event = buffer[..idx].to_string();
@@ -636,6 +637,9 @@ impl OpenAICompatibleLLMProvider {
                     }
                 }
             }
+        }
+        if !cancelled {
+            finish_utf8_sse_chunks(&mut buffer, &mut utf8_pending)?;
         }
 
         log::info!(
@@ -709,8 +713,10 @@ impl OpenAICompatibleLLMProvider {
 
         let mut response = response;
         let mut buffer = String::new();
+        let mut utf8_pending: Vec<u8> = Vec::new();
         let mut full_text = String::new();
         let mut delta_count: u64 = 0;
+        let mut cancelled = false;
         loop {
             if should_cancel() {
                 log::info!(
@@ -718,6 +724,7 @@ impl OpenAICompatibleLLMProvider {
                     delta_count,
                     full_text.chars().count()
                 );
+                cancelled = true;
                 break;
             }
             let chunk_opt = response
@@ -725,9 +732,7 @@ impl OpenAICompatibleLLMProvider {
                 .await
                 .map_err(|e| LLMError::Network(e.to_string()))?;
             let Some(chunk) = chunk_opt else { break };
-            let s = std::str::from_utf8(&chunk)
-                .map_err(|e| LLMError::Network(format!("non-utf8 SSE chunk: {e}")))?;
-            buffer.push_str(s);
+            append_utf8_sse_chunk(&mut buffer, &mut utf8_pending, &chunk)?;
 
             while let Some(idx) = buffer.find("\n\n") {
                 let event = buffer[..idx].to_string();
@@ -762,6 +767,9 @@ impl OpenAICompatibleLLMProvider {
                     }
                 }
             }
+        }
+        if !cancelled {
+            finish_utf8_sse_chunks(&mut buffer, &mut utf8_pending)?;
         }
 
         log::info!(
@@ -1065,11 +1073,14 @@ impl CodexOAuthLLMProvider {
 
         let mut response = response;
         let mut buffer = String::new();
+        let mut utf8_pending: Vec<u8> = Vec::new();
         let mut full_text = String::new();
         let mut final_text = String::new();
+        let mut cancelled = false;
         loop {
             if should_cancel() {
                 log::info!("[llm] codex stream cancelled by caller; breaking SSE loop");
+                cancelled = true;
                 break;
             }
             let chunk_opt = response
@@ -1077,15 +1088,16 @@ impl CodexOAuthLLMProvider {
                 .await
                 .map_err(|e| LLMError::Network(e.to_string()))?;
             let Some(chunk) = chunk_opt else { break };
-            let s = std::str::from_utf8(&chunk)
-                .map_err(|e| LLMError::Network(format!("non-utf8 SSE chunk: {e}")))?;
-            buffer.push_str(s);
+            append_utf8_sse_chunk(&mut buffer, &mut utf8_pending, &chunk)?;
 
             while let Some(idx) = buffer.find("\n\n") {
                 let event = buffer[..idx].to_string();
                 buffer.drain(..idx + 2);
                 handle_codex_sse_event(&event, &mut full_text, &mut final_text, &on_delta);
             }
+        }
+        if !cancelled {
+            finish_utf8_sse_chunks(&mut buffer, &mut utf8_pending)?;
         }
         if !buffer.trim().is_empty() {
             handle_codex_sse_event(&buffer, &mut full_text, &mut final_text, &on_delta);
@@ -1105,6 +1117,51 @@ impl CodexOAuthLLMProvider {
             });
         }
         Ok(clean_polish_output(&full_text))
+    }
+}
+
+fn append_utf8_sse_chunk(
+    buffer: &mut String,
+    pending: &mut Vec<u8>,
+    chunk: &[u8],
+) -> Result<(), LLMError> {
+    pending.extend_from_slice(chunk);
+    drain_complete_utf8(buffer, pending)
+}
+
+fn finish_utf8_sse_chunks(buffer: &mut String, pending: &mut Vec<u8>) -> Result<(), LLMError> {
+    drain_complete_utf8(buffer, pending)?;
+    if pending.is_empty() {
+        Ok(())
+    } else {
+        Err(LLMError::Network(
+            "non-utf8 SSE chunk: stream ended in the middle of a UTF-8 codepoint".to_string(),
+        ))
+    }
+}
+
+fn drain_complete_utf8(buffer: &mut String, pending: &mut Vec<u8>) -> Result<(), LLMError> {
+    loop {
+        match std::str::from_utf8(pending) {
+            Ok(s) => {
+                buffer.push_str(s);
+                pending.clear();
+                return Ok(());
+            }
+            Err(e) => {
+                let valid_up_to = e.valid_up_to();
+                if valid_up_to > 0 {
+                    let valid = std::str::from_utf8(&pending[..valid_up_to]).expect("valid prefix");
+                    buffer.push_str(valid);
+                    pending.drain(..valid_up_to);
+                    continue;
+                }
+                if e.error_len().is_none() {
+                    return Ok(());
+                }
+                return Err(LLMError::Network(format!("non-utf8 SSE chunk: {e}")));
+            }
+        }
     }
 }
 
@@ -2145,6 +2202,136 @@ mod tests {
         format!("{}.{}.sig", header, payload)
     }
 
+    #[test]
+    fn utf8_sse_decoder_preserves_multibyte_split_across_chunks() {
+        let mut buffer = String::new();
+        let mut pending = Vec::new();
+        let event = "data: {\"choices\":[{\"delta\":{\"content\":\"你好🙂\"}}]}\n\n";
+        let bytes = event.as_bytes();
+        let split = event.find("好").expect("contains CJK char") + 1;
+
+        append_utf8_sse_chunk(&mut buffer, &mut pending, &bytes[..split]).unwrap();
+        assert!(!pending.is_empty());
+        assert!(!buffer.contains('好'));
+
+        append_utf8_sse_chunk(&mut buffer, &mut pending, &bytes[split..]).unwrap();
+        finish_utf8_sse_chunks(&mut buffer, &mut pending).unwrap();
+        assert_eq!(buffer, event);
+        assert!(pending.is_empty());
+    }
+
+    #[test]
+    fn utf8_sse_decoder_rejects_invalid_byte() {
+        let mut buffer = String::new();
+        let mut pending = Vec::new();
+        let err = append_utf8_sse_chunk(&mut buffer, &mut pending, b"data: \xff\n\n")
+            .expect_err("invalid byte should fail");
+        assert!(err.to_string().contains("non-utf8 SSE chunk"));
+    }
+
+    #[test]
+    fn utf8_sse_decoder_rejects_unfinished_codepoint_on_finish() {
+        let mut buffer = String::new();
+        let mut pending = Vec::new();
+        append_utf8_sse_chunk(&mut buffer, &mut pending, &[0xE4]).unwrap();
+        let err = finish_utf8_sse_chunks(&mut buffer, &mut pending)
+            .expect_err("unfinished codepoint should fail at EOF");
+        assert!(err.to_string().contains("middle of a UTF-8 codepoint"));
+    }
+
+    #[tokio::test]
+    async fn polish_streaming_handles_multibyte_split_in_http_chunk() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        let event = "data: {\"choices\":[{\"delta\":{\"content\":\"你🙂好\"}}]}\n\n";
+        let split = split_inside(event, "🙂");
+        let first = event.as_bytes()[..split].to_vec();
+        let second = event.as_bytes()[split..].to_vec();
+
+        let server = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let request = read_http_request(&mut stream);
+            let request_text = String::from_utf8_lossy(&request);
+            assert!(request_text.starts_with("POST /chat/completions HTTP/1.1"));
+            write_chunked_sse_response(&mut stream, &[&first, &second]);
+        });
+
+        let provider = OpenAICompatibleLLMProvider::new(OpenAICompatibleConfig::new(
+            "ark",
+            "Ark",
+            format!("http://{}", addr),
+            "",
+            "test-model",
+        ));
+        let deltas = StdMutex::new(String::new());
+        let output = provider
+            .polish_streaming(
+                "原文",
+                PolishMode::Raw,
+                &[],
+                &[],
+                ChineseScriptPreference::Auto,
+                OutputLanguagePreference::Auto,
+                None,
+                &[],
+                |delta| deltas.lock().unwrap().push_str(delta),
+                || false,
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(output, "你🙂好");
+        assert_eq!(*deltas.lock().unwrap(), "你🙂好");
+        server.join().unwrap();
+    }
+
+    #[tokio::test]
+    async fn qa_streaming_handles_multibyte_split_in_http_chunk() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        let event = "data: {\"choices\":[{\"delta\":{\"content\":\"答🙂案\"}}]}\n\n";
+        let split = split_inside(event, "🙂");
+        let first = event.as_bytes()[..split].to_vec();
+        let second = event.as_bytes()[split..].to_vec();
+
+        let server = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let request = read_http_request(&mut stream);
+            let request_text = String::from_utf8_lossy(&request);
+            assert!(request_text.starts_with("POST /chat/completions HTTP/1.1"));
+            write_chunked_sse_response(&mut stream, &[&first, &second]);
+        });
+
+        let provider = OpenAICompatibleLLMProvider::new(OpenAICompatibleConfig::new(
+            "ark",
+            "Ark",
+            format!("http://{}", addr),
+            "",
+            "test-model",
+        ));
+        let messages = vec![QaChatMessage {
+            role: "user".into(),
+            content: "问题".into(),
+        }];
+        let deltas = StdMutex::new(String::new());
+        let output = provider
+            .answer_chat_streaming(
+                &messages,
+                &[],
+                ChineseScriptPreference::Auto,
+                OutputLanguagePreference::Auto,
+                None,
+                |delta| deltas.lock().unwrap().push_str(delta),
+                || false,
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(output, "答🙂案");
+        assert_eq!(*deltas.lock().unwrap(), "答🙂案");
+        server.join().unwrap();
+    }
+
     fn base64_url_no_pad(input: &str) -> String {
         const TABLE: &[u8; 64] =
             b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
@@ -2194,6 +2381,24 @@ mod tests {
             }
         }
         request
+    }
+
+    fn write_chunked_sse_response(stream: &mut std::net::TcpStream, chunks: &[&[u8]]) {
+        stream
+            .write_all(
+                b"HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\nTransfer-Encoding: chunked\r\nConnection: close\r\n\r\n",
+            )
+            .unwrap();
+        for chunk in chunks {
+            write!(stream, "{:X}\r\n", chunk.len()).unwrap();
+            stream.write_all(chunk).unwrap();
+            stream.write_all(b"\r\n").unwrap();
+        }
+        stream.write_all(b"0\r\n\r\n").unwrap();
+    }
+
+    fn split_inside(haystack: &str, needle: &str) -> usize {
+        haystack.find(needle).expect("needle exists") + 1
     }
 
     // ──────────────── 对话感知 polish 的 chat 消息构造 ────────────────
@@ -2690,16 +2895,15 @@ mod tests {
             assert!(!request_text.contains(r#""temperature":"#));
 
             let body = concat!(
-                "data: {\"type\":\"response.output_text.delta\",\"delta\":\"最终\"}\n\n",
+                "data: {\"type\":\"response.output_text.delta\",\"delta\":\"最终🙂\"}\n\n",
                 "data: {\"type\":\"response.output_text.delta\",\"delta\":\"文本。\"}\n\n",
                 "data: {\"type\":\"response.completed\",\"response\":{\"output\":[]}}\n\n"
             );
-            let response = format!(
-                "HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
-                body.len(),
-                body
+            let split = split_inside(body, "🙂");
+            write_chunked_sse_response(
+                &mut stream,
+                &[&body.as_bytes()[..split], &body.as_bytes()[split..]],
             );
-            stream.write_all(response.as_bytes()).unwrap();
         });
 
         let provider = CodexOAuthLLMProvider::new(
@@ -2721,7 +2925,7 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(output, "最终文本。");
+        assert_eq!(output, "最终🙂文本。");
         server.join().unwrap();
         let _ = std::fs::remove_file(auth_path);
     }

--- a/openless-all/app/src-tauri/src/unicode_keystroke.rs
+++ b/openless-all/app/src-tauri/src/unicode_keystroke.rs
@@ -2,7 +2,7 @@
 //!
 //! 公开 API 三件套：
 //! - `type_unicode_chunk(text)` —— 阻塞地把一段文字逐 codepoint 当作键盘事件发出去，
-//!   不动剪贴板。各平台用各自的原语。
+//!   不动剪贴板。各平台用各自的原语；返回确认成功发送的字符数。
 //! - `switch_to_ascii(app)` —— 仅 macOS 有效；切到 ABC 输入源以绕过 CJK / 日文 IME
 //!   对 Unicode 字符串事件的拦截。Windows / Linux 上是 no-op。
 //! - `restore_input_source(app, prev)` —— 配对调用，恢复 macOS 上的原输入源。
@@ -41,6 +41,13 @@ use tauri::{AppHandle, Runtime};
 
 #[derive(Debug, thiserror::Error)]
 pub enum TypeError {
+    #[allow(dead_code)]
+    #[error("{source} after {typed_chars} chars were sent")]
+    Partial {
+        typed_chars: usize,
+        #[source]
+        source: Box<TypeError>,
+    },
     #[cfg(target_os = "macos")]
     #[error("CGEventSourceCreate returned null")]
     SourceAllocFailed,
@@ -59,6 +66,15 @@ pub enum TypeError {
     #[cfg(target_os = "linux")]
     #[error("enigo text input failed: {0}")]
     EnigoText(String),
+}
+
+impl TypeError {
+    pub fn typed_chars(&self) -> usize {
+        match self {
+            TypeError::Partial { typed_chars, .. } => *typed_chars,
+            _ => 0,
+        }
+    }
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -91,18 +107,33 @@ mod macos_impl {
     unsafe impl Send for PreviousInputSource {}
     unsafe impl Sync for PreviousInputSource {}
 
-    pub fn type_unicode_chunk(text: &str) -> Result<(), TypeError> {
+    pub fn type_unicode_chunk(text: &str) -> Result<usize, TypeError> {
         if text.is_empty() {
-            return Ok(());
+            return Ok(0);
         }
         if is_secure_input_enabled() {
             return Err(TypeError::SecureInputActive);
         }
+        let mut typed_chars = 0;
         for ch in text.chars() {
-            send_one_codepoint(ch)?;
+            if let Err(e) = send_one_codepoint(ch) {
+                return Err(partial_or_original(typed_chars, e));
+            }
+            typed_chars += 1;
             std::thread::sleep(INTER_KEYSTROKE_DELAY);
         }
-        Ok(())
+        Ok(typed_chars)
+    }
+
+    fn partial_or_original(typed_chars: usize, source: TypeError) -> TypeError {
+        if typed_chars == 0 {
+            source
+        } else {
+            TypeError::Partial {
+                typed_chars,
+                source: Box::new(source),
+            }
+        }
     }
 
     fn send_one_codepoint(ch: char) -> Result<(), TypeError> {
@@ -299,16 +330,36 @@ mod windows_impl {
     /// 兜底跟 macOS 对齐。
     const INTER_KEYSTROKE_DELAY: Duration = Duration::from_millis(1);
 
-    pub fn type_unicode_chunk(text: &str) -> Result<(), TypeError> {
+    pub fn type_unicode_chunk(text: &str) -> Result<usize, TypeError> {
         if text.is_empty() {
-            return Ok(());
+            return Ok(0);
         }
-        for unit in text.encode_utf16() {
-            send_utf16_unit(unit, false)?;
-            send_utf16_unit(unit, true)?;
+        let mut typed_chars = 0;
+        for ch in text.chars() {
+            let mut buf = [0u16; 2];
+            for unit in ch.encode_utf16(&mut buf) {
+                if let Err(e) = send_utf16_unit(*unit, false) {
+                    return Err(partial_or_original(typed_chars, e));
+                }
+                if let Err(e) = send_utf16_unit(*unit, true) {
+                    return Err(partial_or_original(typed_chars, e));
+                }
+            }
+            typed_chars += 1;
             std::thread::sleep(INTER_KEYSTROKE_DELAY);
         }
-        Ok(())
+        Ok(typed_chars)
+    }
+
+    fn partial_or_original(typed_chars: usize, source: TypeError) -> TypeError {
+        if typed_chars == 0 {
+            source
+        } else {
+            TypeError::Partial {
+                typed_chars,
+                source: Box::new(source),
+            }
+        }
     }
 
     fn send_utf16_unit(unit: u16, key_up: bool) -> Result<(), TypeError> {
@@ -366,21 +417,34 @@ mod linux_impl {
 
     pub struct PreviousInputSource;
 
-    /// 用 enigo 一次 `text()` 把整段 chunk 发出去。X11 上走 XTest 稳定；Wayland 上
-    /// 看 compositor 是否给 libei 权限，stock GNOME-Wayland 通常拒绝 —— 此处
-    /// 失败返回 `EnigoInit` / `EnigoText`，调用方应回落到一次性。
+    /// 用 enigo 逐字符发出 chunk。X11 上走 XTest 稳定；Wayland 上看 compositor 是否
+    /// 给 libei 权限，stock GNOME-Wayland 通常拒绝 —— 失败时尽量返回已成功字符数，
+    /// 让调用方的 history / clipboard 与实际落屏内容一致。
     ///
     /// 不处理 fcitx / ibus 输入法切换 —— Linux 输入法栈与 X11 合成事件的交互非常
     /// 碎片化，v1 实验阶段直接交给用户保证当前输入源是英文键盘。
-    pub fn type_unicode_chunk(text: &str) -> Result<(), TypeError> {
+    pub fn type_unicode_chunk(text: &str) -> Result<usize, TypeError> {
         if text.is_empty() {
-            return Ok(());
+            return Ok(0);
         }
         let mut enigo =
             Enigo::new(&Settings::default()).map_err(|e| TypeError::EnigoInit(e.to_string()))?;
-        enigo
-            .text(text)
-            .map_err(|e| TypeError::EnigoText(e.to_string()))
+        let mut typed_chars = 0;
+        for ch in text.chars() {
+            if let Err(e) = enigo.text(&ch.to_string()) {
+                let source = TypeError::EnigoText(e.to_string());
+                return if typed_chars == 0 {
+                    Err(source)
+                } else {
+                    Err(TypeError::Partial {
+                        typed_chars,
+                        source: Box::new(source),
+                    })
+                };
+            }
+            typed_chars += 1;
+        }
+        Ok(typed_chars)
     }
 
     pub async fn switch_to_ascii<R: Runtime>(
@@ -397,17 +461,58 @@ mod linux_impl {
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use super::TypeError;
+
+    #[test]
+    fn type_error_partial_reports_typed_chars() {
+        let err = TypeError::Partial {
+            typed_chars: 2,
+            source: Box::new(platform_error()),
+        };
+
+        assert_eq!(err.typed_chars(), 2);
+    }
+
+    #[test]
+    fn plain_type_error_reports_zero_typed_chars() {
+        assert_eq!(platform_error().typed_chars(), 0);
+    }
+
+    #[cfg(target_os = "macos")]
+    fn platform_error() -> TypeError {
+        TypeError::EventAllocFailed
+    }
+
+    #[cfg(target_os = "windows")]
+    fn platform_error() -> TypeError {
+        TypeError::SendInputFailed("fail".into())
+    }
+
+    #[cfg(target_os = "linux")]
+    fn platform_error() -> TypeError {
+        TypeError::EnigoText("fail".into())
+    }
+}
+
 // ═══════════════════════════════════════════════════════════════════════════
 // 公共导出（按 cfg 分发到对应实现）
 // ═══════════════════════════════════════════════════════════════════════════
 #[cfg(target_os = "macos")]
 #[allow(unused_imports)]
-pub use macos_impl::{restore_input_source, switch_to_ascii, type_unicode_chunk, PreviousInputSource};
+pub use macos_impl::{
+    restore_input_source, switch_to_ascii, type_unicode_chunk, PreviousInputSource,
+};
 
 #[cfg(target_os = "windows")]
 #[allow(unused_imports)]
-pub use windows_impl::{restore_input_source, switch_to_ascii, type_unicode_chunk, PreviousInputSource};
+pub use windows_impl::{
+    restore_input_source, switch_to_ascii, type_unicode_chunk, PreviousInputSource,
+};
 
 #[cfg(target_os = "linux")]
 #[allow(unused_imports)]
-pub use linux_impl::{restore_input_source, switch_to_ascii, type_unicode_chunk, PreviousInputSource};
+pub use linux_impl::{
+    restore_input_source, switch_to_ascii, type_unicode_chunk, PreviousInputSource,
+};


### PR DESCRIPTION
### **User description**
## 变更说明
- 修复 OpenAI-compatible 流式润色、QA 流式、Codex OAuth 流式 SSE 在 HTTP chunk 中切开 UTF-8 多字节字符时误报 `non-utf8` 的问题。
- `type_unicode_chunk` 改为返回已确认输入字符数；中途失败时只记录已实际落屏前缀，保证 history / clipboard / 屏幕内容一致。
- 流式已落屏文本跳过最终简繁收敛与纠正规则，避免后处理改写用户屏幕上已经出现的内容。
- Linux enigo 路径改为逐字符输入，失败时也尽量报告 partial typed chars。

Closes #413

## 验证
- [x] `cargo test --manifest-path src-tauri/Cargo.toml --lib`
- [x] `cargo check --manifest-path src-tauri/Cargo.toml`
- [x] `git diff --check`


___

### **PR Type**
Bug fix, Enhancement, Tests


___

### **Description**
- Fix UTF-8 multi-byte splitting across HTTP chunks by incremental decoding in streaming polish/QA/Codex

- Return typed character count from type_unicode_chunk to prevent history/clipboard mismatch on partial failure

- Skip Chinese script convergence and correction rules for already-streamed text to avoid rewriting displayed content

- Add comprehensive tests for UTF-8 edge cases and partial typing recovery


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>dictation.rs</strong><dd><code>Streamed text consistency and post-processing bypass</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src-tauri/src/coordinator/dictation.rs

<ul><li>Add <code>append_typed_prefix()</code> and <code>finalize_dictation_text()</code> helpers<br> <li> Use <code>typed_chars</code> from <code>type_unicode_chunk</code> to record only confirmed <br>prefix<br> <li> Skip mutating post-processing for streamed text to preserve on-screen <br>content<br> <li> Add unit tests for prefix truncation and post-processing bypass</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/415/files#diff-4cf79887f41f4811eb2b1ef682c62ee34c14a0ab969362a9ba1046de59c8578b">+135/-43</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>polish.rs</strong><dd><code>Incremental UTF-8 decoding for SSE streaming endpoints</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src-tauri/src/polish.rs

<ul><li>Introduce <code>utf8_pending</code> buffer and <code>append_utf8_sse_chunk()</code> for <br>incremental decoding<br> <li> Replace direct <code>from_utf8()</code> calls in three streaming methods<br> <li> Add <code>finish_utf8_sse_chunks()</code> to validate final pending bytes<br> <li> Add integration tests simulating split UTF-8 across HTTP chunks</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/415/files#diff-1be30d25d0bf8fc3e6c11bf4fa179521045a52ef4843271545acedfd0535e38b">+220/-16</a></td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>unicode_keystroke.rs</strong><dd><code>Return typed char count on partial keystroke failure</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src-tauri/src/unicode_keystroke.rs

<ul><li>Change <code>type_unicode_chunk</code> return type to <code>Result<usize, TypeError></code><br> <li> Add <code>TypeError::Partial</code> variant carrying successfully typed char count<br> <li> Implement per-character accounting on macOS, Windows, and Linux<br> <li> Add tests for <code>Partial</code> error reporting</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/415/files#diff-8cc0a36519da475e8ea9bfa356414bd11b70aa1f656da9f841c004ded6a338d2">+127/-22</a></td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

