### PR TITLE
fix(llm): retry transient network errors once before failing polish

### DIFF
--- a/openless-all/app/src-tauri/src/polish.rs
+++ b/openless-all/app/src-tauri/src/polish.rs
@@ -1236,15 +1236,17 @@ pub(crate) fn http_client_builder(base_url: &str, timeout_secs: u64) -> reqwest:
     }
 }
 
-/// 发请求 + 网络抖动 retry：connect / request / timeout 三类 transient 错误首次失败时
-/// 等 500ms 重试一次，再失败按原样返回。HTTP 4xx/5xx 不在这里触发——那些走 response
-/// 的 status 分支单独处理。
+/// 发请求 + 网络抖动 retry：**只**对 `is_connect()` / `is_request()` 这两类「服务端
+/// 必然没收到」的失败重试一次。`is_timeout()` 故意**不**重试——超时时服务端可能已经
+/// 在处理请求并扣计费（LLM completion 是非幂等动作），重试会导致重复 billing + 重复
+/// completion。HTTP 4xx/5xx 不在这里触发——那些走 response.status() 分支单独处理。
 ///
 /// 调用前提：传入的 RequestBuilder body 必须是内存型（json / form），不能是 stream
 /// reader——retry 用 `try_clone()` 复制 RequestBuilder，stream body 不支持。
 ///
