### PR TITLE
fix(ci): detach HEAD 释放本地分支名，避开 fork PR 同名冲突

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -39,6 +39,17 @@ jobs:
         with:
           fetch-depth: 1
 
+      # Detach HEAD 释放 refs/heads/<default-branch> 这个本地分支名。
+      # 背景：claude-code-action 在 fork PR 上会执行
+      #   git fetch origin pull/<n>/head:<head-ref-name>
+      # 把 PR head 拉到与 fork 端 head 同名的本地分支。当 fork PR 的 head ref
+      # 与本仓库 base / 默认分支同名（例如 fork 也是 beta → beta）时，
+      # 上面那条 fetch 会撞上"当前已 checkout 的分支"而失败：
+      #   fatal: refusing to fetch into branch 'refs/heads/beta' checked out at ...
+      # 提前 detach 让本地分支名可以被 action 重新使用。
+      - name: Detach HEAD to free local branch ref
+        run: git checkout --detach
+
       - name: Pick model (default sonnet, opt-in opus)
         id: pick_model
         env:


### PR DESCRIPTION
### **User description**
## 背景

PR #451 (fork `aeoform/openless`, head ref 也叫 `beta`) 上有人 @claude，云端 review action 失败：

> failed run: https://github.com/Open-Less/openless/actions/runs/25978532215

错误链：

```
PR #451 is from a fork, fetching via refs/pull/451/head...
fatal: refusing to fetch into branch 'refs/heads/beta' checked out at '/home/runner/work/openless/openless'
##[error]Action failed with error: Command failed: git fetch origin --depth=20 pull/451/head:beta
```

## 根因（三连命中才会触发）

1. PR 来自 fork (`isCrossRepository: true`)
2. **fork 的 head 分支名也叫 `beta`** —— 与本仓库 base / 默认分支同名
3. `actions/checkout@v4` 默认把 worktree checkout 到了 `refs/heads/beta`

`claude-code-action@v1` 内部执行：

```
git fetch origin --depth=20 pull/451/head:beta
```

把 PR head 拉到**本地同名分支 `beta`**（命名取自 fork 端 head ref name）。但 `beta` 已是当前 checked-out 分支，git 拒绝 fetch 到已 checkout 的分支 → 失败。

## 修复

在 `actions/checkout` 之后立即 `git checkout --detach`，释放 `refs/heads/<default-branch>` 这个本地分支名，让 action 自己 fetch 不撞名。

仅对 fork head ref == base ref name 这个 corner case 有影响；其他场景（本仓库分支、fork 分支名不同）detach 都是无副作用的。

## 改动

- `.github/workflows/claude.yml`: +11 行，单 step + 注释，无其他改动。

## Test plan

- [ ] 合入后在 PR #451 上重新 `@claude`，确认 action run 成功，不再出现 `refusing to fetch into branch` 错误
- [ ] 在本仓库分支的 PR / Issue 上 `@claude`，确认正常路径不退化
- [ ] 若有第二个 fork PR head ref name 与 base 不同名，确认仍正常工作


___

### **PR Type**
Bug fix


___

### **Description**
- Detach checkout before Claude action

- Free default branch ref on forks

- Prevent fetch collisions in CI


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["actions/checkout"] -- "detach HEAD" --> B["Free local branch ref"]
  B -- "avoids ref collision" --> C["claude-code-action fetches PR head"]
  C -- "CI succeeds" --> D["Claude review workflow"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>claude.yml</strong><dd><code>Detach HEAD before Claude review step</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/claude.yml

<ul><li>Adds a <code>git checkout --detach</code> step after repository checkout.<br> <li> Prevents <code>claude-code-action</code> from fetching into an already checked-out <br>branch.<br> <li> Documents the fork PR ref-name collision scenario in workflow <br>comments.</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/464/files#diff-53fec9c265fdba82268df5cd90315b8da57cce43d8e20efbf5c0bdcd1de1342e">+11/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

