### PR TITLE
chore(ci): 允许 Open-Less 组织成员触发 @claude

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -2,7 +2,7 @@ name: Claude Code
 
 # 触发策略：
 # - 默认不主动 review；任何 PR 打开 / 同步都不会自动调用模型，避免烧 OAuth token 额度。
-# - 评论 / review / issue 中出现 `@claude` 才触发，且发起者必须是仓库 OWNER（appergb）。
+# - 评论 / review / issue 中出现 `@claude` 才触发，且发起者必须是 Open-Less 组织成员（OWNER 或 MEMBER）。
 # - 模型默认 claude-sonnet-4-6（量大、成本低）；评论里写 `--opus` 或包含 `claude-opus`
 #   字样会切到 claude-opus-4-7（用于需要更深推理的任务）。
 
@@ -18,13 +18,14 @@ on:
 
 jobs:
   claude:
-    # 双重门禁：(1) 内容含 @claude  (2) 触发者是 OWNER。
-    # author_association == 'OWNER' 是 GitHub 内建字段，免一次 API 调用。
+    # 双重门禁：(1) 内容含 @claude  (2) 触发者是 OWNER 或 MEMBER（Open-Less 组织成员）。
+    # 注：仓库已转入 Open-Less 组织后，author_association 对人类用户最高只会是 MEMBER，
+    # OWNER 此时只对个人账号下的同名仓库有效，这里保留是为了兼容仓库再次个人持有的情形。
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude') && github.event.comment.author_association == 'OWNER') ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude') && github.event.comment.author_association == 'OWNER') ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude') && github.event.review.author_association == 'OWNER') ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')) && github.event.issue.author_association == 'OWNER')
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude') && contains(fromJson('["OWNER","MEMBER"]'), github.event.comment.author_association)) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude') && contains(fromJson('["OWNER","MEMBER"]'), github.event.comment.author_association)) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude') && contains(fromJson('["OWNER","MEMBER"]'), github.event.review.author_association)) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')) && contains(fromJson('["OWNER","MEMBER"]'), github.event.issue.author_association))
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
### **User description**
## 背景

仓库转入 `Open-Less` 组织后，`claude.yml` 的触发门禁 `author_association == 'OWNER'` 对**所有人**（包括转移前的原 owner）都不再匹配 —— 因为 GitHub 的 `OWNER` 这个 author_association 值只对**个人账号下的同名仓库**有效，组织仓库下人类用户最高只会拿到 `MEMBER`。

证据：beta 上最近 10 次 `claude.yml` 的 workflow run 全部 `conclusion: skipped`，从未真正执行过 job。

## 改动

把四条 `if:` 子表达式的 `author_association == 'OWNER'` 全部换成 `contains(fromJson('["OWNER","MEMBER"]'), …author_association)`。OWNER 保留是为了兼容仓库未来再次个人持有的情形，**新增 MEMBER 才是实际生效的那条**。

顺手把注释里的"必须是仓库 OWNER（appergb）"同步更新为"OWNER 或 MEMBER（Open-Less 组织成员）"，并新增一行说明为什么 OWNER 在 org 仓库下不会匹配（避免下次有人疑惑）。

未触碰：
- 触发事件 (`on:`) 范围 —— 仍然只在评论/issue 出现 `@claude` 时才跑，不改变成本特征
- 模型选择逻辑、`--opus` 升级逻辑、`additional_permissions`、OAuth token 用法
- 任何其它 workflow / 代码

## 测试计划

合并后：

- [ ] 任一 Open-Less 成员在任意 issue 评论 `@claude ping`
- [ ] `gh run list -w claude.yml -L 1 --repo Open-Less/openless` 显示 conclusion 不再是 `skipped`
- [ ] 如果 run 跑了但 Claude 没回复 → 还需要在 https://github.com/apps/claude 把 Claude App 安装到 Open-Less 组织
- [ ] 外部 (`COLLABORATOR`) 评论不会触发 —— 故意保留为成员限定

## 不在本 PR 范围

- 自动 PR review：仓库目前由 `pr-agent.yml`（Kimi + GPT-5 fallback）承担，本 PR 不动它
- Claude App 在 Open-Less 组织的安装：那是 GitHub 网页操作，没法靠 commit 解决


___

### **PR Type**
Bug fix


___

### **Description**
- 放宽 `@claude` 触发者门禁

- 允许 `OWNER` 与 `MEMBER`

- 更新工作流注释说明


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["@claude comments and reviews"] --> B["Check author association"]
  B --> C["Allow OWNER or MEMBER"]
  C --> D["Trigger Claude workflow"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>claude.yml</strong><dd><code>Allow org members to trigger Claude</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/claude.yml

<ul><li>Expands the <code>author_association</code> gate from only <code>OWNER</code> to <code>OWNER</code> or <br><code>MEMBER</code>.<br> <li> Keeps the same <code>@claude</code>-based trigger conditions for comments, reviews, <br>and issues.<br> <li> Updates inline comments to explain Open-Less org membership behavior.</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/461/files#diff-53fec9c265fdba82268df5cd90315b8da57cce43d8e20efbf5c0bdcd1de1342e">+8/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