-/// 对流式 SSE 路径 retry 是安全的：失败发生在 `send().await` 阶段，response 还没回
-/// 来 → on_delta 必然未被调用 → 不会有「已流式输出的字被重复」的问题。
+/// 对流式 SSE 路径 retry 是安全的：connect / request 类失败发生在 TCP 握手 / HTTP
+/// 请求写出阶段，response 还没回 → on_delta 必然未被调用 → 不会有「已流式输出的字
+/// 被重复」的问题。
 async fn send_with_transient_retry(
     request: reqwest::RequestBuilder,
 ) -> Result<reqwest::Response, LLMError> {
@@ -1254,7 +1256,7 @@ async fn send_with_transient_retry(
         .expect("memory-backed body (json/form) must be clonable for retry");
     match initial.send().await {
         Ok(r) => Ok(r),
-        Err(e) if e.is_connect() || e.is_request() || e.is_timeout() => {
+        Err(e) if e.is_connect() || e.is_request() => {
             log::warn!(
                 "[llm] send transient failure, retry in {}ms: {}",
                 RETRY_DELAY_MS,

--- a/openless-all/app/src-tauri/src/polish.rs
+++ b/openless-all/app/src-tauri/src/polish.rs
@@ -514,15 +514,7 @@ impl OpenAICompatibleLLMProvider {
         }
         let request = request.json(body);
 
-        let response = match request.send().await {
-            Ok(r) => r,
-            Err(e) => {
-                if e.is_timeout() {
-                    return Err(LLMError::Timeout);
-                }
-                return Err(LLMError::Network(e.to_string()));
-            }
-        };
+        let response = send_with_transient_retry(request).await?;
 
         let status = response.status();
         let body_text = response
@@ -588,15 +580,7 @@ impl OpenAICompatibleLLMProvider {
         }
         let request = request.json(&body);
 
-        let response = match request.send().await {
-            Ok(r) => r,
-            Err(e) => {
-                if e.is_timeout() {
-                    return Err(LLMError::Timeout);
-                }
-                return Err(LLMError::Network(e.to_string()));
-            }
-        };
+        let response = send_with_transient_retry(request).await?;
 
         let status = response.status();
         if !status.is_success() {
@@ -717,15 +701,7 @@ impl OpenAICompatibleLLMProvider {
         }
         let request = request.json(&body);
 
-        let response = match request.send().await {
-            Ok(r) => r,
-            Err(e) => {
-                if e.is_timeout() {
-                    return Err(LLMError::Timeout);
-                }
-                return Err(LLMError::Network(e.to_string()));
-            }
-        };
+        let response = send_with_transient_retry(request).await?;
 
         let status = response.status();
         if !status.is_success() {
@@ -1257,6 +1233,52 @@ pub(crate) fn http_client_builder(base_url: &str, timeout_secs: u64) -> reqwest:
         builder.no_proxy()
     } else {
         builder
+    }
+}
+
+/// 发请求 + 网络抖动 retry：connect / request / timeout 三类 transient 错误首次失败时
+/// 等 500ms 重试一次，再失败按原样返回。HTTP 4xx/5xx 不在这里触发——那些走 response
+/// 的 status 分支单独处理。
+///
+/// 调用前提：传入的 RequestBuilder body 必须是内存型（json / form），不能是 stream
+/// reader——retry 用 `try_clone()` 复制 RequestBuilder，stream body 不支持。
+///
+/// 对流式 SSE 路径 retry 是安全的：失败发生在 `send().await` 阶段，response 还没回
+/// 来 → on_delta 必然未被调用 → 不会有「已流式输出的字被重复」的问题。
+async fn send_with_transient_retry(
+    request: reqwest::RequestBuilder,
+) -> Result<reqwest::Response, LLMError> {
+    const RETRY_DELAY_MS: u64 = 500;
+    let initial = request
+        .try_clone()
+        .expect("memory-backed body (json/form) must be clonable for retry");
+    match initial.send().await {
+        Ok(r) => Ok(r),
+        Err(e) if e.is_connect() || e.is_request() || e.is_timeout() => {
+            log::warn!(
+                "[llm] send transient failure, retry in {}ms: {}",
+                RETRY_DELAY_MS,
+                e
+            );
+            tokio::time::sleep(Duration::from_millis(RETRY_DELAY_MS)).await;
+            match request.send().await {
+                Ok(r) => Ok(r),
+                Err(e2) => {
+                    if e2.is_timeout() {
+                        Err(LLMError::Timeout)
+                    } else {
+                        Err(LLMError::Network(e2.to_string()))
+                    }
+                }
+            }
+        }
+        Err(e) => {
+            if e.is_timeout() {
+                Err(LLMError::Timeout)
+            } else {
+                Err(LLMError::Network(e.to_string()))
+            }
+        }
     }
 }
 


### PR DESCRIPTION
### **User description**
## Summary

用户反馈 streaming polish 偶发失败，日志显示：
\`\`\`
[ERROR] [coord] streaming polish FAILED: network error:
        error sending request for url (https://api.deepseek.com/v1/chat/completions)
\`\`\`
出现 4 次（02:53 / 03:17 / 03:23 / 03:25），夹在大量成功 polish 之间——证明网络没断、是间歇性抖动（DNS / TLS handshake / connection reset / 链路超时）。

## 改动

抽 \`send_with_transient_retry\` helper（polish.rs 末尾），首次失败 + 错误是 transient（\`is_connect\` / \`is_request\` / \`is_timeout\`）→ sleep 500ms 重试一次。HTTP 4xx/5xx 走 \`response.status()\` 分支不受影响。

3 处 reqwest send 都用 helper：
- \`chat_completion_messages_streaming\` (SSE 流式)
- \`chat_completion_messages_streaming\` 的非流式兄弟
- \`send_chat_request\` 一次性 chat 调用

## 安全前提

- **body 可 clone**：3 处都用 \`json(...)\` 设置内存型 body，\`try_clone()\` 必能成功
- **流式 retry 不重复输出**：失败发生在 \`send().await\` 阶段，response 还没回 → \`on_delta\` 必然未被调用 → 不会有「已流式输出的字被重复」

## 不变

- Codex OAuth 路径（line 1085）独立 client，结构不同，本 PR 不动。后续如有相同抖动反馈再扩展。
- 错误**仍然**会 emit 到 capsule（如果 retry 也失败），文案不变。
- 重试发生时记日志：\`[llm] send transient failure, retry in 500ms: ...\` 方便诊断。

## Test plan

- [x] \`cargo test --lib\` → 263 全过
- [ ] 手工验证：临时 block DNS 一秒（pfctl / hosts 改 api.deepseek.com 到无效 IP），录一段 → 看日志能否看到 \`retry in 500ms\` + 重试成功

## 跟 #442 关系

独立 PR。#442 是「默认值 + 提示词重构」；本 PR 是「LLM 网络层 retry」，两者无冲突。merge 顺序无所谓。


___

### **PR Type**
Bug fix


___

### **Description**
- Retry transient request send failures once

- Skip retries for timeout errors

- Reuse helper across three LLM paths

- Preserve existing HTTP status handling


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["LLM request builders"] 
  B["send_with_transient_retry helper"]
  C["connect/request failure"]
  D["timeout or network error"]
  E["HTTP response handling"]

  A -- "json/body request" --> B
  B -- "retry once on transient failure" --> C
  B -- "map timeout/network errors" --> D
  B -- "return response" --> E
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>polish.rs</strong><dd><code>Add transient retry for LLM requests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src-tauri/src/polish.rs

<ul><li>Replaced direct <code>request.send().await</code> calls with <br><code>send_with_transient_retry</code>.<br> <li> Added a shared helper that retries only <code>is_connect()</code> and <code>is_request()</code> <br>failures.<br> <li> Kept <code>is_timeout()</code> as a hard failure to avoid duplicate billing.<br> <li> Documented retry assumptions for memory-backed request bodies and <br>streaming safety.</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/443/files#diff-1be30d25d0bf8fc3e6c11bf4fa179521045a52ef4843271545acedfd0535e38b">+51/-27</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

