### PR TITLE
fix(windows): 快捷键二次按键失效 - 串行化 Pressed/Released edge

### DIFF
--- a/openless-all/app/src-tauri/src/coordinator.rs
+++ b/openless-all/app/src-tauri/src/coordinator.rs
@@ -1305,11 +1305,17 @@ fn combo_hotkey_bridge_loop(inner: Arc<Inner>, rx: mpsc::Receiver<ComboHotkeyEve
         }
         let inner_cloned = Arc::clone(&inner);
         match evt {
+            // P0 #468/#475: 同 hotkey_bridge_loop —— Pressed/Released 必须串行 await，
+            // 否则 latch 竞态导致 combo 快捷键二次按键失效。
             ComboHotkeyEvent::Pressed => {
-                async_runtime::spawn(async move { handle_pressed_edge(&inner_cloned).await });
+                async_runtime::block_on(async {
+                    handle_pressed_edge(&inner_cloned).await;
+                });
             }
             ComboHotkeyEvent::Released => {
-                async_runtime::spawn(async move { handle_released_edge(&inner_cloned).await });
+                async_runtime::block_on(async {
+                    handle_released_edge(&inner_cloned).await;
+                });
             }
         }
     }
@@ -1697,11 +1703,25 @@ fn hotkey_bridge_loop(inner: Arc<Inner>, rx: mpsc::Receiver<HotkeyEvent>) {
         }
         let inner_cloned = Arc::clone(&inner);
         match evt {
+            // P0 #468/#475: Pressed/Released 必须串行处理，否则在 Windows 上 WH_KEYBOARD_LL
+            // 边沿间隔微秒级 → 两个独立 spawn 的 task 被 work-stealing 调度器并行执行 →
+            // `hotkey_trigger_held` latch 翻转顺序错乱 → 下次按键被静默吞掉
+            // (UI 关不掉 / 录音停不下来)。改为 bridge 线程内 block_on 顺序 await，
+            // recv 的 FIFO 顺序就是 handler 执行顺序。
+            // 注意：handle_pressed_edge / handle_released_edge 内部走 .await（含网络
+            // 握手），会暂时阻塞本 bridge 线程；Hold 模式短按时 Released 会排队在 channel
+            // 里直到 begin_session 完成，但 SessionPhase::Starting 已经有
+            // request_stop_during_starting 兜底，begin_session 完成进 Listening 后
+            // bridge 立刻 recv Released → end_session，行为正确，仅有短暂 stop 延迟。
             HotkeyEvent::Pressed => {
-                async_runtime::spawn(async move { handle_pressed_edge(&inner_cloned).await });
+                async_runtime::block_on(async {
+                    handle_pressed_edge(&inner_cloned).await;
+                });
             }
             HotkeyEvent::Released => {
-                async_runtime::spawn(async move { handle_released_edge(&inner_cloned).await });
+                async_runtime::block_on(async {
+                    handle_released_edge(&inner_cloned).await;
+                });
             }
             HotkeyEvent::Cancelled => {
                 cancel_session(&inner_cloned);
@@ -2091,7 +2111,10 @@ fn ensure_asr_credentials() -> Result<(), String> {
         {
             return Err("Foundry Local Whisper 当前仅支持 Windows".to_string());
         }
-        return Ok(());
+        #[cfg(target_os = "windows")]
+        {
+            return Ok(());
+        }
     }
 
     if is_whisper_compatible_provider(&active_asr) || is_bailian_provider(&active_asr) {


### PR DESCRIPTION
> **Note:** 此 PR **不是** #468 (silent-startup) 的修复。它修的是用户在 1.3.4-4 Beta 上**单独反馈**的另一个 Windows bug —— 快捷键二次按键失效。两者只是同一个 Beta 版本中并发出现，无代码关联。autostart 的修复在 #488。

## 问题

Windows Beta 1.3.4-4 上快捷键二次按键失效：
1. 按快捷键打开 capsule UI 后，再按一次同样的快捷键无法关闭
2. 按快捷键开始录音后，再按一次无法停止，只能按 ESC

macOS 正常。

## 根因

`hotkey_bridge_loop` 和 `combo_hotkey_bridge_loop` 把每条 `HotkeyEvent::Pressed` / `Released` 边沿独立 `async_runtime::spawn` 成两个 task：

```rust
HotkeyEvent::Pressed  => { async_runtime::spawn(async move { handle_pressed_edge(...).await }); }
HotkeyEvent::Released => { async_runtime::spawn(async move { handle_released_edge(...).await }); }
```

两个 task 被 tokio work-stealing 调度器并行执行：

- **macOS**：CGEventTap 边沿间隔几十毫秒，Pressed 大概率先完成 `swap(false→true)`，race window 极窄
- **Windows**：`WH_KEYBOARD_LL` 是 kernel 注入回调，KEYDOWN/KEYUP 间隔微秒级 → Released task **经常先 `swap(true→false)`** → `hotkey_trigger_held` 卡在 true → 下一次 Pressed 看到 `was_held=true` → toggle 静默吞掉

ESC 走 `HotkeyEvent::Cancelled` 直接调 `cancel_session`，不经过 latch，所以唯一逃脱路径。

## 修复

把 bridge loop 内的两次独立 spawn 改为 `tauri::async_runtime::block_on` 顺序 await。bridge 线程是独立 OS 线程（`std::thread`，非 tokio worker），`block_on` 安全。`mpsc::Receiver::recv()` FIFO 保证 Pressed/Released 严格按到达顺序处理。

`combo_hotkey_bridge_loop` 同模式替换。`qa_hotkey_bridge_loop` 只有 Pressed 单事件、`translation_hotkey_bridge_loop` 不走 `handle_*_edge`，本地审查已确认都无需修。

附带清理 `coordinator.rs:2094` 的 `unreachable_code` warning。

## 取舍

Hold 模式下 bridge 线程会被 `block_on` 短暂占用，相邻 Released 事件最多延迟一个 `handle_pressed_edge` 完成时间（≤500ms，主要是 ASR OpenSession 握手）。`request_stop_during_starting` 已覆盖 Starting 阶段松手语义，本地审查已验证路径正确。三平台同源，无 cfg 分叉。

## 本地审查结论

- **rust-reviewer: APPROVE** — 5 个审查点全部验证通过
- `cargo check --all-targets`：零 error，无新增 warning
- 唯一存量 `cargo fmt` 问题在 `coordinator.rs:1662`，与本 PR 无关

## Test plan

- [ ] Windows 实机：按快捷键开 capsule → 再按一次关 capsule
- [ ] Windows 实机：按快捷键开始录音 → 再按一次停止录音
- [ ] Windows Hold 模式短按松手 stop 行为
- [ ] macOS 回归测试 toggle / hold 双模式
- [ ] Linux fcitx5 路径 hotkey 行为

🤖 Generated with [Claude Code](https://claude.com/claude-code)