### PR TITLE
fix(local-asr): Qwen3-ASR 长语音末段丢内容 + 长录音超时

### DIFF
--- a/openless-all/app/src-tauri/src/asr/local/local_provider.rs
+++ b/openless-all/app/src-tauri/src/asr/local/local_provider.rs
@@ -41,6 +41,13 @@ impl LocalQwenAsr {
         }
     }
 
+    /// 当前缓冲音频时长（毫秒）。Coordinator 在 transcribe() 调用前读取，
+    /// 用来给本地 Qwen ASR 计算动态超时（max(15, ceil(audio_s × 0.6) + 10)）。
+    /// 不消费缓冲。
+    pub fn buffer_duration_ms(&self) -> u64 {
+        (self.buffer.lock().len() as u64 / 2) * 1000 / 16_000
+    }
+
     /// stop 时调用：把 buffer 的 i16 PCM 转 f32，跑流式转写，token 实时
     /// 通过事件吐到前端胶囊；最终文本一起返回供 polish/insert。
     pub async fn transcribe(self: Arc<Self>) -> Result<RawTranscript> {
@@ -52,7 +59,13 @@ impl LocalQwenAsr {
             });
         }
         let duration_ms = (pcm_bytes.len() as u64 / 2) * 1000 / 16_000;
-        let samples_f32 = i16_le_bytes_to_f32(&pcm_bytes);
+        let mut samples_f32 = i16_le_bytes_to_f32(&pcm_bytes);
+        // `transcribe_stream` 内部按 2s chunk 切片；末 chunk < 2s 且缓冲没有
+        // 静默尾巴时，C 引擎不会把它当作"语音已结束"，该 chunk 的转写结果
+        // 会被丢弃，导致末段内容消失。这里追加 0.5s 静默（@16kHz = 8000 个
+        // f32 零值）作为收尾信号。`duration_ms` 仍按原始缓冲长度计算（上面
+        // 一行），padding 不计入。
+        samples_f32.extend(std::iter::repeat(0.0f32).take(8_000));
 
         // 注册 token 回调：每个稳定 token 抛 `local-asr-token` 事件。
         // capsule 前端按 sessionId 累积显示。

--- a/openless-all/app/src-tauri/src/coordinator.rs
+++ b/openless-all/app/src-tauri/src/coordinator.rs
@@ -3096,6 +3096,42 @@ mod tests {
         );
     }
 
