### PR TITLE
docs(windows): 独占全屏游戏 capsule/hotkey OS 级限制 (#457)

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -119,6 +119,15 @@ Windows：在「设置 → 权限」中检查监听器状态。
 **Q: 文字没有插入，只是复制到了剪贴板？**  
 当目标输入框不支持辅助功能写入时（如某些安全限制的应用），OpenLess 会自动回退到剪贴板复制，手动粘贴即可。
 
+**Q: 在 Windows 玩 Minecraft 等全屏游戏时，OpenLess capsule 不弹出 / 字符无法输入？**  
+这是 **Windows 操作系统层面的限制**，OpenLess 应用本身无法绕过（详见 [issue #457](https://github.com/Open-Less/openless/issues/457)）：
+
+- **独占全屏（exclusive fullscreen）**：标准应用窗口（包括 OpenLess capsule）**不会绘制在独占全屏 DirectX/OpenGL 应用之上**。请把游戏切换到 **无边框窗口化全屏（Borderless Windowed Fullscreen）**。Minecraft：视频设置 → 全屏 关闭（保持窗口最大化即可）。
+- **管理员权限不一致（UIPI）**：若游戏以管理员身份运行而 OpenLess 不是，Windows 阻止 OpenLess 接收游戏前台的按键，hotkey 完全不触发。让两者权限对齐（要么都以管理员运行，要么都以普通用户运行）。
+- **游戏聊天框未打开**：识别字符通过模拟键盘事件落字。Minecraft 中必须先按 `T` 打开聊天框，OpenLess 的输入才会落到聊天里。
+
+macOS 不存在独占全屏（所有"全屏"都是带 Spaces 的无边框窗口），所以此限制不适用。
+
 **Q: 润色结果和预期不符？**  
 尝试切换输出模式，或在词典中添加相关专有名词。
 

--- a/openless-all/app/src-tauri/src/coordinator.rs
+++ b/openless-all/app/src-tauri/src/coordinator.rs
@@ -3998,6 +3998,18 @@ fn capture_ime_submit_target() -> Option<ImeSubmitTarget> {
     })
 }
 
