### PR TITLE
fix(startup): autostart catch 块缺 return 导致复活主窗口 (#468)

### DIFF
--- a/openless-all/app/src/App.tsx
+++ b/openless-all/app/src/App.tsx
@@ -53,9 +53,12 @@ export function App({ isCapsule, isQa }: AppProps) {
           const prefs = await getSettings();
           if (prefs.startMinimized) return;
         } catch (err) {
-          // 读 prefs 失败兜底走原有 show 行为：让权限探测失败的用户也能进 UI，
-          // 避免透明 / 空白窗口前卡死（issue #163 引入这个 show 的原始意图）。
-          console.warn('[startup] read startMinimized failed, falling back to show', err);
+          // 安全侧默认 = 不弹窗。autostart 早期 IPC 抖动会让 getSettings() 偶发
+          // 失败，旧逻辑（fall through to show）会在用户明明开了静默启动时仍把
+          // 主窗口弹出来 —— issue #468 复现路径。宁可让用户从 tray 手动唤起，
+          // 也不要在 autostart 抖动时强 show 一个白色 / 透明主窗口。
+          console.warn('[startup] read startMinimized failed; staying hidden to avoid #468', err);
+          return;
         }
         const { getCurrentWindow } = await import('@tauri-apps/api/window');
         if (cancelled) return;

--- a/openless-all/app/src/App.tsx
+++ b/openless-all/app/src/App.tsx
@@ -53,11 +53,18 @@ export function App({ isCapsule, isQa }: AppProps) {
           const prefs = await getSettings();
           if (prefs.startMinimized) return;
         } catch (err) {
-          // 安全侧默认 = 不弹窗。autostart 早期 IPC 抖动会让 getSettings() 偶发
-          // 失败，旧逻辑（fall through to show）会在用户明明开了静默启动时仍把
-          // 主窗口弹出来 —— issue #468 复现路径。宁可让用户从 tray 手动唤起，
-          // 也不要在 autostart 抖动时强 show 一个白色 / 透明主窗口。
-          console.warn('[startup] read startMinimized failed; staying hidden to avoid #468', err);
+          // 安全侧默认 = 不弹窗。Rust 端 get_settings 签名是
+          // `pub fn get_settings(...) -> UserPreferences`（非 Result），所以
+          // 该 catch 唯一会被触发的场景是 Tauri IPC 基础设施抖动（autostart 早期
+          // __TAURI_INTERNALS__ 还没就绪）。旧逻辑 fall-through to show 会在用户
+          // 开了静默启动时仍把主窗口弹出来 —— #468 复现路径。
+          //
+          // 此时 tray 已由 Rust 端 setup() 在 webview 加载前注册完成，是稳定的
+          // 兜底入口；宁可让用户从 tray 手动唤起，也不要在抖动时强 show 一个白色
+          // / 透明主窗口。首次安装的"prefs 不存在"场景不走这里 —— Rust 端会返回
+          // 默认 UserPreferences。
+          const detail = err instanceof Error ? err.message : String(err);
+          console.warn('[startup] read startMinimized failed; staying hidden to avoid #468:', detail, err);
           return;
         }
         const { getCurrentWindow } = await import('@tauri-apps/api/window');


### PR DESCRIPTION
### **User description**
## 问题

PR #474 引入的"前端兜底" useEffect (\`src/App.tsx:48-60\`) 在 webview ready 后读 \`prefs.startMinimized\`，true 则跳过 \`currentWindow.show()\`。但 catch 块只 \`console.warn\` 没有 \`return\`，控制流继续走到 \`show()\` —— 等于"prefs 读取失败 = 强 show"。

autostart 早期 IPC 还没完全 ready 时，\`getSettings()\` 偶发失败，**用户明明开了静默启动仍把主窗口弹出来**。这是 issue #468 在 PR #474 修复后剩下的最后一条复现路径。

## 修复

catch 块加 \`return\`，把语义从"读不到 prefs = 强 show"反转为"读不到 prefs = 当作 startMinimized=true 保持隐藏"。

\`\`\`ts
// Before
try {
  const prefs = await getSettings();
  if (prefs.startMinimized) return;
} catch (err) {
  console.warn('...', err);
  // ← 缺 return，fall through 到下面的 show()
}
const { getCurrentWindow } = await import('@tauri-apps/api/window');
// ...show()

// After
try {
  const prefs = await getSettings();
  if (prefs.startMinimized) return;
} catch (err) {
  console.warn('[startup] read startMinimized failed; staying hidden to avoid #468', err);
  return;  // ← 安全侧默认 = 不弹窗
}
// ...
\`\`\`

宁可让用户从 tray 手动唤起，也不要在 autostart 抖动时强 show 一个白色 / 透明主窗口。

## 不在本 PR 范围

\`Info.plist\` 的 \`LSUIElement\` 是另一个 macOS UX 决策：

- 它是**全局开关**，会让 Finder 双击 / Spotlight / Launchpad 启动都没 Dock 图标 / 菜单栏
- 正确做法是 Rust 端根据"是否 autostart 启动"动态切 \`activationPolicy(.accessory ↔ .regular)\`，而非 plist 静态写死
- 影响范围远超 #468，应作为独立 PR + 单独评审

\`tauri-plugin-autostart\` 的 \`--silent\` 参数注入也是同理 — 独立 PR。

## Test plan

- [ ] Windows 11 自启动后保持隐藏（IPC 正常）
- [ ] Windows 11 自启动 + 模拟 IPC 失败（断点 / network throttle） → 仍保持隐藏
- [ ] macOS 自启动同上
- [ ] 关闭 startMinimized → 自启动应正常 show 主窗口
- [ ] 用户从 tray 唤起 → 主窗口正常显示

Refs #468

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Bug fix, Documentation


___

### **Description**
- Guard `show()` behind `startMinimized`

- Keep hidden on settings read failure

- Improve startup warning diagnostics


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["App startup"] -- "read settings" --> B["getSettings()"]
  B -- "startMinimized=true" --> C["Skip show()"]
  B -- "read fails" --> D["Log and stay hidden"]
  C -- "keep silent launch" --> E["Main window hidden"]
  D -- "avoid reopening window" --> E["Main window hidden"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>App.tsx</strong><dd><code>Guard startup reveal with silent-launch fallback</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src/App.tsx

<ul><li>Reads <code>startMinimized</code> before revealing the window.<br> <li> Returns early when settings are unavailable, preserving hidden <br>startup.<br> <li> Logs a clearer diagnostic message with extracted error details.<br> <li> Expands inline comments to explain the autostart fallback path.</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/488/files#diff-de79c17c8d207a15e4b63b322a56e9f063721228677fe7e3c4a49813ab4c3576">+13/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