+    #[test]
+    fn local_qwen_timeout_floors_at_global_timeout_for_short_audio() {
+        // 5s 录音：5 × 0.6 = 3, +10 = 13, max(15) = 15。短录音保留 15s 兜底。
+        assert_eq!(
+            local_qwen_transcribe_timeout(5.0),
+            std::time::Duration::from_secs(COORDINATOR_GLOBAL_TIMEOUT_SECS)
+        );
+    }
+
+    #[test]
+    fn local_qwen_timeout_scales_with_audio_duration() {
+        // 60s 录音：60 × 0.6 = 36, +10 = 46s。覆盖 RTF ≈ 0.5 的边界。
+        assert_eq!(
+            local_qwen_transcribe_timeout(60.0),
+            std::time::Duration::from_secs(46)
+        );
+    }
+
+    #[test]
+    fn local_qwen_timeout_ceils_partial_seconds() {
+        // 10.1s 录音：10.1 × 0.6 = 6.06, ceil = 7, +10 = 17, max(15) = 17。
+        assert_eq!(
+            local_qwen_transcribe_timeout(10.1),
+            std::time::Duration::from_secs(17)
+        );
+    }
+
+    #[test]
+    fn local_qwen_timeout_handles_zero_duration() {
+        // 0 时长（空 buffer 边界）：0 × 0.6 = 0, +10 = 10, max(15) = 15。
+        assert_eq!(
+            local_qwen_transcribe_timeout(0.0),
+            std::time::Duration::from_secs(COORDINATOR_GLOBAL_TIMEOUT_SECS)
+        );
+    }
+
     #[cfg(target_os = "windows")]
     #[test]
     fn foundry_release_uses_foundry_keep_loaded_preference() {
@@ -3595,6 +3631,17 @@ const COORDINATOR_GLOBAL_TIMEOUT_SECS: u64 = 15;
 #[cfg(target_os = "windows")]
 fn foundry_audio_transcribe_timeout_duration() -> std::time::Duration {
     std::time::Duration::from_secs(COORDINATOR_GLOBAL_TIMEOUT_SECS)
+}
+
+/// 本地 Qwen3-ASR 的动态转写超时。固定 15 秒在长录音（≥ 30s）+ 慢机器
+/// （RTF ≈ 0.3–0.5）上必然超时把整段内容丢掉。改用 max(15, ceil(audio_s
+/// × 0.6) + 10)：基础保留 15s 兜住短录音；长录音按音频长度的 0.6 倍 +
+/// 10s 余量，覆盖 RTF ≤ 0.5 的机器。
+fn local_qwen_transcribe_timeout(audio_secs: f64) -> std::time::Duration {
+    let secs = ((audio_secs * 0.6).ceil() as u64)
+        .saturating_add(10)
+        .max(COORDINATOR_GLOBAL_TIMEOUT_SECS);
+    std::time::Duration::from_secs(secs)
 }
 
 /// 检查 begin_session 的 await 间隙是否被 cancel_session 打断。

--- a/openless-all/app/src-tauri/src/coordinator/dictation.rs
+++ b/openless-all/app/src-tauri/src/coordinator/dictation.rs
@@ -1120,10 +1120,18 @@ pub(super) async fn end_session(inner: &Arc<Inner>) -> Result<(), String> {
         #[cfg(target_os = "macos")]
         ActiveAsr::Local(local) => {
             debug_assert!(uses_global_timeout);
-            // 与 Volcengine/Whisper 一致包一层 global timeout（来自 origin/main）。
-            // 注：缓存命中时 transcribe 不含 load 时间；冷启动 load 已在 build_local_qwen3
-            // 提前完成，所以 15s 给 transcribe 本身足够。
-            let timeout_duration = std::time::Duration::from_secs(COORDINATOR_GLOBAL_TIMEOUT_SECS);
+            // 缓存命中时 transcribe 不含 load 时间；冷启动 load 已在 build_local_qwen3
+            // 提前完成。但 transcribe 本身受音频长度影响：用户实测 RTF ≈ 0.3，慢机
+            // 可达 0.5；15s 固定超时在 ≥ 30s 录音上会把整段结果丢掉。改用动态
+            // 超时 max(15, ceil(audio_s × 0.6) + 10)，公式与单测见
+            // `local_qwen_transcribe_timeout`。
+            let audio_secs = (local.buffer_duration_ms() as f64) / 1000.0;
+            let timeout_duration = local_qwen_transcribe_timeout(audio_secs);
+            log::info!(
+                "[coord] local Qwen3-ASR transcribe: audio={:.2}s timeout={}s",
+                audio_secs,
+                timeout_duration.as_secs()
+            );
             let result = tokio::time::timeout(timeout_duration, local.transcribe()).await;
             inner.local_asr_cache.touch();
             schedule_local_asr_release(inner);
@@ -1146,8 +1154,9 @@ pub(super) async fn end_session(inner: &Arc<Inner>) -> Result<(), String> {
                 }
                 Err(_) => {
                     log::error!(
-                        "[coord] local Qwen3-ASR 全局超时 {} 秒",
-                        COORDINATOR_GLOBAL_TIMEOUT_SECS
+                        "[coord] local Qwen3-ASR 动态超时 {}s（音频 {:.2}s）",
+                        timeout_duration.as_secs(),
+                        audio_secs
                     );
                     emit_capsule(
                         inner,


### PR DESCRIPTION
### **User description**
## 背景

两个独立缺陷叠加，导致本地 Qwen3-ASR 在长语音 / 立即松键场景下丢内容或全段失败。

### 缺陷 1（主要，丢内容）

`qwen_engine.rs:94` 注释明确写出 `transcribe_stream` 内部按 2s chunk 切片。用户说完最后一个字立刻按快捷键时，录音缓冲里没有任何静默尾巴 → 最后一个不足 2s 的 chunk 拿不到静默帧 → C 引擎不会把它当作"语音已结束" → 该 chunk 的转写结果被丢弃，末段内容消失。

复现侧验证：等 5–10 秒静默再按快捷键，那段静默会随录音进入缓冲 → C 引擎见到静默 → 末 chunk 正常收尾 → 无丢失。

### 缺陷 2（次要，长录音超时）

`COORDINATOR_GLOBAL_TIMEOUT_SECS = 15`（`coordinator.rs:3593`）。本地 Qwen 路径走 `asr_transcribe_uses_global_timeout` 的默认 true 分支（`coordinator.rs:87-93`），命中 15s 全局超时。

用户实测 RTF ≈ 0.3、慢机器可达 0.5 → 60s 录音需要约 18s 转写 → 直接超时把整段结果丢弃。

## 修复

### 缺陷 1（`local_provider.rs`）

```rust
let mut samples_f32 = i16_le_bytes_to_f32(&pcm_bytes);
// 末 chunk 收尾信号：追加 0.5s 静默 = 8000 个 f32 零值 @ 16kHz
samples_f32.extend(std::iter::repeat(0.0f32).take(8_000));
```

`duration_ms` 仍按原始缓冲长度计算，padding 不计入。

### 缺陷 2（`coordinator.rs` + `coordinator/dictation.rs`）

新增 module-level helper：

```rust
fn local_qwen_transcribe_timeout(audio_secs: f64) -> std::time::Duration {
    let secs = ((audio_secs * 0.6).ceil() as u64)
        .saturating_add(10)
        .max(COORDINATOR_GLOBAL_TIMEOUT_SECS);
    std::time::Duration::from_secs(secs)
}
```

`dictation.rs` 的 `ActiveAsr::Local` 分支在调 `transcribe()` 前读 `local.buffer_duration_ms()` 算出 `audio_secs`，用新 helper 决定超时。其他 ASR 路径（Volcengine / Whisper / Bailian / Foundry / QA）**全部未改**，仍是固定 15s。

配套新增 `LocalQwenAsr::buffer_duration_ms() -> u64`，`&self` 不消费缓冲。

## Test plan

- [x] `cargo check --manifest-path openless-all/app/src-tauri/Cargo.toml` 通过
- [x] `cargo test --manifest-path openless-all/app/src-tauri/Cargo.toml --lib local_qwen_timeout` — 4 条新单测全过：
  - 短录音 5s 兜底返回 15s
  - 60s 录音返回 46s（与用户给的公式示例一致）
  - 10.1s 录音 ceil 到 17s
  - 0s 边界返回 15s
- [x] `cargo test ... --lib coordinator` — 39 条现有测试全过，零回归
- [ ] **真机回归（macOS，必须）**：
  - 60s 一口气说完立刻松键 → 末段不应丢字（验证缺陷 1）
  - 90s 长录音 → 不再超时失败（验证缺陷 2）
  - 短录音（5s 内）行为不变

## 关联

issue #420 评论里 @aeoform 反馈触发延伸排查时发现的两条独立缺陷，与 #420 主线（Wayland CLI 触发）无直接关联。


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Fix local Qwen trailing audio loss

- Replace fixed timeout with dynamic scaling

- Add buffer duration reader for coordinator

- Cover timeout rules with unit tests


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Local audio buffer"] --> B["LocalQwenAsr transcribe"]
  B --> C["Append 0.5s silence padding"]
  A --> D["Read buffered duration"]
  D --> E["Dynamic Qwen timeout"]
  E --> F["Coordinator end_session"]
  F --> G["Transcribe with timeout"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>local_provider.rs</strong><dd><code>Add silence padding and buffer duration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src-tauri/src/asr/local/local_provider.rs

<ul><li>Added <code>buffer_duration_ms()</code> to read queued audio length without <br>consuming it.<br> <li> Appended 0.5 seconds of silence before local Qwen transcription.<br> <li> Kept returned <code>duration_ms</code> based on original audio only.<br> <li> Documented why padding helps the C engine finish the last chunk.</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/434/files#diff-f373759ba295a5442f874d39c95aef83a2c1f5b38ffeb619f6139ced433bc7e5">+14/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>coordinator.rs</strong><dd><code>Add dynamic local Qwen timeout logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src-tauri/src/coordinator.rs

<ul><li>Added <code>local_qwen_transcribe_timeout(audio_secs)</code> helper.<br> <li> Uses <code>max(15, ceil(audio_s × 0.6) + 10)</code> for local Qwen ASR.<br> <li> Added unit tests for short audio, long audio, rounding, and zero <br>length.<br> <li> Preserved existing timeout behavior for other ASR paths.</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/434/files#diff-73d8c004670b27293f74f0f3991b9a6fc28f0ff0b883214de2b078b1e09797ca">+47/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>dictation.rs</strong><dd><code>Use audio-based timeout during transcription</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src-tauri/src/coordinator/dictation.rs

<ul><li>Switched local Qwen transcription from fixed timeout to dynamic <br>timeout.<br> <li> Read buffered audio duration before calling <code>transcribe()</code>.<br> <li> Added runtime logging for audio length and computed timeout.<br> <li> Updated timeout error handling to report dynamic values.</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/434/files#diff-4cf79887f41f4811eb2b1ef682c62ee34c14a0ab969362a9ba1046de59c8578b">+15/-6</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

