### PR TITLE
Fix/revert windows capsule qa acrylic

### DIFF
--- a/.github/workflows/release-tauri.yml
+++ b/.github/workflows/release-tauri.yml
@@ -1,4 +1,5 @@
 name: Release Tauri (cross-platform)
+# meta: ensure Actions indexes this workflow on forks (no behavior change).
 # 触发条件：
 #   - 推 v*.*.*-tauri 形式的 tag（与老 Swift 版的 vX.Y.Z 区分开,不冲突）
 #   - 手动 dispatch（用于测试构建,不发版）

--- a/.gitignore
+++ b/.gitignore
@@ -79,3 +79,6 @@ docs/github-tracking/
 docs/superpowers/
 docs/windows-lifecycle-tracking/
 docs/windows-ui-tracking/
+
+# 用于本地语音推理的参考文件。
+CapsWriter

--- a/openless-all/app/src-tauri/src/lib.rs
+++ b/openless-all/app/src-tauri/src/lib.rs
@@ -129,19 +129,6 @@ pub fn run() {
                 if let Err(e) = position_capsule_bottom_center(&capsule, false) {
                     log::warn!("[capsule] position failed: {e}");
                 }
-                // Windows 上 transparent:true 让窗口对桌面完全透明，Webview2 的
-                // backdrop-filter 只能模糊 DOM 内部，模糊不到 OS 桌面 → 胶囊背景
-                // 看起来就是「透到桌面」。这里给 Win10/Win11 都支持的 Acrylic 做兜底，
-                // 让 OS 提供毛玻璃材质，胶囊 rgba(255,255,255,0.85) 上面再叠 DOM 模糊。
-                // 失败不阻塞（老 Win10 / Win7 上 Acrylic 不可用），仅 warn。
-                #[cfg(target_os = "windows")]
-                {
-                    use window_vibrancy::apply_acrylic;
-                    // 中性偏冷的浅灰半透，与胶囊白底叠合后保持可读性。
-                    if let Err(e) = apply_acrylic(&capsule, Some((30, 32, 38, 140))) {
-                        log::warn!("[capsule] acrylic failed: {e}");
-                    }
-                }
                 let _ = capsule.hide();
             }
 
@@ -155,16 +142,6 @@ pub fn run() {
                 }
                 #[cfg(target_os = "macos")]
                 make_qa_window_draggable_macos(&qa);
-                // 同 capsule：Windows 下 QA 浮窗也走 Acrylic 兜底。QA 面板自身
-                // 已经把 alpha 拉到 0.97（QaPanel.tsx:623），主要是防止 0.03 缝隙
-                // 透到桌面、以及 Win10 上完全无毛玻璃感的兜底。
-                #[cfg(target_os = "windows")]
-                {
-                    use window_vibrancy::apply_acrylic;
-                    if let Err(e) = apply_acrylic(&qa, Some((30, 32, 38, 140))) {
-                        log::warn!("[qa] acrylic failed: {e}");
-                    }
-                }
                 let _ = qa.hide();
             } else {
                 log::info!("[qa] qa 窗口未在 tauri.conf.json 中声明，前端 agent 会补上");


### PR DESCRIPTION
## 摘要

Fixes #487。

`fix(windows): 移除胶囊与 QA 浮窗的整窗 Acrylic 黑边`

这个 PR 只解决一个问题：Windows 上 `capsule` 和 `qa` 宿主窗口套用了整窗 Acrylic，导致透明宿主被染成明显的深色矩形，录音胶囊和 QA 浮窗外侧出现大块黑边。本次改动回退这两处 Acrylic，仅保留原有的透明宿主 + 前端白色可见内容层。

## 修复 / 新增 / 改进

- 移除 Windows 启动阶段对 `capsule` 窗口的 `apply_acrylic(...)`
- 移除 Windows 启动阶段对 `qa` 窗口的 `apply_acrylic(...)`
- 保持胶囊与 QA 浮窗原有的定位、显示、隐藏与生命周期逻辑不变
- 保持主窗口 `main` 的 Mica 路径不变，不扩大这次修复范围

## 兼容

- 不包含：
- 不调整 `capsule` / `qa` 的尺寸、阴影 inset、动画、焦点策略或主窗口材质方案
- 不处理 `windows-ui-config.test.mjs` 里现存的主窗口旧断言漂移问题

- 对现有用户 / 本地环境 / 构建流程的影响：
- Windows 下胶囊和 QA 浮窗将不再使用整窗 Acrylic，避免出现整块深色宿主矩形
- 现有前端白色 pill / 白色 QA 卡片样式保持不变
- 不引入新的配置项、依赖或构建步骤变更

## 测试计划

- [ ] 命令：`node openless-all/app/scripts/windows-ui-config.test.mjs`
- [ ] 结果：确认本次改动未影响既有窗口配置与胶囊几何相关契约；如失败，单独记录当前已知的主窗口旧断言漂移，不作为本 PR 阻塞项
- [ ] 证据路径：`openless-all/app/scripts/windows-ui-config.test.mjs`

- [ ] 命令：Windows 本机启动应用，触发录音胶囊
- [ ] 结果：胶囊外围不再出现整块深色矩形，仅保留白色圆角 pill
- [ ] 证据路径：录屏 / 截图，重点对比浅色背景下的胶囊宿主边界

- [ ] 命令：Windows 本机打开 QA 浮窗
- [ ] 结果：QA 浮窗不再出现整块深色宿主底；允许轻微透桌面作为当前可接受 trade-off
- [ ] 证据路径：录屏 / 截图，重点查看卡片外侧是否仍有整窗染色