### PR TITLE
refactor(settings): split Settings.tsx + simplify Advanced labels

### DIFF
--- a/openless-all/app/src/i18n/en.ts
+++ b/openless-all/app/src/i18n/en.ts
@@ -487,16 +487,16 @@ export const en: typeof zhCN = {
       streamingInsertTitle: 'Streaming insertion',
       streamingInsertTitleLinux: 'Streaming insertion (experimental)',
       streamingInsertDesc:
-        'When on, polished output streams to the cursor character by character as the LLM SSE arrives — perceived latency drops noticeably. Requires an OpenAI-compatible LLM provider (Ark / DeepSeek / etc.), not Raw / translation mode, and focus that is not a Secure Input field (password / 1Password). When any condition fails the path transparently falls back to one-shot paste — identical to having the toggle off.',
-      streamingInsertLabel: 'Enable streaming insertion',
+        'Streams polished text to the cursor character by character, noticeably lowering perceived latency. Falls back to one-shot paste when the prerequisites are not met (non OpenAI-compatible LLM, Raw / translation mode, or Secure Input focus).',
+      streamingInsertLabel: 'Streaming insertion',
       streamingInsertHintMac:
-        'During streaming the input source is temporarily switched to ABC (so CJK / Japanese IMEs cannot intercept the Unicode keystrokes) and restored when the session ends.',
+        'Temporarily switches the input source to ABC so CJK IMEs cannot intercept keystrokes; restored on session end.',
       streamingInsertHintWindows:
-        'Uses SendInput Unicode to type characters directly, bypassing TSF / IME — no input-method switching needed.',
+        'SendInput Unicode types directly, bypassing TSF / IME — no input-method switching needed.',
       streamingInsertHintLinux:
-        'Experimental: uses enigo + XTest to synthesize keystrokes. Stable on X11; on Wayland it depends on whether the compositor grants libei access — failures fall back automatically to one-shot insertion.',
-      streamingInsertSaveClipboardLabel: 'Also copy to clipboard',
-      streamingInsertSaveClipboardHint: 'After a successful streaming insert, write the final text to the system clipboard so Cmd+V can paste it again. Off = streaming never touches the clipboard.',
+        'enigo + XTest synthesize keystrokes. Stable on X11; on Wayland it depends on the compositor — failures fall back automatically.',
+      streamingInsertSaveClipboardLabel: 'Copy to clipboard',
+      streamingInsertSaveClipboardHint: 'After a successful insert, write the final text to the clipboard so Cmd+V can paste it again. Off = clipboard is never touched.',
       localAsrTitle: 'Local ASR models (experimental)',
       localAsrDesc: 'Move transcription from cloud ASR to on-device inference. Offline / privacy-sensitive use only.',
       localAsrWarningShort: 'Local inference is slower; under-spec hardware may drop words.',

--- a/openless-all/app/src/i18n/ja.ts
+++ b/openless-all/app/src/i18n/ja.ts
@@ -489,16 +489,16 @@ export const ja: typeof zhCN = {
       streamingInsertTitle: 'ストリーミング入力',
       streamingInsertTitleLinux: 'ストリーミング入力（実験的）',
       streamingInsertDesc:
-        'ON にすると、整形済みテキストが SSE の到着に合わせて 1 文字ずつカーソル位置に挿入され、体感遅延が大幅に短くなります。条件：OpenAI 互換 LLM プロバイダ（Ark / DeepSeek 等）+ Raw / 翻訳モード以外 + フォーカスがパスワード欄など Secure Input 制御でないこと。いずれかの条件を満たさない場合は自動で従来の一括貼り付けに戻り、OFF と同じ挙動になります。',
-      streamingInsertLabel: 'ストリーミング入力を有効化',
+        '整形済みテキストを SSE 到着に合わせて 1 文字ずつカーソルへ流し込み、体感遅延を大幅に低減します。条件を満たさない場合（OpenAI 互換以外の LLM、Raw / 翻訳モード、Secure Input フォーカス）は一括貼り付けへ自動フォールバックします。',
+      streamingInsertLabel: 'ストリーミング入力',
       streamingInsertHintMac:
-        'ストリーミング中は一時的に ABC 入力ソースへ切り替わります（中国語 / 日本語 IME による Unicode 文字傍受を回避）。セッション終了時に自動で元に戻ります。',
+        'ストリーミング中は一時的に ABC 入力ソースへ切替（CJK IME による傍受を回避）。セッション終了時に自動で元へ戻ります。',
       streamingInsertHintWindows:
-        'SendInput Unicode で文字イベントを直接送信し、TSF / IME を迂回します。入力ソースの切り替えは不要です。',
+        'SendInput Unicode で TSF / IME を迂回。入力ソースの切替は不要です。',
       streamingInsertHintLinux:
-        '実験的：enigo + XTest によるキーボードイベント合成。X11 では安定動作、Wayland では compositor が libei を許可するかどうかに依存し、失敗時は自動的に一括挿入にフォールバックします。',
-      streamingInsertSaveClipboardLabel: 'クリップボードにも保存',
-      streamingInsertSaveClipboardHint: 'ストリーミング入力成功後、最終テキストをシステムクリップボードに書き込んで Cmd+V で再貼り付けできるようにします。OFF にすると、ストリーミング処理はクリップボードに一切触れません。',
+        'enigo + XTest でキー合成。X11 は安定、Wayland は compositor 依存で失敗時は自動フォールバック。',
+      streamingInsertSaveClipboardLabel: 'クリップボードに保存',
+      streamingInsertSaveClipboardHint: '挿入成功後に最終テキストをクリップボードへ書き込み、Cmd+V で再貼付け可能にします。OFF ではクリップボードに触れません。',
       localAsrTitle: 'ローカル ASR モデル（実験的）',
       localAsrDesc: '転写をクラウドから本機推論に切り替えます。オフライン／プライバシー重視向け。',
       localAsrWarningShort: 'ローカル推論は遅く、スペック不足では欠字の可能性があります。',

--- a/openless-all/app/src/i18n/ko.ts
+++ b/openless-all/app/src/i18n/ko.ts
@@ -489,16 +489,16 @@ export const ko: typeof zhCN = {
       streamingInsertTitle: '스트리밍 입력',
       streamingInsertTitleLinux: '스트리밍 입력 (실험적)',
       streamingInsertDesc:
-        '활성화하면 정제된 텍스트가 SSE 도착에 맞춰 글자 단위로 커서에 입력되어 체감 지연이 크게 줄어듭니다. 조건: OpenAI 호환 LLM 제공자 (Ark / DeepSeek 등) + Raw / 번역 모드가 아님 + 포커스가 비밀번호 입력란 등 Secure Input 컨트롤이 아님. 조건 중 하나라도 충족되지 않으면 기존 일괄 붙여넣기 경로로 자동 폴백되어, OFF 와 동일한 동작을 합니다.',
-      streamingInsertLabel: '스트리밍 입력 사용',
+        '정제된 텍스트가 SSE 도착에 맞춰 글자 단위로 커서에 입력되어 체감 지연이 크게 줄어듭니다. 조건을 충족하지 못하면 (OpenAI 호환이 아닌 LLM, Raw / 번역 모드, Secure Input 포커스) 일괄 붙여넣기로 자동 폴백됩니다.',
+      streamingInsertLabel: '스트리밍 입력',
       streamingInsertHintMac:
-        '스트리밍 중에는 입력 소스가 일시적으로 ABC 로 전환됩니다 (중국어 / 일본어 IME 의 Unicode 문자 가로채기 방지). 세션 종료 시 자동으로 원래 입력 소스로 복귀합니다.',
+        '스트리밍 중 입력 소스를 ABC 로 임시 전환 (CJK IME 가로채기 방지). 세션 종료 시 자동 복원.',
       streamingInsertHintWindows:
-        'SendInput Unicode 로 문자 이벤트를 직접 전송하여 TSF / IME 를 우회합니다. 입력 소스 전환이 필요하지 않습니다.',
+        'SendInput Unicode 로 TSF / IME 를 우회. 입력 소스 전환 불필요.',
       streamingInsertHintLinux:
-        '실험적: enigo + XTest 로 키보드 이벤트를 합성합니다. X11 에서는 안정적이며, Wayland 에서는 compositor 가 libei 를 허용하는지에 따라 다르고, 실패 시 자동으로 일괄 삽입으로 폴백됩니다.',
-      streamingInsertSaveClipboardLabel: '클립보드에도 저장',
-      streamingInsertSaveClipboardHint: '스트리밍 입력 성공 후 최종 텍스트를 시스템 클립보드에 기록하여 Cmd+V 로 재붙여넣기를 할 수 있도록 합니다. 끄면 스트리밍 동안 클립보드를 일절 건드리지 않습니다.',
+        'enigo + XTest 로 키 합성. X11 안정; Wayland 는 compositor 의존이며 실패 시 자동 폴백.',
+      streamingInsertSaveClipboardLabel: '클립보드에 저장',
+      streamingInsertSaveClipboardHint: '삽입 성공 후 최종 텍스트를 클립보드에 기록하여 Cmd+V 로 다시 붙여넣을 수 있게 합니다. 끄면 클립보드를 건드리지 않습니다.',
       localAsrTitle: '로컬 ASR 모델 (실험적)',
       localAsrDesc: '전사를 클라우드에서 로컬 추론으로 전환합니다. 오프라인 / 프라이버시용에만 권장됩니다.',
       localAsrWarningShort: '로컬 추론은 느리며, 사양 부족 시 글자 누락이 발생할 수 있습니다.',

--- a/openless-all/app/src/i18n/zh-CN.ts
+++ b/openless-all/app/src/i18n/zh-CN.ts
@@ -485,16 +485,16 @@ export const zhCN = {
       streamingInsertTitle: '流式输入',
       streamingInsertTitleLinux: '流式输入（实验）',
       streamingInsertDesc:
-        '开启后润色 SSE 边到达边逐字落到光标，感知延迟显著降低。需要满足：OpenAI 兼容 LLM 提供商（Ark / DeepSeek 等）+ 非 Raw / 翻译模式 + 焦点不是密码框等 Secure Input 控件。任何条件不满足都自动回落到原一次性粘贴路径，行为与关闭等价。',
-      streamingInsertLabel: '启用流式输入',
+        '润色一边到达一边逐字落到光标，显著降低感知延迟。条件不满足时（非 OpenAI 兼容 LLM、Raw / 翻译模式、Secure Input 焦点）自动回落到一次性粘贴。',
+      streamingInsertLabel: '流式输入',
       streamingInsertHintMac:
-        '流式期间临时切换到 ABC 输入源（规避中文 / 日文 IME 拦截 Unicode 字符），session 结束自动切回。',
+        '临时切到 ABC 输入源，避免 CJK IME 拦截，会话结束后自动切回。',
       streamingInsertHintWindows:
-        'SendInput Unicode 直接发字符事件，绕过 TSF / IME，不切输入法。',
+        'SendInput Unicode 直接送字符，绕过 TSF / IME，不切输入法。',
       streamingInsertHintLinux:
-        '实验性：enigo + XTest 模拟键盘事件，X11 稳定；Wayland 看 compositor 是否允许 libei，失败自动回落到一次性插入。',
-      streamingInsertSaveClipboardLabel: '同步写入剪贴板',
-      streamingInsertSaveClipboardHint: '流式输入成功后把这次的最终文本写到系统剪贴板，方便 Cmd+V 再次粘贴。关闭后流式过程完全不动剪贴板。',
+        'enigo + XTest 合成按键。X11 稳定；Wayland 取决于 compositor，失败自动回落。',
+      streamingInsertSaveClipboardLabel: '同步到剪贴板',
+      streamingInsertSaveClipboardHint: '插入成功后把最终文本写入剪贴板，方便 Cmd+V 再次粘贴；关闭后流式过程不动剪贴板。',
       localAsrTitle: '本地 ASR 模型（实验性）',
       localAsrDesc: '把转写从云端切到本机推理。仅推荐离线 / 隐私敏感场景。',
       localAsrWarningShort: '本地推理较慢，配置不足时可能吞字。',

--- a/openless-all/app/src/i18n/zh-TW.ts
+++ b/openless-all/app/src/i18n/zh-TW.ts
@@ -487,16 +487,16 @@ export const zhTW: typeof zhCN = {
       streamingInsertTitle: '流式輸入',
       streamingInsertTitleLinux: '流式輸入（實驗）',
       streamingInsertDesc:
-        '開啟後潤色 SSE 邊到達邊逐字落到游標，感知延遲顯著降低。需要滿足：OpenAI 相容 LLM 提供商（Ark / DeepSeek 等）+ 非 Raw / 翻譯模式 + 焦點不是密碼框等 Secure Input 控件。任何條件不滿足都自動回落到原一次性貼上路徑，行為與關閉等價。',
-      streamingInsertLabel: '啟用流式輸入',
+        '潤色一邊到達一邊逐字落到游標，顯著降低感知延遲。條件不滿足時（非 OpenAI 相容 LLM、Raw / 翻譯模式、Secure Input 焦點）自動回落到一次性貼上。',
+      streamingInsertLabel: '流式輸入',
       streamingInsertHintMac:
-        '流式期間臨時切換到 ABC 輸入源（規避中文 / 日文 IME 攔截 Unicode 字元），session 結束自動切回。',
+        '臨時切到 ABC 輸入源，避免 CJK IME 攔截，會話結束後自動切回。',
       streamingInsertHintWindows:
-        'SendInput Unicode 直接發字元事件，繞過 TSF / IME，不切輸入法。',
+        'SendInput Unicode 直接送字元，繞過 TSF / IME，不切輸入法。',
       streamingInsertHintLinux:
-        '實驗性：enigo + XTest 模擬鍵盤事件，X11 穩定；Wayland 看 compositor 是否允許 libei，失敗自動回落到一次性插入。',
-      streamingInsertSaveClipboardLabel: '同步寫入剪貼簿',
-      streamingInsertSaveClipboardHint: '流式輸入成功後把這次的最終文字寫到系統剪貼簿，方便 Cmd+V 再次貼上。關閉後流式過程完全不動剪貼簿。',
+        'enigo + XTest 合成按鍵。X11 穩定；Wayland 取決於 compositor，失敗自動回落。',
+      streamingInsertSaveClipboardLabel: '同步到剪貼簿',
+      streamingInsertSaveClipboardHint: '插入成功後把最終文字寫入剪貼簿，方便 Cmd+V 再次貼上；關閉後流式過程不動剪貼簿。',
       localAsrTitle: '本地 ASR 模型（實驗性）',
       localAsrDesc: '把轉寫從雲端切到本機推理。僅推薦離線 / 隱私敏感場景。',
       localAsrWarningShort: '本地推理較慢，配置不足時可能吞字。',

--- a/openless-all/app/src/pages/Settings.tsx
+++ b/openless-all/app/src/pages/Settings.tsx
@@ -1,68 +1,42 @@
 // Settings.tsx — ported verbatim from design_handoff_openless/pages.jsx::Settings.
-// Internal sub-sections (Recording / Providers / Shortcuts / Permissions / Language / About)
-// keep their inline-style literals 1:1 with the source JSX.
+// Section 拆分见 settings/ 子目录；本文件保留 dispatcher + RecordingSection + ProvidersSection（含其内嵌助手），
+// 其他 section 已挪出。原导出 Toggle / AboutUpdateControl / SettingsSectionId 通过 re-export 维持向后兼容。
 
 import { useCallback, useEffect, useLayoutEffect, useRef, useState, type CSSProperties, type ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Icon } from '../components/Icon';
 import { ShortcutRecorder } from '../components/ShortcutRecorder';
-import { isDialogStatus, UpdateDialog, useAutoUpdate } from '../components/AutoUpdate';
 import { detectOS } from '../components/WindowChrome';
-import { LocalAsr } from './LocalAsr';
-import { APP_VERSION_LABEL } from '../lib/appVersion';
 import { isHotkeyModeMigrationNoticeActive } from '../lib/hotkeyMigration';
 import {
-  defaultQaShortcut,
   getHotkeyBindingCodes,
   getHotkeyBindingLabel,
   getHotkeyCodeLabel,
 } from '../lib/hotkey';
 import { createHotkeyRecorderState, orderHotkeyCodes, updateHotkeyRecorderState } from '../lib/hotkeyRecorder';
 import {
-  checkAccessibilityPermission,
-  checkMicrophonePermission,
-  getHotkeyStatus,
-  getWindowsImeStatus,
   isTauri,
   listMicrophoneDevices,
   openExternal,
-  openSystemSettings,
   listProviderModels,
   readCredential,
-  requestAccessibilityPermission,
-  requestMicrophonePermission,
   setActiveAsrProvider,
   setActiveLlmProvider,
   setCredential,
   setDictationHotkey,
-  setOpenAppHotkey,
-  setQaHotkey,
-  setSwitchStyleHotkey,
-  setTranslationHotkey,
   startMicrophoneLevelMonitor,
   stopMicrophoneLevelMonitor,
   validateProviderCredentials,
 } from '../lib/ipc';
 import type {
-  HotkeyCapability,
   HotkeyBinding,
   HotkeyMode,
-  HotkeyStatus,
   HotkeyTrigger,
   MicrophoneDevice,
   PasteShortcut,
-  PermissionStatus,
-  WindowsImeStatus,
 } from '../lib/types';
 import { emitSaved } from '../lib/savedEvent';
 import { useHotkeySettings } from '../state/HotkeySettingsContext';
-import i18n, {
-  FOLLOW_SYSTEM,
-  getLocalePreference,
-  outputPrefsForLocale,
-  setLocalePreference,
-  type SupportedLocale,
-} from '../i18n';
 import { Btn, Card, Collapsible, PageHeader, Pill } from './_atoms';
 import {
   deleteLocalAsrModel,
@@ -71,6 +45,14 @@ import {
   type LocalAsrModelStatus,
   type LocalAsrSettings,
 } from '../lib/localAsr';
+import { SettingRow, Toggle, inputStyle, type AsrPresetId } from './settings/shared';
+import { AdvancedSection } from './settings/AdvancedSection';
+import { ShortcutsSection } from './settings/ShortcutsSection';
+import { PermissionsSection } from './settings/PermissionsSection';
+import { LanguageSection } from './settings/LanguageSection';
+
+export { Toggle } from './settings/shared';
+export { AboutUpdateControl } from './settings/AboutUpdateControl';
 
 /// Settings → ASR 选了 local-qwen3 时触发跳到「模型设置」页 + 关 Settings modal。
 /// FloatingShell 监听同名事件做 setCurrentTab('localAsr') + setSettingsOpen(false)。
@@ -206,25 +188,6 @@ export function Settings({ embedded = false, initialSection = 'recording' }: Set
         </div>
       </div>
     </>
-  );
-}
-
-interface SettingRowProps {
-  label: string;
-  desc?: string;
-  children: ReactNode;
-  controlWidth?: number | string;
-}
-
-function SettingRow({ label, desc, children, controlWidth }: SettingRowProps) {
-  return (
-    <div style={{ display: 'grid', gridTemplateColumns: 'minmax(0, 180px) minmax(0, 1fr)', gap: 16, padding: '14px 0', borderTop: '0.5px solid var(--ol-line-soft)' }}>
-      <div style={{ minWidth: 0 }}>
-        <div style={{ fontSize: 13, fontWeight: 500, color: 'var(--ol-ink)' }}>{label}</div>
-        {desc && <div style={{ fontSize: 11.5, color: 'var(--ol-ink-4)', marginTop: 4, lineHeight: 1.5 }}>{desc}</div>}
-      </div>
-      <div style={{ display: 'flex', alignItems: 'flex-start', minWidth: 0, width: controlWidth ?? 'auto' }}>{children}</div>
-    </div>
   );
 }
 
@@ -1134,28 +1097,6 @@ function AutostartRow() {
   );
 }
 
-export function Toggle({ on, onToggle }: { on: boolean; onToggle?: (next: boolean) => void }) {
-  return (
-    <button
-      onClick={() => onToggle?.(!on)}
-      style={{
-        position: 'relative', width: 32, height: 18, borderRadius: 999, border: 0,
-        background: on ? 'var(--ol-blue)' : 'rgba(0,0,0,0.15)',
-        cursor: 'default',
-        transition: 'background 0.16s var(--ol-motion-quick)',
-      }}
-    >
-      <span
-        style={{
-          position: 'absolute', top: 2, left: on ? 16 : 2,
-          width: 14, height: 14, borderRadius: 999, background: '#fff',
-          boxShadow: '0 1px 2px rgba(0,0,0,.25)', transition: 'left .16s var(--ol-motion-spring)',
-        }}
-      />
-    </button>
-  );
-}
-
 function LlmThinkingToggle({ enabled, onToggle }: { enabled: boolean; onToggle: (next: boolean) => void }) {
   const { t } = useTranslation();
   return (
@@ -1271,7 +1212,8 @@ const ASR_DEFAULT_RESOURCE_ID = 'volc.bigasr.sauc.duration';
 //   1. 在这里加一项 `{ id, nameKey, baseUrl, model }`；
 //   2. `coordinator.rs::is_whisper_compatible_provider` 加同名 id；
 //   3. 在 i18n 的 `settings.providers.presets.<nameKey>` 加文案。
-const ASR_PRESETS = [
+// `AsrPresetId` 定义在 settings/shared.ts，AdvancedSection / ProvidersSection 共用同一份。
+const ASR_PRESETS: ReadonlyArray<{ id: AsrPresetId; nameKey: string; baseUrl: string; model: string }> = [
   { id: 'volcengine',   nameKey: 'asrVolcengine',   baseUrl: '',                                              model: ''                              },
   { id: 'bailian',      nameKey: 'asrBailian',     baseUrl: 'wss://dashscope.aliyuncs.com/api-ws/v1/inference/', model: 'fun-asr-realtime'             },
   { id: 'siliconflow',  nameKey: 'asrSiliconflow',  baseUrl: 'https://api.siliconflow.cn/v1',                  model: 'FunAudioLLM/SenseVoiceSmall' },
@@ -1281,9 +1223,7 @@ const ASR_PRESETS = [
   { id: 'foundry-local-whisper', nameKey: 'asrFoundryLocalWhisper', baseUrl: '',                              model: ''                              },
   // 本地 Qwen3-ASR：无 baseUrl/model 配置，模型在「模型设置」页下载与切换。
   { id: 'local-qwen3',  nameKey: 'asrLocalQwen3',   baseUrl: '',                                              model: ''                              },
-] as const;
-
-type AsrPresetId = typeof ASR_PRESETS[number]['id'];
+];
 
 function ProvidersSection() {
   const { t } = useTranslation();
@@ -1611,259 +1551,6 @@ function ProvidersSection() {
   );
 }
 
-/// 「高级」标签页——本地推理 / 实验性开关都集中在这里。
-///
-/// 设计：
-/// - 主 Providers 下拉只列云端选项；本地推理 (local-qwen3 / foundry-local-whisper)
-///   完全收纳到此栏，新手不会在主流程里误开 CPU 推理。
-/// - 启用本地推理时弹出**屏幕中央**的 modal（背景模糊）——一个框、一段短话、确认/取消。
-/// - 旧的「模型设置」独立页 (LocalAsr.tsx 作为 nav tab) 已下线，模型管理 UI
-///   通过 <LocalAsr embedded /> 内嵌在此处统一管理。
-///
-/// 平台对称（每端只露本机有后端的引擎，另一端的引擎以 disabled 行 + "本平台暂不支持"提示露出）：
-/// - macOS:   Qwen3-ASR 主行可启用；Foundry **不显示**（macOS 不展示 Windows 端模型内容）。
-/// - Windows: Foundry 主行可启用；Qwen3 行 disabled，desc 为 notSupportedHere。
-/// - Linux:   「该平台暂未支持本地 ASR 模型集成」整段兜底。
-function AdvancedSection() {
-  const { t } = useTranslation();
-  const { prefs, updatePrefs } = useHotkeySettings();
-  const os = detectOS();
-  const isMac = os === 'mac';
-  const isWin = os === 'win';
-  const isLinux = os === 'linux';
-  const platformSupported = isMac || isWin;
-  const switchSeqRef = useRef(0);
-  const [busy, setBusy] = useState(false);
-  // 待确认的启用目标。!== null 时中央 modal 弹出 + 背景模糊；用户点确认 → 真切；
-  // 点取消 → 回到 null。一次只允许一个 modal。
-  const [pendingTarget, setPendingTarget] = useState<AsrPresetId | null>(null);
-
-  const activeAsrProvider = (prefs?.activeAsrProvider ?? 'volcengine') as AsrPresetId;
-  const isOnLocalQwen3 = activeAsrProvider === 'local-qwen3';
-  const isOnFoundry = activeAsrProvider === 'foundry-local-whisper';
-  const isOnAnyLocal = isOnLocalQwen3 || isOnFoundry;
-
-  const requestEnable = (target: AsrPresetId) => {
-    setPendingTarget(target);
-  };
-
-  const performSwitch = async (target: AsrPresetId) => {
-    setBusy(true);
-    const seq = ++switchSeqRef.current;
-    try {
-      await setActiveAsrProvider(target);
-      if (seq !== switchSeqRef.current) return;
-      if (prefs) {
-        await updatePrefs({ ...prefs, activeAsrProvider: target });
-      }
-    } finally {
-      if (seq === switchSeqRef.current) {
-        setBusy(false);
-        setPendingTarget(null);
-      }
-    }
-  };
-
-  const pendingNameKey =
-    pendingTarget === 'local-qwen3' ? 'asrLocalQwen3'
-    : pendingTarget === 'foundry-local-whisper' ? 'asrFoundryLocalWhisper'
-    : null;
-
-  return (
-    <>
-      {/* ─── 屏幕中央确认 modal（背景模糊） ─────────────────────────────
-          点击遮罩或取消按钮关闭；切换中（busy）禁止任何关闭路径以免半切失败。 */}
-      {pendingTarget && pendingNameKey && (
-        <div
-          role="dialog"
-          aria-modal="true"
-          style={{
-            position: 'fixed',
-            inset: 0,
-            background: 'rgba(0, 0, 0, 0.32)',
-            backdropFilter: 'blur(8px)',
-            WebkitBackdropFilter: 'blur(8px)',
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            zIndex: 1000,
-            padding: 16,
-          }}
-          onClick={(e) => {
-            if (e.target === e.currentTarget && !busy) setPendingTarget(null);
-          }}>
-          <Card
-            style={{
-              background: 'rgba(255, 188, 60, 0.12)',
-              border: '1px solid rgba(220, 110, 0, 0.55)',
-              maxWidth: 360,
-              width: '100%',
-            }}>
-            <div style={{ fontSize: 13, fontWeight: 600, color: '#A04500', marginBottom: 6 }}>
-              ⚠️ {t('settings.advanced.confirmEnableLocalTitle')}
-            </div>
-            <div style={{ fontSize: 12.5, color: 'var(--ol-ink-2)', lineHeight: 1.6, marginBottom: 10 }}>
-              {t('settings.advanced.confirmEnableLocalBody', {
-                target: t(`settings.providers.presets.${pendingNameKey}`),
-              })}
-            </div>
-            <div style={{ display: 'flex', gap: 8, justifyContent: 'flex-end' }}>
-              <Btn variant="ghost" size="sm" disabled={busy} onClick={() => setPendingTarget(null)}>
-                {t('common.cancel')}
-              </Btn>
-              <Btn
-                variant="primary"
-                size="sm"
-                disabled={busy}
-                onClick={() => void performSwitch(pendingTarget)}>
-                {t('settings.advanced.confirm')}
-              </Btn>
-            </div>
-          </Card>
-        </div>
-      )}
-
-      {/* ─── 流式输入（全平台 opt-in） ───────────────────────────────────
-          润色 SSE 一边到达一边逐字模拟键盘事件落到光标。开启后用户感知到的处理
-          时延显著降低，但有几个限制（不满足时自动回落原一次性插入路径）：
-          - macOS：CGEvent Unicode + 临时切到 ABC 输入源（CJK / 日文 IME 拦截兜底）
-          - Windows：SendInput Unicode，绕过 TSF / IME，不需要切输入法
-          - Linux（实验）：enigo XTest；Wayland compositor 拒绝 libei 时失败回落
-          - 仅 OpenAI-compatible provider 实装；Gemini / Codex 透明降级
-          - 密码框 / 1Password / SSH prompt 等 Secure Input 框拒绝合成按键 → 失败回落
-          每个平台用各自的 hint key，互相不显示对方平台的细节。 */}
-      <Card>
-        <div style={{ fontSize: 13, fontWeight: 600, marginBottom: 4 }}>
-          {t(isLinux
-            ? 'settings.advanced.streamingInsertTitleLinux'
-            : 'settings.advanced.streamingInsertTitle')}
-        </div>
-        <div style={{ fontSize: 11.5, color: 'var(--ol-ink-4)', marginBottom: 10 }}>
-          {t('settings.advanced.streamingInsertDesc')}
-        </div>
-        <SettingRow
-          label={t('settings.advanced.streamingInsertLabel')}
-          desc={t(
-            isMac
-              ? 'settings.advanced.streamingInsertHintMac'
-              : isWin
-                ? 'settings.advanced.streamingInsertHintWindows'
-                : 'settings.advanced.streamingInsertHintLinux'
-          )}>
-          <Toggle
-            on={!!prefs?.streamingInsert}
-            onToggle={(next) => {
-              if (prefs) void updatePrefs({ ...prefs, streamingInsert: next });
-            }}
-          />
-        </SettingRow>
-        <SettingRow
-          label={t('settings.advanced.streamingInsertSaveClipboardLabel')}
-          desc={t('settings.advanced.streamingInsertSaveClipboardHint')}>
-          <Toggle
-            on={!!prefs?.streamingInsertSaveClipboard}
-            onToggle={(next) => {
-              if (prefs) void updatePrefs({ ...prefs, streamingInsertSaveClipboard: next });
-            }}
-          />
-        </SettingRow>
-      </Card>
-
-      <Card>
-        {/* 标题 + 右上角 inline 警告小字（替换原琥珀大警告条）。 */}
-        <div style={{ display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', gap: 12, marginBottom: 14 }}>
-          <div style={{ minWidth: 0 }}>
-            <div style={{ fontSize: 13, fontWeight: 600 }}>{t('settings.advanced.localAsrTitle')}</div>
-            <div style={{ fontSize: 11.5, color: 'var(--ol-ink-4)', marginTop: 2 }}>
-              {t('settings.advanced.localAsrDesc')}
-            </div>
-          </div>
-          <div style={{
-            fontSize: 11,
-            color: '#A04500',
-            fontWeight: 500,
-            lineHeight: 1.4,
-            textAlign: 'right',
-            flexShrink: 0,
-            maxWidth: '52%',
-            paddingTop: 2,
-          }}>
-            ⚠️ {t('settings.advanced.localAsrWarningShort')}
-          </div>
-        </div>
-
-        {!platformSupported ? (
-          <div style={{ fontSize: 12.5, color: 'var(--ol-ink-3)', lineHeight: 1.6, padding: '8px 0' }}>
-            {t('settings.advanced.platformNotSupported')}
-          </div>
-        ) : (
-          <>
-            {/* Qwen3 行 —— macOS Toggle 可点切换；Windows 后端是 stub，Toggle 始终 off
-                + 不可点 + desc=notSupportedHere，跟"本平台不可用"视觉一致。跨平台
-                异常（Windows profile 同步到 local-qwen3）时 active 状态靠下方独立
-                "禁用本地 ASR" 行兜底，避免 Toggle ON + desc 说不支持的自相矛盾感
-                （pr_agent #403 'Stale Windows state' 修法）。 */}
-            <SettingRow
-              label={t('settings.providers.presets.asrLocalQwen3')}
-              desc={isMac ? t('settings.advanced.qwen3Desc') : t('settings.advanced.notSupportedHere')}>
-              <div style={{ display: 'flex', justifyContent: 'flex-end', width: '100%' }}>
-                <Toggle
-                  on={isMac && isOnLocalQwen3}
-                  onToggle={isMac && !busy && pendingTarget === null ? (next) => {
-                    if (next) requestEnable('local-qwen3');
-                    else void performSwitch('volcengine');
-                  } : undefined}
-                />
-              </div>
-            </SettingRow>
-
-            {/* Foundry 行 —— 仅 Windows 露出（macOS 不展示 Windows 端模型内容）。 */}
-            {isWin && (
-              <SettingRow
-                label={t('settings.providers.presets.asrFoundryLocalWhisper')}
-                desc={t('settings.advanced.foundryDesc')}>
-                <div style={{ display: 'flex', justifyContent: 'flex-end', width: '100%' }}>
-                  <Toggle
-                    on={isOnFoundry}
-                    onToggle={!busy && pendingTarget === null ? (next) => {
-                      if (next) requestEnable('foundry-local-whisper');
-                      else void performSwitch('volcengine');
-                    } : undefined}
-                  />
-                </div>
-              </SettingRow>
-            )}
-          </>
-        )}
-
-        {/* 「禁用本地 ASR」逃生入口——只在行内 Toggle 关不掉的场景露出：
-            - Linux / 不支持平台：根本没有任何引擎行
-            - 跨平台异常（macOS profile 同步到 foundry / Windows profile 同步到 qwen3）：
-              本机引擎 Toggle 是 off，关不动异常 active 的对方引擎
-            否则平台本机 Toggle 自身就能 off → 关停，重复 disable 行徒增视觉。 */}
-        {isOnAnyLocal && !((isMac && isOnLocalQwen3) || (isWin && isOnFoundry)) && (
-          <SettingRow
-            label={t('settings.advanced.disableLocalLabel')}
-            desc={t('settings.advanced.disableLocalDesc')}>
-            <div style={{ display: 'flex', justifyContent: 'flex-end', width: '100%' }}>
-              <Btn
-                variant="primary"
-                size="sm"
-                disabled={busy || pendingTarget !== null}
-                onClick={() => void performSwitch('volcengine')}>
-                {t('settings.advanced.disable')}
-              </Btn>
-            </div>
-          </SettingRow>
-        )}
-      </Card>
-
-      {/* 模型管理 UI（镜像源 / 模型列表 / 下载 / 删除 / 设为默认 / Foundry Local）
-          inline 渲染——「模型设置」独立页已删，这里是唯一入口。 */}
-      {platformSupported && <LocalAsr embedded />}
-    </>
-  );
-}
 
 type ProviderToolStatus = 'idle' | 'loading' | 'success' | 'empty' | 'error';
 
@@ -2164,15 +1851,6 @@ function CredentialField({ label, account, placeholder, mono, mask, defaultValue
   );
 }
 
-const inputStyle: CSSProperties = {
-  flex: 1, height: 32, padding: '0 10px',
-  border: '0.5px solid var(--ol-line-strong)',
-  borderRadius: 8, fontSize: 12.5,
-  fontFamily: 'inherit', outline: 'none',
-  background: 'var(--ol-surface-2)',
-  width: '100%', maxWidth: 360,
-  transition: 'background 0.16s var(--ol-motion-quick), border-color 0.16s var(--ol-motion-quick)',
-};
 const miniBtnStyle: CSSProperties = {
   height: 32, padding: '0 10px',
   border: '0.5px solid var(--ol-line-strong)',
@@ -2264,371 +1942,10 @@ const iconBtnStyle: CSSProperties = {
   transition: 'background 0.16s var(--ol-motion-quick), border-color 0.16s var(--ol-motion-quick), color 0.16s var(--ol-motion-quick)',
 };
 
-function ShortcutsSection() {
-  const { t } = useTranslation();
-  const { prefs, hotkey, capability, updatePrefs: savePrefs } = useHotkeySettings();
 
-  if (!prefs || !hotkey || !capability) {
-    return (
-      <Card>
-        <div style={{ fontSize: 12, color: 'var(--ol-ink-4)' }}>{t('common.loading')}</div>
-      </Card>
-    );
-  }
 
-  const desc = capability.requiresAccessibilityPermission
-    ? t('settings.shortcuts.descAcc')
-    : t('settings.shortcuts.descNoAcc');
-  const readonlyRows: Array<[string, string]> = [
-    [t('settings.shortcuts.cancel'), 'Esc'],
-    [t('settings.shortcuts.confirm'), t('settings.shortcuts.confirmHint')],
-  ];
-  return (
-    <Card>
-      <div style={{ fontSize: 13, fontWeight: 600, marginBottom: 4 }}>{t('settings.shortcuts.title')}</div>
-      <div style={{ fontSize: 11.5, color: 'var(--ol-ink-4)', marginBottom: 6 }}>{desc}</div>
-      <SettingRow label={t('settings.shortcuts.startStop')}>
-        <div style={{ display: 'flex', flexDirection: 'column', gap: 6, width: '100%' }}>
-          <ShortcutRecorder
-            value={prefs.dictationHotkey}
-            alignRecordButton
-            onSave={async binding => {
-              await setDictationHotkey(binding);
-              await savePrefs({ ...prefs, dictationHotkey: binding });
-            }}
-          />
-          <div style={{ fontSize: 11, color: 'var(--ol-ink-4)' }}>
-            {hotkey.mode === 'hold' ? t('hotkey.modeHoldSuffix') : t('hotkey.modeToggleSuffix')}
-          </div>
-        </div>
-      </SettingRow>
-      <SettingRow label={t('translation.hotkey.title', 'Translation shortcut')}>
-        <ShortcutRecorder
-          value={prefs.translationHotkey}
-          alignRecordButton
-          onSave={async binding => {
-            await setTranslationHotkey(binding);
-            await savePrefs({ ...prefs, translationHotkey: binding });
-          }}
-        />
-      </SettingRow>
-      <SettingRow label={t('selectionAsk.hotkey.title')}>
-        {prefs.qaHotkey ? (
-          <ShortcutRecorder
-            value={prefs.qaHotkey}
-            alignRecordButton
-            onSave={async binding => {
-              await setQaHotkey(binding);
-              await savePrefs({ ...prefs, qaHotkey: binding });
-            }}
-          />
-        ) : (
-          <button
-            onClick={async () => {
-              const binding = defaultQaShortcut();
-              await setQaHotkey(binding);
-              await savePrefs({ ...prefs, qaHotkey: binding });
-            }}
-            style={{ fontSize: 12, padding: '5px 14px', background: 'var(--ol-blue)', color: '#fff', border: 0, borderRadius: 6, fontFamily: 'inherit', fontWeight: 500, cursor: 'default' }}
-          >
-            {t('selectionAsk.hotkey.enable', 'Enable')}
-          </button>
-        )}
-      </SettingRow>
-      <SettingRow label={t('settings.shortcuts.switchStyle')}>
-        <ShortcutRecorder
-          value={prefs.switchStyleHotkey}
-          alignRecordButton
-          onSave={async binding => {
-            await setSwitchStyleHotkey(binding);
-            await savePrefs({ ...prefs, switchStyleHotkey: binding });
-          }}
-        />
-      </SettingRow>
-      <SettingRow label={t('settings.shortcuts.openApp')}>
-        <ShortcutRecorder
-          value={prefs.openAppHotkey}
-          alignRecordButton
-          onSave={async binding => {
-            await setOpenAppHotkey(binding);
-            await savePrefs({ ...prefs, openAppHotkey: binding });
-          }}
-        />
-      </SettingRow>
-      {readonlyRows.map(([k, v]) => (
-        <SettingRow key={k} label={k}>
-          <kbd style={{
-            display: 'inline-flex', alignItems: 'center', gap: 4,
-            padding: '4px 10px', fontSize: 12, fontFamily: 'var(--ol-font-mono)',
-            borderRadius: 6, background: 'var(--ol-surface-2)',
-            border: '0.5px solid var(--ol-line-strong)',
-            boxShadow: '0 1px 0 rgba(0,0,0,0.04)',
-            color: 'var(--ol-ink-2)',
-          }}>{v}</kbd>
-        </SettingRow>
-      ))}
-    </Card>
-  );
-}
 
-function PermissionsSection() {
-  const { t } = useTranslation();
-  const [accessibility, setAccessibility] = useState<PermissionStatus | 'loading'>('loading');
-  const [microphone, setMicrophone] = useState<PermissionStatus | 'loading'>('loading');
-  const [hotkey, setHotkey] = useState<HotkeyStatus | null>(null);
-  const [windowsIme, setWindowsIme] = useState<WindowsImeStatus | null>(null);
-  const { capability } = useHotkeySettings();
 
-  const refreshPermissions = async () => {
-    const [a, m] = await Promise.all([
-      checkAccessibilityPermission(),
-      checkMicrophonePermission(),
-    ]);
-    setAccessibility(a);
-    setMicrophone(m);
-  };
-
-  const refreshHotkey = async () => {
-    setHotkey(await getHotkeyStatus());
-  };
-
-  const refreshWindowsIme = async () => {
-    setWindowsIme(await getWindowsImeStatus());
-  };
-
-  useEffect(() => {
-    refreshPermissions();
-    refreshHotkey();
-    refreshWindowsIme();
-    const hotkeyId = window.setInterval(refreshHotkey, 1000);
-    // 麦克风检查会短暂打开输入流，避免每秒探测导致隐私指示器频繁闪烁。
-    const permissionId = window.setInterval(refreshPermissions, 10000);
-    const onFocus = () => {
-      refreshPermissions();
-      refreshHotkey();
-      refreshWindowsIme();
-    };
-    window.addEventListener('focus', onFocus);
-    return () => {
-      window.clearInterval(hotkeyId);
-      window.clearInterval(permissionId);
-      window.removeEventListener('focus', onFocus);
-    };
-  }, []);
-
-  const reRequestAccessibility = async () => {
-    await requestAccessibilityPermission();
-    refreshPermissions();
-  };
-
-  const reRequestMicrophone = async () => {
-    if (microphone === 'denied' || microphone === 'restricted') {
-      await openSystemSettings('microphone');
-      refreshPermissions();
-      return;
-    }
-    const status = await requestMicrophonePermission();
-    setMicrophone(status);
-    if (status === 'denied' || status === 'restricted') {
-      await openSystemSettings('microphone');
-    }
-    refreshPermissions();
-  };
-
-  const desc = capability?.requiresAccessibilityPermission
-    ? t('settings.permissions.descAcc')
-    : t('settings.permissions.descNoAcc');
-
-  return (
-    <Card>
-      <div style={{ fontSize: 13, fontWeight: 600, marginBottom: 4 }}>{t('settings.permissions.title')}</div>
-      <div style={{ fontSize: 11.5, color: 'var(--ol-ink-4)', marginBottom: 6 }}>
-        {desc}
-      </div>
-      <SettingRow label={t('settings.permissions.micLabel')} desc={t('settings.permissions.micDesc')}>
-        <div style={{ display: 'flex', gap: 8, alignItems: 'center', justifyContent: 'flex-end', width: '100%' }}>
-          <PermissionPill status={microphone} />
-          {microphone !== 'granted' && microphone !== 'notApplicable' && microphone !== 'loading' && (
-            <Btn variant="ghost" size="sm" onClick={reRequestMicrophone}>
-              {microphone === 'denied' || microphone === 'restricted' ? t('settings.permissions.openSystem') : t('settings.permissions.grant')}
-            </Btn>
-          )}
-        </div>
-      </SettingRow>
-      {capability?.requiresAccessibilityPermission && (
-        <SettingRow label={t('settings.permissions.accLabel')} desc={t('settings.permissions.accDesc')}>
-          <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
-            <PermissionPill status={accessibility} />
-            {accessibility !== 'granted' && accessibility !== 'notApplicable' && (
-              <Btn variant="ghost" size="sm" onClick={reRequestAccessibility}>
-                {t('settings.permissions.grant')}
-              </Btn>
-            )}
-          </div>
-        </SettingRow>
-      )}
-      <SettingRow
-        label={t('settings.permissions.hotkeyLabel')}
-        desc={capability ? t('settings.permissions.hotkeyDescWithAdapter', { adapter: adapterDisplayName(capability.adapter) }) : t('settings.permissions.hotkeyDescPlain')}
-      >
-        <div style={{ display: 'flex', gap: 8, alignItems: 'center', minWidth: 0, justifyContent: 'flex-end', width: '100%' }}>
-          {hotkey?.message && (
-            <span style={{ fontSize: 11.5, color: 'var(--ol-ink-4)', overflow: 'hidden', textOverflow: 'ellipsis' }}>
-              {hotkey.message}
-            </span>
-          )}
-          <HotkeyStatusPill status={hotkey} />
-        </div>
-      </SettingRow>
-      {windowsIme?.state !== 'notWindows' && (
-        <SettingRow
-          label={t('settings.permissions.windowsImeLabel')}
-          desc={t('settings.permissions.windowsImeDesc')}
-        >
-          <div style={{ display: 'flex', gap: 8, alignItems: 'center', minWidth: 0, justifyContent: 'flex-end', width: '100%' }}>
-            {windowsIme && (
-              <span style={{ fontSize: 11.5, color: 'var(--ol-ink-4)', overflow: 'hidden', textOverflow: 'ellipsis' }}>
-                {t(`settings.permissions.windowsIme.${windowsIme.state}`)}
-              </span>
-            )}
-            <WindowsImeStatusPill status={windowsIme} />
-          </div>
-        </SettingRow>
-      )}
-      <SettingRow label={t('settings.permissions.networkLabel')} desc={t('settings.permissions.networkDesc')}>
-        <div style={{ display: 'flex', justifyContent: 'flex-end', width: '100%' }}>
-          <Pill tone="ok"><Icon name="check" size={11} />{t('settings.permissions.networkOk')}</Pill>
-        </div>
-      </SettingRow>
-    </Card>
-  );
-}
-
-function PermissionPill({ status }: { status: PermissionStatus | 'loading' }) {
-  const { t } = useTranslation();
-  if (status === 'loading') {
-    return <Pill tone="default">{t('settings.permissions.checking')}</Pill>;
-  }
-  if (status === 'granted') {
-    return <Pill tone="ok"><Icon name="check" size={11} />{t('settings.permissions.granted')}</Pill>;
-  }
-  if (status === 'notApplicable') {
-    return <Pill tone="default">{t('settings.permissions.notApplicable')}</Pill>;
-  }
-  if (status === 'denied' || status === 'restricted') {
-    return <Pill tone="outline">{t('settings.permissions.denied')}</Pill>;
-  }
-  return <Pill tone="outline">{t('settings.permissions.indeterminate')}</Pill>;
-}
-
-function LanguageSection() {
-  const { t } = useTranslation();
-  const { updatePrefs } = useHotkeySettings();
-  const [pref, setPref] = useState<SupportedLocale | typeof FOLLOW_SYSTEM>(getLocalePreference());
-
-  const apply = async (next: SupportedLocale | typeof FOLLOW_SYSTEM) => {
-    setPref(next);
-    const resolved = await setLocalePreference(next);
-    const localePrefs = outputPrefsForLocale(resolved);
-    await updatePrefs(current => {
-      if (
-        current.chineseScriptPreference === localePrefs.chineseScriptPreference &&
-        current.outputLanguagePreference === localePrefs.outputLanguagePreference
-      ) {
-        return current;
-      }
-      return { ...current, ...localePrefs };
-    });
-  };
-
-  return (
-    <Card>
-      <div style={{ fontSize: 13, fontWeight: 600, marginBottom: 4 }}>{t('settings.language.title')}</div>
-      <div style={{ fontSize: 11.5, color: 'var(--ol-ink-4)', marginBottom: 6 }}>{t('settings.language.desc')}</div>
-      <SettingRow label={t('settings.language.label')} desc={t('settings.language.labelDesc')}>
-        <select
-          value={pref}
-          onChange={e => apply(e.target.value as SupportedLocale | typeof FOLLOW_SYSTEM)}
-          style={{ ...inputStyle, maxWidth: 220 }}
-        >
-          <option value={FOLLOW_SYSTEM}>{t('settings.language.followSystem')}</option>
-          <option value="zh-CN">{t('settings.language.zh')}</option>
-          <option value="zh-TW">{t('settings.language.zhTW')}</option>
-          <option value="en">{t('settings.language.en')}</option>
-          <option value="ja">{t('settings.language.ja')}</option>
-          <option value="ko">{t('settings.language.ko')}</option>
-        </select>
-      </SettingRow>
-      <div style={{ fontSize: 11, color: 'var(--ol-ink-4)', marginTop: 8, lineHeight: 1.6 }}>
-        {t('settings.language.restartHint')}
-      </div>
-    </Card>
-  );
-}
-
-// AboutSection 已移除：内容并入 SettingsModal 的 AboutMini，避免设置内外两个"关于"重复入口。
-
-export function AboutUpdateControl({ tagline }: { tagline: string }) {
-  const { t } = useTranslation();
-  const u = useAutoUpdate();
-  return (
-    <>
-      <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginTop: 2 }}>
-        <span style={{ fontSize: 12, color: 'var(--ol-ink-3)' }}>{tagline} 路 {APP_VERSION_LABEL}</span>
-        <Btn variant="ghost" size="sm" onClick={u.checkForUpdates} disabled={u.checking || u.busy}>
-          {u.checking ? t('settings.about.checkingUpdate') : t('settings.about.checkUpdateBtn')}
-        </Btn>
-      </div>
-      {(u.status === 'none' || u.status === 'error') && (
-        <div style={{ fontSize: 11, color: u.status === 'error' ? 'var(--ol-err)' : 'var(--ol-ink-4)', marginTop: 4 }}>
-          {u.status === 'none' ? t('settings.about.upToDate') : t('settings.about.updateError')}
-        </div>
-      )}
-      {isDialogStatus(u.status) && (
-        <UpdateDialog
-          status={u.status}
-          version={u.version}
-          progress={u.progress}
-          downloaded={u.downloaded}
-          contentLength={u.contentLength}
-          onInstall={u.installUpdate}
-          onClose={u.dismissDialog}
-        />
-      )}
-    </>
-  );
-}
-
-function HotkeyStatusPill({ status }: { status: HotkeyStatus | null }) {
-  const { t } = useTranslation();
-  if (!status) {
-    return <Pill tone="default">{t('settings.permissions.checking')}</Pill>;
-  }
-  if (status.state === 'installed') {
-    return <Pill tone="ok"><Icon name="check" size={11} />{t('settings.permissions.hotkeyInstalled')}</Pill>;
-  }
-  if (status.state === 'starting') {
-    return <Pill tone="default">{t('settings.permissions.hotkeyStarting')}</Pill>;
-  }
-  return <Pill tone="outline">{t('settings.permissions.hotkeyFailed')}</Pill>;
-}
-
-function WindowsImeStatusPill({ status }: { status: WindowsImeStatus | null }) {
-  const { t } = useTranslation();
-  if (!status) {
-    return <Pill tone="default">{t('settings.permissions.checking')}</Pill>;
-  }
-  if (status.state === 'installed') {
-    return <Pill tone="ok"><Icon name="check" size={11} />{t('settings.permissions.windowsImeInstalled')}</Pill>;
-  }
-  return <Pill tone="outline">{t('settings.permissions.windowsImeUnavailable')}</Pill>;
-}
-
-function adapterDisplayName(adapter: HotkeyCapability['adapter'] | HotkeyStatus['adapter']) {
-  if (adapter === 'macEventTap') return i18n.t('hotkey.adapter.macEventTap');
-  if (adapter === 'windowsLowLevel') return i18n.t('hotkey.adapter.windowsLowLevel');
-  return i18n.t('hotkey.adapter.rdev');
-}
 
 /// 本地 Qwen3-ASR 在 Settings → 服务商区里**不**让用户填空——展示当前激活模型
 /// 是否已下载、列出所有已下载模型 + 删除按钮，并提示性能/质量预期，引导跳到

--- a/openless-all/app/src/pages/settings/AboutUpdateControl.tsx
+++ b/openless-all/app/src/pages/settings/AboutUpdateControl.tsx
@@ -1,0 +1,38 @@
+// 关于面板里嵌入的"检查更新"控件。
+// 注：原 Settings 内的 About tab 已并入 SettingsModal 的 AboutMini；这里只是版本号 + 检查按钮。
+
+import { useTranslation } from 'react-i18next';
+import { isDialogStatus, UpdateDialog, useAutoUpdate } from '../../components/AutoUpdate';
+import { APP_VERSION_LABEL } from '../../lib/appVersion';
+import { Btn } from '../_atoms';
+
+export function AboutUpdateControl({ tagline }: { tagline: string }) {
+  const { t } = useTranslation();
+  const u = useAutoUpdate();
+  return (
+    <>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginTop: 2 }}>
+        <span style={{ fontSize: 12, color: 'var(--ol-ink-3)' }}>{tagline} 路 {APP_VERSION_LABEL}</span>
+        <Btn variant="ghost" size="sm" onClick={u.checkForUpdates} disabled={u.checking || u.busy}>
+          {u.checking ? t('settings.about.checkingUpdate') : t('settings.about.checkUpdateBtn')}
+        </Btn>
+      </div>
+      {(u.status === 'none' || u.status === 'error') && (
+        <div style={{ fontSize: 11, color: u.status === 'error' ? 'var(--ol-err)' : 'var(--ol-ink-4)', marginTop: 4 }}>
+          {u.status === 'none' ? t('settings.about.upToDate') : t('settings.about.updateError')}
+        </div>
+      )}
+      {isDialogStatus(u.status) && (
+        <UpdateDialog
+          status={u.status}
+          version={u.version}
+          progress={u.progress}
+          downloaded={u.downloaded}
+          contentLength={u.contentLength}
+          onInstall={u.installUpdate}
+          onClose={u.dismissDialog}
+        />
+      )}
+    </>
+  );
+}

--- a/openless-all/app/src/pages/settings/AdvancedSection.tsx
+++ b/openless-all/app/src/pages/settings/AdvancedSection.tsx
@@ -1,0 +1,252 @@
+// 高级设置：流式输入开关 / 同步剪贴板 / 本地 ASR 模型启用与禁用。
+// 拆出自 Settings.tsx，逻辑零改动；i18n key 全部保持 `settings.advanced.*`。
+
+import { useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { LocalAsr } from '../LocalAsr';
+import { detectOS } from '../../components/WindowChrome';
+import { setActiveAsrProvider } from '../../lib/ipc';
+import { useHotkeySettings } from '../../state/HotkeySettingsContext';
+import { Btn, Card } from '../_atoms';
+import { SettingRow, Toggle, type AsrPresetId } from './shared';
+
+export function AdvancedSection() {
+  const { t } = useTranslation();
+  const { prefs, updatePrefs } = useHotkeySettings();
+  const os = detectOS();
+  const isMac = os === 'mac';
+  const isWin = os === 'win';
+  const isLinux = os === 'linux';
+  const platformSupported = isMac || isWin;
+  const switchSeqRef = useRef(0);
+  const [busy, setBusy] = useState(false);
+  // 待确认的启用目标。!== null 时中央 modal 弹出 + 背景模糊；用户点确认 → 真切；
+  // 点取消 → 回到 null。一次只允许一个 modal。
+  const [pendingTarget, setPendingTarget] = useState<AsrPresetId | null>(null);
+
+  const activeAsrProvider = (prefs?.activeAsrProvider ?? 'volcengine') as AsrPresetId;
+  const isOnLocalQwen3 = activeAsrProvider === 'local-qwen3';
+  const isOnFoundry = activeAsrProvider === 'foundry-local-whisper';
+  const isOnAnyLocal = isOnLocalQwen3 || isOnFoundry;
+
+  const requestEnable = (target: AsrPresetId) => {
+    setPendingTarget(target);
+  };
+
+  const performSwitch = async (target: AsrPresetId) => {
+    setBusy(true);
+    const seq = ++switchSeqRef.current;
+    try {
+      await setActiveAsrProvider(target);
+      if (seq !== switchSeqRef.current) return;
+      if (prefs) {
+        await updatePrefs({ ...prefs, activeAsrProvider: target });
+      }
+    } finally {
+      if (seq === switchSeqRef.current) {
+        setBusy(false);
+        setPendingTarget(null);
+      }
+    }
+  };
+
+  const pendingNameKey =
+    pendingTarget === 'local-qwen3' ? 'asrLocalQwen3'
+    : pendingTarget === 'foundry-local-whisper' ? 'asrFoundryLocalWhisper'
+    : null;
+
+  return (
+    <>
+      {/* ─── 屏幕中央确认 modal（背景模糊） ─────────────────────────────
+          点击遮罩或取消按钮关闭；切换中（busy）禁止任何关闭路径以免半切失败。 */}
+      {pendingTarget && pendingNameKey && (
+        <div
+          role="dialog"
+          aria-modal="true"
+          style={{
+            position: 'fixed',
+            inset: 0,
+            background: 'rgba(0, 0, 0, 0.32)',
+            backdropFilter: 'blur(8px)',
+            WebkitBackdropFilter: 'blur(8px)',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            zIndex: 1000,
+            padding: 16,
+          }}
+          onClick={(e) => {
+            if (e.target === e.currentTarget && !busy) setPendingTarget(null);
+          }}>
+          <Card
+            style={{
+              background: 'rgba(255, 188, 60, 0.12)',
+              border: '1px solid rgba(220, 110, 0, 0.55)',
+              maxWidth: 360,
+              width: '100%',
+            }}>
+            <div style={{ fontSize: 13, fontWeight: 600, color: '#A04500', marginBottom: 6 }}>
+              ⚠️ {t('settings.advanced.confirmEnableLocalTitle')}
+            </div>
+            <div style={{ fontSize: 12.5, color: 'var(--ol-ink-2)', lineHeight: 1.6, marginBottom: 10 }}>
+              {t('settings.advanced.confirmEnableLocalBody', {
+                target: t(`settings.providers.presets.${pendingNameKey}`),
+              })}
+            </div>
+            <div style={{ display: 'flex', gap: 8, justifyContent: 'flex-end' }}>
+              <Btn variant="ghost" size="sm" disabled={busy} onClick={() => setPendingTarget(null)}>
+                {t('common.cancel')}
+              </Btn>
+              <Btn
+                variant="primary"
+                size="sm"
+                disabled={busy}
+                onClick={() => void performSwitch(pendingTarget)}>
+                {t('settings.advanced.confirm')}
+              </Btn>
+            </div>
+          </Card>
+        </div>
+      )}
+
+      {/* ─── 流式输入（全平台 opt-in） ───────────────────────────────────
+          润色 SSE 一边到达一边逐字模拟键盘事件落到光标。开启后用户感知到的处理
+          时延显著降低，但有几个限制（不满足时自动回落原一次性插入路径）：
+          - macOS：CGEvent Unicode + 临时切到 ABC 输入源（CJK / 日文 IME 拦截兜底）
+          - Windows：SendInput Unicode，绕过 TSF / IME，不需要切输入法
+          - Linux（实验）：enigo XTest；Wayland compositor 拒绝 libei 时失败回落
+          - 仅 OpenAI-compatible provider 实装；Gemini / Codex 透明降级
+          - 密码框 / 1Password / SSH prompt 等 Secure Input 框拒绝合成按键 → 失败回落
+          每个平台用各自的 hint key，互相不显示对方平台的细节。 */}
+      <Card>
+        <div style={{ fontSize: 13, fontWeight: 600, marginBottom: 4 }}>
+          {t(isLinux
+            ? 'settings.advanced.streamingInsertTitleLinux'
+            : 'settings.advanced.streamingInsertTitle')}
+        </div>
+        <div style={{ fontSize: 11.5, color: 'var(--ol-ink-4)', marginBottom: 10 }}>
+          {t('settings.advanced.streamingInsertDesc')}
+        </div>
+        <SettingRow
+          label={t('settings.advanced.streamingInsertLabel')}
+          desc={t(
+            isMac
+              ? 'settings.advanced.streamingInsertHintMac'
+              : isWin
+                ? 'settings.advanced.streamingInsertHintWindows'
+                : 'settings.advanced.streamingInsertHintLinux'
+          )}>
+          <Toggle
+            on={!!prefs?.streamingInsert}
+            onToggle={(next) => {
+              if (prefs) void updatePrefs({ ...prefs, streamingInsert: next });
+            }}
+          />
+        </SettingRow>
+        <SettingRow
+          label={t('settings.advanced.streamingInsertSaveClipboardLabel')}
+          desc={t('settings.advanced.streamingInsertSaveClipboardHint')}>
+          <Toggle
+            on={!!prefs?.streamingInsertSaveClipboard}
+            onToggle={(next) => {
+              if (prefs) void updatePrefs({ ...prefs, streamingInsertSaveClipboard: next });
+            }}
+          />
+        </SettingRow>
+      </Card>
+
+      <Card>
+        {/* 标题 + 右上角 inline 警告小字（替换原琥珀大警告条）。 */}
+        <div style={{ display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', gap: 12, marginBottom: 14 }}>
+          <div style={{ minWidth: 0 }}>
+            <div style={{ fontSize: 13, fontWeight: 600 }}>{t('settings.advanced.localAsrTitle')}</div>
+            <div style={{ fontSize: 11.5, color: 'var(--ol-ink-4)', marginTop: 2 }}>
+              {t('settings.advanced.localAsrDesc')}
+            </div>
+          </div>
+          <div style={{
+            fontSize: 11,
+            color: '#A04500',
+            fontWeight: 500,
+            lineHeight: 1.4,
+            textAlign: 'right',
+            flexShrink: 0,
+            maxWidth: '52%',
+            paddingTop: 2,
+          }}>
+            ⚠️ {t('settings.advanced.localAsrWarningShort')}
+          </div>
+        </div>
+
+        {!platformSupported ? (
+          <div style={{ fontSize: 12.5, color: 'var(--ol-ink-3)', lineHeight: 1.6, padding: '8px 0' }}>
+            {t('settings.advanced.platformNotSupported')}
+          </div>
+        ) : (
+          <>
+            {/* Qwen3 行 —— macOS Toggle 可点切换；Windows 后端是 stub，Toggle 始终 off
+                + 不可点 + desc=notSupportedHere，跟"本平台不可用"视觉一致。跨平台
+                异常（Windows profile 同步到 local-qwen3）时 active 状态靠下方独立
+                "禁用本地 ASR" 行兜底，避免 Toggle ON + desc 说不支持的自相矛盾感
+                （pr_agent #403 'Stale Windows state' 修法）。 */}
+            <SettingRow
+              label={t('settings.providers.presets.asrLocalQwen3')}
+              desc={isMac ? t('settings.advanced.qwen3Desc') : t('settings.advanced.notSupportedHere')}>
+              <div style={{ display: 'flex', justifyContent: 'flex-end', width: '100%' }}>
+                <Toggle
+                  on={isMac && isOnLocalQwen3}
+                  onToggle={isMac && !busy && pendingTarget === null ? (next) => {
+                    if (next) requestEnable('local-qwen3');
+                    else void performSwitch('volcengine');
+                  } : undefined}
+                />
+              </div>
+            </SettingRow>
+
+            {/* Foundry 行 —— 仅 Windows 露出（macOS 不展示 Windows 端模型内容）。 */}
+            {isWin && (
+              <SettingRow
+                label={t('settings.providers.presets.asrFoundryLocalWhisper')}
+                desc={t('settings.advanced.foundryDesc')}>
+                <div style={{ display: 'flex', justifyContent: 'flex-end', width: '100%' }}>
+                  <Toggle
+                    on={isOnFoundry}
+                    onToggle={!busy && pendingTarget === null ? (next) => {
+                      if (next) requestEnable('foundry-local-whisper');
+                      else void performSwitch('volcengine');
+                    } : undefined}
+                  />
+                </div>
+              </SettingRow>
+            )}
+          </>
+        )}
+
+        {/* 「禁用本地 ASR」逃生入口——只在行内 Toggle 关不掉的场景露出：
+            - Linux / 不支持平台：根本没有任何引擎行
+            - 跨平台异常（macOS profile 同步到 foundry / Windows profile 同步到 qwen3）：
+              本机引擎 Toggle 是 off，关不动异常 active 的对方引擎
+            否则平台本机 Toggle 自身就能 off → 关停，重复 disable 行徒增视觉。 */}
+        {isOnAnyLocal && !((isMac && isOnLocalQwen3) || (isWin && isOnFoundry)) && (
+          <SettingRow
+            label={t('settings.advanced.disableLocalLabel')}
+            desc={t('settings.advanced.disableLocalDesc')}>
+            <div style={{ display: 'flex', justifyContent: 'flex-end', width: '100%' }}>
+              <Btn
+                variant="primary"
+                size="sm"
+                disabled={busy || pendingTarget !== null}
+                onClick={() => void performSwitch('volcengine')}>
+                {t('settings.advanced.disable')}
+              </Btn>
+            </div>
+          </SettingRow>
+        )}
+      </Card>
+
+      {/* 模型管理 UI（镜像源 / 模型列表 / 下载 / 删除 / 设为默认 / Foundry Local）
+          inline 渲染——「模型设置」独立页已删，这里是唯一入口。 */}
+      {platformSupported && <LocalAsr embedded />}
+    </>
+  );
+}

--- a/openless-all/app/src/pages/settings/LanguageSection.tsx
+++ b/openless-all/app/src/pages/settings/LanguageSection.tsx
@@ -1,0 +1,60 @@
+// 语言切换面板：跟随系统 / 简中 / 繁中 / 英文 / 日文 (Beta) / 韩文 (Beta)。
+// 切换语言同时把对应的 outputPrefs（中文偏好、输出语言）合并进 prefs。
+
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useHotkeySettings } from '../../state/HotkeySettingsContext';
+import {
+  FOLLOW_SYSTEM,
+  getLocalePreference,
+  outputPrefsForLocale,
+  setLocalePreference,
+  type SupportedLocale,
+} from '../../i18n';
+import { Card } from '../_atoms';
+import { SettingRow, inputStyle } from './shared';
+
+export function LanguageSection() {
+  const { t } = useTranslation();
+  const { updatePrefs } = useHotkeySettings();
+  const [pref, setPref] = useState<SupportedLocale | typeof FOLLOW_SYSTEM>(getLocalePreference());
+
+  const apply = async (next: SupportedLocale | typeof FOLLOW_SYSTEM) => {
+    setPref(next);
+    const resolved = await setLocalePreference(next);
+    const localePrefs = outputPrefsForLocale(resolved);
+    await updatePrefs(current => {
+      if (
+        current.chineseScriptPreference === localePrefs.chineseScriptPreference &&
+        current.outputLanguagePreference === localePrefs.outputLanguagePreference
+      ) {
+        return current;
+      }
+      return { ...current, ...localePrefs };
+    });
+  };
+
+  return (
+    <Card>
+      <div style={{ fontSize: 13, fontWeight: 600, marginBottom: 4 }}>{t('settings.language.title')}</div>
+      <div style={{ fontSize: 11.5, color: 'var(--ol-ink-4)', marginBottom: 6 }}>{t('settings.language.desc')}</div>
+      <SettingRow label={t('settings.language.label')} desc={t('settings.language.labelDesc')}>
+        <select
+          value={pref}
+          onChange={e => apply(e.target.value as SupportedLocale | typeof FOLLOW_SYSTEM)}
+          style={{ ...inputStyle, maxWidth: 220 }}
+        >
+          <option value={FOLLOW_SYSTEM}>{t('settings.language.followSystem')}</option>
+          <option value="zh-CN">{t('settings.language.zh')}</option>
+          <option value="zh-TW">{t('settings.language.zhTW')}</option>
+          <option value="en">{t('settings.language.en')}</option>
+          <option value="ja">{t('settings.language.ja')}</option>
+          <option value="ko">{t('settings.language.ko')}</option>
+        </select>
+      </SettingRow>
+      <div style={{ fontSize: 11, color: 'var(--ol-ink-4)', marginTop: 8, lineHeight: 1.6 }}>
+        {t('settings.language.restartHint')}
+      </div>
+    </Card>
+  );
+}

--- a/openless-all/app/src/pages/settings/PermissionsSection.tsx
+++ b/openless-all/app/src/pages/settings/PermissionsSection.tsx
@@ -1,0 +1,206 @@
+// 权限/连通性面板：麦克风 / 辅助功能 / 全局热键 / Windows IME / 网络。
+// 内含三个状态 Pill + 适配器名称翻译辅助函数。
+
+import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Icon } from '../../components/Icon';
+import {
+  checkAccessibilityPermission,
+  checkMicrophonePermission,
+  getHotkeyStatus,
+  getWindowsImeStatus,
+  openSystemSettings,
+  requestAccessibilityPermission,
+  requestMicrophonePermission,
+} from '../../lib/ipc';
+import type {
+  HotkeyCapability,
+  HotkeyStatus,
+  PermissionStatus,
+  WindowsImeStatus,
+} from '../../lib/types';
+import { useHotkeySettings } from '../../state/HotkeySettingsContext';
+import i18n from '../../i18n';
+import { Btn, Card, Pill } from '../_atoms';
+import { SettingRow } from './shared';
+
+export function PermissionsSection() {
+  const { t } = useTranslation();
+  const [accessibility, setAccessibility] = useState<PermissionStatus | 'loading'>('loading');
+  const [microphone, setMicrophone] = useState<PermissionStatus | 'loading'>('loading');
+  const [hotkey, setHotkey] = useState<HotkeyStatus | null>(null);
+  const [windowsIme, setWindowsIme] = useState<WindowsImeStatus | null>(null);
+  const { capability } = useHotkeySettings();
+
+  const refreshPermissions = async () => {
+    const [a, m] = await Promise.all([
+      checkAccessibilityPermission(),
+      checkMicrophonePermission(),
+    ]);
+    setAccessibility(a);
+    setMicrophone(m);
+  };
+
+  const refreshHotkey = async () => {
+    setHotkey(await getHotkeyStatus());
+  };
+
+  const refreshWindowsIme = async () => {
+    setWindowsIme(await getWindowsImeStatus());
+  };
+
+  useEffect(() => {
+    refreshPermissions();
+    refreshHotkey();
+    refreshWindowsIme();
+    const hotkeyId = window.setInterval(refreshHotkey, 1000);
+    // 麦克风检查会短暂打开输入流，避免每秒探测导致隐私指示器频繁闪烁。
+    const permissionId = window.setInterval(refreshPermissions, 10000);
+    const onFocus = () => {
+      refreshPermissions();
+      refreshHotkey();
+      refreshWindowsIme();
+    };
+    window.addEventListener('focus', onFocus);
+    return () => {
+      window.clearInterval(hotkeyId);
+      window.clearInterval(permissionId);
+      window.removeEventListener('focus', onFocus);
+    };
+  }, []);
+
+  const reRequestAccessibility = async () => {
+    await requestAccessibilityPermission();
+    refreshPermissions();
+  };
+
+  const reRequestMicrophone = async () => {
+    if (microphone === 'denied' || microphone === 'restricted') {
+      await openSystemSettings('microphone');
+      refreshPermissions();
+      return;
+    }
+    const status = await requestMicrophonePermission();
+    setMicrophone(status);
+    if (status === 'denied' || status === 'restricted') {
+      await openSystemSettings('microphone');
+    }
+    refreshPermissions();
+  };
+
+  const desc = capability?.requiresAccessibilityPermission
+    ? t('settings.permissions.descAcc')
+    : t('settings.permissions.descNoAcc');
+
+  return (
+    <Card>
+      <div style={{ fontSize: 13, fontWeight: 600, marginBottom: 4 }}>{t('settings.permissions.title')}</div>
+      <div style={{ fontSize: 11.5, color: 'var(--ol-ink-4)', marginBottom: 6 }}>
+        {desc}
+      </div>
+      <SettingRow label={t('settings.permissions.micLabel')} desc={t('settings.permissions.micDesc')}>
+        <div style={{ display: 'flex', gap: 8, alignItems: 'center', justifyContent: 'flex-end', width: '100%' }}>
+          <PermissionPill status={microphone} />
+          {microphone !== 'granted' && microphone !== 'notApplicable' && microphone !== 'loading' && (
+            <Btn variant="ghost" size="sm" onClick={reRequestMicrophone}>
+              {microphone === 'denied' || microphone === 'restricted' ? t('settings.permissions.openSystem') : t('settings.permissions.grant')}
+            </Btn>
+          )}
+        </div>
+      </SettingRow>
+      {capability?.requiresAccessibilityPermission && (
+        <SettingRow label={t('settings.permissions.accLabel')} desc={t('settings.permissions.accDesc')}>
+          <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+            <PermissionPill status={accessibility} />
+            {accessibility !== 'granted' && accessibility !== 'notApplicable' && (
+              <Btn variant="ghost" size="sm" onClick={reRequestAccessibility}>
+                {t('settings.permissions.grant')}
+              </Btn>
+            )}
+          </div>
+        </SettingRow>
+      )}
+      <SettingRow
+        label={t('settings.permissions.hotkeyLabel')}
+        desc={capability ? t('settings.permissions.hotkeyDescWithAdapter', { adapter: adapterDisplayName(capability.adapter) }) : t('settings.permissions.hotkeyDescPlain')}
+      >
+        <div style={{ display: 'flex', gap: 8, alignItems: 'center', minWidth: 0, justifyContent: 'flex-end', width: '100%' }}>
+          {hotkey?.message && (
+            <span style={{ fontSize: 11.5, color: 'var(--ol-ink-4)', overflow: 'hidden', textOverflow: 'ellipsis' }}>
+              {hotkey.message}
+            </span>
+          )}
+          <HotkeyStatusPill status={hotkey} />
+        </div>
+      </SettingRow>
+      {windowsIme?.state !== 'notWindows' && (
+        <SettingRow
+          label={t('settings.permissions.windowsImeLabel')}
+          desc={t('settings.permissions.windowsImeDesc')}
+        >
+          <div style={{ display: 'flex', gap: 8, alignItems: 'center', minWidth: 0, justifyContent: 'flex-end', width: '100%' }}>
+            {windowsIme && (
+              <span style={{ fontSize: 11.5, color: 'var(--ol-ink-4)', overflow: 'hidden', textOverflow: 'ellipsis' }}>
+                {t(`settings.permissions.windowsIme.${windowsIme.state}`)}
+              </span>
+            )}
+            <WindowsImeStatusPill status={windowsIme} />
+          </div>
+        </SettingRow>
+      )}
+      <SettingRow label={t('settings.permissions.networkLabel')} desc={t('settings.permissions.networkDesc')}>
+        <div style={{ display: 'flex', justifyContent: 'flex-end', width: '100%' }}>
+          <Pill tone="ok"><Icon name="check" size={11} />{t('settings.permissions.networkOk')}</Pill>
+        </div>
+      </SettingRow>
+    </Card>
+  );
+}
+
+function PermissionPill({ status }: { status: PermissionStatus | 'loading' }) {
+  const { t } = useTranslation();
+  if (status === 'loading') {
+    return <Pill tone="default">{t('settings.permissions.checking')}</Pill>;
+  }
+  if (status === 'granted') {
+    return <Pill tone="ok"><Icon name="check" size={11} />{t('settings.permissions.granted')}</Pill>;
+  }
+  if (status === 'notApplicable') {
+    return <Pill tone="default">{t('settings.permissions.notApplicable')}</Pill>;
+  }
+  if (status === 'denied' || status === 'restricted') {
+    return <Pill tone="outline">{t('settings.permissions.denied')}</Pill>;
+  }
+  return <Pill tone="outline">{t('settings.permissions.indeterminate')}</Pill>;
+}
+
+function HotkeyStatusPill({ status }: { status: HotkeyStatus | null }) {
+  const { t } = useTranslation();
+  if (!status) {
+    return <Pill tone="default">{t('settings.permissions.checking')}</Pill>;
+  }
+  if (status.state === 'installed') {
+    return <Pill tone="ok"><Icon name="check" size={11} />{t('settings.permissions.hotkeyInstalled')}</Pill>;
+  }
+  if (status.state === 'starting') {
+    return <Pill tone="default">{t('settings.permissions.hotkeyStarting')}</Pill>;
+  }
+  return <Pill tone="outline">{t('settings.permissions.hotkeyFailed')}</Pill>;
+}
+
+function WindowsImeStatusPill({ status }: { status: WindowsImeStatus | null }) {
+  const { t } = useTranslation();
+  if (!status) {
+    return <Pill tone="default">{t('settings.permissions.checking')}</Pill>;
+  }
+  if (status.state === 'installed') {
+    return <Pill tone="ok"><Icon name="check" size={11} />{t('settings.permissions.windowsImeInstalled')}</Pill>;
+  }
+  return <Pill tone="outline">{t('settings.permissions.windowsImeUnavailable')}</Pill>;
+}
+
+function adapterDisplayName(adapter: HotkeyCapability['adapter'] | HotkeyStatus['adapter']) {
+  if (adapter === 'macEventTap') return i18n.t('hotkey.adapter.macEventTap');
+  if (adapter === 'windowsLowLevel') return i18n.t('hotkey.adapter.windowsLowLevel');
+  return i18n.t('hotkey.adapter.rdev');
+}

--- a/openless-all/app/src/pages/settings/ShortcutsSection.tsx
+++ b/openless-all/app/src/pages/settings/ShortcutsSection.tsx
@@ -1,0 +1,122 @@
+// 快捷键设置：开始/停止、翻译、问答、切风格、唤起 App、以及只读取消/确认提示。
+
+import { useTranslation } from 'react-i18next';
+import { ShortcutRecorder } from '../../components/ShortcutRecorder';
+import { defaultQaShortcut } from '../../lib/hotkey';
+import {
+  setDictationHotkey,
+  setOpenAppHotkey,
+  setQaHotkey,
+  setSwitchStyleHotkey,
+  setTranslationHotkey,
+} from '../../lib/ipc';
+import { useHotkeySettings } from '../../state/HotkeySettingsContext';
+import { Card } from '../_atoms';
+import { SettingRow } from './shared';
+
+export function ShortcutsSection() {
+  const { t } = useTranslation();
+  const { prefs, hotkey, capability, updatePrefs: savePrefs } = useHotkeySettings();
+
+  if (!prefs || !hotkey || !capability) {
+    return (
+      <Card>
+        <div style={{ fontSize: 12, color: 'var(--ol-ink-4)' }}>{t('common.loading')}</div>
+      </Card>
+    );
+  }
+
+  const desc = capability.requiresAccessibilityPermission
+    ? t('settings.shortcuts.descAcc')
+    : t('settings.shortcuts.descNoAcc');
+  const readonlyRows: Array<[string, string]> = [
+    [t('settings.shortcuts.cancel'), 'Esc'],
+    [t('settings.shortcuts.confirm'), t('settings.shortcuts.confirmHint')],
+  ];
+  return (
+    <Card>
+      <div style={{ fontSize: 13, fontWeight: 600, marginBottom: 4 }}>{t('settings.shortcuts.title')}</div>
+      <div style={{ fontSize: 11.5, color: 'var(--ol-ink-4)', marginBottom: 6 }}>{desc}</div>
+      <SettingRow label={t('settings.shortcuts.startStop')}>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 6, width: '100%' }}>
+          <ShortcutRecorder
+            value={prefs.dictationHotkey}
+            alignRecordButton
+            onSave={async binding => {
+              await setDictationHotkey(binding);
+              await savePrefs({ ...prefs, dictationHotkey: binding });
+            }}
+          />
+          <div style={{ fontSize: 11, color: 'var(--ol-ink-4)' }}>
+            {hotkey.mode === 'hold' ? t('hotkey.modeHoldSuffix') : t('hotkey.modeToggleSuffix')}
+          </div>
+        </div>
+      </SettingRow>
+      <SettingRow label={t('translation.hotkey.title', 'Translation shortcut')}>
+        <ShortcutRecorder
+          value={prefs.translationHotkey}
+          alignRecordButton
+          onSave={async binding => {
+            await setTranslationHotkey(binding);
+            await savePrefs({ ...prefs, translationHotkey: binding });
+          }}
+        />
+      </SettingRow>
+      <SettingRow label={t('selectionAsk.hotkey.title')}>
+        {prefs.qaHotkey ? (
+          <ShortcutRecorder
+            value={prefs.qaHotkey}
+            alignRecordButton
+            onSave={async binding => {
+              await setQaHotkey(binding);
+              await savePrefs({ ...prefs, qaHotkey: binding });
+            }}
+          />
+        ) : (
+          <button
+            onClick={async () => {
+              const binding = defaultQaShortcut();
+              await setQaHotkey(binding);
+              await savePrefs({ ...prefs, qaHotkey: binding });
+            }}
+            style={{ fontSize: 12, padding: '5px 14px', background: 'var(--ol-blue)', color: '#fff', border: 0, borderRadius: 6, fontFamily: 'inherit', fontWeight: 500, cursor: 'default' }}
+          >
+            {t('selectionAsk.hotkey.enable', 'Enable')}
+          </button>
+        )}
+      </SettingRow>
+      <SettingRow label={t('settings.shortcuts.switchStyle')}>
+        <ShortcutRecorder
+          value={prefs.switchStyleHotkey}
+          alignRecordButton
+          onSave={async binding => {
+            await setSwitchStyleHotkey(binding);
+            await savePrefs({ ...prefs, switchStyleHotkey: binding });
+          }}
+        />
+      </SettingRow>
+      <SettingRow label={t('settings.shortcuts.openApp')}>
+        <ShortcutRecorder
+          value={prefs.openAppHotkey}
+          alignRecordButton
+          onSave={async binding => {
+            await setOpenAppHotkey(binding);
+            await savePrefs({ ...prefs, openAppHotkey: binding });
+          }}
+        />
+      </SettingRow>
+      {readonlyRows.map(([k, v]) => (
+        <SettingRow key={k} label={k}>
+          <kbd style={{
+            display: 'inline-flex', alignItems: 'center', gap: 4,
+            padding: '4px 10px', fontSize: 12, fontFamily: 'var(--ol-font-mono)',
+            borderRadius: 6, background: 'var(--ol-surface-2)',
+            border: '0.5px solid var(--ol-line-strong)',
+            boxShadow: '0 1px 0 rgba(0,0,0,0.04)',
+            color: 'var(--ol-ink-2)',
+          }}>{v}</kbd>
+        </SettingRow>
+      ))}
+    </Card>
+  );
+}

--- a/openless-all/app/src/pages/settings/shared.tsx
+++ b/openless-all/app/src/pages/settings/shared.tsx
@@ -1,0 +1,67 @@
+// 共享在 Settings 各 section 间的原子（SettingRow / Toggle / inputStyle）。
+// AsrPresetId 也放在这里，让 AdvancedSection 与 Settings.tsx 都从一处来源拿。
+
+import type { CSSProperties, ReactNode } from 'react';
+
+interface SettingRowProps {
+  label: string;
+  desc?: string;
+  children: ReactNode;
+  controlWidth?: number | string;
+}
+
+export function SettingRow({ label, desc, children, controlWidth }: SettingRowProps) {
+  return (
+    <div style={{ display: 'grid', gridTemplateColumns: 'minmax(0, 180px) minmax(0, 1fr)', gap: 16, padding: '14px 0', borderTop: '0.5px solid var(--ol-line-soft)' }}>
+      <div style={{ minWidth: 0 }}>
+        <div style={{ fontSize: 13, fontWeight: 500, color: 'var(--ol-ink)' }}>{label}</div>
+        {desc && <div style={{ fontSize: 11.5, color: 'var(--ol-ink-4)', marginTop: 4, lineHeight: 1.5 }}>{desc}</div>}
+      </div>
+      <div style={{ display: 'flex', alignItems: 'flex-start', minWidth: 0, width: controlWidth ?? 'auto' }}>{children}</div>
+    </div>
+  );
+}
+
+export function Toggle({ on, onToggle }: { on: boolean; onToggle?: (next: boolean) => void }) {
+  return (
+    <button
+      onClick={() => onToggle?.(!on)}
+      style={{
+        position: 'relative', width: 32, height: 18, borderRadius: 999, border: 0,
+        background: on ? 'var(--ol-blue)' : 'rgba(0,0,0,0.15)',
+        cursor: 'default',
+        transition: 'background 0.16s var(--ol-motion-quick)',
+      }}
+    >
+      <span
+        style={{
+          position: 'absolute', top: 2, left: on ? 16 : 2,
+          width: 14, height: 14, borderRadius: 999, background: '#fff',
+          boxShadow: '0 1px 2px rgba(0,0,0,.25)', transition: 'left .16s var(--ol-motion-spring)',
+        }}
+      />
+    </button>
+  );
+}
+
+export const inputStyle: CSSProperties = {
+  flex: 1, height: 32, padding: '0 10px',
+  border: '0.5px solid var(--ol-line-strong)',
+  borderRadius: 8, fontSize: 12.5,
+  fontFamily: 'inherit', outline: 'none',
+  background: 'var(--ol-surface-2)',
+  width: '100%', maxWidth: 360,
+  transition: 'background 0.16s var(--ol-motion-quick), border-color 0.16s var(--ol-motion-quick)',
+};
+
+// ASR provider id 集合，跟 Settings.tsx::ASR_PRESETS 一一对应。
+// 拆成独立类型让 AdvancedSection / ProvidersSection 都能用同一份不互相依赖。
+export type AsrPresetId =
+  | 'volcengine'
+  | 'bailian'
+  | 'siliconflow'
+  | 'zhipu'
+  | 'groq'
+  | 'whisper'
+  | 'foundry-local-whisper'
+  | 'local-qwen3';


### PR DESCRIPTION
### **User description**
## Summary
- **Modularization (no behavior change).** `Settings.tsx` ballooned to **2835 lines** — well past the 800-line hard-split trigger in `CLAUDE.md`. This PR moves each tab (Advanced / Shortcuts / Permissions / Language / About) into its own file under `src/pages/settings/`, plus a `shared.tsx` for the `SettingRow` / `Toggle` / `inputStyle` atoms used cross-section. `Settings.tsx` drops to **~2150 lines** and re-exports the public symbols (`Toggle`, `AboutUpdateControl`, `SettingsSectionId`, `NAVIGATE_LOCAL_ASR_EVENT`) so `SettingsModal` / `FloatingShell` keep working unchanged. `RecordingSection` and `ProvidersSection` stay in `Settings.tsx` for now (their helper tangle — `HotkeyRecorder`, `MicrophonePickerDialog`, `ProviderTools`, `CredentialField`, `LocalAsrProviderHint`, `LLM_PRESETS` / `ASR_PRESETS` — is large; follow-up PR).
- **Shortened Advanced-tab labels.** Per direct user feedback: `启用流式输入 → 流式输入`, `同步写入剪贴板 → 同步到剪贴板`, plus trimmed `streamingInsertDesc` and per-OS hint blocks across all five locales (zh-CN / zh-TW / en / ja / ko). The Toggle next to the label already conveys enable/disable; the prefix was redundant. Long technical detail stays in the description / hint text.

## Why this is safe
- Pure file-split + i18n-text edits. Zero functional change.
- All extracted React components are imported back into `Settings.tsx` via the new directory; the public surface (`export { Toggle, AboutUpdateControl, SettingsSectionId, NAVIGATE_LOCAL_ASR_EVENT }`) is preserved by re-export.
- No Rust backend changes — the dictation / QA / hotkey / insertion pipelines on macOS + Windows are untouched.
- `AsrPresetId` was lifted out of the `as const` derivation in `Settings.tsx` into `shared.tsx` so `AdvancedSection` can depend on it without importing back from `Settings.tsx` (one-way deps).

## Test plan
- [x] `npm run build` — tsc clean, vite build green.
- [x] `cargo check --manifest-path src-tauri/Cargo.toml` — green (83 pre-existing warnings, unchanged).
- [x] `cargo test --manifest-path src-tauri/Cargo.toml --lib` — **222 passed; 0 failed**.
- [x] `npx tsx src/lib/providerSetup.test.ts` — passes silently (assertion script throws on failure).
- [ ] Manual smoke: open Settings modal → Advanced tab → toggle "流式输入" / "同步到剪贴板"; verify each other tab (Recording / Providers / Shortcuts / Permissions / Language) still renders identically pixel-wise.


___

### **PR Type**
Enhancement


___

### **Description**
- Split Settings.tsx into per-section modules: Advanced, Shortcuts, Permissions, Language, AboutUpdateControl, shared

- Shorten Advanced labels and hints across all five locales (zh-CN, zh-TW, en, ja, ko)

- Preserve public exports for backward compatibility; zero functional change


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>en.ts</strong><dd><code>Shorten Advanced labels and hints for streaming insert/clipboard</code></dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/416/files#diff-bb2f4fa05787923f8aeb23b6f11ad8705e02d9ff03a45790f9181e4615c79d83">+7/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ja.ts</strong><dd><code>Shorten Advanced labels and hints in Japanese</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/416/files#diff-be57f0090cf34e3ff924cfa35f13d5d9e6514d3af5a1ebfdeb92bd7d36ed9cf4">+7/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ko.ts</strong><dd><code>Shorten Advanced labels and hints in Korean</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/416/files#diff-daf35bcb6a2f8a31565b83d119cb59b69c1dededbabfccfd0d56693fdb3726ca">+7/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>zh-CN.ts</strong><dd><code>Shorten Advanced labels and hints in Simplified Chinese</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/416/files#diff-571576f3c7b6c4a78ae0f91accdccc5da5cbed00409955c9914c046fee6c80ea">+7/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>zh-TW.ts</strong><dd><code>Shorten Advanced labels and hints in Traditional Chinese</code>&nbsp; </dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/416/files#diff-a8d5953f9c76bc3c90ec583270be04c852bd7540297500e6ff3260760fc61ea4">+7/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Refactoring</strong></td><td><details><summary>7 files</summary><table>
<tr>
  <td><strong>Settings.tsx</strong><dd><code>Decompose into per-section modules and re-export shared components</code></dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/416/files#diff-b493ca85e083b07f67da1b3ac96aeab153b20c97405e26292b47b95e13368c38">+13/-696</a></td>

</tr>

<tr>
  <td><strong>AboutUpdateControl.tsx</strong><dd><code>Extract about update control component</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/416/files#diff-02ffab5b9be29c3db18ea84d93156aa7dc780917e02e9c44a91c4798c8e59b4c">+38/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>AdvancedSection.tsx</strong><dd><code>Extract Advanced settings tab (streaming insert, local ASR)</code></dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/416/files#diff-8a7f8c575d69971725afc58f937b354ff5342dda944233c84ea0ba9de25d5198">+252/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>LanguageSection.tsx</strong><dd><code>Extract language selection panel</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/416/files#diff-b41f608eeb7629dc7de5594975838f48613f383ba96e73a8d186b120eb216250">+60/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>PermissionsSection.tsx</strong><dd><code>Extract permissions and connectivity status panel</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/416/files#diff-2896b718081970bad5fcda36c960b1041fdfbd84fed2ea07fd500b7ff85ebffe">+206/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>ShortcutsSection.tsx</strong><dd><code>Extract shortcut configuration panel</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/416/files#diff-2278f6bf152693f76255e52340adc9558f3da4764473c2682fd0eef36dcb83de">+122/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>shared.tsx</strong><dd><code>Extract shared utilities (Toggle, SettingRow, inputStyle, AsrPresetId)</code></dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/416/files#diff-6e9d525a512046935216033f39bd85274b5eeb3d8bf5731e470deb019dcd7be8">+67/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

