### PR TITLE
fix(windows): capsule/qa 透明窗口 Acrylic 兜底

### DIFF
--- a/openless-all/app/src-tauri/src/lib.rs
+++ b/openless-all/app/src-tauri/src/lib.rs
@@ -129,6 +129,19 @@ pub fn run() {
                 if let Err(e) = position_capsule_bottom_center(&capsule, false) {
                     log::warn!("[capsule] position failed: {e}");
                 }
+                // Windows 上 transparent:true 让窗口对桌面完全透明，Webview2 的
+                // backdrop-filter 只能模糊 DOM 内部，模糊不到 OS 桌面 → 胶囊背景
+                // 看起来就是「透到桌面」。这里给 Win10/Win11 都支持的 Acrylic 做兜底，
+                // 让 OS 提供毛玻璃材质，胶囊 rgba(255,255,255,0.85) 上面再叠 DOM 模糊。
+                // 失败不阻塞（老 Win10 / Win7 上 Acrylic 不可用），仅 warn。
+                #[cfg(target_os = "windows")]
+                {
+                    use window_vibrancy::apply_acrylic;
+                    // 中性偏冷的浅灰半透，与胶囊白底叠合后保持可读性。
+                    if let Err(e) = apply_acrylic(&capsule, Some((30, 32, 38, 140))) {
+                        log::warn!("[capsule] acrylic failed: {e}");
+                    }
+                }
                 let _ = capsule.hide();
             }
 
@@ -142,6 +155,16 @@ pub fn run() {
                 }
                 #[cfg(target_os = "macos")]
                 make_qa_window_draggable_macos(&qa);
+                // 同 capsule：Windows 下 QA 浮窗也走 Acrylic 兜底。QA 面板自身
+                // 已经把 alpha 拉到 0.97（QaPanel.tsx:623），主要是防止 0.03 缝隙
+                // 透到桌面、以及 Win10 上完全无毛玻璃感的兜底。
+                #[cfg(target_os = "windows")]
+                {
+                    use window_vibrancy::apply_acrylic;
+                    if let Err(e) = apply_acrylic(&qa, Some((30, 32, 38, 140))) {
+                        log::warn!("[qa] acrylic failed: {e}");
+                    }
+                }
                 let _ = qa.hide();
             } else {
                 log::info!("[qa] qa 窗口未在 tauri.conf.json 中声明，前端 agent 会补上");

--- a/openless-all/app/src/styles/global.css
+++ b/openless-all/app/src/styles/global.css
@@ -109,22 +109,3 @@ a { color: inherit; text-decoration: none; }
   }
 }
 
-/* P0 fallback: Windows / 旧浏览器没有 backdrop-filter 时，半透白底会直接
-   透到桌面（OS material 没接上 / 用户关了透明）。这里给依赖 backdrop 营造
-   可读性的 root 容器一个实色兜底。
-   注意：Capsule.tsx / FloatingShell.tsx 多数样式走 inline style，CSS 选择器
-   无法覆盖 inline；这层只是二级防护。一级防护是 Rust 侧 apply_acrylic。 */
-@supports not ((backdrop-filter: blur(1px)) or (-webkit-backdrop-filter: blur(1px))) {
-  html, body {
-    background: var(--ol-surface, #f6f7fb);
-  }
-}
-
-/* Win11「设置 → 颜色 → 透明效果关闭」、macOS Reduce Transparency 时，
-   不应再让任何窗口背景保持半透状态。给 html/body 拉一层不透明底，
-   配合上面的 inline-style 限制，至少桌面不会直接透过来。 */
-@media (prefers-reduced-transparency: reduce) {
-  html, body {
-    background: var(--ol-surface, #f6f7fb);
-  }
-}

--- a/openless-all/app/src/styles/global.css
+++ b/openless-all/app/src/styles/global.css
@@ -108,3 +108,23 @@ a { color: inherit; text-decoration: none; }
     transform: translate3d(12px, 0, 0) scale(0.985);
   }
 }
