### PR TITLE
Route qwen-asr submodule through organization fork

### DIFF
--- a/.github/workflows/release-tauri.yml
+++ b/.github/workflows/release-tauri.yml
@@ -59,7 +59,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           # vendor/qwen-asr 是 macOS 上 build.rs 必须的 git submodule（cc-rs 编译
-          # antirez/qwen-asr 的 C 源），不拉就会在 mac 端 cargo build 阶段挂掉。
+          # Open-Less/qwen-asr fork 的 C 源），不拉就会在 mac 端 cargo build 阶段挂掉。
           submodules: recursive
 
       - uses: actions/setup-node@v4

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "openless-all/app/src-tauri/vendor/qwen-asr"]
 	path = openless-all/app/src-tauri/vendor/qwen-asr
-	url = https://github.com/antirez/qwen-asr.git
+	url = https://github.com/Open-Less/qwen-asr.git

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ OpenLess does one thing: **turn speech into usable written text (especially AI p
 - Tauri 2 + Rust backend + React/TS frontend. macOS 12+, Windows 10+.
 - **Toggle and push-to-talk** recording modes. `Esc` cancels at any phase, including polish/insert.
 - **Cloud ASR**: Volcengine streaming ASR, OpenAI Whisper-compatible batch ASR, Apple Speech (macOS).
-- **Local ASR**: bundled Qwen3-ASR (0.6B / 1.7B) via vendored `antirez/qwen-asr`; Windows Foundry Local Whisper variants.
+- **Local ASR**: bundled Qwen3-ASR (0.6B / 1.7B) via vendored `Open-Less/qwen-asr`; Windows Foundry Local Whisper variants.
 - **Polish providers**: Ark / DeepSeek / OpenAI / Doubao / Anthropic-compatible chat-completions, plus any OpenAI-compatible endpoint you bring.
 - 4 output modes: raw, light polish, structured (**AI prompt mode**), formal. Plus a **translation hotkey** that converts speech directly into the configured target language ([#43](../../issues/43)).
 - **Selection-ask QA panel** — separate hotkey opens a floating panel that runs voice Q&A against the highlighted text in any app ([#118](../../issues/118)).
@@ -189,7 +189,7 @@ Full end-user walkthrough: [USAGE.md](USAGE.md).
 
 ## Build from source (developers)
 
-The active codebase is in `openless-all/app/` (Tauri 2 + Rust + React/TS). The macOS build links a vendored C ASR engine ([`antirez/qwen-asr`](https://github.com/antirez/qwen-asr)) pulled in as a git submodule under `src-tauri/vendor/qwen-asr/`, so initialize submodules on first clone.
+The active codebase is in `openless-all/app/` (Tauri 2 + Rust + React/TS). The macOS build links a vendored C ASR engine ([`Open-Less/qwen-asr`](https://github.com/Open-Less/qwen-asr), forked from `antirez/qwen-asr`) pulled in as a git submodule under `src-tauri/vendor/qwen-asr/`, so initialize submodules on first clone.
 
 ```bash
 # First clone only — pull in vendored submodules

--- a/README.zh.md
+++ b/README.zh.md
@@ -141,7 +141,7 @@ OpenLess 只做一件事：**把语音变成可用的书面文字（尤其是 AI
 - Tauri 2 + Rust 后端 + React/TS 前端；macOS 12+，Windows 10+。
 - **切换式 + 按住说话** 双模式录音；任意阶段按 `Esc` 都能取消（包括润色 / 插入中）。
 - **云端 ASR**：火山引擎流式 ASR、OpenAI Whisper 兼容批式 ASR、Apple Speech（macOS）。
-- **本地 ASR**：内置 Qwen3-ASR（0.6B / 1.7B），通过 vendored `antirez/qwen-asr` 链接；Windows 端支持 Foundry Local Whisper。
+- **本地 ASR**：内置 Qwen3-ASR（0.6B / 1.7B），通过 vendored `Open-Less/qwen-asr` 链接；Windows 端支持 Foundry Local Whisper。
 - **润色 Provider**：Ark / DeepSeek / OpenAI / Doubao / Anthropic 兼容的 Chat Completions，以及任意 OpenAI 兼容的自定义 endpoint。
 - 4 种输出模式：原文、轻度润色、清晰结构（**AI prompt 模式**）、正式表达。另含**翻译热键**——按下后说一段话直接转成目标语言插入（[#43](../../issues/43)）。
 - **划词语音问答（QA）面板** — 独立热键打开浮窗，对当前选中文本发起语音 Q&A（[#118](../../issues/118)）。
@@ -192,7 +192,7 @@ OpenLess 只做一件事：**把语音变成可用的书面文字（尤其是 AI
 
 ## 从源码构建（开发者）
 
-当前活跃代码库在 `openless-all/app/`（Tauri 2 + Rust + React/TS）。macOS 构建会链接一份 vendored 的本地 ASR 引擎（[`antirez/qwen-asr`](https://github.com/antirez/qwen-asr)），以 git submodule 形式挂在 `src-tauri/vendor/qwen-asr/`，首次 clone 后必须先拉子模块。
+当前活跃代码库在 `openless-all/app/`（Tauri 2 + Rust + React/TS）。macOS 构建会链接一份 vendored 的本地 ASR 引擎（[`Open-Less/qwen-asr`](https://github.com/Open-Less/qwen-asr)，fork 自 `antirez/qwen-asr`），以 git submodule 形式挂在 `src-tauri/vendor/qwen-asr/`，首次 clone 后必须先拉子模块。
 
 ```bash
 # 首次 clone 后拉取子模块

--- a/docs/qwen-asr-submodule-upgrade-checklist.md
+++ b/docs/qwen-asr-submodule-upgrade-checklist.md
@@ -1,0 +1,49 @@
+# qwen-asr submodule 升级检查清单
+
+`openless-all/app/src-tauri/vendor/qwen-asr` 是 macOS 本地 Qwen3-ASR 的 C 引擎来源。OpenLess 只从组织 fork `https://github.com/Open-Less/qwen-asr.git` 拉取 submodule；`antirez/qwen-asr` 只作为上游同步来源，不直接进入主仓构建链路。
+
+## 升级原则
+
+- 不直接把 `.gitmodules` 改回个人上游仓库。
+- 不在未审查 upstream diff 的情况下推进 submodule commit。
+- 每次升级只推进 submodule 指针；除非编译或 FFI 必需，不混入 OpenLess 主项目逻辑改动。
+- 保留当前锁定 commit 的可回滚性，必要时能 `git checkout <old-commit> -- openless-all/app/src-tauri/vendor/qwen-asr` 回退。
+
+## 操作步骤
+
+1. 在 `Open-Less/qwen-asr` fork 中同步 upstream。
+2. 审查 fork 中待引入 commit：
+   - C 源码：`qwen_asr*.c`、`qwen_asr*.h`
+   - 构建脚本 / 模型下载脚本
+   - 新增二进制、大文件、网络下载地址或 shell 命令
+   - FFI API 是否改变：`qwen_load`、`qwen_free`、`qwen_set_token_callback`、`qwen_transcribe_audio`、`qwen_transcribe_stream`
+3. 在 OpenLess 主仓更新 submodule：
+   ```bash
+   git submodule sync --recursive openless-all/app/src-tauri/vendor/qwen-asr
+   git submodule update --init --recursive openless-all/app/src-tauri/vendor/qwen-asr
+   cd openless-all/app/src-tauri/vendor/qwen-asr
+   git fetch origin
+   git checkout <reviewed-commit>
+   cd -
+   ```
+4. 验证 submodule 来源仍是组织 fork：
+   ```bash
+   git config --file .gitmodules --get submodule.openless-all/app/src-tauri/vendor/qwen-asr.url
+   git -C openless-all/app/src-tauri/vendor/qwen-asr remote get-url origin
+   git submodule status openless-all/app/src-tauri/vendor/qwen-asr
+   git diff --submodule=log -- openless-all/app/src-tauri/vendor/qwen-asr
+   ```
+5. 至少运行：
+   ```bash
+   cd openless-all/app
+   npm run build
+   cargo check --manifest-path src-tauri/Cargo.toml
+   ```
+   macOS 发布前还要用 `INSTALL=0 ./scripts/build-mac.sh` 验证 C 源编译和链接。
+
+## PR / commit 说明必须包含
+
+- 旧 submodule commit 和新 submodule commit。
+- 已审查的 upstream commit 范围。
+- 是否有 FFI API、模型文件结构、下载脚本或构建参数变化。
+- 已运行的验证命令和未覆盖的平台。

--- a/openless-all/README.md
+++ b/openless-all/README.md
@@ -4,7 +4,7 @@ This is the current cross-platform OpenLess workspace.
 
 ## App Directory
 
-The runnable Tauri app lives in `app/`. The macOS build links a vendored C ASR engine (`antirez/qwen-asr`) tracked as a git submodule under `app/src-tauri/vendor/qwen-asr/`, so initialize submodules on first clone.
+The runnable Tauri app lives in `app/`. The macOS build links a vendored C ASR engine (`Open-Less/qwen-asr`, forked from `antirez/qwen-asr`) tracked as a git submodule under `app/src-tauri/vendor/qwen-asr/`, so initialize submodules on first clone.
 
 ```bash
 # First clone only — pull in vendored submodules

--- a/openless-all/app/src-tauri/Cargo.toml
+++ b/openless-all/app/src-tauri/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["staticlib", "cdylib", "rlib"]
 
 [build-dependencies]
 tauri-build = { version = "2", features = [] }
-# Compile antirez/qwen-asr C sources for the local ASR engine on macOS.
+# Compile vendored Open-Less/qwen-asr C sources for the local ASR engine on macOS.
 cc = "1.1"
 
 [dependencies]
@@ -74,7 +74,7 @@ core-graphics = "0.24"
 objc2 = "0.5"
 objc2-foundation = "0.2"
 objc2-app-kit = "0.2"
-# antirez/qwen-asr 用 malloc 分配返回字符串，必须用 C `free()` 释放。
+# qwen-asr 用 malloc 分配返回字符串，必须用 C `free()` 释放。
 libc = "0.2"
 
 [target.'cfg(target_os = "windows")'.dependencies]

--- a/openless-all/app/src-tauri/build.rs
+++ b/openless-all/app/src-tauri/build.rs
@@ -5,7 +5,7 @@ fn main() {
     tauri_build::build();
 }
 
-/// 编译 antirez/qwen-asr 的 C 源（仅 macOS）。
+/// 编译 vendored Open-Less/qwen-asr 的 C 源（仅 macOS）。
 ///
 /// 上游 Makefile `make blas` 等价配置：BLAS 加速通过 Accelerate framework，
 /// `USE_BLAS` + `ACCELERATE_NEW_LAPACK` 是必要宏。
@@ -34,7 +34,7 @@ fn build_qwen_asr_macos() {
         .define("ACCELERATE_NEW_LAPACK", None)
         .flag("-O3")
         .flag("-ffast-math")
-        // 上游开 `-Wall -Wextra`；我们把 antirez 的代码当三方依赖，把无关警告压成静默
+        // 上游开 `-Wall -Wextra`；我们把 qwen-asr 的代码当三方依赖，把无关警告压成静默
         // 避免 build log 噪音淹没我们自己的告警。
         .flag("-Wno-unused-parameter")
         .flag("-Wno-unused-variable")

--- a/openless-all/app/src-tauri/src/asr/local/mod.rs
+++ b/openless-all/app/src-tauri/src/asr/local/mod.rs
@@ -1,6 +1,6 @@
 //! 本地 ASR 引擎入口。
 //!
-//! 当前只在 macOS 编入 antirez/qwen-asr (纯 C + Accelerate)；Windows 端
+//! 当前只在 macOS 编入 vendored Open-Less/qwen-asr (纯 C + Accelerate)；Windows 端
 //! 的本地推理路径见 issue #256，本期不实现。
 
 pub mod cache;

--- a/openless-all/app/src-tauri/src/asr/local/qwen_engine.rs
+++ b/openless-all/app/src-tauri/src/asr/local/qwen_engine.rs
@@ -1,4 +1,4 @@
-//! antirez/qwen-asr 的安全 Rust 包装。
+//! vendored Open-Less/qwen-asr 的安全 Rust 包装。
 //!
 //! 当前只暴露**最小可用面**：`load` / `transcribe_audio` / `transcribe_stream`
 //! + token 回调。后续接 coordinator 时再扩 prompt/language 设置。
@@ -35,7 +35,7 @@ unsafe impl Sync for QwenAsrEngine {}
 
 impl QwenAsrEngine {
     /// 从模型目录加载（目录里需含 `config.json` / `model.safetensors*` /
-    /// `vocab.json` / `merges.txt`，结构见 antirez `download_model.sh`）。
+    /// `vocab.json` / `merges.txt`，结构见 qwen-asr `download_model.sh`）。
     pub fn load(model_dir: &Path) -> Result<Self> {
         let dir_str = model_dir
             .to_str()

--- a/openless-all/app/src-tauri/src/asr/local/qwen_ffi.rs
+++ b/openless-all/app/src-tauri/src/asr/local/qwen_ffi.rs
@@ -1,4 +1,4 @@
-//! 对 antirez/qwen-asr 公共 C API 的最小 FFI 声明。
+//! 对 vendored Open-Less/qwen-asr 公共 C API 的最小 FFI 声明。
 //!
 //! 头文件见 `vendor/qwen-asr/qwen_asr.h`。这里**不**复刻 `qwen_ctx_t`
 //! 内部布局——保持不透明指针即可，避免 pthread/对齐相关的脆弱假设。

--- a/openless-all/app/src-tauri/src/persistence.rs
+++ b/openless-all/app/src-tauri/src/persistence.rs
@@ -125,7 +125,7 @@ fn ensure_dir(dir: &Path) -> Result<()> {
 }
 
 /// 本地 ASR 模型根目录：`<data_dir>/models/qwen3-asr/`。
-/// 子目录 = 模型 id（如 `qwen3-asr-0.6b`），存 antirez `download_model.sh`
+/// 子目录 = 模型 id（如 `qwen3-asr-0.6b`），存 qwen-asr `download_model.sh`
 /// 列出的 5–7 个文件。
 pub fn local_models_root() -> Result<PathBuf> {
     let dir = data_dir()?.join("models").join("qwen3-asr");

--- a/openless-all/app/src/lib/localAsr.ts
+++ b/openless-all/app/src/lib/localAsr.ts
@@ -14,7 +14,7 @@ export interface LocalAsrSettings {
   providerId: string;
   activeModel: string;
   mirror: string;
-  /** macOS 才编入 antirez/qwen-asr 引擎；Win 端 UI 据此把"开始"按钮灰掉。 */
+  /** macOS 才编入 vendored Open-Less/qwen-asr 引擎；Win 端 UI 据此把"开始"按钮灰掉。 */
   engineAvailable: boolean;
 }
 


### PR DESCRIPTION
### **User description**
## Summary
- move `vendor/qwen-asr` submodule URL from the personal upstream repo to `Open-Less/qwen-asr`
- keep the submodule pinned at the current reviewed commit `b00b789b17051aea61e9717458171100662318a4`
- document the future qwen-asr submodule upgrade review checklist

Closes #301

## Verification
- `gh repo view Open-Less/qwen-asr --json nameWithOwner,isFork,parent,defaultBranchRef,updatedAt,url`
- `git submodule update --init --recursive openless-all/app/src-tauri/vendor/qwen-asr`
- `git diff --check`
- `npm run build`
- `cargo check --manifest-path src-tauri/Cargo.toml`

## Not tested
- macOS `INSTALL=0 ./scripts/build-mac.sh` C-link verification (not available in this Linux session)


___

### **PR Type**
Enhancement, Documentation


___

### **Description**
- Switch `vendor/qwen-asr` submodule URL from personal upstream to `Open-Less/qwen-asr` fork

- Add `docs/qwen-asr-submodule-upgrade-checklist.md` with review process and safety steps

- Update all in-code comments, docs, and CI config to reference the new fork


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["antirez/qwen-asr (upstream)"] -- "forks to" --> B["Open-Less/qwen-asr"]
  B -- "becomes submodule URL" --> C[".gitmodules"]
  C -- "comment & doc updates" --> D["Rust source files, READMEs, CI"]
  C -- "new file" --> E["docs/qwen-asr-submodule-upgrade-checklist.md"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>.gitmodules</strong><dd><code>Point submodule URL to organization fork `Open-Less/qwen-asr`</code></dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/424/files#diff-fe7afb5c9c916e521401d3fcfb4277d5071798c3baf83baf11d6071742823584">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>12 files</summary><table>
<tr>
  <td><strong>qwen-asr-submodule-upgrade-checklist.md</strong><dd><code>Add thorough upgrade checklist for qwen-asr submodule</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/424/files#diff-cad47a5a3976b8a1eca04239c4c59e583ae4bfebbcca847bc73d762a96a6d1b4">+49/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>build.rs</strong><dd><code>Update comment to reference `Open-Less/qwen-asr` instead of antirez</code></dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/424/files#diff-23a18e9d7f95098dba8f2c841bcea8d436ca8971fcd3268c75a812e4b2ab306a">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>Cargo.toml</strong><dd><code>Update dependency comments to mention `Open-Less/qwen-asr`</code></dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/424/files#diff-334952ba03e62939865bbf0351f0916ea88c6457f8ea1259336e73ee4e2f088b">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>mod.rs</strong><dd><code>Adjust module doc to note vendored `Open-Less/qwen-asr` engine</code></dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/424/files#diff-ec9502d9604ecbd21442964972db1a78783dac407d9734d81c3d082d424fa62d">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>qwen_engine.rs</strong><dd><code>Revise doc comments to refer to `Open-Less/qwen-asr` fork</code></dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/424/files#diff-983299174f88fae08767128a403bb2c235fa7c6ed5773ad0b01d28b0b2228d19">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>qwen_ffi.rs</strong><dd><code>Update FFI doc comment to mention vendored `Open-Less/qwen-asr`</code></dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/424/files#diff-162a3edc92f71372863208e08b3f4168b086baa8bae8a60f2bee27ce0209a419">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>persistence.rs</strong><dd><code>Change inline doc from antirez to `qwen-asr` (fork)</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/424/files#diff-fe150b5c0806f2cac2827075208fe552ab2b17590ad3dddfbdbdc240084e1adb">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>localAsr.ts</strong><dd><code>Adjust comment to reference `Open-Less/qwen-asr` engine availability</code></dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/424/files#diff-d0e5f04ee3e7e20d560f0a2450a2fcabc9b7d99f32cad392c8c9204d20e3cc0b">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>release-tauri.yml</strong><dd><code>Update CI comment about submodule source being `Open-Less/qwen-asr`</code></dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/424/files#diff-cac78cd4d340dc05703d65bee14ea766337499de655e15553ceb8181eef097cb">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>README.md</strong><dd><code>Replace <code>antirez/qwen-asr</code> with <code>Open-Less/qwen-asr</code> in key descriptions</code></dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/424/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>README.zh.md</strong><dd><code>Sync Chinese README with new `Open-Less/qwen-asr` fork reference</code></dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/424/files#diff-b024066e6d6250813a9bc9284332cc3b84edc264857d6a671b7513f2c7ef90a8">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>README.md</strong><dd><code>Update submodule description to point to `Open-Less/qwen-asr`</code></dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/424/files#diff-8ef407d59b06770de238fdd10b58968ed239cc0db8686e099d8fbbf49741f31b">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

