### PR TITLE
fix(ui): Windows 原生 chrome / 胶囊缩小 / 自定义下拉 (#417 #418)

### DIFF
--- a/openless-all/app/package-lock.json
+++ b/openless-all/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openless-app",
-  "version": "1.3.0",
+  "version": "1.3.1-1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openless-app",
-      "version": "1.3.0",
+      "version": "1.3.1-1",
       "dependencies": {
         "@tauri-apps/api": "^2.1.1",
         "@tauri-apps/plugin-autostart": "^2.5.1",

--- a/openless-all/app/src/components/SettingsModal.tsx
+++ b/openless-all/app/src/components/SettingsModal.tsx
@@ -21,14 +21,6 @@ import {
   type LatestBetaRelease,
   type UpdateChannel,
 } from '../lib/ipc';
-import {
-  FOLLOW_SYSTEM,
-  getLocalePreference,
-  outputPrefsForLocale,
-  setLocalePreference,
-  type SupportedLocale,
-} from '../i18n';
-import { useHotkeySettings } from '../state/HotkeySettingsContext';
 import type { OS } from './WindowChrome';
 
 interface SettingsModalProps {
@@ -264,9 +256,6 @@ function PersonalizeSection() {
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
-      <Row label={t('modal.personalize.language')}>
-        <LanguagePicker />
-      </Row>
       <Row label={t('modal.personalize.font')} desc={t('modal.personalize.fontDesc')}>
         <div style={{ display: 'flex', gap: 4, padding: 2, background: 'rgba(0,0,0,0.04)', borderRadius: 8 }}>
           {fontOptions.map(([id, label]) => {
@@ -533,46 +522,3 @@ const btnGhost: CSSProperties = {
   transition: 'background 0.16s var(--ol-motion-quick), border-color 0.16s var(--ol-motion-quick)',
 };
 
-// 真正可用的语言切换器 —— 用原生 <select>，与 Settings → Language 分区共享同一份 localStorage 偏好。
-function LanguagePicker() {
-  const { t } = useTranslation();
-  const { updatePrefs } = useHotkeySettings();
-  const [pref, setPref] = useState<SupportedLocale | typeof FOLLOW_SYSTEM>(getLocalePreference());
-
-  const apply = async (next: SupportedLocale | typeof FOLLOW_SYSTEM) => {
-    setPref(next);
-    const resolved = await setLocalePreference(next);
-    const localePrefs = outputPrefsForLocale(resolved);
-    await updatePrefs(current => {
-      if (
-        current.chineseScriptPreference === localePrefs.chineseScriptPreference &&
-        current.outputLanguagePreference === localePrefs.outputLanguagePreference
-      ) {
-        return current;
-      }
-      return { ...current, ...localePrefs };
-    });
-  };
-
-  return (
-    <select
-      value={pref}
-      onChange={e => apply(e.target.value as SupportedLocale | typeof FOLLOW_SYSTEM)}
-      style={{
-        height: 32, padding: '0 10px',
-        border: '0.5px solid var(--ol-line-strong)',
-        borderRadius: 8, fontSize: 12.5,
-        fontFamily: 'inherit', outline: 'none',
-        background: 'var(--ol-surface-2)',
-        minWidth: 200, cursor: 'default',
-      }}
-    >
-      <option value={FOLLOW_SYSTEM}>{t('settings.language.followSystem')}</option>
-      <option value="zh-CN">{t('settings.language.zh')}</option>
-      <option value="zh-TW">{t('settings.language.zhTW')}</option>
-      <option value="en">{t('settings.language.en')}</option>
-      <option value="ja">{t('settings.language.ja')}</option>
-      <option value="ko">{t('settings.language.ko')}</option>
-    </select>
-  );
-}

--- a/openless-all/app/src/components/WindowChrome.tsx
+++ b/openless-all/app/src/components/WindowChrome.tsx
@@ -1,6 +1,4 @@
-import { useState, type CSSProperties, type ReactNode } from 'react';
-import { useTranslation } from 'react-i18next';
-import { getCurrentWindow } from '@tauri-apps/api/window';
+import { type CSSProperties, type ReactNode } from 'react';
 
 export type OS = 'mac' | 'win' | 'linux';
 
@@ -18,21 +16,7 @@ export function detectOS(): OS {
 
 const MAC_TITLEBAR_HEIGHT = 28;
 const MAC_SYSTEM_CONTROLS_RESERVED_WIDTH = 76;
-export const WIN_TITLEBAR_HEIGHT = 36;
-export const WIN_WINDOW_RADIUS = 10;
-export const WIN_CONSOLE_RADIUS = 10;
-const WIN_RESIZE_EDGE = 6;
-const WIN_RESIZE_CORNER = 14;
-
-type ResizeDirection =
-  | 'East'
-  | 'North'
-  | 'NorthEast'
-  | 'NorthWest'
-  | 'South'
-  | 'SouthEast'
-  | 'SouthWest'
-  | 'West';
+const WIN_CONSOLE_RADIUS = 10;
 
 interface WindowChromeProps {
   os?: OS;
@@ -43,48 +27,46 @@ interface WindowChromeProps {
 
 export function WindowChrome({
   os = 'mac',
-  title = 'OpenLess',
   children,
   height = 800,
 }: WindowChromeProps) {
-  const shellRadius = os === 'mac' ? 0 : os === 'win' ? WIN_WINDOW_RADIUS : 14;
+  // Windows 下交还原生外壳（decorations:true）：外层不画圆角 / 边框 / 阴影 / 标题栏，
+  // 避免与原生窗口的角和关闭按钮重叠。内层卡片保留 10px 圆角，跟整体设计对齐。
+  const shellRadius = os === 'mac' ? 0 : os === 'win' ? 0 : 14;
   const consoleRadius = os === 'mac' ? 20 : os === 'win' ? WIN_CONSOLE_RADIUS : 14;
+  const titlebarHeight = os === 'mac' ? MAC_TITLEBAR_HEIGHT : 0;
+
+  const background = os === 'win'
+    ? 'linear-gradient(180deg, rgba(245,245,247,1) 0%, rgba(232,232,236,1) 100%)'
+    : `
+        radial-gradient(120% 80% at 0% 0%, rgba(255,255,255,0.7) 0%, rgba(255,255,255,0) 60%),
+        radial-gradient(100% 70% at 100% 100%, rgba(37,99,235,0.07) 0%, rgba(37,99,235,0) 55%),
+        linear-gradient(180deg, rgba(245,245,247,0.92) 0%, rgba(232,232,236,0.92) 100%)
+      `;
 
   return (
     <div
       style={{
         '--ol-window-shell-radius': `${shellRadius}px`,
         '--ol-window-console-radius': `${consoleRadius}px`,
-        '--ol-window-titlebar-height': `${os === 'mac' ? MAC_TITLEBAR_HEIGHT : WIN_TITLEBAR_HEIGHT}px`,
+        '--ol-window-titlebar-height': `${titlebarHeight}px`,
         width: '100%',
         height,
         position: 'relative',
         borderRadius: 'var(--ol-window-shell-radius)',
-        boxShadow: os === 'win'
-          ? '0 22px 54px -28px rgba(15, 17, 22, 0.38), 0 10px 30px -20px rgba(15, 17, 22, 0.22), 0 0 0 0.5px rgba(0, 0, 0, 0.10)'
-          : 'var(--ol-shadow-xl)',
+        boxShadow: os === 'win' ? 'none' : 'var(--ol-shadow-xl)',
         overflow: 'hidden',
         display: 'flex',
         flexDirection: 'column',
-        border: os === 'mac'
-          ? 'none'
-          : os === 'win'
-            ? '1px solid rgba(255,255,255,0.18)'
-            : '0.5px solid rgba(0,0,0,.10)',
-        background: `
-          radial-gradient(120% 80% at 0% 0%, rgba(255,255,255,0.7) 0%, rgba(255,255,255,0) 60%),
-          radial-gradient(100% 70% at 100% 100%, rgba(37,99,235,0.07) 0%, rgba(37,99,235,0) 55%),
-          linear-gradient(180deg, rgba(245,245,247,0.92) 0%, rgba(232,232,236,0.92) 100%)
-        `,
-        backdropFilter: 'blur(var(--ol-glass-blur-strong)) saturate(190%)',
-        WebkitBackdropFilter: 'blur(var(--ol-glass-blur-strong)) saturate(190%)',
+        border: os === 'win' ? 'none' : os === 'mac' ? 'none' : '0.5px solid rgba(0,0,0,.10)',
+        background,
+        backdropFilter: os === 'win' ? undefined : 'blur(var(--ol-glass-blur-strong)) saturate(190%)',
+        WebkitBackdropFilter: os === 'win' ? undefined : 'blur(var(--ol-glass-blur-strong)) saturate(190%)',
         animation: os === 'win' ? undefined : 'ol-window-enter 0.42s var(--ol-motion-spring) both',
         transition: 'box-shadow 0.28s var(--ol-motion-soft), border-color 0.28s var(--ol-motion-soft), backdrop-filter 0.28s var(--ol-motion-soft)',
         willChange: 'opacity, transform, filter',
       } as CSSProperties}
     >
-      {os === 'win' && <WinTitleBar title={title} />}
-      {os === 'win' && <WindowsResizeHandles />}
       {os === 'mac' && (
         <div
           data-tauri-drag-region
@@ -104,154 +86,3 @@ export function WindowChrome({
     </div>
   );
 }
-
-interface WinTitleBarProps {
-  title: string;
-}
-
-function WinTitleBar({ title }: WinTitleBarProps) {
-  const { t } = useTranslation();
-  return (
-    <div
-      style={{
-        height: WIN_TITLEBAR_HEIGHT,
-        flexShrink: 0,
-        display: 'flex',
-        alignItems: 'stretch',
-        position: 'relative',
-        zIndex: 70,
-        borderBottom: '0.5px solid rgba(0, 0, 0, 0.08)',
-        background: 'linear-gradient(180deg, rgba(255,255,255,0.20) 0%, rgba(255,255,255,0.08) 100%)',
-      }}
-    >
-      <div
-        data-tauri-drag-region
-        style={{ flex: 1, display: 'flex', alignItems: 'center', padding: '0 14px', gap: 10 }}
-      >
-        <img src="AppIcon.png" alt="" style={{ width: 14, height: 14, borderRadius: 3 }} />
-        <span style={{ fontSize: 12, color: 'var(--ol-ink-3)', fontWeight: 500 }}>{title}</span>
-      </div>
-      <div style={{ display: 'flex', pointerEvents: 'auto' }}>
-        <WinTitleButton title={t('windowChrome.minimize')} action="minimize">
-          <svg width="10" height="10" viewBox="0 0 10 10"><path d="M0 5h10" stroke="currentColor" strokeWidth="1" /></svg>
-        </WinTitleButton>
-        <WinTitleButton title={t('windowChrome.maximize')} action="toggleMaximize">
-          <svg width="10" height="10" viewBox="0 0 10 10"><rect x="0.5" y="0.5" width="9" height="9" stroke="currentColor" strokeWidth="1" fill="none" /></svg>
-        </WinTitleButton>
-        <WinTitleButton title={t('windowChrome.close')} action="close" tone="danger">
-          <svg width="10" height="10" viewBox="0 0 10 10"><path d="M0 0L10 10M10 0L0 10" stroke="currentColor" strokeWidth="1" /></svg>
-        </WinTitleButton>
-      </div>
-    </div>
-  );
-}
-
-function WindowsResizeHandles() {
-  const handles: Array<{
-    direction: ResizeDirection;
-    cursor: CSSProperties['cursor'];
-    style: CSSProperties;
-  }> = [
-    { direction: 'North', cursor: 'ns-resize', style: { top: 0, left: WIN_RESIZE_CORNER, right: WIN_RESIZE_CORNER, height: WIN_RESIZE_EDGE } },
-    { direction: 'South', cursor: 'ns-resize', style: { bottom: 0, left: WIN_RESIZE_CORNER, right: WIN_RESIZE_CORNER, height: WIN_RESIZE_EDGE } },
-    { direction: 'West', cursor: 'ew-resize', style: { top: WIN_RESIZE_CORNER, bottom: WIN_RESIZE_CORNER, left: 0, width: WIN_RESIZE_EDGE } },
-    { direction: 'East', cursor: 'ew-resize', style: { top: WIN_RESIZE_CORNER, bottom: WIN_RESIZE_CORNER, right: 0, width: WIN_RESIZE_EDGE } },
-    { direction: 'NorthWest', cursor: 'nwse-resize', style: { top: 0, left: 0, width: WIN_RESIZE_CORNER, height: WIN_RESIZE_CORNER } },
-    { direction: 'NorthEast', cursor: 'nesw-resize', style: { top: 0, right: 0, width: WIN_RESIZE_CORNER, height: WIN_RESIZE_CORNER } },
-    { direction: 'SouthWest', cursor: 'nesw-resize', style: { bottom: 0, left: 0, width: WIN_RESIZE_CORNER, height: WIN_RESIZE_CORNER } },
-    { direction: 'SouthEast', cursor: 'nwse-resize', style: { bottom: 0, right: 0, width: WIN_RESIZE_CORNER, height: WIN_RESIZE_CORNER } },
-  ];
-
-  return (
-    <div aria-hidden style={{ position: 'absolute', inset: 0, pointerEvents: 'none', zIndex: 60 }}>
-      {handles.map(handle => (
-        <div
-          key={handle.direction}
-          onMouseDown={event => {
-            if (event.button !== 0) return;
-            event.preventDefault();
-            event.stopPropagation();
-            void startResizeDragging(handle.direction);
-          }}
-          style={{
-            position: 'absolute',
-            pointerEvents: 'auto',
-            cursor: handle.cursor,
-            ...handle.style,
-          }}
-        />
-      ))}
-    </div>
-  );
-}
-
-interface WinTitleButtonProps {
-  title: string;
-  action: 'minimize' | 'toggleMaximize' | 'close';
-  tone?: 'default' | 'danger';
-  children: ReactNode;
-}
-
-function WinTitleButton({ title, action, tone = 'default', children }: WinTitleButtonProps) {
-  const [hovered, setHovered] = useState(false);
-  const [pressed, setPressed] = useState(false);
-  const danger = tone === 'danger';
-  const background = pressed
-    ? danger ? '#c42b1c' : 'rgba(0, 0, 0, 0.12)'
-    : hovered ? danger ? '#e81123' : 'rgba(0, 0, 0, 0.08)'
-      : 'transparent';
-  const color = danger && (hovered || pressed) ? '#fff' : 'var(--ol-ink-3)';
-
-  return (
-    <button
-      style={{ ...winBtnStyle, background, color }}
-      title={title}
-      onClick={() => runWindowsWindowAction(action)}
-      onMouseEnter={() => setHovered(true)}
-      onMouseLeave={() => {
-        setHovered(false);
-        setPressed(false);
-      }}
-      onMouseDown={() => setPressed(true)}
-      onMouseUp={() => setPressed(false)}
-    >
-      {children}
-    </button>
-  );
-}
-
-async function startResizeDragging(direction: ResizeDirection) {
-  try {
-    await getCurrentWindow().startResizeDragging(direction);
-  } catch (error) {
-    console.warn(`[window] Windows resize ${direction} failed`, error);
-  }
-}
-
-async function runWindowsWindowAction(action: 'minimize' | 'toggleMaximize' | 'close') {
-  try {
-    const currentWindow = getCurrentWindow();
-    if (action === 'minimize') {
-      await currentWindow.minimize();
-    } else if (action === 'toggleMaximize') {
-      await currentWindow.toggleMaximize();
-    } else {
-      await currentWindow.close();
-    }
-  } catch (error) {
-    console.warn(`[window] Windows title button ${action} failed`, error);
-  }
-}
-
-const winBtnStyle: CSSProperties = {
-  width: 46,
-  height: '100%',
-  border: 0,
-  background: 'transparent',
-  display: 'flex',
-  alignItems: 'center',
-  justifyContent: 'center',
-  color: 'var(--ol-ink-3)',
-  cursor: 'default',
-  transition: 'background 0.16s var(--ol-motion-quick), color 0.16s var(--ol-motion-quick)',
-};

--- a/openless-all/app/src/components/ui/SelectLite.tsx
+++ b/openless-all/app/src/components/ui/SelectLite.tsx
@@ -183,6 +183,7 @@ export function SelectLite({
       <button
         ref={triggerRef}
         type="button"
+        className="ol-focus-ring"
         role="combobox"
         aria-haspopup="listbox"
         aria-expanded={open}

--- a/openless-all/app/src/components/ui/SelectLite.tsx
+++ b/openless-all/app/src/components/ui/SelectLite.tsx
@@ -1,24 +1,279 @@
-// SelectLite — dropdown-styled display used in the Settings modal sub-sections.
+// SelectLite — 受控的下拉组件，替代 native <select> 以避开 Windows Win32 ComboBox
+// 弹框的直角丑框（issue #418）。
+//
+// 设计：
+// - 触发器是一个 button（chevron + 当前值标签），样式可被 `style` 覆盖
+// - popover 用 portal 渲染到 document.body，避开父容器 overflow:hidden
+// - 键盘：ArrowDown/ArrowUp 切换高亮，Enter 确认，Esc 关闭
+// - 点击外部 / 滚动 / resize 都会关闭或重定位
 
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+  type CSSProperties,
+  type KeyboardEvent as ReactKeyboardEvent,
+} from 'react';
+import { createPortal } from 'react-dom';
 import { Icon } from '../Icon';
+
+export interface SelectOption {
+  value: string;
+  label: string;
+  disabled?: boolean;
+}
 
 interface SelectLiteProps {
   value: string;
+  onChange: (value: string) => void;
+  options: SelectOption[];
+  placeholder?: string;
+  disabled?: boolean;
+  style?: CSSProperties;
+  ariaLabel?: string;
 }
 
-export function SelectLite({ value }: SelectLiteProps) {
+const DEFAULT_TRIGGER_STYLE: CSSProperties = {
+  display: 'inline-flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  gap: 8,
+  padding: '0 10px',
+  height: 32,
+  fontSize: 12.5,
+  fontFamily: 'inherit',
+  borderRadius: 8,
+  border: '0.5px solid var(--ol-line-strong)',
+  background: 'var(--ol-surface-2)',
+  color: 'var(--ol-ink)',
+  cursor: 'default',
+  outline: 'none',
+  textAlign: 'left',
+  minWidth: 160,
+};
+
+export function SelectLite({
+  value,
+  onChange,
+  options,
+  placeholder,
+  disabled = false,
+  style,
+  ariaLabel,
+}: SelectLiteProps) {
+  const [open, setOpen] = useState(false);
+  const [highlight, setHighlight] = useState<number>(-1);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const popoverRef = useRef<HTMLDivElement>(null);
+  const [anchor, setAnchor] = useState<{ left: number; top: number; width: number } | null>(null);
+
+  const selected = useMemo(
+    () => options.find(opt => opt.value === value),
+    [options, value],
+  );
+  const displayLabel = selected?.label ?? placeholder ?? '';
+
+  const positionPopover = useCallback(() => {
+    const trigger = triggerRef.current;
+    if (!trigger) return;
+    const rect = trigger.getBoundingClientRect();
+    // 默认在触发器下方；若下方空间放不下 popover（按 maxHeight 280 估），翻转向上以避免被视口裁剪。
+    const popoverMaxHeight = popoverRef.current?.getBoundingClientRect().height ?? 280;
+    const spaceBelow = window.innerHeight - rect.bottom;
+    const flipUp = spaceBelow < popoverMaxHeight + 8 && rect.top > popoverMaxHeight + 8;
+    const top = flipUp ? rect.top - popoverMaxHeight - 4 : rect.bottom + 4;
+    setAnchor({ left: rect.left, top, width: rect.width });
+  }, []);
+
+  useLayoutEffect(() => {
+    if (!open) return;
+    positionPopover();
+    const handleReflow = () => positionPopover();
+    window.addEventListener('resize', handleReflow);
+    window.addEventListener('scroll', handleReflow, true);
+    return () => {
+      window.removeEventListener('resize', handleReflow);
+      window.removeEventListener('scroll', handleReflow, true);
+    };
+  }, [open, positionPopover]);
+
+  useEffect(() => {
+    if (!open) return;
+    const handlePointerDown = (event: MouseEvent) => {
+      const target = event.target as Node | null;
+      if (!target) return;
+      if (triggerRef.current?.contains(target)) return;
+      if (popoverRef.current?.contains(target)) return;
+      setOpen(false);
+    };
+    document.addEventListener('mousedown', handlePointerDown);
+    return () => document.removeEventListener('mousedown', handlePointerDown);
+  }, [open]);
+
+  const openMenu = () => {
+    if (disabled) return;
+    const initial = options.findIndex(opt => opt.value === value && !opt.disabled);
+    setHighlight(initial >= 0 ? initial : options.findIndex(opt => !opt.disabled));
+    setOpen(true);
+  };
+
+  const closeMenu = () => {
+    setOpen(false);
+    setHighlight(-1);
+  };
+
+  const selectIndex = (index: number) => {
+    const option = options[index];
+    if (!option || option.disabled) return;
+    onChange(option.value);
+    closeMenu();
+    triggerRef.current?.focus();
+  };
+
+  const moveHighlight = (direction: 1 | -1) => {
+    if (options.length === 0) return;
+    let next = highlight;
+    for (let i = 0; i < options.length; i += 1) {
+      next = (next + direction + options.length) % options.length;
+      if (!options[next]?.disabled) {
+        setHighlight(next);
+        return;
+      }
+    }
+  };
+
+  const handleKeyDown = (event: ReactKeyboardEvent<HTMLButtonElement>) => {
+    if (disabled) return;
+    if (!open) {
+      if (event.key === 'ArrowDown' || event.key === 'ArrowUp' || event.key === 'Enter' || event.key === ' ') {
+        event.preventDefault();
+        openMenu();
+      }
+      return;
+    }
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      closeMenu();
+    } else if (event.key === 'ArrowDown') {
+      event.preventDefault();
+      moveHighlight(1);
+    } else if (event.key === 'ArrowUp') {
+      event.preventDefault();
+      moveHighlight(-1);
+    } else if (event.key === 'Enter') {
+      event.preventDefault();
+      if (highlight >= 0) selectIndex(highlight);
+    } else if (event.key === 'Tab') {
+      closeMenu();
+    }
+  };
+
+  const triggerStyle: CSSProperties = {
+    ...DEFAULT_TRIGGER_STYLE,
+    ...style,
+    opacity: disabled ? 0.5 : 1,
+    cursor: disabled ? 'not-allowed' : 'default',
+  };
+
   return (
-    <div
-      style={{
-        display: 'inline-flex', alignItems: 'center', gap: 8,
-        padding: '6px 10px', fontSize: 12.5,
-        borderRadius: 8, border: '0.5px solid var(--ol-line-strong)',
-        background: 'var(--ol-surface-2)',
-        minWidth: 200, justifyContent: 'space-between',
-      }}
-    >
-      <span>{value}</span>
-      <Icon name="chevDown" size={11} />
-    </div>
+    <>
+      <button
+        ref={triggerRef}
+        type="button"
+        role="combobox"
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        aria-disabled={disabled}
+        aria-label={ariaLabel}
+        disabled={disabled}
+        onClick={() => (open ? closeMenu() : openMenu())}
+        onKeyDown={handleKeyDown}
+        style={triggerStyle}
+      >
+        <span
+          style={{
+            flex: 1,
+            minWidth: 0,
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+            color: selected ? 'var(--ol-ink)' : 'var(--ol-ink-4)',
+          }}
+        >
+          {displayLabel}
+        </span>
+        <Icon name="chevDown" size={11} />
+      </button>
+      {open && anchor && createPortal(
+        <div
+          ref={popoverRef}
+          role="listbox"
+          style={{
+            position: 'fixed',
+            left: anchor.left,
+            top: anchor.top,
+            minWidth: anchor.width,
+            maxHeight: 280,
+            overflowY: 'auto',
+            padding: 4,
+            borderRadius: 10,
+            border: '0.5px solid rgba(0, 0, 0, 0.10)',
+            background: 'rgba(252, 252, 254, 0.94)',
+            backdropFilter: 'blur(20px) saturate(180%)',
+            WebkitBackdropFilter: 'blur(20px) saturate(180%)',
+            boxShadow: '0 12px 30px -10px rgba(15, 17, 22, 0.25), 0 0 0 0.5px rgba(0, 0, 0, 0.06)',
+            zIndex: 9999,
+            fontFamily: 'inherit',
+            fontSize: 12.5,
+            animation: 'ol-select-pop .14s var(--ol-motion-quick) both',
+          }}
+        >
+          {options.map((option, index) => {
+            const isSelected = option.value === value;
+            const isHighlighted = index === highlight;
+            return (
+              <div
+                key={option.value || `__opt_${index}`}
+                role="option"
+                aria-selected={isSelected}
+                aria-disabled={option.disabled}
+                onMouseEnter={() => !option.disabled && setHighlight(index)}
+                onMouseDown={event => {
+                  event.preventDefault();
+                  selectIndex(index);
+                }}
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: 8,
+                  padding: '7px 10px',
+                  borderRadius: 6,
+                  cursor: option.disabled ? 'not-allowed' : 'default',
+                  opacity: option.disabled ? 0.45 : 1,
+                  background: isHighlighted && !option.disabled
+                    ? 'rgba(37, 99, 235, 0.10)'
+                    : 'transparent',
+                  color: isSelected ? 'var(--ol-blue)' : 'var(--ol-ink)',
+                  fontWeight: isSelected ? 600 : 500,
+                  whiteSpace: 'nowrap',
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                  transition: 'background 0.10s var(--ol-motion-quick)',
+                }}
+              >
+                <span style={{ flex: 1, minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis' }}>
+                  {option.label}
+                </span>
+                {isSelected && <Icon name="check" size={12} />}
+              </div>
+            );
+          })}
+        </div>,
+        document.body,
+      )}
+    </>
   );
 }

--- a/openless-all/app/src/components/ui/SelectLite.tsx
+++ b/openless-all/app/src/components/ui/SelectLite.tsx
@@ -80,12 +80,18 @@ export function SelectLite({
     const trigger = triggerRef.current;
     if (!trigger) return;
     const rect = trigger.getBoundingClientRect();
-    // 默认在触发器下方；若下方空间放不下 popover（按 maxHeight 280 估），翻转向上以避免被视口裁剪。
-    const popoverMaxHeight = popoverRef.current?.getBoundingClientRect().height ?? 280;
+    const popoverRect = popoverRef.current?.getBoundingClientRect();
+    const popoverHeight = popoverRect?.height ?? 280;
+    const popoverWidth = popoverRect?.width ?? rect.width;
+    // 纵向：默认在触发器下方；若下方空间放不下 popover，翻转向上以避免被视口裁剪。
     const spaceBelow = window.innerHeight - rect.bottom;
-    const flipUp = spaceBelow < popoverMaxHeight + 8 && rect.top > popoverMaxHeight + 8;
-    const top = flipUp ? rect.top - popoverMaxHeight - 4 : rect.bottom + 4;
-    setAnchor({ left: rect.left, top, width: rect.width });
+    const flipUp = spaceBelow < popoverHeight + 8 && rect.top > popoverHeight + 8;
+    const top = flipUp ? rect.top - popoverHeight - 4 : rect.bottom + 4;
+    // 横向：在窗口右边的 select 可能让 popover 溢出屏幕；clamp 到 [8, viewport - width - 8] 区间。
+    const minLeft = 8;
+    const maxLeft = Math.max(minLeft, window.innerWidth - popoverWidth - 8);
+    const left = Math.min(Math.max(rect.left, minLeft), maxLeft);
+    setAnchor({ left, top, width: rect.width });
   }, []);
 
   useLayoutEffect(() => {
@@ -99,6 +105,17 @@ export function SelectLite({
       window.removeEventListener('scroll', handleReflow, true);
     };
   }, [open, positionPopover]);
+
+  // 键盘 ArrowUp/Down 改 highlight 后把高亮项 scroll into view —— 长 dropdown 超过
+  // maxHeight 280 时键盘用户能看到当前高亮。{ block: 'nearest' } 避免把已经可见的项
+  // 强行滚到顶部，符合 listbox 滚动惯例。
+  useEffect(() => {
+    if (!open || highlight < 0) return;
+    const target = popoverRef.current?.querySelector(
+      `[data-option-index="${highlight}"]`,
+    ) as HTMLElement | null;
+    target?.scrollIntoView({ block: 'nearest' });
+  }, [highlight, open]);
 
   useEffect(() => {
     if (!open) return;
@@ -238,6 +255,7 @@ export function SelectLite({
             return (
               <div
                 key={option.value || `__opt_${index}`}
+                data-option-index={index}
                 role="option"
                 aria-selected={isSelected}
                 aria-disabled={option.disabled}

--- a/openless-all/app/src/components/ui/SwitchLite.tsx
+++ b/openless-all/app/src/components/ui/SwitchLite.tsx
@@ -11,6 +11,7 @@ export function SwitchLite({ on: initial = false }: SwitchLiteProps) {
   return (
     <button
       type="button"
+      className="ol-focus-ring"
       onClick={() => setOn(!on)}
       style={{
         position: 'relative', width: 32, height: 18, borderRadius: 999, border: 0,

--- a/openless-all/app/src/components/ui/SwitchLite.tsx
+++ b/openless-all/app/src/components/ui/SwitchLite.tsx
@@ -10,11 +10,13 @@ export function SwitchLite({ on: initial = false }: SwitchLiteProps) {
   const [on, setOn] = useState(initial);
   return (
     <button
+      type="button"
       onClick={() => setOn(!on)}
       style={{
         position: 'relative', width: 32, height: 18, borderRadius: 999, border: 0,
         background: on ? 'var(--ol-blue)' : 'rgba(0,0,0,0.18)',
         cursor: 'default',
+        outline: 'none',
       }}
     >
       <span

--- a/openless-all/app/src/i18n/en.ts
+++ b/openless-all/app/src/i18n/en.ts
@@ -600,7 +600,6 @@ export const en: typeof zhCN = {
       appearanceSystem: 'Follow system',
       appearanceLight: 'Light',
       appearanceDark: 'Dark',
-      language: 'Interface language',
       font: 'Font size',
       fontDesc: 'Scale the entire UI font size — applies instantly.',
       fontSmall: 'Small',

--- a/openless-all/app/src/i18n/ja.ts
+++ b/openless-all/app/src/i18n/ja.ts
@@ -602,7 +602,6 @@ export const ja: typeof zhCN = {
       appearanceSystem: 'システムに従う',
       appearanceLight: 'ライト',
       appearanceDark: 'ダーク',
-      language: '表示言語',
       font: 'フォントサイズ',
       fontDesc: 'UI のフォントサイズを全体的にスケール。即時反映。',
       fontSmall: '小',

--- a/openless-all/app/src/i18n/ko.ts
+++ b/openless-all/app/src/i18n/ko.ts
@@ -602,7 +602,6 @@ export const ko: typeof zhCN = {
       appearanceSystem: '시스템 따라가기',
       appearanceLight: '라이트',
       appearanceDark: '다크',
-      language: '인터페이스 언어',
       font: '글꼴 크기',
       fontDesc: 'UI 글꼴 크기를 전체 스케일. 즉시 반영.',
       fontSmall: '소',

--- a/openless-all/app/src/i18n/zh-CN.ts
+++ b/openless-all/app/src/i18n/zh-CN.ts
@@ -598,7 +598,6 @@ export const zhCN = {
       appearanceSystem: '跟随系统',
       appearanceLight: '浅色',
       appearanceDark: '深色',
-      language: '界面语言',
       font: '字体大小',
       fontDesc: '整体缩放界面字号，立即生效。',
       fontSmall: '小',

--- a/openless-all/app/src/i18n/zh-TW.ts
+++ b/openless-all/app/src/i18n/zh-TW.ts
@@ -600,7 +600,6 @@ export const zhTW: typeof zhCN = {
       appearanceSystem: '跟隨系統',
       appearanceLight: '淺色',
       appearanceDark: '深色',
-      language: '界面語言',
       font: '字體大小',
       fontDesc: '整體縮放界面字號，立即生效。',
       fontSmall: '小',

--- a/openless-all/app/src/lib/capsuleLayout.ts
+++ b/openless-all/app/src/lib/capsuleLayout.ts
@@ -26,7 +26,8 @@ export interface CapsuleMessageLayout {
 export function getCapsulePillMetrics(os: OS): CapsulePillMetrics {
   if (os === 'win') {
     // Windows metrics describe the visible outer footprint of the pill.
-    return { width: 196, height: 52, textWidth: 104, boxSizing: 'border-box' };
+    // 与 macOS pill 接近以保持视觉密度一致；保留 ~4-5% 余量适配 Windows 字体 metrics。
+    return { width: 180, height: 44, textWidth: 88, boxSizing: 'border-box' };
   }
 
   return { width: 176, height: 42, textWidth: 84, boxSizing: 'border-box' };

--- a/openless-all/app/src/pages/LocalAsr.tsx
+++ b/openless-all/app/src/pages/LocalAsr.tsx
@@ -47,6 +47,7 @@ import {
 } from '../lib/localAsr';
 import { useHotkeySettings } from '../state/HotkeySettingsContext';
 import { detectOS } from '../components/WindowChrome';
+import { SelectLite } from '../components/ui/SelectLite';
 import { Btn, Card, PageHeader, Pill } from './_atoms';
 
 // Foundry Local Whisper 后端只在 Windows 编译实体（foundry_local_sdk 仅 Windows），
@@ -626,73 +627,52 @@ export function LocalAsr({ embedded = false }: LocalAsrProps = {}) {
             <div style={{ display: 'flex', gap: 10, flexWrap: 'wrap', justifyContent: 'flex-end' }}>
               <label style={{ display: 'flex', flexDirection: 'column', gap: 4, fontSize: 11, color: 'var(--ol-ink-4)' }}>
                 {t('localAsr.foundrySelectedModel')}
-                <select
+                <SelectLite
                   value={selectedFoundryAlias}
-                  onChange={e => {
+                  onChange={next => {
                     foundrySelectionDirty.current = true;
-                    setSelectedFoundryAlias(e.target.value as FoundryLocalAsrModelAlias);
+                    setSelectedFoundryAlias(next as FoundryLocalAsrModelAlias);
                   }}
                   disabled={foundryBusy !== null}
-                  style={{
-                    fontSize: 13,
-                    padding: '6px 10px',
-                    borderRadius: 8,
-                    border: '0.5px solid rgba(0,0,0,0.12)',
-                    background: 'var(--ol-surface)',
-                    color: 'var(--ol-ink)',
-                    minWidth: 260,
-                  }}>
-                  {FOUNDRY_LOCAL_ASR_MODELS.map(model => {
+                  options={FOUNDRY_LOCAL_ASR_MODELS.map(model => {
                     const catalog = foundryCatalog.find(item => item.alias === model.alias);
                     const sizeMb = formatFoundrySizeMb(catalog?.fileSizeMb);
-                    return (
-                      <option key={model.alias} value={model.alias}>
-                        {t(model.labelKey)}
-                        {sizeMb ? ` · ${t('localAsr.foundryApproxSizeMb', { mb: sizeMb })}` : ''}
-                      </option>
-                    );
+                    const sizeSuffix = sizeMb ? ` · ${t('localAsr.foundryApproxSizeMb', { mb: sizeMb })}` : '';
+                    return { value: model.alias, label: `${t(model.labelKey)}${sizeSuffix}` };
                   })}
-                </select>
+                  ariaLabel={t('localAsr.foundrySelectedModel')}
+                  style={{ fontSize: 13, background: 'var(--ol-surface)', minWidth: 260 }}
+                />
               </label>
               <label style={{ display: 'flex', flexDirection: 'column', gap: 4, fontSize: 11, color: 'var(--ol-ink-4)' }}>
                 {t('localAsr.foundryRuntimeSourceLabel')}
-                <select
+                <SelectLite
                   value={selectedFoundryRuntimeSource}
-                  onChange={e => void handleFoundryRuntimeSourceChange(e.target.value as FoundryRuntimeSource)}
+                  onChange={next => void handleFoundryRuntimeSourceChange(next as FoundryRuntimeSource)}
                   disabled={foundryBusy !== null}
-                  style={{
-                    fontSize: 13,
-                    padding: '6px 10px',
-                    borderRadius: 8,
-                    border: '0.5px solid rgba(0,0,0,0.12)',
-                    background: 'var(--ol-surface)',
-                    color: 'var(--ol-ink)',
-                    minWidth: 200,
-                  }}>
-                  <option value="auto">{t('localAsr.foundryRuntimeSourceAuto')}</option>
-                  <option value="nuget">{t('localAsr.foundryRuntimeSourceNuget')}</option>
-                  <option value="ort-nightly">{t('localAsr.foundryRuntimeSourceOrtNightly')}</option>
-                </select>
+                  options={[
+                    { value: 'auto', label: t('localAsr.foundryRuntimeSourceAuto') },
+                    { value: 'nuget', label: t('localAsr.foundryRuntimeSourceNuget') },
+                    { value: 'ort-nightly', label: t('localAsr.foundryRuntimeSourceOrtNightly') },
+                  ]}
+                  ariaLabel={t('localAsr.foundryRuntimeSourceLabel')}
+                  style={{ fontSize: 13, background: 'var(--ol-surface)', minWidth: 200 }}
+                />
               </label>
               <label style={{ display: 'flex', flexDirection: 'column', gap: 4, fontSize: 11, color: 'var(--ol-ink-4)' }}>
                 {t('localAsr.foundryLanguageLabel')}
-                <select
+                <SelectLite
                   value={selectedFoundryLanguageHint}
-                  onChange={e => void handleFoundryLanguageChange(e.target.value as FoundryLocalAsrLanguageHint)}
+                  onChange={next => void handleFoundryLanguageChange(next as FoundryLocalAsrLanguageHint)}
                   disabled={foundryBusy !== null}
-                  style={{
-                    fontSize: 13,
-                    padding: '6px 10px',
-                    borderRadius: 8,
-                    border: '0.5px solid rgba(0,0,0,0.12)',
-                    background: 'var(--ol-surface)',
-                    color: 'var(--ol-ink)',
-                    minWidth: 132,
-                  }}>
-                  <option value="">{t('localAsr.foundryLanguageAuto')}</option>
-                  <option value="zh">{t('localAsr.foundryLanguageZh')}</option>
-                  <option value="en">{t('localAsr.foundryLanguageEn')}</option>
-                </select>
+                  options={[
+                    { value: '', label: t('localAsr.foundryLanguageAuto') },
+                    { value: 'zh', label: t('localAsr.foundryLanguageZh') },
+                    { value: 'en', label: t('localAsr.foundryLanguageEn') },
+                  ]}
+                  ariaLabel={t('localAsr.foundryLanguageLabel')}
+                  style={{ fontSize: 13, background: 'var(--ol-surface)', minWidth: 132 }}
+                />
               </label>
             </div>
           </div>
@@ -805,21 +785,16 @@ export function LocalAsr({ embedded = false }: LocalAsrProps = {}) {
               {t('localAsr.mirrorDesc')}
             </div>
           </div>
-          <select
+          <SelectLite
             value={settings?.mirror ?? 'huggingface'}
-            onChange={e => void handleMirrorChange(e.target.value)}
-            style={{
-              fontSize: 13,
-              padding: '6px 10px',
-              borderRadius: 8,
-              border: '0.5px solid rgba(0,0,0,0.12)',
-              background: 'var(--ol-surface)',
-              color: 'var(--ol-ink)',
-              minWidth: 200,
-            }}>
-            <option value="huggingface">{t('localAsr.mirrorHuggingface')}</option>
-            <option value="hf-mirror">{t('localAsr.mirrorHfMirror')}</option>
-          </select>
+            onChange={next => void handleMirrorChange(next)}
+            options={[
+              { value: 'huggingface', label: t('localAsr.mirrorHuggingface') },
+              { value: 'hf-mirror', label: t('localAsr.mirrorHfMirror') },
+            ]}
+            ariaLabel={t('localAsr.mirrorLabel')}
+            style={{ fontSize: 13, background: 'var(--ol-surface)', minWidth: 200 }}
+          />
         </div>
       </Card>
 
@@ -859,24 +834,19 @@ export function LocalAsr({ embedded = false }: LocalAsrProps = {}) {
                   {t('localAsr.keepLoadedDesc')}
                 </div>
               </div>
-              <select
-                value={engineStatus?.keepLoadedSecs ?? 300}
-                onChange={e => void handleKeepLoadedChange(Number(e.target.value))}
-                style={{
-                  fontSize: 13,
-                  padding: '6px 10px',
-                  borderRadius: 8,
-                  border: '0.5px solid rgba(0,0,0,0.12)',
-                  background: 'var(--ol-surface)',
-                  color: 'var(--ol-ink)',
-                  minWidth: 200,
-                }}>
-                <option value={0}>{t('localAsr.keepImmediate')}</option>
-                <option value={60}>{t('localAsr.keep1min')}</option>
-                <option value={300}>{t('localAsr.keep5min')}</option>
-                <option value={1800}>{t('localAsr.keep30min')}</option>
-                <option value={86400}>{t('localAsr.keepForever')}</option>
-              </select>
+              <SelectLite
+                value={String(engineStatus?.keepLoadedSecs ?? 300)}
+                onChange={next => void handleKeepLoadedChange(Number(next))}
+                options={[
+                  { value: '0', label: t('localAsr.keepImmediate') },
+                  { value: '60', label: t('localAsr.keep1min') },
+                  { value: '300', label: t('localAsr.keep5min') },
+                  { value: '1800', label: t('localAsr.keep30min') },
+                  { value: '86400', label: t('localAsr.keepForever') },
+                ]}
+                ariaLabel={t('localAsr.keepLoadedLabel')}
+                style={{ fontSize: 13, background: 'var(--ol-surface)', minWidth: 200 }}
+              />
             </div>
           </div>
         </Card>

--- a/openless-all/app/src/pages/Settings.tsx
+++ b/openless-all/app/src/pages/Settings.tsx
@@ -37,6 +37,7 @@ import type {
 } from '../lib/types';
 import { emitSaved } from '../lib/savedEvent';
 import { useHotkeySettings } from '../state/HotkeySettingsContext';
+import { SelectLite } from '../components/ui/SelectLite';
 import { Btn, Card, Collapsible, PageHeader, Pill } from './_atoms';
 import {
   deleteLocalAsrModel,
@@ -454,15 +455,17 @@ function RecordingSection() {
           label={t('settings.recording.pasteShortcutLabel')}
           desc={t('settings.recording.pasteShortcutDesc')}
         >
-          <select
+          <SelectLite
             value={prefs.pasteShortcut}
-            onChange={e => onPasteShortcutChange(e.target.value as PasteShortcut)}
+            onChange={next => onPasteShortcutChange(next as PasteShortcut)}
+            options={[
+              { value: 'ctrlV', label: t('settings.recording.pasteShortcutCtrlV') },
+              { value: 'ctrlShiftV', label: t('settings.recording.pasteShortcutCtrlShiftV') },
+              { value: 'shiftInsert', label: t('settings.recording.pasteShortcutShiftInsert') },
+            ]}
+            ariaLabel={t('settings.recording.pasteShortcutLabel')}
             style={{ ...inputStyle, maxWidth: 220 }}
-          >
-            <option value="ctrlV">{t('settings.recording.pasteShortcutCtrlV')}</option>
-            <option value="ctrlShiftV">{t('settings.recording.pasteShortcutCtrlShiftV')}</option>
-            <option value="shiftInsert">{t('settings.recording.pasteShortcutShiftInsert')}</option>
-          </select>
+          />
         </SettingRow>
       )}
       {capability.adapter === 'windowsLowLevel' && (
@@ -1386,15 +1389,16 @@ function ProvidersSection() {
         {/* desc 已去掉——'选择后将自动填入 Base URL 默认值' 在 180px label 列必换行成两行，
             视觉上 label 区出现"字体单独占一行"。下拉自身已经表达了"切换"含义，desc 冗余。 */}
         <SettingRow label={t('settings.providers.providerLabel')}>
-          <select
+          <SelectLite
             value={llmProvider}
-            onChange={e => onLlmProviderChange(e.target.value as LlmPresetId)}
+            onChange={next => onLlmProviderChange(next as LlmPresetId)}
+            options={LLM_PRESETS.map(p => ({
+              value: p.id,
+              label: t(`settings.providers.presets.${p.nameKey}`),
+            }))}
+            ariaLabel={t('settings.providers.providerLabel')}
             style={{ ...inputStyle, maxWidth: 200 }}
-          >
-            {LLM_PRESETS.map(p => (
-              <option key={p.id} value={p.id}>{t(`settings.providers.presets.${p.nameKey}`)}</option>
-            ))}
-          </select>
+          />
         </SettingRow>
         {codexOAuthSelected ? (
           <div style={{ fontSize: 11.5, color: 'var(--ol-ink-4)', lineHeight: 1.6, margin: '2px 0 10px' }}>
@@ -1455,30 +1459,33 @@ function ProvidersSection() {
                 : null;
             return (
               <div style={{ display: 'flex', flexDirection: 'column', gap: 6, alignItems: 'flex-start', minWidth: 0 }}>
-                <select
+                <SelectLite
                   value={selectedValue}
                   disabled={isLocked}
-                  onChange={e => onAsrProviderChange(e.target.value as AsrPresetId)}
-                  style={{
-                    ...inputStyle,
-                    maxWidth: 200,
-                    ...(isLocked ? { opacity: 0.65, cursor: 'not-allowed' } : {}),
-                  }}
-                >
-                  {visibleAsrPresets.map(p => (
-                    <option key={p.id} value={p.id}>{t(`settings.providers.presets.${p.nameKey}`)}</option>
-                  ))}
-                  {platformLocalAsr && platformLocalNameKey && (
-                    <option key={platformLocalAsr} value={platformLocalAsr} disabled>
-                      {t(`settings.providers.presets.${platformLocalNameKey}`)}
-                    </option>
-                  )}
-                  {anomalousLocal && anomalousNameKey && (
-                    <option key={anomalousLocal} value={anomalousLocal} disabled>
-                      {t(`settings.providers.presets.${anomalousNameKey}`)}
-                    </option>
-                  )}
-                </select>
+                  onChange={next => onAsrProviderChange(next as AsrPresetId)}
+                  options={[
+                    ...visibleAsrPresets.map(p => ({
+                      value: p.id,
+                      label: t(`settings.providers.presets.${p.nameKey}`),
+                    })),
+                    ...(platformLocalAsr && platformLocalNameKey
+                      ? [{
+                          value: platformLocalAsr,
+                          label: t(`settings.providers.presets.${platformLocalNameKey}`),
+                          disabled: true,
+                        }]
+                      : []),
+                    ...(anomalousLocal && anomalousNameKey
+                      ? [{
+                          value: anomalousLocal,
+                          label: t(`settings.providers.presets.${anomalousNameKey}`),
+                          disabled: true,
+                        }]
+                      : []),
+                  ]}
+                  ariaLabel={t('settings.providers.providerLabel')}
+                  style={{ ...inputStyle, maxWidth: 200 }}
+                />
                 {platformLocalAsr && platformLocalNameKey && (
                   <div style={{ fontSize: 11, color: 'var(--ol-ink-4)', lineHeight: 1.5, maxWidth: 320 }}>
                     {t('settings.providers.localAsrTakeoverHint', {
@@ -1623,15 +1630,15 @@ function ProviderTools({ kind, modelAccount, onModelSelected }: { kind: 'llm' | 
           <button onClick={validate} style={miniBtnStyle} disabled={status === 'loading'}>{t('settings.providers.validate')}</button>
           <button onClick={loadModels} style={miniBtnStyle} disabled={status === 'loading'}>{t('settings.providers.fetchModels')}</button>
           {models.length > 0 && (
-            <select
+            <SelectLite
               value={selectedModel}
-              onChange={e => applyModel(e.target.value)}
+              onChange={applyModel}
               disabled={status === 'loading'}
+              options={models.map(model => ({ value: model, label: model }))}
+              placeholder={t('settings.providers.selectModel')}
+              ariaLabel={t('settings.providers.selectModel')}
               style={{ ...inputStyle, maxWidth: 220 }}
-            >
-              <option value="" disabled>{t('settings.providers.selectModel')}</option>
-              {models.map(model => <option key={model} value={model}>{model}</option>)}
-            </select>
+            />
           )}
         </div>
         {message && (

--- a/openless-all/app/src/pages/Translation.tsx
+++ b/openless-all/app/src/pages/Translation.tsx
@@ -4,10 +4,11 @@
 //   - 选一个翻译目标语言（单选；选"不启用"则 Shift 不触发翻译）
 //   - 看完整使用说明（怎么触发、按钮位置、胶囊显示）
 
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Card, PageHeader } from './_atoms';
 import { SavedToast } from '../components/SavedToast';
+import { SelectLite } from '../components/ui/SelectLite';
 import { SUPPORTED_LANGUAGES } from '../lib/types';
 import { useHotkeySettings } from '../state/HotkeySettingsContext';
 import { formatComboLabel } from '../lib/hotkey';
@@ -120,6 +121,11 @@ export function Translation() {
   const translationHotkeyLabel = formatComboLabel(prefs.translationHotkey);
   const enabled = prefs.translationTargetLanguage.trim() !== '';
 
+  const targetOptions = useMemo(() => ([
+    { value: '', label: t('translation.target.disabled') },
+    ...SUPPORTED_LANGUAGES.map(lang => ({ value: lang, label: lang })),
+  ]), [t]);
+
   return (
     <>
       <PageHeader title={t('translation.title')} />
@@ -216,28 +222,14 @@ export function Translation() {
               {enabled ? t('translation.statusEnabled') : t('translation.statusDisabled')}
             </span>
           </div>
-          <select
+          <SelectLite
             value={prefs.translationTargetLanguage}
-            onChange={e => onTargetChange(e.target.value)}
-            style={{
-              width: '100%',
-              maxWidth: 360,
-              height: 32,
-              padding: '0 10px',
-              fontSize: 13,
-              border: '0.5px solid var(--ol-line-strong)',
-              borderRadius: 8,
-              background: '#fff',
-              color: 'var(--ol-ink)',
-              fontFamily: 'inherit',
-              cursor: 'default',
-            }}
-          >
-            <option value="">{t('translation.target.disabled')}</option>
-            {SUPPORTED_LANGUAGES.map(lang => (
-              <option key={lang} value={lang}>{lang}</option>
-            ))}
-          </select>
+            onChange={onTargetChange}
+            options={targetOptions}
+            placeholder={t('translation.target.disabled')}
+            ariaLabel={t('translation.target.title')}
+            style={{ width: '100%', maxWidth: 360, fontSize: 13, background: '#fff' }}
+          />
         </Card>
 
         {/* 3. 使用方法 */}

--- a/openless-all/app/src/pages/settings/LanguageSection.tsx
+++ b/openless-all/app/src/pages/settings/LanguageSection.tsx
@@ -1,7 +1,7 @@
 // 语言切换面板：跟随系统 / 简中 / 繁中 / 英文 / 日文 (Beta) / 韩文 (Beta)。
 // 切换语言同时把对应的 outputPrefs（中文偏好、输出语言）合并进 prefs。
 
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useHotkeySettings } from '../../state/HotkeySettingsContext';
 import {
@@ -11,13 +11,23 @@ import {
   setLocalePreference,
   type SupportedLocale,
 } from '../../i18n';
+import { SelectLite } from '../../components/ui/SelectLite';
 import { Card } from '../_atoms';
-import { SettingRow, inputStyle } from './shared';
+import { SettingRow } from './shared';
 
 export function LanguageSection() {
   const { t } = useTranslation();
   const { updatePrefs } = useHotkeySettings();
   const [pref, setPref] = useState<SupportedLocale | typeof FOLLOW_SYSTEM>(getLocalePreference());
+
+  const options = useMemo(() => ([
+    { value: FOLLOW_SYSTEM, label: t('settings.language.followSystem') },
+    { value: 'zh-CN', label: t('settings.language.zh') },
+    { value: 'zh-TW', label: t('settings.language.zhTW') },
+    { value: 'en', label: t('settings.language.en') },
+    { value: 'ja', label: t('settings.language.ja') },
+    { value: 'ko', label: t('settings.language.ko') },
+  ]), [t]);
 
   const apply = async (next: SupportedLocale | typeof FOLLOW_SYSTEM) => {
     setPref(next);
@@ -39,18 +49,13 @@ export function LanguageSection() {
       <div style={{ fontSize: 13, fontWeight: 600, marginBottom: 4 }}>{t('settings.language.title')}</div>
       <div style={{ fontSize: 11.5, color: 'var(--ol-ink-4)', marginBottom: 6 }}>{t('settings.language.desc')}</div>
       <SettingRow label={t('settings.language.label')} desc={t('settings.language.labelDesc')}>
-        <select
+        <SelectLite
           value={pref}
-          onChange={e => apply(e.target.value as SupportedLocale | typeof FOLLOW_SYSTEM)}
-          style={{ ...inputStyle, maxWidth: 220 }}
-        >
-          <option value={FOLLOW_SYSTEM}>{t('settings.language.followSystem')}</option>
-          <option value="zh-CN">{t('settings.language.zh')}</option>
-          <option value="zh-TW">{t('settings.language.zhTW')}</option>
-          <option value="en">{t('settings.language.en')}</option>
-          <option value="ja">{t('settings.language.ja')}</option>
-          <option value="ko">{t('settings.language.ko')}</option>
-        </select>
+          onChange={next => apply(next as SupportedLocale | typeof FOLLOW_SYSTEM)}
+          options={options}
+          ariaLabel={t('settings.language.label')}
+          style={{ maxWidth: 220, minWidth: 200 }}
+        />
       </SettingRow>
       <div style={{ fontSize: 11, color: 'var(--ol-ink-4)', marginTop: 8, lineHeight: 1.6 }}>
         {t('settings.language.restartHint')}

--- a/openless-all/app/src/styles/global.css
+++ b/openless-all/app/src/styles/global.css
@@ -27,6 +27,11 @@ button {
   padding: 0;
 }
 
+@keyframes ol-select-pop {
+  from { opacity: 0; transform: translateY(-4px) scale(.98); }
+  to   { opacity: 1; transform: translateY(0) scale(1); }
+}
+
 input, textarea {
   font-family: inherit;
   user-select: text;

--- a/openless-all/app/src/styles/global.css
+++ b/openless-all/app/src/styles/global.css
@@ -32,6 +32,13 @@ button {
   to   { opacity: 1; transform: translateY(0) scale(1); }
 }
 
+/* 键盘焦点指示：鼠标点击 (:focus) 不显示，键盘 Tab (:focus-visible) 才显示。
+   用 box-shadow 而非 outline 是因为组件内联 style 可能用 outline:none
+   把默认 ring 干掉，box-shadow 不受影响仍能上色。配合 pr-agent #407 的 a11y 要求。 */
+.ol-focus-ring:focus-visible {
+  box-shadow: 0 0 0 2px rgba(37, 99, 235, 0.45);
+}
+
 input, textarea {
   font-family: inherit;
   user-select: text;


### PR DESCRIPTION
### **User description**
## Summary

Windows 端 UI 一致性整理。三件事打包：

- **Windows 原生 chrome**：删除自定义标题栏 + resize handles，交还 Tauri `decorations:true` 原生 Win11 标题栏。修复用户反馈的 X 按钮重叠 + 圆角处黑边/白线（双层 chrome 之间露出的窗口背景）。macOS 路径零变化。
- **胶囊缩小 (#417)**：Windows pill 从 196×52、textWidth 104 缩到 180×44、textWidth 88，与 macOS 的 176×42/84 视觉密度对齐。
- **自定义下拉 (#418)**：`SelectLite` 重写为完整受控组件——portal popover、键盘 Arrow/Enter/Esc/Tab 导航、视口边缘自动翻转、`role="combobox"` / `role="listbox"` a11y。替换全仓库 11 处 native `<select>`，彻底绕开 Win32 ComboBox 的直角丑框。
- 顺手收尾：删 "个性化 → 界面语言" 的重复入口（"设置 → 语言" 早有等价控件）；SwitchLite 加 `outline:none` 解决 Windows 上开关黑框；保留 `_atoms.tsx` Collapsible 的键盘 outline（pr-agent #407）。

## Closes
- #417
- #418

## Test plan
- [ ] Windows: 主窗口顶部是原生 Win11 标题栏，X 按钮只有一个
- [ ] Windows: 主窗口四角无黑色三角缝隙
- [ ] Windows: 胶囊视觉尺寸明显小于改前，与 macOS 接近
- [ ] Windows: Settings / Translation / LocalAsr / Language 所有下拉弹框是圆角玻璃感（不是直角丑框）
- [ ] Windows: 下拉键盘 Arrow/Enter/Esc 工作
- [ ] Windows: 下拉位于窗口底部时自动向上翻转，不被裁剪
- [ ] Windows: 点击 Toggle 开关无黑色焦点框
- [ ] Windows: Tab 键导航到 Collapsible 按钮时仍有默认 outline（a11y）
- [ ] macOS: 视觉零变化（流量灯、毛玻璃、入场动画都和改前一致）
- [ ] 个性化分区不再有 "界面语言" 行；"设置 → 语言" 仍可正常切换 UI 语言
- [ ] `npx tsc --noEmit` 干净（CI 上 build 也应该绿）


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Replace native `<select>` with portal-based custom `SelectLite` dropdown for glass styling and keyboard a11y
  - Sub‑bullet: covers Settings, LocalAsr, Translation, and Language sections

- Remove Windows custom title bar and resize handles, restoring native Win11 decorations
  - Sub‑bullet: fixes X‑button overlap and corner black‑line artifacts

- Downsize Windows capsule pill to 180×44 for visual parity with macOS

- Delete duplicate interface‑language picker from Personalize; keep in Language section only

- Add `.ol-focus-ring` class for keyboard focus visibility across components


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["WindowChrome.tsx: custom chrome removed"] --> B["Native Win11 title bar"]
  C["capsuleLayout.ts: smaller metrics"] --> D["Windows pill matches macOS"]
  E["SelectLite.tsx: full dropdown component"] --> F["Replaces all native <select>"]
  G["SettingsModal.tsx: LanguagePicker deleted"] --> H["One language entry point"]
  I["global.css: .ol-focus-ring"] --> J["Keyboard ring on buttons/dropdowns"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>WindowChrome.tsx</strong><dd><code>Remove Windows custom title bar and resize handles</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/419/files#diff-ca98272202276bc772e02f5bdd6dfd006d06a0da7bb6d9705d03e1da14edca4c">+20/-189</a></td>

</tr>

<tr>
  <td><strong>capsuleLayout.ts</strong><dd><code>Reduce Windows pill to 180×44 for macOS parity</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/419/files#diff-64a0fa382ce669f9eb4d0aa71205f37ecbc20817808cbc9f8fb792d7b8db9d7f">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>7 files</summary><table>
<tr>
  <td><strong>SelectLite.tsx</strong><dd><code>Rewrite as controlled dropdown with portal popover and a11y</code></dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/419/files#diff-c625bbec3046e9adc89a9a80594523d3afdd25a2c6edea0e1f06a8c2b5a04ba6">+288/-14</a></td>

</tr>

<tr>
  <td><strong>SwitchLite.tsx</strong><dd><code>Add .ol-focus-ring and outline:none</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/419/files#diff-969694d4888603c8d3dfd5b0c230d1fb12a7575a1d01676ac4d632f0c9fa8ab8">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>LocalAsr.tsx</strong><dd><code>Swap native <select> for SelectLite (5 instances)</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/419/files#diff-35c7e3db3ea48b533df9bb63195bf0f2762ed382d681aee7f0da7e3a246e881d">+52/-82</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>Settings.tsx</strong><dd><code>Replace all native <select> with SelectLite</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/419/files#diff-b493ca85e083b07f67da1b3ac96aeab153b20c97405e26292b47b95e13368c38">+49/-42</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>Translation.tsx</strong><dd><code>Replace native target‑language <select> with SelectLite</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/419/files#diff-ac2243e818f550360a2beccf9a687f0e6c42d75fe8736a09d8823d15d20bc761">+14/-22</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>LanguageSection.tsx</strong><dd><code>Replace native language <select> with SelectLite</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/419/files#diff-b41f608eeb7629dc7de5594975838f48613f383ba96e73a8d186b120eb216250">+18/-13</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>global.css</strong><dd><code>Add ol-select-pop keyframe and .ol-focus-ring class</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/419/files#diff-ba6dfef13673e14e7e2ae1888f48b081d20a99e6b5a93c451cff7096e80ea47f">+12/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Cleanup</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>SettingsModal.tsx</strong><dd><code>Delete duplicate LanguagePicker from Personalize section</code>&nbsp; </dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/419/files#diff-518aaa44065a9800e52b80d874e513ea210188d25cba2cff3e258b88c05c96cf">+0/-54</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>en.ts</strong><dd><code>Remove personalize.language key</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/419/files#diff-bb2f4fa05787923f8aeb23b6f11ad8705e02d9ff03a45790f9181e4615c79d83">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ja.ts</strong><dd><code>Remove personalize.language key</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/419/files#diff-be57f0090cf34e3ff924cfa35f13d5d9e6514d3af5a1ebfdeb92bd7d36ed9cf4">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ko.ts</strong><dd><code>Remove personalize.language key</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/419/files#diff-daf35bcb6a2f8a31565b83d119cb59b69c1dededbabfccfd0d56693fdb3726ca">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>zh-CN.ts</strong><dd><code>Remove personalize.language key</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/419/files#diff-571576f3c7b6c4a78ae0f91accdccc5da5cbed00409955c9914c046fee6c80ea">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>zh-TW.ts</strong><dd><code>Remove personalize.language key</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/419/files#diff-a8d5953f9c76bc3c90ec583270be04c852bd7540297500e6ff3260760fc61ea4">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

