### PR TITLE
fix(shell): sidebar 底部翻回两行（版本在上、设置在下）

### DIFF
--- a/openless-all/app/src/components/FloatingShell.tsx
+++ b/openless-all/app/src/components/FloatingShell.tsx
@@ -265,39 +265,20 @@ function FloatingShellBody({ os, initialTab, initialSettings }: { os: OS; initia
 
           <div style={{ flex: 1 }} />
 
-          {/* 底部一行：设置按钮（左）+ 版本 chip（右，marginLeft: auto 推到行尾）。
-              之前是两行：设置一行、版本另一行；浪费纵向空间，且把版本顶得太靠下。 */}
-          <div style={{ display: 'flex', alignItems: 'center', gap: 8, paddingTop: 10 }}>
-            <button
-              onClick={() => openSettings()}
-              className={settingsOpen ? 'ol-nav-btn ol-nav-btn-active' : 'ol-nav-btn'}
-              style={{
-                display: 'inline-flex', alignItems: 'center', gap: 10,
-                padding: '7px 10px',
-                borderRadius: 8, border: 0,
-                background: settingsOpen ? 'var(--ol-surface)' : 'transparent',
-                boxShadow: settingsOpen ? '0 1px 2px rgba(0,0,0,.05), 0 0 0 0.5px rgba(0,0,0,.06)' : 'none',
-                fontFamily: 'inherit', fontSize: 13,
-                cursor: 'default',
-                transition: 'color 0.16s var(--ol-motion-quick), background 0.16s var(--ol-motion-quick)',
-                textAlign: 'left',
-              }}
-            >
-              <Icon name="settings" size={14} />
-              <span>{t('shell.footer.settings')}</span>
-            </button>
-
+          {/* 底部两行：上行 = 版本 chip（含 BETA 标），下行 = 设置按钮。
+              单行布局在窄 sidebar 下会把「设置」挤成两行竖字 + 版本糊一起；
+              翻回两行同时把顺序反过来：设置真正落到最底，版本在它上面。 */}
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 8, paddingTop: 10 }}>
             <div
               style={{
-                marginLeft: 'auto',
                 display: 'flex',
                 alignItems: 'center',
-                gap: 6,
-                paddingRight: 10,
+                gap: 8,
+                flexWrap: 'wrap',
+                padding: '0 10px',
                 fontFamily: 'var(--ol-font-sans)',
                 fontSize: 11,
                 color: 'var(--ol-ink-4)',
-                whiteSpace: 'nowrap',
               }}
             >
               {IS_BETA_BUILD && (
@@ -316,6 +297,25 @@ function FloatingShellBody({ os, initialTab, initialSettings }: { os: OS; initia
 
               <span>{t('shell.footer.version', { version: APP_VERSION_LABEL })}</span>
             </div>
+
+            <button
+              onClick={() => openSettings()}
+              className={settingsOpen ? 'ol-nav-btn ol-nav-btn-active' : 'ol-nav-btn'}
+              style={{
+                display: 'flex', alignItems: 'center', gap: 10,
+                padding: '7px 10px',
+                borderRadius: 8, border: 0,
+                background: settingsOpen ? 'var(--ol-surface)' : 'transparent',
+                boxShadow: settingsOpen ? '0 1px 2px rgba(0,0,0,.05), 0 0 0 0.5px rgba(0,0,0,.06)' : 'none',
+                fontFamily: 'inherit', fontSize: 13,
+                cursor: 'default',
+                transition: 'color 0.16s var(--ol-motion-quick), background 0.16s var(--ol-motion-quick)',
+                textAlign: 'left',
+              }}
+            >
+              <Icon name="settings" size={14} />
+              <span style={{ flex: 1 }}>{t('shell.footer.settings')}</span>
+            </button>
           </div>
         </aside>
 


### PR DESCRIPTION
### **User description**
## Summary

PR #462 把底部折成一行后，在窄 sidebar 下「设置」被挤成两行竖字、版本 chip 糊一起 —— 见 #462 合并后的截图。

改回两行但**反过来**：版本在上、设置在下 —— 设置真正落到最底（符合最初诉求），版本有独立空间容下 BETA 标 + 完整版本号。设置按钮恢复 display:flex + label flex:1，跟上面 nav 按钮风格统一。

## Test plan

- [x] tsc clean
- [x] 本地装包验证（截图 OK，已在会话中确认）


___

### **PR Type**
Enhancement, Other


___

### **Description**
- Reflow sidebar footer into two rows

- Keep version chip above settings

- Restore compact settings button styling

- Bump app versions to `1.3.4-1`


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Sidebar footer layout"] -- "reordered into two rows" --> B["Version chip"]
  A -- "settings moved below" --> C["Settings button"]
  D["App metadata"] -- "bumped to" --> E["1.3.4-1 release"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>FloatingShell.tsx</strong><dd><code>Reorder footer into stacked rows</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src/components/FloatingShell.tsx

<ul><li>Change the sidebar footer from a single row to a vertical stack.<br> <li> Place the version chip above the settings button.<br> <li> Restore the settings button to <code>display: flex</code> with a full-width label.<br> <li> Keep the beta tag and version text in a compact wrap-friendly row.</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/463/files#diff-ef6d623d372a1cb87a4833f1435927fc2e2ceeedb75c18ea4064d45e1f44df38">+26/-26</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>package.json</strong><dd><code>Bump app package version</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/package.json

- Update the app package version from `1.3.3` to `1.3.4-1`.


</details>


  </td>
  <td><a href=""></a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>package-lock.json</strong><dd><code>Sync locked app version</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/package-lock.json

- Align the lockfile metadata with the new `1.3.4-1` app version.


</details>


  </td>
  <td><a href=""></a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Cargo.toml</strong><dd><code>Bump Tauri package version</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src-tauri/Cargo.toml

- Update the Rust/Tauri package version from `1.3.3` to `1.3.4-1`.


</details>


  </td>
  <td><a href=""></a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Cargo.lock</strong><dd><code>Sync Rust lockfile version</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src-tauri/Cargo.lock

- Keep the Rust lockfile aligned with the `1.3.4-1` release bump.


</details>


  </td>
  <td><a href=""></a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>tauri.conf.json</strong><dd><code>Sync Tauri app version</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src-tauri/tauri.conf.json

- Update the Tauri app version from `1.3.3` to `1.3.4-1`.


</details>


  </td>
  <td><a href=""></a></td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

