### PR TITLE
chore: bump 1.3.4-1 + sidebar 底部行折成单行

### DIFF
--- a/openless-all/app/package-lock.json
+++ b/openless-all/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openless-app",
-  "version": "1.3.3",
+  "version": "1.3.4-1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openless-app",
-      "version": "1.3.3",
+      "version": "1.3.4-1",
       "dependencies": {
         "@tauri-apps/api": "^2.1.1",
         "@tauri-apps/plugin-autostart": "^2.5.1",

--- a/openless-all/app/package.json
+++ b/openless-all/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openless-app",
   "private": true,
-  "version": "1.3.3",
+  "version": "1.3.4-1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/openless-all/app/src-tauri/Cargo.lock
+++ b/openless-all/app/src-tauri/Cargo.lock
@@ -3751,7 +3751,7 @@ dependencies = [
 
 [[package]]
 name = "openless"
-version = "1.3.3"
+version = "1.3.4-1"
 dependencies = [
  "anyhow",
  "arboard",

--- a/openless-all/app/src-tauri/Cargo.toml
+++ b/openless-all/app/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openless"
-version = "1.3.3"
+version = "1.3.4-1"
 description = "OpenLess — local voice input that types where your cursor is"
 authors = ["OpenLess"]
 edition = "2021"

--- a/openless-all/app/src-tauri/tauri.conf.json
+++ b/openless-all/app/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "OpenLess",
-  "version": "1.3.3",
+  "version": "1.3.4-1",
   "identifier": "com.openless.app",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/openless-all/app/src/components/FloatingShell.tsx
+++ b/openless-all/app/src/components/FloatingShell.tsx
@@ -265,12 +265,14 @@ function FloatingShellBody({ os, initialTab, initialSettings }: { os: OS; initia
 
           <div style={{ flex: 1 }} />
 
-          <div style={{ display: 'flex', flexDirection: 'column', gap: 8, paddingTop: 10 }}>
+          {/* 底部一行：设置按钮（左）+ 版本 chip（右，marginLeft: auto 推到行尾）。
+              之前是两行：设置一行、版本另一行；浪费纵向空间，且把版本顶得太靠下。 */}
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8, paddingTop: 10 }}>
             <button
               onClick={() => openSettings()}
               className={settingsOpen ? 'ol-nav-btn ol-nav-btn-active' : 'ol-nav-btn'}
               style={{
-                display: 'flex', alignItems: 'center', gap: 10,
+                display: 'inline-flex', alignItems: 'center', gap: 10,
                 padding: '7px 10px',
                 borderRadius: 8, border: 0,
                 background: settingsOpen ? 'var(--ol-surface)' : 'transparent',
@@ -282,19 +284,20 @@ function FloatingShellBody({ os, initialTab, initialSettings }: { os: OS; initia
               }}
             >
               <Icon name="settings" size={14} />
-              <span style={{ flex: 1 }}>{t('shell.footer.settings')}</span>
+              <span>{t('shell.footer.settings')}</span>
             </button>
 
             <div
               style={{
+                marginLeft: 'auto',
                 display: 'flex',
                 alignItems: 'center',
-                gap: 8,
-                flexWrap: 'wrap',
-                padding: '0 10px',
+                gap: 6,
+                paddingRight: 10,
                 fontFamily: 'var(--ol-font-sans)',
                 fontSize: 11,
                 color: 'var(--ol-ink-4)',
+                whiteSpace: 'nowrap',
               }}
             >
               {IS_BETA_BUILD && (


### PR DESCRIPTION
### **User description**
## Summary

- **UI**：sidebar 底部「⚙ 设置」和「版本」从上下两行折成一行（设置左、版本 chip 右）。设置按钮去掉 label `flex:1`，由 flex 改 inline-flex，紧贴文字。
- **Release**：bump 版本 `1.3.3` → `1.3.4-1`。dash 后缀让 `appVersion.ts::IS_BETA_BUILD` 自动判为 Beta，UI 的 BETA 标签自动恢复。后续打 tag `v1.3.4-1-beta-tauri` 走 Beta channel。

本轮 Beta release 累积内容（自 v1.3.3-beta-tauri 之后）：
- #456 macOS no-activate capsule（AeroSpace 不被拉走 workspace）
- #460 style pack i18n 全语种 + Marketplace 差量缓存 + 内置三包升级 v2 + EN 翻译整段切到专用 prompt + 我的发布加载/计数修复
- #458 Windows 独占全屏游戏 capsule/hotkey OS 级限制文档
- 本 PR：sidebar 底部行折叠 + bump

## Test plan

- [x] `npx tsc --noEmit` exit 0
- [x] `cargo check` clean（只有 pre-existing warnings）
- [x] 6 处版本号（package.json / package-lock.json root + nested / tauri.conf.json / Cargo.toml / Cargo.lock）全部对齐为 1.3.4-1
- [ ] 本地装包后 sidebar 底部显示「⚙ 设置 BETA v1.3.4-1」一行


___

### **PR Type**
Enhancement, Other


___

### **Description**
- Compact the sidebar footer layout

- Align settings button and version chip

- Bump app and Tauri versions


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["FloatingShell footer"] -- "one-line layout" --> B["Settings button"]
  A -- "push to end" --> C["Version chip"]
  D["Version metadata"] -- "bump" --> E["1.3.4-1 release"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>FloatingShell.tsx</strong><dd><code>Compact sidebar footer into one row</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src/components/FloatingShell.tsx

<ul><li>Change the footer from a vertical stack to a single horizontal row<br> <li> Make the settings button <code>inline-flex</code> and remove the stretched label<br> <li> Push the version chip to the far right with <code>marginLeft: auto</code><br> <li> Add a comment explaining the new compact footer layout</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/462/files#diff-ef6d623d372a1cb87a4833f1435927fc2e2ceeedb75c18ea4064d45e1f44df38">+9/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>package.json</strong><dd><code>Bump app package version</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/package.json

- Update the app package version from `1.3.3` to `1.3.4-1`


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/462/files#diff-2650f8aa2f7ec97aa8af47f1f8a7c9ae4677fb69754b20d554e1d542507cf4ea">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Cargo.toml</strong><dd><code>Bump Tauri crate version</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src-tauri/Cargo.toml

- Update the Rust package version from `1.3.3` to `1.3.4-1`


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/462/files#diff-334952ba03e62939865bbf0351f0916ea88c6457f8ea1259336e73ee4e2f088b">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>tauri.conf.json</strong><dd><code>Sync Tauri config version</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src-tauri/tauri.conf.json

- Update the Tauri app version from `1.3.3` to `1.3.4-1`


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/462/files#diff-e9c2f15638ea988f61c82aeb2257147fb9cc96d7bda8709e8bad6b6517f5369c">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