+// Windows topmost overlay 的已知 OS 级限制（issue #457）：
+// `SetWindowPos(HWND_TOPMOST)` 让 capsule 在普通桌面合成、最大化窗口、borderless
+// windowed fullscreen 上正常叠加；但**对独占全屏（exclusive fullscreen）DirectX /
+// OpenGL 应用无效** —— 那条路径绕过桌面合成器，标准 topmost 窗口不参与合成 →
+// 用户看不见 capsule。这是 OS 层面的限制，用户空间无法绕过（除非接入 DirectX
+// overlay，工程量与风险都不在 surgical 修复范围内）。
+//
+// 用户侧 workaround：把游戏切到 borderless windowed fullscreen（Minecraft Java 默认
+// 即是；F11 在不同版本表现不一致，按设置里的「全屏」选项决定）。
+//
+// 相关 UIPI 限制：若游戏以管理员身份运行而 OpenLess 不是，`WH_KEYBOARD_LL` 收不到
+// 游戏的按键 → hotkey 完全不触发。这里跟 SetWindowPos 路径无关，但同源不可绕过。
 #[cfg(target_os = "windows")]
 fn show_capsule_window_no_activate<R: tauri::Runtime>(
     _app: &AppHandle<R>,


### PR DESCRIPTION
### **User description**
关联 issue #457。

## 摘要

记录 Windows 端独占全屏游戏（典型例：Minecraft）下 OpenLess 行为失效的**操作系统级根因**与**用户侧 workaround**：

- 代码侧（`coordinator.rs`）：在 `show_capsule_window_no_activate` Windows 路径上方加注释块，说明 `SetWindowPos(HWND_TOPMOST)` 对独占全屏 DirectX/OpenGL 应用无效（绕过桌面合成器），以及 UIPI 阻挡 hotkey 的同源现象。给后续维护者留下「这条路走不通」的明确路标。
- 文档侧（`USAGE.md`）：FAQ 加 1 条 —— 用户应把游戏切到 borderless windowed fullscreen，对齐管理员权限，预先打开聊天框。

**不修改运行时行为。** 真正绕过独占全屏需要 DirectX overlay 注入（Discord / MSI Afterburner 路线），工程量 + 风险都超出 surgical 修复范围；本 PR 不动这一层。

## 根因分析

按可能性排序（详见 issue #457）：

1. **独占全屏 OS 限制**：标准 Win32 topmost 窗口（无论 `WS_EX_TOPMOST` 还是运行时 `SetWindowPos(HWND_TOPMOST)`）**不会**被绘制在独占全屏 DirectX/OpenGL 应用之上。借助 desktop 合成器叠加 = 必然不可见。
2. **UIPI 阻挡 hotkey**：低权限进程的 `WH_KEYBOARD_LL` 收不到高权限进程的按键。若游戏以管理员运行而 OpenLess 不是，hotkey 完全不触发。
3. **游戏聊天框未打开**：SendInput Unicode keystrokes 进游戏窗口但落不到文本输入位置。Minecraft 必须先按 `T` 打开聊天框。

macOS 不存在独占全屏（所有"全屏"都是带 Spaces 的 borderless），故平台不可比。

## 改动

| 文件 | 改动类型 | 行数 |
|---|---|---|
| `openless-all/app/src-tauri/src/coordinator.rs` | 注释块 | +12 |
| `USAGE.md` | FAQ 条目 | +9 |

## Why draft

我（claude code session）的当前环境是 macOS，**无法在 Windows 本机实测**用户场景。本 PR 是 0 行为变更的纯文档改动，cargo check 通过（仅 pre-existing warnings），但仍标 draft 以便 reviewer 在 Windows 机器上：

- 实际验证 USAGE.md 中给出的 workaround 路径（borderless windowed + admin 对齐 + 聊天框）是否能让 OpenLess 在 Minecraft 下正常工作
- 决定是否还需要补充用户面更详细的诊断步骤（如何在游戏内确认是哪种 fullscreen 模式）

## 测试计划

- [ ] cargo check 通过（macOS 本机已通过；Windows CI 待跑）
- [ ] Windows 实测：把 Minecraft 切到 borderless windowed → capsule 应能正常显示
- [ ] Windows 实测：把 Minecraft 切到 exclusive fullscreen → capsule 不可见（确认 OS 限制）
- [ ] Windows 实测：游戏以 admin 运行 + OpenLess 普通用户 → hotkey 应被 UIPI 阻挡
- [ ] 阅读 USAGE.md FAQ：表述是否对非技术用户友好


___

### **PR Type**
Documentation


___

### **Description**
- Document Windows exclusive-fullscreen limits

- Note UIPI hotkey permission mismatch

- Add Minecraft fullscreen FAQ workaround

- Clarify chat-box prerequisite


___

### Diagram Walkthrough


```mermaid
flowchart LR
  I["Issue #457: Windows fullscreen failure"]
  C["coordinator.rs comment"]
  U["USAGE.md FAQ"]
  W["User workarounds"]
  I -- "documents root cause" --> C
  I -- "adds guidance" --> U
  C -- "explains OS limits" --> W
  U -- "suggests borderless fullscreen, matching permissions, open chat" --> W
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>coordinator.rs</strong><dd><code>Add Windows fullscreen limitation notes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src-tauri/src/coordinator.rs

<ul><li>Adds a Windows-specific comment above <code>show_capsule_window_no_activate</code><br> <li> Explains why <code>SetWindowPos(HWND_TOPMOST)</code> fails over exclusive <br>fullscreen apps<br> <li> Notes the related UIPI hotkey limitation when privilege levels differ<br> <li> Mentions borderless fullscreen as the practical workaround</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/458/files#diff-73d8c004670b27293f74f0f3991b9a6fc28f0ff0b883214de2b078b1e09797ca">+12/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>USAGE.md</strong><dd><code>Add Windows Minecraft fullscreen FAQ</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

USAGE.md

<ul><li>Adds a FAQ entry for capsule invisibility and missing text input in <br>Windows games<br> <li> Describes exclusive fullscreen as an OS-level limitation<br> <li> Recommends borderless windowed fullscreen and matching admin <br>privileges<br> <li> Reminds users to open Minecraft chat with <code>T</code> before inputting text</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/458/files#diff-58a825c70bccfbe691d7ddbddb133275f4f657de6aeb4a502fa9fce279f8bf8d">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

