### PR TITLE
Package Windows beta feedback UI gates

### DIFF
--- a/openless-all/app/scripts/long-input-local-qwen-contract.test.mjs
+++ b/openless-all/app/scripts/long-input-local-qwen-contract.test.mjs
@@ -1,0 +1,98 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+function sliceBetween(source, start, end, name) {
+  const startIndex = source.indexOf(start);
+  assert.notEqual(startIndex, -1, `${name}: missing start marker ${start}`);
+  const endIndex = source.indexOf(end, startIndex + start.length);
+  assert.notEqual(endIndex, -1, `${name}: missing end marker ${end}`);
+  return source.slice(startIndex, endIndex);
+}
+
+function assertOrdered(source, fragments, name) {
+  let cursor = -1;
+  for (const fragment of fragments) {
+    const next = source.indexOf(fragment, cursor + 1);
+    assert.notEqual(next, -1, `${name}: missing or out of order fragment ${fragment}`);
+    cursor = next;
+  }
+}
+
+const localProviderRs = await readFile(
+  new URL("../src-tauri/src/asr/local/local_provider.rs", import.meta.url),
+  "utf8",
+);
+const coordinatorRs = await readFile(
+  new URL("../src-tauri/src/coordinator.rs", import.meta.url),
+  "utf8",
+);
+const dictationRs = await readFile(
+  new URL("../src-tauri/src/coordinator/dictation.rs", import.meta.url),
+  "utf8",
+);
+
+const localQwenImpl = sliceBetween(
+  localProviderRs,
+  "impl LocalQwenAsr {",
+  "impl crate::recorder::AudioConsumer for LocalQwenAsr {",
+  "LocalQwenAsr impl",
+);
+
+assertOrdered(
+  localQwenImpl,
+  [
+    "pub fn buffer_duration_ms(&self) -> u64 {",
+    "(self.buffer.lock().len() as u64 / 2) * 1000 / 16_000",
+    "pub async fn transcribe(self: Arc<Self>) -> Result<RawTranscript> {",
+    "let pcm_bytes = std::mem::take(&mut *self.buffer.lock());",
+    "let duration_ms = (pcm_bytes.len() as u64 / 2) * 1000 / 16_000;",
+    "let mut samples_f32 = i16_le_bytes_to_f32(&pcm_bytes);",
+    "samples_f32.extend(std::iter::repeat(0.0f32).take(8_000));",
+    "engine.transcribe_stream(&samples_f32)",
+    "Ok(RawTranscript { text, duration_ms })",
+  ],
+  "local Qwen ASR should measure original audio, append 0.5s silence, and transcribe padded samples",
+);
+
+const localQwenBranch = sliceBetween(
+  dictationRs,
+  "ActiveAsr::Local(local) => {",
+  "inner.local_asr_cache.touch();",
+  "dictation local Qwen branch",
+);
+assertOrdered(
+  localQwenBranch,
+  [
+    "let audio_secs = (local.buffer_duration_ms() as f64) / 1000.0;",
+    "let timeout_duration = local_qwen_transcribe_timeout(audio_secs);",
+    "\"[coord] local Qwen3-ASR transcribe: audio={:.2}s timeout={}s\"",
+    "let result = tokio::time::timeout(timeout_duration, local.transcribe()).await;",
+  ],
+  "dictation should compute a dynamic timeout from buffered audio before consuming local Qwen ASR",
+);
+
+const timeoutHelper = sliceBetween(
+  coordinatorRs,
+  "fn local_qwen_transcribe_timeout(audio_secs: f64) -> std::time::Duration {",
+  "fn startup_race_status_for_starting(",
+  "local_qwen_transcribe_timeout",
+);
+assertOrdered(
+  timeoutHelper,
+  [
+    "let secs = ((audio_secs * 0.6).ceil() as u64)",
+    ".saturating_add(10)",
+    ".max(COORDINATOR_GLOBAL_TIMEOUT_SECS);",
+    "std::time::Duration::from_secs(secs)",
+  ],
+  "local Qwen ASR timeout should be max(15, ceil(audio_s * 0.6) + 10)",
+);
+
+for (const testName of [
+  "local_qwen_timeout_floors_at_global_timeout_for_short_audio",
+  "local_qwen_timeout_scales_with_audio_duration",
+  "local_qwen_timeout_ceils_partial_seconds",
+  "local_qwen_timeout_handles_zero_duration",
+]) {
+  assert.match(coordinatorRs, new RegExp(`fn ${testName}\\(\\)`), `missing Rust timeout test ${testName}`);
+}

