### PR TITLE
fix(asr): surface Volcengine 403 as 'credentials rejected'

### DIFF
--- a/openless-all/app/src-tauri/src/asr/volcengine.rs
+++ b/openless-all/app/src-tauri/src/asr/volcengine.rs
@@ -50,6 +50,12 @@ pub enum VolcengineASRError {
     CredentialsMissing,
     #[error("connection failed: {0}")]
     ConnectionFailed(String),
+    /// WebSocket 握手阶段服务端返回 401 / 403：凭据被拒。
+    /// 区分自 `ConnectionFailed`（DNS/TLS/网络层失败）—— 前者通常是 App ID / Access
+    /// Token / Resource ID 错或账号没开通 bigmodel；后者是网络断 / 防火墙 / DNS。
+    /// 显式 variant 让 coordinator 在 capsule 给用户中文「检查凭据」提示，不是 raw HTTP error。
+    #[error("Volcengine 凭据被拒（HTTP {0}）：请检查 Settings → 凭据 → Volcengine 的 App ID 和 Access Token，或确认账号已开通 SAUC bigmodel 资源")]
+    AuthRejected(u16),
     #[error("authentication failed")]
     AuthenticationFailed,
     #[error("no final result")]
@@ -155,9 +161,7 @@ impl VolcengineStreamingASR {
                 .map_err(|e| VolcengineASRError::ConnectionFailed(e.to_string()))?,
         );
 
-        let (ws, _resp) = connect_async(request)
-            .await
-            .map_err(|e| VolcengineASRError::ConnectionFailed(e.to_string()))?;
+        let (ws, _resp) = connect_async(request).await.map_err(classify_connect_error)?;
         let (write, read) = ws.split();
 
         let (tx, rx) = oneshot::channel();
@@ -635,6 +639,20 @@ fn normalized_result(json: &Value) -> Option<&Value> {
         return Some(json);
     }
     None
+}
+
+/// 把 tokio-tungstenite 的 connect 错误分类：握手收到 HTTP 401 / 403 → `AuthRejected`
+/// （凭据被拒，要 user 检查 App ID / Access Token / 账号资源开通状态）；其它 → 通用
+/// `ConnectionFailed`（DNS / TLS / 网络层）。让 capsule 文案能跟泛泛 HTTP error 区分。
+fn classify_connect_error(err: tokio_tungstenite::tungstenite::Error) -> VolcengineASRError {
+    use tokio_tungstenite::tungstenite::Error as WsError;
+    if let WsError::Http(resp) = &err {
+        let status = resp.status().as_u16();
+        if status == 401 || status == 403 {
+            return VolcengineASRError::AuthRejected(status);
+        }
+    }
+    VolcengineASRError::ConnectionFailed(err.to_string())
 }
 
 fn hotword_context(entries: &[DictionaryHotword]) -> Option<String> {

--- a/openless-all/app/src-tauri/src/asr/volcengine.rs
+++ b/openless-all/app/src-tauri/src/asr/volcengine.rs
@@ -53,8 +53,8 @@ pub enum VolcengineASRError {
     /// WebSocket 握手阶段服务端返回 401 / 403：凭据被拒。
     /// 区分自 `ConnectionFailed`（DNS/TLS/网络层失败）—— 前者通常是 App ID / Access
     /// Token / Resource ID 错或账号没开通 bigmodel；后者是网络断 / 防火墙 / DNS。
-    /// 显式 variant 让 coordinator 在 capsule 给用户中文「检查凭据」提示，不是 raw HTTP error。
-    #[error("Volcengine 凭据被拒（HTTP {0}）：请检查 Settings → 凭据 → Volcengine 的 App ID 和 Access Token，或确认账号已开通 SAUC bigmodel 资源")]
+    /// 文案简短，原因在文档里说明，capsule 不堆长引导。
+    #[error("凭据被拒（{0}）")]
     AuthRejected(u16),
     #[error("authentication failed")]
     AuthenticationFailed,


### PR DESCRIPTION
### **User description**
## Summary

用户反馈日志（openless-2026-05-15T01-12-07.log）显示 9 次连续：
\`\`\`
[coord] open ASR session failed: connection failed: HTTP error: 403 Forbidden
\`\`\`

诊断：HTTP 403 是 Volcengine bigmodel ASR 在 WebSocket 握手阶段返回的，**网络通**到了 Volcengine 服务器（不然不会有 HTTP 状态码），但服务端拒绝。这是凭据问题（App ID / Access Token 错、Resource ID 错、或账号没开通 SAUC bigmodel 资源），不是网络 / 代码 bug。

但当前 capsule 显示原始 `HTTP error: 403 Forbidden`，普通用户不会读 → 反馈到客服。

## 改动

\`volcengine.rs\`：
- 加 \`VolcengineASRError::AuthRejected(u16)\` variant，display 是中文具体引导
- 加 \`classify_connect_error()\` 函数：tokio-tungstenite 握手返回 \`Error::Http\` 且 status ∈ {401, 403} 时归入 AuthRejected，其它握手错误（DNS / TLS / connection refused）仍走 ConnectionFailed 不变

用户看到的新文案：
> Volcengine 凭据被拒（HTTP 403）：请检查 Settings → 凭据 → Volcengine 的 App ID 和 Access Token，或确认账号已开通 SAUC bigmodel 资源

## Test plan

- [x] \`cargo test --lib\` → 258 全过
- [ ] 手工验证：故意填错 Volcengine App ID → 录一段 → 看 capsule 显示新中文文案
- [ ] 手工验证：正确凭据 → 录音正常，不被误判为 AuthRejected
- [ ] 手工验证：断网 → capsule 仍显示原来的 \`connection failed: ...\` 不被这次改动污染

## 不发 tag

按 hotfix 计划，merge 到 beta 后**不**发 \`v1.3.2-3-beta-tauri\` tag，下一个 Beta 一起出去。


___

### **PR Type**
Bug fix


___

### **Description**
- Classify Volcengine 401/403 handshakes

- Surface credential rejections as `AuthRejected`

- Keep other connect failures unchanged


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["connect_async handshake error"] -- "HTTP 401/403" --> B["AuthRejected(status)"]
  A -- "other errors" --> C["ConnectionFailed"]
  B -- "capsule text" --> D["凭据被拒（403）"]
  C -- "capsule text" --> E["connection failed: ..."]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>volcengine.rs</strong><dd><code>Classify Volcengine handshake credential errors</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src-tauri/src/asr/volcengine.rs

<ul><li>Adds <code>AuthRejected(u16)</code> for 401/403 handshake responses<br> <li> Replaces direct <code>connect_async</code> error mapping with <br><code>classify_connect_error</code><br> <li> Keeps DNS, TLS, and network failures as <code>ConnectionFailed</code><br> <li> Documents why credential rejections are handled separately</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/438/files#diff-2fc7df3684f696c8aed87ee4e9bb6564e2048cece6769c9d2a787e08a257b140">+21/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

