### PR TITLE
Avoid activating OpenLess when showing dictation capsule

### DIFF
--- a/openless-all/app/src-tauri/src/coordinator.rs
+++ b/openless-all/app/src-tauri/src/coordinator.rs
@@ -73,6 +73,47 @@ use resources::{
     stop_microphone_preview_monitor, stop_qa_recorder, SessionResource, SharedRecordingMuteState,
 };
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum CapsuleShowStrategy {
+    NoActivate,
+    FallbackShow,
+}
+
+fn capsule_show_strategy_for_platform() -> CapsuleShowStrategy {
+    #[cfg(any(target_os = "macos", target_os = "windows"))]
+    {
+        CapsuleShowStrategy::NoActivate
+    }
+    #[cfg(not(any(target_os = "macos", target_os = "windows")))]
+    {
+        CapsuleShowStrategy::FallbackShow
+    }
+}
+
+static CAPSULE_NO_ACTIVATE_FALLBACK_WARNED: AtomicBool = AtomicBool::new(false);
+
+fn show_capsule_window_for_recording<R: tauri::Runtime>(
+    app: &AppHandle<R>,
+    window: &tauri::WebviewWindow<R>,
+) {
+    let mut needs_fallback = true;
+    if capsule_show_strategy_for_platform() == CapsuleShowStrategy::NoActivate {
+        needs_fallback = !show_capsule_window_no_activate(app, window);
+        if needs_fallback && !CAPSULE_NO_ACTIVATE_FALLBACK_WARNED.swap(true, Ordering::SeqCst) {
+            // 产品取舍：no-activate 是 macOS/AeroSpace 的主路径；但如果 ns_window
+            // 暂不可用，仍优先保住录音反馈，不让用户以为听写没启动。fallback 可能
+            // 重新触发 workspace 跳转，只在 no-activate 失败时作为降级路径。
+            log::warn!("[capsule] no-activate show failed; falling back to window.show()");
+        }
+    }
+
+    if needs_fallback {
+        if let Err(e) = window.show() {
+            log::warn!("[capsule] show fallback failed: {e}");
+        }
+    }
+}
+
 enum ActiveAsr {
     Volcengine(Arc<VolcengineStreamingASR>),
     Whisper(Arc<WhisperBatchASR>),
@@ -3501,6 +3542,21 @@ mod tests {
     }
 
     #[test]
+    fn capsule_show_strategy_matches_platform_activation_contract() {
+        #[cfg(any(target_os = "macos", target_os = "windows"))]
+        assert_eq!(
+            capsule_show_strategy_for_platform(),
+            CapsuleShowStrategy::NoActivate
+        );
+
+        #[cfg(not(any(target_os = "macos", target_os = "windows")))]
+        assert_eq!(
+            capsule_show_strategy_for_platform(),
+            CapsuleShowStrategy::FallbackShow
+        );
+    }
+
+    #[test]
     #[cfg(target_os = "windows")]
     fn prepared_windows_ime_slot_is_taken_only_for_matching_session() {
         let mut slots = vec![PreparedWindowsImeSessionSlot {
@@ -4033,11 +4089,32 @@ fn show_capsule_window_no_activate<R: tauri::Runtime>(
     true
 }
 
-// macOS / Linux 上不走 no-activate 路径：胶囊由 emit_capsule 的 fallback
-// `window.show()` 直接显示，再用 restore_main_window_key_if_active 把焦点还给
-// 主窗口。这是 1.2.11 的实现 — 单独走 orderFrontRegardless 会让胶囊在 webview
-// 未完整初始化时偶发不可见。
-#[cfg(not(target_os = "windows"))]
+#[cfg(target_os = "macos")]
+fn show_capsule_window_no_activate<R: tauri::Runtime>(
+    _app: &AppHandle<R>,
+    window: &tauri::WebviewWindow<R>,
+) -> bool {
+    use objc2::msg_send;
+    use objc2::runtime::AnyObject;
+
+    let Ok(handle) = window.ns_window() else {
+        return false;
+    };
+    let ns_window = handle as *mut AnyObject;
+    if ns_window.is_null() {
+        return false;
+    }
+
+    // emit_capsule 已经把窗口操作 marshal 到 Tauri 主线程；这里不能再调用
+    // window.show()/set_focus()/NSApp.activate，否则 AeroSpace 会把 workspace 切回
+    // OpenLess 主窗口所在空间。orderFrontRegardless 只让胶囊可见，不成为 key window。
+    unsafe {
+        let _: () = msg_send![ns_window, orderFrontRegardless];
+    }
+    true
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "windows")))]
 fn show_capsule_window_no_activate<R: tauri::Runtime>(
     _app: &AppHandle<R>,
     _window: &tauri::WebviewWindow<R>,
@@ -4128,10 +4205,8 @@ fn emit_capsule(
         // 处理，不依赖把 Done/Cancelled/Error 打成 invisible。详见 PR #140 评论。
         maybe_position_capsule_bottom_center(&inner_for_main, &window, translation);
         if show_capsule && visible {
-            if !show_capsule_window_no_activate(&app_for_main, &window) {
-                let _ = window.show();
-            }
-            // macOS/Windows 优先走 no-activate show，避免录音胶囊抢走主窗口点击焦点。
+            show_capsule_window_for_recording(&app_for_main, &window);
+            // macOS/Windows 优先走 no-activate show，避免录音胶囊抢走当前工作 app 焦点。
             // 若 fallback 到 show()，OpenLess 已是前台 app 时再把 key window 还给 main。
             #[cfg(target_os = "macos")]
             crate::restore_main_window_key_if_active(&app_for_main);


### PR DESCRIPTION
### **User description**
## Summary
- Route the dictation capsule show path through platform no-activate behavior.
- Add a macOS `NSWindow orderFrontRegardless` path so showing the recording capsule does not normally activate OpenLess or pull AeroSpace back to the OpenLess workspace.
- Keep the existing `window.show()` fallback when no-activate cannot access the native window, so recording feedback is not lost.

## Fallback behavior
- macOS no-activate is the intended path for issue #452.
- If `ns_window()` is unavailable/null, the code intentionally falls back to `window.show()`.
- That fallback may still trigger the old AeroSpace workspace switch, but it is retained as a product decision so users still see that dictation has started instead of getting no capsule feedback.

## Needs macOS real-device validation
This PR was implemented and tested from a non-macOS environment. Before treating issue #452 as fully accepted, please verify on a real macOS machine with AeroSpace:

1. Put the OpenLess main window on workspace A.
2. Put a working text app on workspace B.
3. Trigger dictation from workspace B.
4. Confirm the workspace does not switch back to OpenLess during normal capsule display.
5. Confirm the capsule is visible, the working app remains frontmost, and dictated text inserts into the working app.
6. Also verify tray / explicit “show main window” behavior still focuses OpenLess as expected.

## Test plan
- [x] `npm run build`
- [x] `cargo test --manifest-path openless-all/app/src-tauri/Cargo.toml --lib -- --test-threads=1`
- [x] `git diff --check`
- [ ] Real macOS + AeroSpace workspace validation

Refs #452


___

### **PR Type**
Bug fix


___

### **Description**
- Route capsule display through no-activate

- Preserve fallback when native handle unavailable

- Add macOS AeroSpace-safe window showing

- Cover platform strategy with tests


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["emit_capsule"] -- "show capsule" --> B["show_capsule_window_for_recording"]
  B -- "macOS/Windows" --> C["no-activate show"]
  C -- "macOS" --> D["orderFrontRegardless"]
  C -- "Windows" --> E["SWP_NOACTIVATE show"]
  B -- "fallback" --> F["window.show()"]
  B -- "logs once" --> G["warning"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>coordinator.rs</strong><dd><code>Use no-activate capsule showing by platform</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src-tauri/src/coordinator.rs

<ul><li>Introduce <code>CapsuleShowStrategy</code> to choose no-activate or fallback <br>behavior per platform.<br> <li> Add <code>show_capsule_window_for_recording()</code> to centralize capsule display <br>and fallback logging.<br> <li> Implement macOS <code>ns_window()</code> handling with <code>orderFrontRegardless</code> to <br>avoid AeroSpace workspace switches.<br> <li> Add a test asserting the platform strategy matches the activation <br>contract.</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/456/files#diff-73d8c004670b27293f74f0f3991b9a6fc28f0ff0b883214de2b078b1e09797ca">+84/-9</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