--- a/openless-all/app/scripts/windows-ime-restore.test.mjs
+++ b/openless-all/app/scripts/windows-ime-restore.test.mjs
@@ -1,0 +1,207 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+function sliceBetween(source, start, end, name) {
+  const startIndex = source.indexOf(start);
+  assert.notEqual(startIndex, -1, `${name}: missing start marker ${start}`);
+  const endIndex = source.indexOf(end, startIndex + start.length);
+  assert.notEqual(endIndex, -1, `${name}: missing end marker ${end}`);
+  return source.slice(startIndex, endIndex);
+}
+
+function assertOrdered(source, fragments, name) {
+  let cursor = -1;
+  for (const fragment of fragments) {
+    const next = source.indexOf(fragment, cursor + 1);
+    assert.notEqual(next, -1, `${name}: missing or out of order fragment ${fragment}`);
+    cursor = next;
+  }
+}
+
+function assertMatch(source, pattern, name) {
+  assert.match(source, pattern, name);
+}
+
+const profileRs = await readFile(
+  new URL("../src-tauri/src/windows_ime_profile.rs", import.meta.url),
+  "utf8",
+);
+const sessionRs = await readFile(
+  new URL("../src-tauri/src/windows_ime_session.rs", import.meta.url),
+  "utf8",
+);
+const coordinatorRs = await readFile(
+  new URL("../src-tauri/src/coordinator.rs", import.meta.url),
+  "utf8",
+);
+const dictationRs = await readFile(
+  new URL("../src-tauri/src/coordinator/dictation.rs", import.meta.url),
+  "utf8",
+);
+
+const activateOpenLess = sliceBetween(
+  profileRs,
+  "pub fn activate_openless_profile() -> WindowsImeProfileResult<()> {",
+  "pub fn restore_profile(snapshot: &ImeProfileSnapshot) -> WindowsImeProfileResult<()> {",
+  "activate_openless_profile",
+);
+assertOrdered(
+  activateOpenLess,
+  [
+    "profiles.EnableLanguageProfile(&clsid, OPENLESS_TSF_LANG_ID, &profile_guid, true)?;",
+    "profiles.ChangeCurrentLanguage(OPENLESS_TSF_LANG_ID)?;",
+    "profiles.ActivateLanguageProfile(&clsid, OPENLESS_TSF_LANG_ID, &profile_guid)",
+    "manager.ActivateProfile(",
+    "TF_PROFILETYPE_INPUTPROCESSOR",
+  ],
+  "OpenLess activation should update legacy TSF before modern TSF",
+);
+
+const restoreProfile = sliceBetween(
+  profileRs,
+  "pub fn restore_profile(snapshot: &ImeProfileSnapshot) -> WindowsImeProfileResult<()> {",
+  "pub fn is_openless_profile_active() -> WindowsImeProfileResult<bool> {",
+  "restore_profile",
+);
+const restoreTextService = sliceBetween(
+  restoreProfile,
+  "ImeProfileKind::TextService => {",
+  "ImeProfileKind::KeyboardLayout => {",
+  "restore_profile text service branch",
+);
+assertOrdered(
+  restoreTextService,
+  [
+    "let lang_id = snapshot.lang_id();",
+    "profiles.ChangeCurrentLanguage(lang_id)?;",
+    "profiles.ActivateLanguageProfile(&clsid, lang_id, &profile_guid)",
+    "let modern_result = with_profile_manager",
+    "manager.ActivateProfile(",
+    "TF_PROFILETYPE_INPUTPROCESSOR",
+    "if let Err(err) = modern_result",
+    "[windows-ime] legacy restore OK but modern ActivateProfile failed",
+  ],
+  "saved text-service restore should mirror activation and log modern TSF drift",
+);
+const restoreKeyboard = restoreProfile.slice(
+  restoreProfile.indexOf("ImeProfileKind::KeyboardLayout => {"),
+);
+assertOrdered(
+  restoreKeyboard,
+  [
+    "let lang_id = snapshot.lang_id();",
+    "profiles.ChangeCurrentLanguage(lang_id)",
+    "let modern_result = with_profile_manager",
+    "manager.ActivateProfile(",
+    "TF_PROFILETYPE_KEYBOARDLAYOUT",
+    "if let Err(err) = modern_result",
+    "[windows-ime] legacy restore OK but modern ActivateProfile (keyboard) failed",
+  ],
+  "saved keyboard-layout restore should restore legacy language before modern TSF bookkeeping",
+);
+
+const prepareSession = sliceBetween(
+  sessionRs,
+  "pub fn prepare_session(&self) -> PreparedWindowsImeSession {",
+  "pub async fn submit_prepared(",
+  "prepare_session",
+);
+assertOrdered(
+  prepareSession,
+  [
+    "self.profile_manager.capture_active_profile()",
+    "self.profile_manager.activate_openless_profile()",
+    "saved_profile: Some(saved_profile)",
+    "PreparedWindowsImeSession::activation_failed(saved_profile)",
+  ],
+  "Windows IME session should snapshot the user profile before activating OpenLess",
+);
+
+const restoreSession = sliceBetween(
+  sessionRs,
+  "pub fn restore_session(&self, prepared: PreparedWindowsImeSession) {",
+  "#[cfg(test)]",
+  "restore_session",
+);
+assertOrdered(
+  restoreSession,
+  [
+    "self.profile_manager.is_openless_profile_active()",
+    "restore_decision(",
+    "ProfileRestoreDecision::RestoreSavedProfile",
+    "self.profile_manager.restore_profile(saved_profile)",
+    "[windows-ime] restore saved profile failed",
+  ],
+  "Windows IME restore session should make a restore decision and log API-level restore failures",
+);
+
+const insertWithWindowsImeFirst = sliceBetween(
+  coordinatorRs,
+  "async fn insert_with_windows_ime_first(",
+  "fn should_try_non_tsf_insertion_fallback(",
+  "insert_with_windows_ime_first",
+);
+assertOrdered(
+  insertWithWindowsImeFirst,
+  [
+    "take_matching_prepared_windows_ime_session(&mut slot, session_id)",
+    "inner.windows_ime.submit_prepared(&prepared, request).await",
+    "inner.windows_ime.restore_session(prepared);",
+    "insert_via_non_tsf_fallback(inner, polished, restore_clipboard, paste_shortcut)",
+  ],
+  "TSF submit should restore the saved IME before falling back to non-TSF insertion",
+);
+
+const beginSession = sliceBetween(
+  dictationRs,
+  "pub(super) async fn begin_session(inner: &Arc<Inner>) -> Result<(), String> {",
+  "pub(super) async fn start_recorder_and_enter_listening(",
+  "dictation begin_session",
+);
+assertOrdered(
+  beginSession,
+  [
+    "let prepared = inner.windows_ime.prepare_session();",
+    "store_prepared_windows_ime_session(&mut slots, current_session_id, prepared);",
+    "if let Err(message) = ensure_asr_credentials()",
+    "restore_prepared_windows_ime_session(inner, current_session_id);",
+    "if let Err(message) = ensure_microphone_permission(inner)",
+    "restore_prepared_windows_ime_session(inner, current_session_id);",
+  ],
+  "begin_session should prepare IME early and restore it on pre-recorder errors",
+);
+
+const finishInsert = sliceBetween(
+  dictationRs,
+  "let status = if already_streamed {",
+  "let inserted_chars = polished.chars().count() as u32;",
+  "dictation finish insert",
+);
+assertOrdered(
+  finishInsert,
+  [
+    "InsertStatus::Inserted",
+    "insert_with_windows_ime_first(",
+    "inner.inserter.copy_fallback(&polished)",
+    "restore_prepared_windows_ime_session(inner, current_session_id);",
+  ],
+  "dictation success, TSF fallback, copy fallback, and streamed insert paths should converge on IME restore",
+);
+
+assertMatch(
+  dictationRs,
+  /if inner\.state\.lock\(\)\.cancelled \{[\s\S]*?\[coord\] cancel detected after ASR[\s\S]*?restore_prepared_windows_ime_session\(inner, current_session_id\);[\s\S]*?return Ok\(\(\)\);/,
+  "cancel after ASR should restore the prepared Windows IME session",
+);
+assertMatch(
+  dictationRs,
+  /pub\(super\) fn cancel_session\(inner: &Arc<Inner>\) \{[\s\S]*?cancel_asr_for_session\(inner, decision\.session_id\);[\s\S]*?restore_prepared_windows_ime_session\(inner, decision\.session_id\);/,
+  "explicit cancel_session should restore the prepared Windows IME session",
+);
+
+const currentSessionRestoreCalls =
+  dictationRs.match(/restore_prepared_windows_ime_session\(inner, current_session_id\);/g) ?? [];
+assert.ok(
+  currentSessionRestoreCalls.length >= 20,
+  `dictation should keep broad Windows IME cleanup coverage; found ${currentSessionRestoreCalls.length} current-session restore calls`,
+);

--- a/openless-all/app/scripts/windows-main-opaque-canvas.test.mjs
+++ b/openless-all/app/scripts/windows-main-opaque-canvas.test.mjs
@@ -1,0 +1,23 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+const mainTsx = await readFile(new URL("../src/main.tsx", import.meta.url), "utf8");
+const globalCss = await readFile(new URL("../src/styles/global.css", import.meta.url), "utf8");
+
+assert.match(
+  mainTsx,
+  /const openlessWindowKind = isCapsule \? "capsule" : isQa \? "qa" : "main";[\s\S]*const openlessPlatform = detectOS\(\);[\s\S]*document\.documentElement\.dataset\.openlessWindow = openlessWindowKind;[\s\S]*document\.documentElement\.dataset\.openlessPlatform = openlessPlatform;[\s\S]*document\.body\.dataset\.openlessWindow = openlessWindowKind;[\s\S]*document\.body\.dataset\.openlessPlatform = openlessPlatform;/,
+  "frontend should mark each webview kind and platform before rendering",
+);
+
+assert.match(
+  globalCss,
+  /html, body, #root \{[\s\S]*background: transparent;[\s\S]*\}/,
+  "capsule and QA windows should keep the shared transparent WebView baseline",
+);
+
+assert.match(
+  globalCss,
+  /html\[data-openless-window="main"\]\[data-openless-platform="win"\],[\s\S]*html\[data-openless-window="main"\]\[data-openless-platform="win"\] body,[\s\S]*html\[data-openless-window="main"\]\[data-openless-platform="win"\] #root \{[\s\S]*background: #f5f5f7;[\s\S]*\}/,
+  "Windows main window should have an internal opaque canvas to prevent transparent WebView bleed-through",
+);

--- a/openless-all/app/scripts/windows-right-ctrl-policy.test.mjs
+++ b/openless-all/app/scripts/windows-right-ctrl-policy.test.mjs
@@ -1,0 +1,34 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+function assertMatch(source, pattern, message) {
+  assert.match(source, pattern, message);
+}
+
+const settingsTsx = await readFile(new URL("../src/pages/Settings.tsx", import.meta.url), "utf8");
+
+assertMatch(
+  settingsTsx,
+  /const showRightCtrlHoldWarning = detectOS\(\) === 'win'[\s\S]*&& prefs\.hotkey\.mode === 'hold'[\s\S]*&& prefs\.dictationHotkey\.primary === 'RightControl'[\s\S]*&& prefs\.dictationHotkey\.modifiers\.length === 0;/,
+  "Right Ctrl warning should be scoped to Windows + RightControl + hold mode only",
+);
+
+assertMatch(
+  settingsTsx,
+  /\{showRightCtrlHoldWarning && \([\s\S]*settings\.recording\.rightCtrlHoldWarningTitle[\s\S]*settings\.recording\.rightCtrlHoldWarningDesc[\s\S]*\)\}/,
+  "Recording settings should render the scoped Right Ctrl hold warning",
+);
+
+for (const locale of ["en", "zh-CN", "zh-TW", "ja", "ko"]) {
+  const source = await readFile(new URL(`../src/i18n/${locale}.ts`, import.meta.url), "utf8");
+  assertMatch(
+    source,
+    /rightCtrlHoldWarningTitle:/,
+    `${locale} should define the Right Ctrl warning title`,
+  );
+  assertMatch(
+    source,
+    /rightCtrlHoldWarningDesc:/,
+    `${locale} should define the Right Ctrl warning description`,
+  );
+}

--- a/openless-all/app/scripts/windows-selectlite-contract.test.mjs
+++ b/openless-all/app/scripts/windows-selectlite-contract.test.mjs
@@ -1,0 +1,70 @@
+import assert from "node:assert/strict";
+import { readFile, readdir } from "node:fs/promises";
+import { join, relative } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const srcRootPath = fileURLToPath(new URL("../src/", import.meta.url));
+
+async function collectTsxFiles(dirPath) {
+  const entries = await readdir(dirPath, { withFileTypes: true });
+  const files = [];
+  for (const entry of entries) {
+    const childPath = join(dirPath, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...await collectTsxFiles(childPath));
+    } else if (entry.name.endsWith(".tsx")) {
+      files.push(childPath);
+    }
+  }
+  return files;
+}
+
+function stripComments(source) {
+  return source
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .replace(/^\s*\/\/.*$/gm, "");
+}
+
+function assertMatch(source, pattern, message) {
+  assert.match(source, pattern, message);
+}
+
+function assertSelectLiteUsage(source, minCount, fileLabel) {
+  const count = source.match(/<SelectLite\b/g)?.length ?? 0;
+  assert.ok(count >= minCount, `${fileLabel} should use SelectLite at least ${minCount} time(s); found ${count}`);
+}
+
+const selectLite = await readFile(new URL("../src/components/ui/SelectLite.tsx", import.meta.url), "utf8");
+const settings = await readFile(new URL("../src/pages/Settings.tsx", import.meta.url), "utf8");
+const localAsr = await readFile(new URL("../src/pages/LocalAsr.tsx", import.meta.url), "utf8");
+const translation = await readFile(new URL("../src/pages/Translation.tsx", import.meta.url), "utf8");
+const languageSection = await readFile(new URL("../src/pages/settings/LanguageSection.tsx", import.meta.url), "utf8");
+
+const tsxFiles = await collectTsxFiles(srcRootPath);
+for (const filePath of tsxFiles) {
+  const source = stripComments(await readFile(filePath, "utf8"));
+  assert.doesNotMatch(
+    source,
+    /<select\b/i,
+    `${join("src", relative(srcRootPath, filePath))} should not render native <select>`,
+  );
+}
+
+assertMatch(selectLite, /export interface SelectOption \{[\s\S]*value: string;[\s\S]*label: string;[\s\S]*disabled\?: boolean;/, "SelectLite should expose value/label/disabled options");
+assertMatch(selectLite, /interface SelectLiteProps \{[\s\S]*value: string;[\s\S]*onChange: \(value: string\) => void;[\s\S]*options: SelectOption\[\];[\s\S]*disabled\?: boolean;/, "SelectLite should accept value, onChange, options, and disabled");
+assertMatch(selectLite, /createPortal\(/, "SelectLite popover should render through a portal");
+assertMatch(selectLite, /role="combobox"[\s\S]*aria-haspopup="listbox"[\s\S]*aria-expanded=\{open\}/, "SelectLite trigger should expose combobox/listbox a11y state");
+assertMatch(selectLite, /role="listbox"/, "SelectLite popover should use role=listbox");
+assertMatch(selectLite, /role="option"[\s\S]*aria-selected=\{isSelected\}[\s\S]*aria-disabled=\{option\.disabled\}/, "SelectLite options should expose selected and disabled state");
+assertMatch(selectLite, /event\.key === 'Escape'[\s\S]*closeMenu\(\)/, "SelectLite should close on Escape");
+assertMatch(selectLite, /event\.key === 'ArrowDown'[\s\S]*moveHighlight\(1\)/, "SelectLite should move highlight down from keyboard");
+assertMatch(selectLite, /event\.key === 'ArrowUp'[\s\S]*moveHighlight\(-1\)/, "SelectLite should move highlight up from keyboard");
+assertMatch(selectLite, /event\.key === 'Enter'[\s\S]*selectIndex\(highlight\)/, "SelectLite should select highlighted option on Enter");
+assertMatch(selectLite, /document\.addEventListener\('mousedown', handlePointerDown\)/, "SelectLite should close on outside pointer down");
+assertMatch(selectLite, /window\.addEventListener\('wheel', handleScrollOutside/, "SelectLite should close on outside wheel/scroll");
+assertMatch(selectLite, /textOverflow: 'ellipsis'/, "SelectLite should constrain long labels instead of expanding layout");
+
+assertSelectLiteUsage(settings, 4, "Settings.tsx");
+assertSelectLiteUsage(localAsr, 5, "LocalAsr.tsx");
+assertSelectLiteUsage(translation, 1, "Translation.tsx");
+assertSelectLiteUsage(languageSection, 1, "LanguageSection.tsx");

--- a/openless-all/app/src/i18n/en.ts
+++ b/openless-all/app/src/i18n/en.ts
@@ -514,6 +514,8 @@ export const en: typeof zhCN = {
       modeDesc: 'Toggle = tap once to start, again to stop. Push-to-talk = hold to record.',
       modeToggle: 'Toggle',
       modeHold: 'Push-to-talk',
+      rightCtrlHoldWarningTitle: 'Right Ctrl may conflict with chat send shortcuts',
+      rightCtrlHoldWarningDesc: 'Push-to-talk reserves Right Ctrl while recording, so Right Ctrl+Enter in apps like QQ or WeChat may arrive as Enter only. Switch back to Toggle, or choose a shortcut that is not used for sending messages.',
       migrationNoticeTitle: 'Default recording mode is now Toggle',
       migrationNoticeDesc: 'This update changes the default; if you prefer push-to-talk, switch it back here.',
       microphoneLabel: 'Preferred microphone',

--- a/openless-all/app/src/i18n/ja.ts
+++ b/openless-all/app/src/i18n/ja.ts
@@ -516,6 +516,8 @@ export const ja: typeof zhCN = {
       modeDesc: 'トグル式 = 1 回押して開始、もう 1 回押して終了；押し続けて話す = 押している間だけ録音。',
       modeToggle: 'トグル式',
       modeHold: '押し続けて話す',
+      rightCtrlHoldWarningTitle: '右 Ctrl はチャット送信ショートカットと競合する場合があります',
+      rightCtrlHoldWarningDesc: '押し続けて話すでは録音中に右 Ctrl を予約するため、QQ / WeChat などの右 Ctrl+Enter が Enter だけとして届く場合があります。トグル式に戻すか、送信に使わないショートカットを選んでください。',
       migrationNoticeTitle: 'デフォルトがトグル式に変更されました',
       migrationNoticeDesc: '以前にトリガー方式を変更していた場合は、ここで再度確認してください。今回のアップデートではショートカット方式のデフォルト値と読み込みロジックが変更されています。「押し続けて話す」が好みであれば再度切り替えてください。',
       microphoneLabel: '優先マイク',

--- a/openless-all/app/src/i18n/ko.ts
+++ b/openless-all/app/src/i18n/ko.ts
@@ -516,6 +516,8 @@ export const ko: typeof zhCN = {
       modeDesc: '토글 방식 = 한 번 누르면 시작, 다시 누르면 종료; 눌러서 말하기 = 누르고 있는 동안만 녹음.',
       modeToggle: '토글 방식',
       modeHold: '눌러서 말하기',
+      rightCtrlHoldWarningTitle: '오른쪽 Ctrl 이 채팅 전송 단축키와 충돌할 수 있습니다',
+      rightCtrlHoldWarningDesc: '눌러서 말하기는 녹음 중 오른쪽 Ctrl 을 예약하므로 QQ / WeChat 등의 오른쪽 Ctrl+Enter 가 Enter 만으로 전달될 수 있습니다. 토글 방식으로 돌아가거나 메시지 전송에 쓰지 않는 단축키를 선택하세요.',
       migrationNoticeTitle: '기본값이 토글 방식으로 변경됨',
       migrationNoticeDesc: '이전에 트리거 방식을 변경했다면 여기서 다시 한 번 확인해 주세요. 이번 업데이트는 단축키 방식의 기본값과 읽기 로직을 조정했습니다. "눌러서 말하기"가 더 익숙하다면 다시 전환할 수 있습니다.',
       microphoneLabel: '기본 선택 마이크',

--- a/openless-all/app/src/i18n/zh-CN.ts
+++ b/openless-all/app/src/i18n/zh-CN.ts
@@ -512,6 +512,8 @@ export const zhCN = {
       modeDesc: '切换式按一次开始、再按一次结束；按住说话按下保持、松开结束。',
       modeToggle: '切换式',
       modeHold: '按住说话',
+      rightCtrlHoldWarningTitle: '右 Ctrl 可能与聊天发送快捷键冲突',
+      rightCtrlHoldWarningDesc: '按住说话会在录音期间占用右 Ctrl，QQ / 微信里的右 Ctrl+Enter 可能只收到 Enter。建议切回切换式，或改用不参与发送消息的快捷键。',
       migrationNoticeTitle: '默认已改为切换式说话',
       migrationNoticeDesc: '本次更新调整了默认值，如果习惯按住说话，请在此处切回。',
       microphoneLabel: '首选麦克风',

--- a/openless-all/app/src/i18n/zh-TW.ts
+++ b/openless-all/app/src/i18n/zh-TW.ts
@@ -514,6 +514,8 @@ export const zhTW: typeof zhCN = {
       modeDesc: '切換式 = 按一次開始、再按一次結束；按住說話 = 按住開始、鬆開結束。',
       modeToggle: '切換式',
       modeHold: '按住說話',
+      rightCtrlHoldWarningTitle: '右 Ctrl 可能與聊天送出快捷鍵衝突',
+      rightCtrlHoldWarningDesc: '按住說話會在錄音期間佔用右 Ctrl，QQ / 微信裏的右 Ctrl+Enter 可能只收到 Enter。建議切回切換式，或改用不參與送出訊息的快捷鍵。',
       migrationNoticeTitle: '默認已改爲切換式說話',
       migrationNoticeDesc: '如果你之前改過快捷鍵觸發方式，請在這裏手動確認一次。本次更新調整了快捷鍵方式的默認值與讀取邏輯；如果你更習慣按住說話，可以重新切回“按住說話”。',
       comboRecordLabel: '錄製快捷鍵',

--- a/openless-all/app/src/main.tsx
+++ b/openless-all/app/src/main.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
 import { App } from "./App";
+import { detectOS } from "./components/WindowChrome";
 import i18n from "./i18n"; // 副作用：触发 i18next init
 import "./styles/tokens.css";
 import "./styles/global.css";
@@ -9,6 +10,13 @@ const params = new URLSearchParams(window.location.search);
 const windowKind = params.get("window");
 const isCapsule = windowKind === "capsule";
 const isQa = windowKind === "qa";
+const openlessWindowKind = isCapsule ? "capsule" : isQa ? "qa" : "main";
+const openlessPlatform = detectOS();
+
+document.documentElement.dataset.openlessWindow = openlessWindowKind;
+document.documentElement.dataset.openlessPlatform = openlessPlatform;
+document.body.dataset.openlessWindow = openlessWindowKind;
+document.body.dataset.openlessPlatform = openlessPlatform;
 
 const root = ReactDOM.createRoot(document.getElementById("root")!);
 

--- a/openless-all/app/src/pages/Settings.tsx
+++ b/openless-all/app/src/pages/Settings.tsx
@@ -343,6 +343,10 @@ function RecordingSection() {
   const selectedMicrophoneLabel = effectiveMicrophoneDeviceName
     ? effectiveMicrophoneDeviceName
     : t('settings.recording.microphoneDefault');
+  const showRightCtrlHoldWarning = detectOS() === 'win'
+    && prefs.hotkey.mode === 'hold'
+    && prefs.dictationHotkey.primary === 'RightControl'
+    && prefs.dictationHotkey.modifiers.length === 0;
 
   return (
     <>
@@ -398,6 +402,25 @@ function RecordingSection() {
           ))}
         </div>
       </SettingRow>
+      {showRightCtrlHoldWarning && (
+        <div
+          style={{
+            marginTop: 2,
+            marginBottom: 10,
+            padding: '10px 12px',
+            borderRadius: 8,
+            background: 'rgba(245, 158, 11, 0.10)',
+            border: '0.5px solid rgba(245, 158, 11, 0.24)',
+          }}
+        >
+          <div style={{ fontSize: 12, fontWeight: 600, color: '#92400e', marginBottom: 3 }}>
+            {t('settings.recording.rightCtrlHoldWarningTitle')}
+          </div>
+          <div style={{ fontSize: 11.5, color: 'var(--ol-ink-3)', lineHeight: 1.55 }}>
+            {t('settings.recording.rightCtrlHoldWarningDesc')}
+          </div>
+        </div>
+      )}
       <SettingRow label={t('settings.recording.microphoneLabel')} desc={t('settings.recording.microphoneDesc')}>
         <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
           <button

--- a/openless-all/app/src/styles/global.css
+++ b/openless-all/app/src/styles/global.css
@@ -7,6 +7,12 @@ html, body, #root {
   overflow: hidden;
 }
 
+html[data-openless-window="main"][data-openless-platform="win"],
+html[data-openless-window="main"][data-openless-platform="win"] body,
+html[data-openless-window="main"][data-openless-platform="win"] #root {
+  background: #f5f5f7;
+}
+
 body {
   background: transparent;
   user-select: none;


### PR DESCRIPTION
### **User description**
## Parent

#478

## Scope

This PR packages the low-conflict Windows beta feedback slices that can be reviewed independently of #490 / #492:

- Fixes #481
- Fixes #482
- Fixes #483
- Fixes #484
- Fixes #485

## What changed

- Added a Windows IME restore contract gate that locks the saved-profile restore symmetry and cleanup paths for success, fallback, cancel, and error flows.
- Scoped the Windows main window to an internal opaque canvas while preserving capsule / QA transparency and non-Windows vibrancy behavior.
- Added a SelectLite contract gate proving Windows-facing settings surfaces no longer render native `<select>` controls and that SelectLite keeps expected keyboard / portal / accessibility behavior.
- Added a local Qwen long-input contract gate for the existing tail-silence padding and dynamic timeout protections.
- Added a scoped Recording settings warning for Windows + Right Ctrl + Push-to-talk, based on the #485 maintainer decision to keep current behavior/defaults and recommend Toggle as the workaround.

## Out of scope

- #480 / #476 QA recording second-hotkey Rust fix. That remains a separate slice because it touches `coordinator.rs` and should be packaged after #490 settles.
- #486 wired headset button investigation. It remains `needs-info` until the reporter provides environment and event-source details.
- #490 / #492 handoff-core work: action shortcut disable/retry cleanup, `Starting` repeated stop/cancel behavior, beta updater readiness probe, and Common Controls v6 manifest validation.
- #493 release workflow hardening.

## Evidence

Issue evidence already posted during triage:

- #481: IME restore evidence and validation notes.
- #482: Windows transparent WebView / white-edge diagnosis and screenshot evidence.
- #483: SelectLite replacement audit and no-native-select gate.
- #484: local Qwen tail-silence + dynamic-timeout evidence.
- #485: Right Ctrl policy decision and scoped Settings warning.

## Validation

Run from `openless-all/app`:

```powershell
node .\scripts\windows-ime-restore.test.mjs
node .\scripts\windows-main-opaque-canvas.test.mjs
node .\scripts\windows-selectlite-contract.test.mjs
node .\scripts\long-input-local-qwen-contract.test.mjs
node .\scripts\windows-right-ctrl-policy.test.mjs
npm run build
```

Additional packaging gate:

```powershell
git diff --check
```

All passed locally. `npm run build` emitted only the existing Vite dynamic-import / chunk-size warnings.

## Cross-agent coordination

This branch was created in a separate worktree from #490's `fix/windows-handoff-core` branch. Scope gate confirmed this PR does not include #490-owned Rust/updater/startup files and does not include the #480 coordinator QA slice.


___

### **PR Type**
Bug fix, Enhancement, Tests


___

### **Description**
- Add Windows IME restore contracts
  - Cover success, fallback, cancel, error

- Mark main window opaque on Windows
  - Keep capsule and QA transparent

- Warn about Right Ctrl conflicts
  - Localize the recording-mode notice

- Lock SelectLite and ASR behavior
  - Prevent native selects and timeout regressions


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Hotkey["Windows recording hotkey"] -- "capture / restore" --> IME["IME session restore"]
  IME -- "submit / fallback / cancel" --> Dictation["Dictation lifecycle"]
  Main["main.tsx + global.css"] -- "platform window flags" --> Canvas["Opaque Windows canvas"]
  Settings["Settings warning"] -- "Right Ctrl hold notice" --> Users["Safer shortcut choice"]
  Select["SelectLite contract"] -- "no native <select>" --> UI["Windows-facing settings UI"]
  ASR["Local Qwen contract"] -- "dynamic timeout" --> Dictation
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>7 files</summary><table>
<tr>
  <td><strong>en.ts</strong><dd><code>Add Right Ctrl warning translations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/494/files#diff-bb2f4fa05787923f8aeb23b6f11ad8705e02d9ff03a45790f9181e4615c79d83">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ja.ts</strong><dd><code>Add Right Ctrl warning translations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/494/files#diff-be57f0090cf34e3ff924cfa35f13d5d9e6514d3af5a1ebfdeb92bd7d36ed9cf4">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ko.ts</strong><dd><code>Add Right Ctrl warning translations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/494/files#diff-daf35bcb6a2f8a31565b83d119cb59b69c1dededbabfccfd0d56693fdb3726ca">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>zh-CN.ts</strong><dd><code>Add Right Ctrl warning translations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/494/files#diff-571576f3c7b6c4a78ae0f91accdccc5da5cbed00409955c9914c046fee6c80ea">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>zh-TW.ts</strong><dd><code>Add Right Ctrl warning translations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/494/files#diff-a8d5953f9c76bc3c90ec583270be04c852bd7540297500e6ff3260760fc61ea4">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>main.tsx</strong><dd><code>Set window kind and platform markers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/494/files#diff-28b93cd994b0d907bce86cd83f6ea7a4093c596a1f678040b0d229359e187278">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>Settings.tsx</strong><dd><code>Show Right Ctrl conflict warning</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/494/files#diff-b493ca85e083b07f67da1b3ac96aeab153b20c97405e26292b47b95e13368c38">+23/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>global.css</strong><dd><code>Use opaque Windows main canvas</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/494/files#diff-ba6dfef13673e14e7e2ae1888f48b081d20a99e6b5a93c451cff7096e80ea47f">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>long-input-local-qwen-contract.test.mjs</strong><dd><code>Validate local Qwen timeout contract</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/494/files#diff-ec48914a50c1e9fd4e640fa9c42a3e6506138c2f666915fe58aada5d348d9541">+98/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>windows-ime-restore.test.mjs</strong><dd><code>Validate Windows IME restore lifecycle</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/494/files#diff-44d7c769437fd4759fca84769d01ce73d437dd989b72a0111d1a822e5a5a25ea">+207/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>windows-main-opaque-canvas.test.mjs</strong><dd><code>Validate opaque Windows main canvas</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/494/files#diff-4fb91a83eb4f7a99d5a91707bdc16ee3e500223722f97f88acbe69da82d01ee0">+23/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>windows-right-ctrl-policy.test.mjs</strong><dd><code>Validate Right Ctrl warning policy</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/494/files#diff-7cc1852a8718e0fb3e8066db54bc584fd67a6871de52603bb28bf16de55a6546">+34/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>windows-selectlite-contract.test.mjs</strong><dd><code>Validate SelectLite and native select</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/494/files#diff-bfb7fff3c2d51c92f7cdffd0466f7f8f2fcb4db045ea44c0d95431f7ade3ecf5">+70/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