+
+/* P0 fallback: Windows / 旧浏览器没有 backdrop-filter 时，半透白底会直接
+   透到桌面（OS material 没接上 / 用户关了透明）。这里给依赖 backdrop 营造
+   可读性的 root 容器一个实色兜底。
+   注意：Capsule.tsx / FloatingShell.tsx 多数样式走 inline style，CSS 选择器
+   无法覆盖 inline；这层只是二级防护。一级防护是 Rust 侧 apply_acrylic。 */
+@supports not ((backdrop-filter: blur(1px)) or (-webkit-backdrop-filter: blur(1px))) {
+  html, body {
+    background: var(--ol-surface, #f6f7fb);
+  }
+}
+
+/* Win11「设置 → 颜色 → 透明效果关闭」、macOS Reduce Transparency 时，
+   不应再让任何窗口背景保持半透状态。给 html/body 拉一层不透明底，
+   配合上面的 inline-style 限制，至少桌面不会直接透过来。 */
+@media (prefers-reduced-transparency: reduce) {
+  html, body {
+    background: var(--ol-surface, #f6f7fb);
+  }
+}


### PR DESCRIPTION
## 问题

Windows Beta 1.3.4-4 上录音胶囊 (capsule) 和 QA 浮窗 (qa) 几乎完全透明，桌面壁纸直接透出，内容看不清。macOS 正常。

## 根因

`tauri.conf.json` 中 main / capsule / qa 三个窗口都设了 `transparent: true`，但 `src-tauri/src/lib.rs` 只对 main 窗口调用了 `apply_mica`。Webview2 的 `backdrop-filter` 只能模糊页面内部 DOM，**无法模糊 OS 桌面**（与 macOS WKWebView + NSVisualEffectView 行为有本质差异）。Capsule.tsx 的 `rgba(255,255,255,0.85)` + `backdrop-filter: blur(28px)` 在 Windows 上等于纯 0.85 alpha 透到桌面壁纸。

## 修复

在 `lib.rs` 的 capsule 和 qa 窗口初始化块里，Windows 下追加 Acrylic：

```rust
#[cfg(target_os = "windows")]
{
    use window_vibrancy::apply_acrylic;
    if let Err(e) = apply_acrylic(&capsule, Some((30, 32, 38, 140))) {
        log::warn!("[capsule] acrylic failed: {e}");
    }
}
```

选 Acrylic 而非 Mica 因为 Acrylic 支持 Win10，Mica 仅 Win11 22H2+。颜色 `(30, 32, 38, 140)` 偏冷深灰，alpha 140 在建议范围中段。失败仅 `log::warn` 不 panic。

macOS 路径完全不动。

## 关于 CSS 兜底

最初的版本附带了 `@supports not (backdrop-filter)` 和 `prefers-reduced-transparency` 两条全局 CSS fallback。本地代码审查指出 `html, body` 选择器过宽，在 macOS reduce-transparency 模式下会波及 main 窗口的 Vibrancy。

再分析后两条规则其实都是"几乎不会触发"的防御代码：现代 Webview2 / WKWebView / Chromium 都原生支持 `backdrop-filter`；macOS 系统 reduce-transparency 已经在 OS 层中和了 Vibrancy 不需要 CSS 再补一刀。**已在第二个 commit 中删除**，PR 现在只保留 Rust 侧 Acrylic 这一处变更，scope 更干净。

## 已知遗留

- `Capsule.tsx:261` 仍是 `rgba(255,255,255,0.85)` inline。预期 Acrylic 兜底足够；若实测仍不清需要单独 PR 调 alpha
- main 窗口仍用 Mica。Win10 用户主面板会偏透；若问题确认存在，后续 PR 给 main 也加 Acrylic 作为 Mica fallback
- Acrylic 在 Win10 v1903+ 拖动有卡顿。胶囊小尺寸固定位置，理论影响很小

## 本地审查结论

- **code-reviewer: REQUEST_CHANGES → APPROVE** (CSS 移除后)
- Rust API 签名 / 插入位置 / 错误处理 / 平台隔离 全部通过
- `cargo check` 无新增 warning
- **github-actions pr_agent_job: "No major issues detected"**

## Test plan

- [ ] Windows 11 实机：capsule 录音时背景磨砂可见
- [ ] Windows 11 实机：QA 浮窗背景可读
- [ ] Windows 10 实机：Acrylic 是否生效（关键测试，因为 Mica 不支持）
- [ ] macOS 回归测试：capsule / qa 视觉无变化
- [ ] 拖动 / 多屏切换：无明显卡顿

🤖 Generated with [Claude Code](https://claude.com/claude-code)