### PR TITLE
Fix Windows capsule native container/input contract

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ promo-openless/
 promo-openless-v2/
 docs/old-promo/
 .worktrees/
+.artifacts/
 # 宣传录屏 / 素材根目录（GB 级二进制，绝不入版本库）
 video-materials/
 

--- a/openless-all/app/scripts/windows-capsule-contract.test.mjs
+++ b/openless-all/app/scripts/windows-capsule-contract.test.mjs
@@ -1,0 +1,104 @@
+import { readFile } from 'node:fs/promises';
+
+function assertMatch(source, pattern, name) {
+  if (!pattern.test(source)) {
+    throw new Error(`${name}: pattern ${pattern} not found`);
+  }
+}
+
+function assertNotMatch(source, pattern, name) {
+  if (pattern.test(source)) {
+    throw new Error(`${name}: forbidden pattern ${pattern} found`);
+  }
+}
+
+const libRs = await readFile(new URL('../src-tauri/src/lib.rs', import.meta.url), 'utf-8');
+const coordinatorRs = await readFile(new URL('../src-tauri/src/coordinator.rs', import.meta.url), 'utf-8');
+const dictationRs = await readFile(new URL('../src-tauri/src/coordinator/dictation.rs', import.meta.url), 'utf-8');
+const capsuleTsx = await readFile(new URL('../src/components/Capsule.tsx', import.meta.url), 'utf-8');
+const capsuleLayoutTs = await readFile(new URL('../src/lib/capsuleLayout.ts', import.meta.url), 'utf-8');
+const hitlRunner = await readFile(new URL('./windows-capsule-hitl.ps1', import.meta.url), 'utf-8');
+
+assertNotMatch(
+  libRs,
+  /apply_acrylic\(&capsule|DwmEnableBlurBehindWindow|DWMWA_SYSTEMBACKDROP_TYPE/,
+  'windows capsule native host must not use Acrylic/Mica/DWM material',
+);
+
+assertNotMatch(
+  libRs,
+  /WS_EX_TRANSPARENT|SetWindowLongPtrW|EnumChildWindows/,
+  'windows capsule must not rely on dynamic WebView child HWND click-through styles',
+);
+
+assertMatch(
+  libRs,
+  /fn configure_windows_capsule_container_region[\s\S]*?GetWindowRect[\s\S]*?windows_capsule_create_region[\s\S]*?SetWindowRgn/,
+  'windows capsule should apply a native container/input envelope',
+);
+
+assertMatch(
+  libRs,
+  /fn windows_capsule_region_rects[\s\S]*?windows_capsule_translation_badge_region_rect[\s\S]*?windows_capsule_pill_region_rect/,
+  'windows capsule native envelope should be derived from rendered capsule surfaces',
+);
+
+assertMatch(
+  libRs,
+  /CreateRoundRectRgn[\s\S]*?CombineRgn[\s\S]*?RGN_OR/,
+  'windows capsule should use rounded native regions for pill and translation badge envelopes',
+);
+
+assertMatch(
+  libRs,
+  /fn windows_capsule_pill_region_rect[\s\S]*?const PILL_WIDTH: f64 = 196\.0;[\s\S]*?const PILL_HEIGHT: f64 = 52\.0;[\s\S]*?const BOTTOM_INSET: f64 = 12\.0;/,
+  'windows native envelope should cover the full rendered capsule, not a strict inner CSS box',
+);
+
+assertMatch(
+  coordinatorRs,
+  /show_capsule_window_for_recording\(&app_for_main,\s*&window\);[\s\S]*?refresh_windows_capsule_container_region\(&window,\s*translation\)/,
+  'windows capsule should refresh the native envelope after no-activate show',
+);
+
+assertMatch(
+  coordinatorRs,
+  /fn capsule_hitl_translation_fixture_enabled\(\)[\s\S]*?OPENLESS_CAPSULE_HITL_TRANSLATION/,
+  'translation badge HITL fixture should be gated behind an explicit debug environment variable',
+);
+
+assertMatch(
+  dictationRs,
+  /if hotkey_injection_dry_run_enabled\(\)[\s\S]*?capsule_hitl_translation_fixture_enabled\(\)[\s\S]*?translation_modifier_seen[\s\S]*?store\(true,[\s\S]*?emit_capsule\(inner,\s*CapsuleState::Recording/,
+  'translation badge HITL fixture should only affect hotkey-injection dry-run sessions',
+);
+
+assertMatch(
+  capsuleLayoutTs,
+  /export interface CapsuleInputEnvelopeMetrics[\s\S]*?export function getCapsuleInputEnvelopeMetrics/,
+  'frontend layout contract should name native input envelope metrics separately from host and pill metrics',
+);
+
+assertMatch(
+  capsuleLayoutTs,
+  /getCapsuleInputEnvelopeMetrics\(os: OS\)[\s\S]*?width: 196,[\s\S]*?height: 52,[\s\S]*?radius: 26,[\s\S]*?bottomInset: 12,[\s\S]*?badgeWidth: 132,[\s\S]*?badgeHeight: 24,[\s\S]*?badgeGap: 8/,
+  'frontend Windows input envelope metrics should match the native region contract',
+);
+
+assertMatch(
+  capsuleTsx,
+  /const useBackdrop = os !== 'win';[\s\S]*?background: os === 'win' \? 'rgba\(255, 255, 255, 0\.96\)' : 'rgba\(255, 255, 255, 0\.85\)'/,
+  'windows capsule DOM pill should own its surface without relying on desktop backdrop blur',
+);
+
+assertMatch(
+  capsuleTsx,
+  /return\s*\(\s*<div\s*style=\{\{[\s\S]*?width:\s*'100%',[\s\S]*?height:\s*'100%',[\s\S]*?paddingLeft:\s*hostMetrics\.horizontalInset,[\s\S]*?paddingRight:\s*hostMetrics\.horizontalInset,[\s\S]*?background:\s*'transparent'/,
+  'capsule host should remain transparent outside the visible pill',
+);
+
+assertMatch(
+  hitlRunner,
+  /\[switch\]\$TranslationActive[\s\S]*?OPENLESS_CAPSULE_HITL_TRANSLATION[\s\S]*?badgeCenterHitsCapsule[\s\S]*?screenBadgeCaptured/,
+  'windows capsule HITL runner should verify the translation badge native region when requested',
+);

--- a/openless-all/app/scripts/windows-capsule-hitl.ps1
+++ b/openless-all/app/scripts/windows-capsule-hitl.ps1
@@ -1,0 +1,537 @@
+param(
+  [string]$RepoRoot = (Get-Location).Path,
+  [string]$ExePath = "",
+  [string]$OutRoot = "",
+  [int]$WaitSeconds = 12,
+  [int]$ExpectedWidth = 0,
+  [int]$ExpectedHeight = 0,
+  [int]$SizeTolerance = 2,
+  [string]$ExpectedMode = "recording-pill",
+  [switch]$TranslationActive,
+  [switch]$KeepOpen,
+  [switch]$AllowScreenCaptureMiss,
+  [switch]$StrictVisualPill
+)
+
+$ErrorActionPreference = "Stop"
+
+$dpiBootstrapSource = @'
+using System;
+using System.Runtime.InteropServices;
+
+public static class OpenLessCapsuleHitlDpi {
+  [DllImport("user32.dll")]
+  public static extern bool SetProcessDpiAwarenessContext(IntPtr dpiContext);
+}
+'@
+
+Add-Type -TypeDefinition $dpiBootstrapSource
+try {
+  [void][OpenLessCapsuleHitlDpi]::SetProcessDpiAwarenessContext([IntPtr]::new(-4))
+} catch {
+  try {
+    [void][OpenLessCapsuleHitlDpi]::SetProcessDpiAwarenessContext([IntPtr]::new(-3))
+  } catch {
+  }
+}
+
+Add-Type -AssemblyName System.Windows.Forms
+Add-Type -AssemblyName System.Drawing
+
+$nativeSource = @'
+using System;
+using System.Text;
+using System.Runtime.InteropServices;
+
+public static class OpenLessCapsuleHitlNative {
+  public delegate bool EnumWindowsProc(IntPtr hWnd, IntPtr lParam);
+
+  [StructLayout(LayoutKind.Sequential)]
+  public struct POINT { public int X; public int Y; }
+
+  [StructLayout(LayoutKind.Sequential)]
+  public struct RECT { public int Left; public int Top; public int Right; public int Bottom; }
+
+  [DllImport("user32.dll")] public static extern bool EnumWindows(EnumWindowsProc lpEnumFunc, IntPtr lParam);
+  [DllImport("user32.dll")] public static extern IntPtr WindowFromPoint(POINT point);
+  [DllImport("user32.dll")] public static extern IntPtr GetAncestor(IntPtr hwnd, uint gaFlags);
+  [DllImport("user32.dll", CharSet=CharSet.Unicode)] public static extern int GetWindowText(IntPtr hWnd, StringBuilder lpString, int nMaxCount);
+  [DllImport("user32.dll", CharSet=CharSet.Unicode)] public static extern int GetClassName(IntPtr hWnd, StringBuilder lpClassName, int nMaxCount);
+  [DllImport("user32.dll")] public static extern bool GetWindowRect(IntPtr hWnd, out RECT rect);
+  [DllImport("user32.dll")] public static extern bool IsWindowVisible(IntPtr hWnd);
+  [DllImport("user32.dll")] public static extern bool ShowWindow(IntPtr hWnd, int nCmdShow);
+  [DllImport("user32.dll")] public static extern bool PrintWindow(IntPtr hwnd, IntPtr hdcBlt, uint nFlags);
+  [DllImport("user32.dll")] public static extern uint GetDpiForWindow(IntPtr hWnd);
+}
+'@
+
+Add-Type -TypeDefinition $nativeSource
+
+function Get-WindowTextValue([IntPtr]$Hwnd) {
+  $sb = [Text.StringBuilder]::new(512)
+  [void][OpenLessCapsuleHitlNative]::GetWindowText($Hwnd, $sb, $sb.Capacity)
+  $sb.ToString()
+}
+
+function Get-ClassNameValue([IntPtr]$Hwnd) {
+  $sb = [Text.StringBuilder]::new(256)
+  [void][OpenLessCapsuleHitlNative]::GetClassName($Hwnd, $sb, $sb.Capacity)
+  $sb.ToString()
+}
+
+function Get-VisibleWindows {
+  $rows = New-Object System.Collections.Generic.List[object]
+  $callback = [OpenLessCapsuleHitlNative+EnumWindowsProc]{
+    param([IntPtr]$h, [IntPtr]$l)
+    if ([OpenLessCapsuleHitlNative]::IsWindowVisible($h)) {
+      $rect = [OpenLessCapsuleHitlNative+RECT]::new()
+      [void][OpenLessCapsuleHitlNative]::GetWindowRect($h, [ref]$rect)
+      $rows.Add([pscustomobject]@{
+        hwnd = $h
+        title = Get-WindowTextValue $h
+        className = Get-ClassNameValue $h
+        rect = $rect
+      })
+    }
+    return $true
+  }
+  [void][OpenLessCapsuleHitlNative]::EnumWindows($callback, [IntPtr]::Zero)
+  $rows
+}
+
+function Hide-OpenLessMainWindow {
+  $callback = [OpenLessCapsuleHitlNative+EnumWindowsProc]{
+    param([IntPtr]$h, [IntPtr]$l)
+    $title = Get-WindowTextValue $h
+    $class = Get-ClassNameValue $h
+    if ([OpenLessCapsuleHitlNative]::IsWindowVisible($h) -and $title -eq "OpenLess" -and $class -eq "Tauri Window") {
+      [void][OpenLessCapsuleHitlNative]::ShowWindow($h, 0)
+    }
+    return $true
+  }
+  [void][OpenLessCapsuleHitlNative]::EnumWindows($callback, [IntPtr]::Zero)
+}
+
+function Stop-OpenLess {
+  Get-Process openless -ErrorAction SilentlyContinue | Stop-Process -Force
+  Start-Sleep -Milliseconds 700
+}
+
+function Invoke-ToggleDictation([string]$Path) {
+  Start-Process -FilePath $Path -ArgumentList "--toggle-dictation" -WorkingDirectory (Split-Path $Path) | Out-Null
+}
+
+function Hit-Point($Name, [int]$X, [int]$Y, [IntPtr]$CapsuleHwnd) {
+  $pt = [OpenLessCapsuleHitlNative+POINT]::new()
+  $pt.X = $X
+  $pt.Y = $Y
+  $hwnd = [OpenLessCapsuleHitlNative]::WindowFromPoint($pt)
+  $root = [OpenLessCapsuleHitlNative]::GetAncestor($hwnd, 2)
+  [pscustomobject]@{
+    name = $Name
+    point = [pscustomobject]@{ x = $X; y = $Y }
+    hwnd = ("0x{0:X}" -f $hwnd.ToInt64())
+    title = Get-WindowTextValue $hwnd
+    className = Get-ClassNameValue $hwnd
+    rootHwnd = ("0x{0:X}" -f $root.ToInt64())
+    rootTitle = Get-WindowTextValue $root
+    rootClassName = Get-ClassNameValue $root
+    isCapsuleRoot = ($root -eq $CapsuleHwnd)
+  }
+}
+
+function Save-PrintWindowCapture([IntPtr]$Hwnd, [int]$Width, [int]$Height, [string]$Path) {
+  $bmp = [Drawing.Bitmap]::new([Math]::Max(1, $Width), [Math]::Max(1, $Height))
+  $graphics = [Drawing.Graphics]::FromImage($bmp)
+  $hdc = $graphics.GetHdc()
+  $ok = $false
+  try {
+    $ok = [OpenLessCapsuleHitlNative]::PrintWindow($Hwnd, $hdc, 2)
+  } finally {
+    $graphics.ReleaseHdc($hdc)
+    $graphics.Dispose()
+  }
+  $bmp.Save($Path, [Drawing.Imaging.ImageFormat]::Png)
+  $bmp.Dispose()
+  return $ok
+}
+
+function Color-Object($Color) {
+  [pscustomobject]@{ r = $Color.R; g = $Color.G; b = $Color.B; a = $Color.A }
+}
+
+function Is-Green($Color) {
+  $Color.R -eq 37 -and $Color.G -eq 200 -and $Color.B -eq 81
+}
+
+function Test-ExpectedDimension([int]$Actual, [int]$Expected, [int]$Tolerance) {
+  if ($Expected -le 0) { return $true }
+  [Math]::Abs($Actual - $Expected) -le $Tolerance
+}
+
+function Convert-LogicalToPhysicalDimension([int]$Logical, [double]$DpiScale) {
+  if ($Logical -le 0) { return 0 }
+  [int][Math]::Round($Logical * $DpiScale)
+}
+
+if ([Environment]::OSVersion.Platform -ne [PlatformID]::Win32NT) {
+  throw "windows-capsule-hitl only runs on Windows."
+}
+
+if (-not $ExePath) {
+  $defaultExe = "D:\cargo-targets\github.com_appergb_openless\debug\openless.exe"
+  if (Test-Path $defaultExe) {
+    $ExePath = $defaultExe
+  } else {
+    throw "Pass -ExePath or build the debug binary at $defaultExe."
+  }
+}
+
+if (-not (Test-Path $ExePath)) {
+  throw "OpenLess exe not found: $ExePath"
+}
+
+if (-not $OutRoot) {
+  $OutRoot = Join-Path $RepoRoot ".artifacts\windows-capsule-hitl"
+}
+New-Item -ItemType Directory -Force -Path $OutRoot | Out-Null
+$stamp = Get-Date -Format "yyyyMMdd-HHmmss"
+$outDir = Join-Path $OutRoot "capsule-hitl-$stamp"
+New-Item -ItemType Directory -Force -Path $outDir | Out-Null
+
+$form = $null
+$screenBmp = $null
+$screenGraphics = $null
+$cropBmp = $null
+$cropGraphics = $null
+$oldDryRun = $env:OPENLESS_HOTKEY_INJECTION_DRY_RUN
+$oldShowMain = $env:OPENLESS_SHOW_MAIN_ON_START
+$oldTranslationFixture = $env:OPENLESS_CAPSULE_HITL_TRANSLATION
+
+try {
+  $preExisting = Get-Process openless -ErrorAction SilentlyContinue | Select-Object Id, Path, StartTime
+  Stop-OpenLess
+
+  $env:OPENLESS_HOTKEY_INJECTION_DRY_RUN = "1"
+  $env:OPENLESS_SHOW_MAIN_ON_START = "0"
+  if ($TranslationActive) {
+    $env:OPENLESS_CAPSULE_HITL_TRANSLATION = "1"
+    if ($ExpectedMode -eq "recording-pill") {
+      $ExpectedMode = "translation-pill"
+    }
+  } else {
+    Remove-Item Env:\OPENLESS_CAPSULE_HITL_TRANSLATION -ErrorAction SilentlyContinue
+  }
+
+  Start-Process -FilePath $ExePath -WorkingDirectory (Split-Path $ExePath) | Out-Null
+  Start-Sleep -Seconds 4
+  Hide-OpenLessMainWindow
+
+  $form = [Windows.Forms.Form]::new()
+  $form.Text = "OpenLess Hit Test Backdrop"
+  $form.FormBorderStyle = [Windows.Forms.FormBorderStyle]::None
+  $form.StartPosition = [Windows.Forms.FormStartPosition]::Manual
+  $form.Bounds = [Windows.Forms.Screen]::PrimaryScreen.Bounds
+  $form.BackColor = [Drawing.Color]::FromArgb(37, 200, 81)
+  $form.ShowInTaskbar = $false
+  $form.TopMost = $false
+  $form.Show()
+  $form.Activate()
+  [Windows.Forms.Application]::DoEvents()
+  Start-Sleep -Milliseconds 400
+
+  $triggerAttempts = 1
+  $lastTriggerAt = Get-Date
+  Invoke-ToggleDictation $ExePath
+
+  $capsuleRow = $null
+  $deadline = (Get-Date).AddSeconds($WaitSeconds)
+  while ((Get-Date) -lt $deadline) {
+    Start-Sleep -Milliseconds 150
+    [Windows.Forms.Application]::DoEvents()
+    Hide-OpenLessMainWindow
+    $capsuleRow = Get-VisibleWindows | Where-Object {
+      $_.title -eq "OpenLess Capsule" -and $_.className -eq "Tauri Window"
+    } | Select-Object -First 1
+    if ($null -ne $capsuleRow) { break }
+    if ($triggerAttempts -lt 3 -and ((Get-Date) - $lastTriggerAt).TotalSeconds -ge 3) {
+      $triggerAttempts += 1
+      $lastTriggerAt = Get-Date
+      Invoke-ToggleDictation $ExePath
+    }
+  }
+
+  if ($null -eq $capsuleRow) {
+    throw "OpenLess Capsule window was not visible within $WaitSeconds seconds."
+  }
+
+  $capsule = [IntPtr]$capsuleRow.hwnd
+  $rect = [OpenLessCapsuleHitlNative+RECT]::new()
+  [void][OpenLessCapsuleHitlNative]::GetWindowRect($capsule, [ref]$rect)
+  $width = $rect.Right - $rect.Left
+  $height = $rect.Bottom - $rect.Top
+  $dpi = [OpenLessCapsuleHitlNative]::GetDpiForWindow($capsule)
+  if ($dpi -le 0) { $dpi = 96 }
+  $dpiScale = [double]$dpi / 96.0
+  $expectedPhysicalWidth = Convert-LogicalToPhysicalDimension $ExpectedWidth $dpiScale
+  $expectedPhysicalHeight = Convert-LogicalToPhysicalDimension $ExpectedHeight $dpiScale
+
+  $hits = [ordered]@{
+    transparentTopLeft = Hit-Point "transparentTopLeft" ($rect.Left + 5) ($rect.Top + 5) $capsule
+    transparentLeftMiddle = Hit-Point "transparentLeftMiddle" ($rect.Left + 5) ($rect.Top + [int]($height / 2)) $capsule
+    transparentBottomRight = Hit-Point "transparentBottomRight" ($rect.Right - 5) ($rect.Bottom - 5) $capsule
+    pillCenter = Hit-Point "pillCenter" ($rect.Left + [int]($width / 2)) ($rect.Top + [int]($height / 2)) $capsule
+  }
+  if ($TranslationActive) {
+    $badgeCenterY = $rect.Top + [int][Math]::Round(34 * $dpiScale)
+    $hits.badgeCenter = Hit-Point "badgeCenter" ($rect.Left + [int]($width / 2)) $badgeCenterY $capsule
+  }
+
+  $screenBounds = [Windows.Forms.Screen]::PrimaryScreen.Bounds
+  $screenBmp = [Drawing.Bitmap]::new($screenBounds.Width, $screenBounds.Height)
+  $screenGraphics = [Drawing.Graphics]::FromImage($screenBmp)
+  $screenGraphics.CopyFromScreen($screenBounds.Location, [Drawing.Point]::Empty, $screenBounds.Size)
+  $fullPath = Join-Path $outDir "screen-green-bg.png"
+  $screenBmp.Save($fullPath, [Drawing.Imaging.ImageFormat]::Png)
+
+  $cropBmp = [Drawing.Bitmap]::new([Math]::Max(1, $width), [Math]::Max(1, $height))
+  $cropGraphics = [Drawing.Graphics]::FromImage($cropBmp)
+  $cropGraphics.DrawImage(
+    $screenBmp,
+    0,
+    0,
+    [Drawing.Rectangle]::new($rect.Left, $rect.Top, [Math]::Max(1, $width), [Math]::Max(1, $height)),
+    [Drawing.GraphicsUnit]::Pixel
+  )
+  $cropPath = Join-Path $outDir "capsule-host-crop.png"
+  $cropBmp.Save($cropPath, [Drawing.Imaging.ImageFormat]::Png)
+
+  $printWindowPath = Join-Path $outDir "capsule-printwindow.png"
+  $printWindowOk = Save-PrintWindowCapture $capsule $width $height $printWindowPath
+  $printWindowSamples = [ordered]@{}
+  $printWindowPillCaptured = $false
+  $printBmp = $null
+  try {
+    $printBmp = [Drawing.Bitmap][Drawing.Image]::FromFile($printWindowPath)
+    $printWindowSamples.center = $printBmp.GetPixel([int]($printBmp.Width / 2), [int]($printBmp.Height / 2))
+    $printWindowSamples.topLeft = $printBmp.GetPixel(5, 5)
+    $printCenter = $printWindowSamples.center
+    $printWindowPillCaptured = -not (
+      ($printCenter.R -eq 0 -and $printCenter.G -eq 0 -and $printCenter.B -eq 0) -or
+      (Is-Green $printCenter)
+    )
+  } finally {
+    if ($printBmp) { $printBmp.Dispose() }
+  }
+
+  $samples = [ordered]@{
+    topLeft = $screenBmp.GetPixel($rect.Left + 5, $rect.Top + 5)
+    leftMiddle = $screenBmp.GetPixel($rect.Left + 5, $rect.Top + [int]($height / 2))
+    bottomRight = $screenBmp.GetPixel($rect.Right - 5, $rect.Bottom - 5)
+    pillCenter = $screenBmp.GetPixel($rect.Left + [int]($width / 2), $rect.Top + [int]($height / 2))
+  }
+  if ($TranslationActive) {
+    $samples.badgeCenter = $screenBmp.GetPixel($hits.badgeCenter.point.x, $hits.badgeCenter.point.y)
+  }
+
+  $checks = [ordered]@{
+    currentExeWasActive = ((Get-Process openless -ErrorAction SilentlyContinue | Where-Object { $_.Path -eq $ExePath }) -ne $null)
+    transparentTopLeftPassesThrough = -not $hits.transparentTopLeft.isCapsuleRoot
+    transparentLeftMiddlePassesThrough = -not $hits.transparentLeftMiddle.isCapsuleRoot
+    transparentBottomRightPassesThrough = -not $hits.transparentBottomRight.isCapsuleRoot
+    pillCenterHitsCapsule = $hits.pillCenter.isCapsuleRoot
+    badgeCenterHitsCapsule = if ($TranslationActive) { $hits.badgeCenter.isCapsuleRoot } else { $true }
+    transparentTopLeftPixelIsGreen = Is-Green $samples.topLeft
+    transparentLeftMiddlePixelIsGreen = Is-Green $samples.leftMiddle
+    transparentBottomRightPixelIsGreen = Is-Green $samples.bottomRight
+    screenPillCaptured = -not (Is-Green $samples.pillCenter)
+    screenBadgeCaptured = if ($TranslationActive) { -not (Is-Green $samples.badgeCenter) } else { $true }
+    printWindowPillCaptured = $printWindowPillCaptured
+    visualPillCaptured = (-not (Is-Green $samples.pillCenter)) -or $printWindowPillCaptured
+    printWindowReturnedTrue = [bool]$printWindowOk
+    capsuleWidthMatchesExpected = Test-ExpectedDimension $width $expectedPhysicalWidth $SizeTolerance
+    capsuleHeightMatchesExpected = Test-ExpectedDimension $height $expectedPhysicalHeight $SizeTolerance
+  }
+  $checks.capsuleSizeMatchesExpected = $checks.capsuleWidthMatchesExpected -and $checks.capsuleHeightMatchesExpected
+  $checks.inputPassed = $checks.currentExeWasActive `
+    -and $checks.transparentTopLeftPassesThrough `
+    -and $checks.transparentLeftMiddlePassesThrough `
+    -and $checks.transparentBottomRightPassesThrough `
+    -and $checks.pillCenterHitsCapsule `
+    -and $checks.badgeCenterHitsCapsule
+  $checks.transparentPixelsPassed = $checks.transparentTopLeftPixelIsGreen `
+    -and $checks.transparentLeftMiddlePixelIsGreen `
+    -and $checks.transparentBottomRightPixelIsGreen
+  $screenCaptureGatePassed = ($checks.screenPillCaptured -and $checks.screenBadgeCaptured) -or $AllowScreenCaptureMiss
+  $checks.allPassed = $checks.inputPassed `
+    -and $checks.transparentPixelsPassed `
+    -and $checks.capsuleSizeMatchesExpected `
+    -and $screenCaptureGatePassed `
+    -and ((-not $StrictVisualPill) -or $checks.visualPillCaptured)
+
+  $warnings = @()
+  if (-not $checks.visualPillCaptured) {
+    $warnings += "Screen capture did not include the visible layered/WebView capsule surface at pillCenter; use hit-test plus crop/PrintWindow artifacts for review, and rerun with a different desktop layer if a PR requires visible-pill screenshot evidence."
+  }
+
+  $contractGates = @(
+    [pscustomobject]@{ id = "process.currentExe"; expected = "openless.exe process path equals ExePath"; observed = $checks.currentExeWasActive; pass = $checks.currentExeWasActive },
+    [pscustomobject]@{ id = "input.transparentTopLeft"; expected = "WindowFromPoint root is not capsule"; observed = $hits.transparentTopLeft.rootTitle; pass = $checks.transparentTopLeftPassesThrough },
+    [pscustomobject]@{ id = "input.transparentLeftMiddle"; expected = "WindowFromPoint root is not capsule"; observed = $hits.transparentLeftMiddle.rootTitle; pass = $checks.transparentLeftMiddlePassesThrough },
+    [pscustomobject]@{ id = "input.transparentBottomRight"; expected = "WindowFromPoint root is not capsule"; observed = $hits.transparentBottomRight.rootTitle; pass = $checks.transparentBottomRightPassesThrough },
+    [pscustomobject]@{ id = "input.pillCenter"; expected = "WindowFromPoint root is OpenLess Capsule"; observed = $hits.pillCenter.rootTitle; pass = $checks.pillCenterHitsCapsule },
+    [pscustomobject]@{ id = "pixels.transparentTopLeft"; expected = "green backdrop #25C851"; observed = Color-Object $samples.topLeft; pass = $checks.transparentTopLeftPixelIsGreen },
+    [pscustomobject]@{ id = "pixels.transparentLeftMiddle"; expected = "green backdrop #25C851"; observed = Color-Object $samples.leftMiddle; pass = $checks.transparentLeftMiddlePixelIsGreen },
+    [pscustomobject]@{ id = "pixels.transparentBottomRight"; expected = "green backdrop #25C851"; observed = Color-Object $samples.bottomRight; pass = $checks.transparentBottomRightPixelIsGreen },
+    [pscustomobject]@{ id = "capture.screenPill"; expected = "screen crop captures a non-green visible pill center"; observed = Color-Object $samples.pillCenter; pass = $checks.screenPillCaptured }
+  )
+  if ($TranslationActive) {
+    $contractGates += [pscustomobject]@{ id = "input.badgeCenter"; expected = "WindowFromPoint root is OpenLess Capsule"; observed = $hits.badgeCenter.rootTitle; pass = $checks.badgeCenterHitsCapsule }
+    $contractGates += [pscustomobject]@{ id = "capture.screenBadge"; expected = "screen crop captures a non-green visible translation badge center"; observed = Color-Object $samples.badgeCenter; pass = $checks.screenBadgeCaptured }
+  }
+  if ($ExpectedWidth -gt 0) {
+    $contractGates += [pscustomobject]@{ id = "shape.width"; expected = "$ExpectedWidth logical px -> $expectedPhysicalWidth physical px +/- $SizeTolerance"; observed = $width; pass = $checks.capsuleWidthMatchesExpected }
+  }
+  if ($ExpectedHeight -gt 0) {
+    $contractGates += [pscustomobject]@{ id = "shape.height"; expected = "$ExpectedHeight logical px -> $expectedPhysicalHeight physical px +/- $SizeTolerance"; observed = $height; pass = $checks.capsuleHeightMatchesExpected }
+  }
+  if ($StrictVisualPill) {
+    $contractGates += [pscustomobject]@{ id = "capture.visiblePill"; expected = "screen or PrintWindow captures a non-green pill center"; observed = $checks.visualPillCaptured; pass = $checks.visualPillCaptured }
+  }
+
+  $result = [ordered]@{
+    timestamp = (Get-Date).ToString("o")
+    repoRoot = $RepoRoot
+    exe = $ExePath
+    dryRun = $true
+    expected = [ordered]@{
+      mode = $ExpectedMode
+      greenBackdrop = "#25C851"
+      capsuleWidth = if ($ExpectedWidth -gt 0) { $ExpectedWidth } else { $null }
+      capsuleHeight = if ($ExpectedHeight -gt 0) { $ExpectedHeight } else { $null }
+      physicalCapsuleWidth = if ($expectedPhysicalWidth -gt 0) { $expectedPhysicalWidth } else { $null }
+      physicalCapsuleHeight = if ($expectedPhysicalHeight -gt 0) { $expectedPhysicalHeight } else { $null }
+      sizeTolerance = $SizeTolerance
+      strictVisualPill = [bool]$StrictVisualPill
+      allowScreenCaptureMiss = [bool]$AllowScreenCaptureMiss
+      translationActive = [bool]$TranslationActive
+    }
+    triggerAttempts = $triggerAttempts
+    preExistingOpenLess = $preExisting
+    runningAfterStart = Get-Process openless -ErrorAction SilentlyContinue | Select-Object Id, Path, StartTime
+    capsuleHwnd = ("0x{0:X}" -f $capsule.ToInt64())
+    capsuleTitle = Get-WindowTextValue $capsule
+    capsuleClassName = Get-ClassNameValue $capsule
+    dpi = $dpi
+    dpiScale = $dpiScale
+    rect = [pscustomobject]@{ left = $rect.Left; top = $rect.Top; right = $rect.Right; bottom = $rect.Bottom; width = $width; height = $height }
+    expectedContract = "transparent host margins pass through; visible pill center hits capsule; transparent pixels show green backdrop"
+    hits = $hits
+    pixelSamples = [ordered]@{
+      topLeft = Color-Object $samples.topLeft
+      leftMiddle = Color-Object $samples.leftMiddle
+      bottomRight = Color-Object $samples.bottomRight
+      pillCenter = Color-Object $samples.pillCenter
+      badgeCenter = if ($TranslationActive) { Color-Object $samples.badgeCenter } else { $null }
+      printWindowCenter = if ($printWindowSamples.center) { Color-Object $printWindowSamples.center } else { $null }
+      printWindowTopLeft = if ($printWindowSamples.topLeft) { Color-Object $printWindowSamples.topLeft } else { $null }
+    }
+    checks = $checks
+    contractGates = $contractGates
+    warnings = $warnings
+    artifacts = [pscustomobject]@{
+      outputDir = $outDir
+      fullScreenshot = $fullPath
+      cropScreenshot = $cropPath
+      printWindowScreenshot = $printWindowPath
+    }
+  }
+
+  $jsonPath = Join-Path $outDir "hit-test.json"
+  $result | ConvertTo-Json -Depth 10 | Set-Content -Encoding UTF8 $jsonPath
+  Get-Content $jsonPath
+
+  if (-not $checks.allPassed) {
+    exit 2
+  }
+} catch {
+  $jsonPath = Join-Path $outDir "hit-test.json"
+  $visibleOpenLessWindows = @()
+  try {
+    $visibleOpenLessWindows = Get-VisibleWindows | Where-Object {
+      $_.title -like "OpenLess*" -or $_.className -eq "Tauri Window"
+    } | ForEach-Object {
+      [pscustomobject]@{
+        hwnd = ("0x{0:X}" -f ([IntPtr]$_.hwnd).ToInt64())
+        title = $_.title
+        className = $_.className
+        rect = [pscustomobject]@{
+          left = $_.rect.Left
+          top = $_.rect.Top
+          right = $_.rect.Right
+          bottom = $_.rect.Bottom
+          width = $_.rect.Right - $_.rect.Left
+          height = $_.rect.Bottom - $_.rect.Top
+        }
+      }
+    }
+  } catch {
+    $visibleOpenLessWindows = @()
+  }
+
+  $failure = [ordered]@{
+    timestamp = (Get-Date).ToString("o")
+    repoRoot = $RepoRoot
+    exe = $ExePath
+    dryRun = ($env:OPENLESS_HOTKEY_INJECTION_DRY_RUN -eq "1")
+    expected = [ordered]@{
+      mode = $ExpectedMode
+      greenBackdrop = "#25C851"
+      capsuleWidth = if ($ExpectedWidth -gt 0) { $ExpectedWidth } else { $null }
+      capsuleHeight = if ($ExpectedHeight -gt 0) { $ExpectedHeight } else { $null }
+      physicalCapsuleWidth = $null
+      physicalCapsuleHeight = $null
+      sizeTolerance = $SizeTolerance
+      strictVisualPill = [bool]$StrictVisualPill
+      allowScreenCaptureMiss = [bool]$AllowScreenCaptureMiss
+      translationActive = [bool]$TranslationActive
+    }
+    error = $_.Exception.Message
+    runningOpenLess = Get-Process openless -ErrorAction SilentlyContinue | Select-Object Id, Path, StartTime
+    visibleOpenLessWindows = $visibleOpenLessWindows
+    checks = [ordered]@{
+      inputPassed = $false
+      transparentPixelsPassed = $false
+      capsuleSizeMatchesExpected = $false
+      allPassed = $false
+    }
+    contractGates = @(
+      [pscustomobject]@{ id = "pipeline.completed"; expected = "runner captures capsule state and writes evidence"; observed = $_.Exception.Message; pass = $false }
+    )
+    artifacts = [pscustomobject]@{
+      outputDir = $outDir
+      fullScreenshot = $null
+      cropScreenshot = $null
+      printWindowScreenshot = $null
+    }
+  }
+  $failure | ConvertTo-Json -Depth 10 | Set-Content -Encoding UTF8 $jsonPath
+  Get-Content $jsonPath
+  exit 2
+} finally {
+  if (-not $KeepOpen) {
+    Stop-OpenLess
+  }
+  if ($form) {
+    $form.Close()
+    $form.Dispose()
+  }
+  if ($screenGraphics) { $screenGraphics.Dispose() }
+  if ($screenBmp) { $screenBmp.Dispose() }
+  if ($cropGraphics) { $cropGraphics.Dispose() }
+  if ($cropBmp) { $cropBmp.Dispose() }
+
+  if ($null -eq $oldDryRun) { Remove-Item Env:\OPENLESS_HOTKEY_INJECTION_DRY_RUN -ErrorAction SilentlyContinue } else { $env:OPENLESS_HOTKEY_INJECTION_DRY_RUN = $oldDryRun }
+  if ($null -eq $oldShowMain) { Remove-Item Env:\OPENLESS_SHOW_MAIN_ON_START -ErrorAction SilentlyContinue } else { $env:OPENLESS_SHOW_MAIN_ON_START = $oldShowMain }
+  if ($null -eq $oldTranslationFixture) { Remove-Item Env:\OPENLESS_CAPSULE_HITL_TRANSLATION -ErrorAction SilentlyContinue } else { $env:OPENLESS_CAPSULE_HITL_TRANSLATION = $oldTranslationFixture }
+}

--- a/openless-all/app/src-tauri/src/coordinator.rs
+++ b/openless-all/app/src-tauri/src/coordinator.rs
@@ -2047,6 +2047,14 @@ fn hotkey_injection_dry_run_enabled() -> bool {
 }
 
 #[cfg(any(debug_assertions, test))]
+fn capsule_hitl_translation_fixture_enabled() -> bool {
+    std::env::var("OPENLESS_CAPSULE_HITL_TRANSLATION")
+        .ok()
+        .as_deref()
+        == Some("1")
+}
+
+#[cfg(any(debug_assertions, test))]
 fn debug_transcript_override_text() -> Option<String> {
     let path = std::env::var_os("OPENLESS_DEBUG_TRANSCRIPT_FILE")?;
     let text = std::fs::read_to_string(path).ok()?;
@@ -4412,6 +4420,8 @@ fn emit_capsule(
                 );
             }
             show_capsule_window_for_recording(&app_for_main, &window);
+            #[cfg(target_os = "windows")]
+            crate::refresh_windows_capsule_container_region(&window, translation);
             // macOS/Windows 优先走 no-activate show，避免录音胶囊抢走当前工作 app 焦点。
             // 若 fallback 到 show()，OpenLess 已是前台 app 时再把 key window 还给 main。
             #[cfg(target_os = "macos")]

--- a/openless-all/app/src-tauri/src/coordinator/dictation.rs
+++ b/openless-all/app/src-tauri/src/coordinator/dictation.rs
@@ -486,6 +486,11 @@ pub(super) async fn begin_session(inner: &Arc<Inner>) -> Result<(), String> {
 
     #[cfg(any(debug_assertions, test))]
     if hotkey_injection_dry_run_enabled() {
+        if capsule_hitl_translation_fixture_enabled() {
+            inner
+                .translation_modifier_seen
+                .store(true, Ordering::SeqCst);
+        }
         emit_capsule(inner, CapsuleState::Recording, 0.0, 0, None, None);
         inner.state.lock().phase = SessionPhase::Listening;
         log::info!("[coord] session started (hotkey-injection dry-run)");

--- a/openless-all/app/src-tauri/src/lib.rs
+++ b/openless-all/app/src-tauri/src/lib.rs
@@ -133,15 +133,12 @@ pub fn run() {
                 // backdrop-filter 只能模糊 DOM 内部，模糊不到 OS 桌面 → 胶囊背景
                 // 看起来就是「透到桌面」。这里给 Win10/Win11 都支持的 Acrylic 做兜底，
                 // 让 OS 提供毛玻璃材质，胶囊 rgba(255,255,255,0.85) 上面再叠 DOM 模糊。
-                // 失败不阻塞（老 Win10 / Win7 上 Acrylic 不可用），仅 warn。
+                // Windows capsule contract: the native HWND is only a transparent
+                // carrier/input envelope. The DOM pill owns the visible surface;
+                // Acrylic/Mica/DWM materials on this host paint the transparent
+                // carrier as a gray rectangle.
                 #[cfg(target_os = "windows")]
-                {
-                    use window_vibrancy::apply_acrylic;
-                    // 中性偏冷的浅灰半透，与胶囊白底叠合后保持可读性。
-                    if let Err(e) = apply_acrylic(&capsule, Some((30, 32, 38, 140))) {
-                        log::warn!("[capsule] acrylic failed: {e}");
-                    }
-                }
+                configure_windows_capsule_container_region(&capsule, false);
                 let _ = capsule.hide();
             }
 
@@ -726,6 +723,205 @@ fn apply_windows_caption_color<R: Runtime>(window: &tauri::WebviewWindow<R>) {
     }
 }
 
+#[cfg(target_os = "windows")]
+#[derive(Clone, Copy, Debug)]
+struct WindowsCapsuleRegionRect {
+    x: f64,
+    y: f64,
+    width: f64,
+    height: f64,
+    radius: f64,
+}
+
+#[cfg(target_os = "windows")]
+fn windows_capsule_pill_region_rect(bounds: CapsuleWindowBounds) -> WindowsCapsuleRegionRect {
+    const PILL_WIDTH: f64 = 196.0;
+    const PILL_HEIGHT: f64 = 52.0;
+    const BOTTOM_INSET: f64 = 12.0;
+
+    WindowsCapsuleRegionRect {
+        x: (bounds.width - PILL_WIDTH) / 2.0,
+        y: bounds.height - BOTTOM_INSET - PILL_HEIGHT,
+        width: PILL_WIDTH,
+        height: PILL_HEIGHT,
+        radius: PILL_HEIGHT / 2.0,
+    }
+}
+
+#[cfg(target_os = "windows")]
+fn windows_capsule_translation_badge_region_rect(
+    bounds: CapsuleWindowBounds,
+) -> WindowsCapsuleRegionRect {
+    const BADGE_WIDTH: f64 = 132.0;
+    const BADGE_HEIGHT: f64 = 24.0;
+    const BADGE_GAP: f64 = 8.0;
+
+    let pill = windows_capsule_pill_region_rect(bounds);
+    WindowsCapsuleRegionRect {
+        x: (bounds.width - BADGE_WIDTH) / 2.0,
+        y: (pill.y - BADGE_GAP - BADGE_HEIGHT).max(0.0),
+        width: BADGE_WIDTH,
+        height: BADGE_HEIGHT,
+        radius: BADGE_HEIGHT / 2.0,
+    }
+}
+
+#[cfg(target_os = "windows")]
+fn windows_capsule_region_rects(
+    bounds: CapsuleWindowBounds,
+    translation_active: bool,
+) -> Vec<WindowsCapsuleRegionRect> {
+    let mut rects = Vec::with_capacity(if translation_active { 2 } else { 1 });
+    if translation_active {
+        rects.push(windows_capsule_translation_badge_region_rect(bounds));
+    }
+    rects.push(windows_capsule_pill_region_rect(bounds));
+    rects
+}
+
+#[cfg(all(target_os = "windows", test))]
+fn windows_capsule_rounded_rect_contains_point(
+    rect: WindowsCapsuleRegionRect,
+    x: f64,
+    y: f64,
+) -> bool {
+    if x < rect.x || x > rect.x + rect.width || y < rect.y || y > rect.y + rect.height {
+        return false;
+    }
+
+    let radius = rect.radius.min(rect.width / 2.0).min(rect.height / 2.0);
+    let nearest_x = if x < rect.x + radius {
+        rect.x + radius
+    } else if x > rect.x + rect.width - radius {
+        rect.x + rect.width - radius
+    } else {
+        x
+    };
+    let nearest_y = if y < rect.y + radius {
+        rect.y + radius
+    } else if y > rect.y + rect.height - radius {
+        rect.y + rect.height - radius
+    } else {
+        y
+    };
+    let dx = x - nearest_x;
+    let dy = y - nearest_y;
+    dx * dx + dy * dy <= radius * radius
+}
+
+#[cfg(all(target_os = "windows", test))]
+fn windows_capsule_region_contains_point(
+    bounds: CapsuleWindowBounds,
+    translation_active: bool,
+    x: f64,
+    y: f64,
+) -> bool {
+    windows_capsule_region_rects(bounds, translation_active)
+        .into_iter()
+        .any(|rect| windows_capsule_rounded_rect_contains_point(rect, x, y))
+}
+
+#[cfg(target_os = "windows")]
+fn windows_capsule_region_px(value: f64, scale: f64, outward: bool) -> i32 {
+    let scaled = value * scale;
+    if outward {
+        scaled.ceil() as i32
+    } else {
+        scaled.floor() as i32
+    }
+}
+
+#[cfg(target_os = "windows")]
+fn windows_capsule_create_region(
+    bounds: CapsuleWindowBounds,
+    translation_active: bool,
+    scale_x: f64,
+    scale_y: f64,
+) -> windows::Win32::Graphics::Gdi::HRGN {
+    use windows::Win32::Graphics::Gdi::{
+        CombineRgn, CreateRoundRectRgn, DeleteObject, HRGN, RGN_ERROR, RGN_OR,
+    };
+
+    let mut combined = HRGN::default();
+    for rect in windows_capsule_region_rects(bounds, translation_active) {
+        let x1 = windows_capsule_region_px(rect.x, scale_x, false);
+        let y1 = windows_capsule_region_px(rect.y, scale_y, false);
+        let x2 = windows_capsule_region_px(rect.x + rect.width, scale_x, true);
+        let y2 = windows_capsule_region_px(rect.y + rect.height, scale_y, true);
+        let round_w = ((rect.radius * 2.0 * scale_x).round() as i32).max(1);
+        let round_h = ((rect.radius * 2.0 * scale_y).round() as i32).max(1);
+        let region = unsafe { CreateRoundRectRgn(x1, y1, x2, y2, round_w, round_h) };
+        if region.is_invalid() {
+            log::warn!("[capsule] create rounded container region failed");
+            continue;
+        }
+
+        if combined.is_invalid() {
+            combined = region;
+        } else {
+            let result = unsafe { CombineRgn(combined, combined, region, RGN_OR) };
+            let _ = unsafe { DeleteObject(region) };
+            if result == RGN_ERROR {
+                log::warn!("[capsule] combine container regions failed");
+                let _ = unsafe { DeleteObject(combined) };
+                return HRGN::default();
+            }
+        }
+    }
+    combined
+}
+
+#[cfg(target_os = "windows")]
+fn configure_windows_capsule_container_region<R: Runtime>(
+    window: &tauri::WebviewWindow<R>,
+    translation_active: bool,
+) {
+    use raw_window_handle::{HasWindowHandle, RawWindowHandle};
+    use windows::Win32::Foundation::{BOOL, HWND, RECT};
+    use windows::Win32::Graphics::Gdi::{DeleteObject, SetWindowRgn};
+    use windows::Win32::UI::WindowsAndMessaging::GetWindowRect;
+
+    let handle = match window.window_handle().map(|h| h.as_raw()) {
+        Ok(RawWindowHandle::Win32(handle)) => handle,
+        Ok(other) => {
+            log::warn!("[capsule] unexpected raw window handle for container region: {other:?}");
+            return;
+        }
+        Err(e) => {
+            log::warn!("[capsule] read raw window handle for container region failed: {e}");
+            return;
+        }
+    };
+    let hwnd = HWND(handle.hwnd.get() as *mut core::ffi::c_void);
+    let bounds = capsule_window_bounds(translation_active);
+    let mut rect = RECT::default();
+    let (scale_x, scale_y) = if unsafe { GetWindowRect(hwnd, &mut rect) }.is_ok() {
+        let width = (rect.right - rect.left).max(1) as f64;
+        let height = (rect.bottom - rect.top).max(1) as f64;
+        (width / bounds.width.max(1.0), height / bounds.height.max(1.0))
+    } else {
+        (1.0, 1.0)
+    };
+
+    let region = windows_capsule_create_region(bounds, translation_active, scale_x, scale_y);
+    if region.is_invalid() {
+        return;
+    }
+
+    if unsafe { SetWindowRgn(hwnd, region, BOOL(1)) } == 0 {
+        let _ = unsafe { DeleteObject(region) };
+        log::warn!("[capsule] apply container region failed");
+    }
+}
+
+#[cfg(target_os = "windows")]
+pub(crate) fn refresh_windows_capsule_container_region<R: Runtime>(
+    window: &tauri::WebviewWindow<R>,
+    translation_active: bool,
+) {
+    configure_windows_capsule_container_region(window, translation_active);
+}
+
 #[tauri::command]
 fn restart_app(app: AppHandle) {
     // macOS：自动更新会让新装的 .app 带 com.apple.quarantine（无论 Tauri updater
@@ -1201,6 +1397,8 @@ pub(crate) fn position_capsule_bottom_center<R: tauri::Runtime>(
     };
     let bounds = capsule_window_bounds(translation_active);
     window.set_size(LogicalSize::new(bounds.width, bounds.height))?;
+    #[cfg(target_os = "windows")]
+    configure_windows_capsule_container_region(window, translation_active);
 
     let scale = monitor.scale_factor();
     let size = monitor.size();
@@ -1361,6 +1559,31 @@ mod tests {
 
         #[cfg(not(target_os = "windows"))]
         assert_eq!(capsule_visual_height(true), 96.0);
+    }
+
+    #[test]
+    #[cfg(target_os = "windows")]
+    fn capsule_container_region_consumes_only_rendered_pill_envelope() {
+        let bounds = capsule_window_bounds(false);
+
+        assert!(!super::windows_capsule_region_contains_point(bounds, false, 4.0, 4.0));
+        assert!(!super::windows_capsule_region_contains_point(bounds, false, 4.0, 50.0));
+        assert!(super::windows_capsule_region_contains_point(bounds, false, 110.0, 50.0));
+        assert!(super::windows_capsule_region_contains_point(bounds, false, 20.0, 50.0));
+        assert!(super::windows_capsule_region_contains_point(bounds, false, 200.0, 50.0));
+        assert!(!super::windows_capsule_region_contains_point(bounds, false, 10.0, 50.0));
+        assert!(!super::windows_capsule_region_contains_point(bounds, false, 110.0, 14.0));
+    }
+
+    #[test]
+    #[cfg(target_os = "windows")]
+    fn capsule_container_region_tracks_translation_badge_and_pill() {
+        let bounds = capsule_window_bounds(true);
+
+        assert!(super::windows_capsule_region_contains_point(bounds, true, 110.0, 46.0));
+        assert!(super::windows_capsule_region_contains_point(bounds, true, 110.0, 84.0));
+        assert!(!super::windows_capsule_region_contains_point(bounds, true, 16.0, 84.0));
+        assert!(!super::windows_capsule_region_contains_point(bounds, true, 110.0, 50.0));
     }
 
     #[test]

--- a/openless-all/app/src/components/Capsule.tsx
+++ b/openless-all/app/src/components/Capsule.tsx
@@ -244,7 +244,7 @@ function Pill({ os, state, level, insertedChars, message, onCancel, onConfirm }:
   const ambient = state === 'recording' ? Math.min(1, Math.max(0, level)) : 0;
   const scale = os === 'win' ? 1 : 1 + ambient * 0.018;
   const shadowAlpha = 0.20 + ambient * 0.10;
-  const useBackdrop = true;
+  const useBackdrop = os !== 'win';
 
   return (
     <div
@@ -258,10 +258,10 @@ function Pill({ os, state, level, insertedChars, message, onCancel, onConfirm }:
         height: metrics.height,
         boxSizing: metrics.boxSizing,
         borderRadius: 999,
-        background: 'rgba(255, 255, 255, 0.85)',
+        background: os === 'win' ? 'rgba(255, 255, 255, 0.96)' : 'rgba(255, 255, 255, 0.85)',
         backdropFilter: useBackdrop ? 'blur(28px) saturate(180%)' : 'none',
         WebkitBackdropFilter: useBackdrop ? 'blur(28px) saturate(180%)' : 'none',
-        border: '1px solid rgba(255, 255, 255, 0.55)',
+        border: os === 'win' ? '1px solid rgba(255, 255, 255, 0.78)' : '1px solid rgba(255, 255, 255, 0.55)',
         boxShadow: os === 'win'
           ? `0 10px 24px -14px rgba(0, 0, 0, ${(0.24 + ambient * 0.06).toFixed(3)}), 0 0 0 0.5px rgba(0, 0, 0, 0.08), inset 0 0.5px 0 rgba(255, 255, 255, 0.55)`
           : `0 18px 50px -10px rgba(0, 0, 0, ${shadowAlpha.toFixed(3)}), 0 0 0 0.5px rgba(0, 0, 0, 0.08), inset 0 0.5px 0 rgba(255, 255, 255, 0.55)`,

--- a/openless-all/app/src/lib/capsuleLayout.test.ts
+++ b/openless-all/app/src/lib/capsuleLayout.test.ts
@@ -1,5 +1,6 @@
 import {
   getCapsuleHostMetrics,
+  getCapsuleInputEnvelopeMetrics,
   getCapsuleMessageLayout,
   getCapsulePillMetrics,
 } from './capsuleLayout.ts';
@@ -37,6 +38,15 @@ assertEqual(winHostWithTranslation.width, 220, 'windows translation capsule keep
 assertEqual(winHostWithTranslation.height, 118, 'windows translation capsule grows vertically only');
 assertEqual(winHostWithTranslation.horizontalInset, 12, 'windows translation capsule keeps symmetric side insets');
 assertEqual(winHostWithTranslation.boxSizing, 'border-box', 'windows translation host keeps the same inset-reserving box model');
+
+const winEnvelope = getCapsuleInputEnvelopeMetrics('win');
+assertEqual(winEnvelope.width, 196, 'windows native input envelope covers the rendered pill width');
+assertEqual(winEnvelope.height, 52, 'windows native input envelope covers the rendered pill height');
+assertEqual(winEnvelope.radius, 26, 'windows native input envelope uses a full pill radius');
+assertEqual(winEnvelope.bottomInset, 12, 'windows native input envelope anchors from the host bottom inset');
+assertEqual(winEnvelope.badgeWidth, 132, 'windows native input envelope tracks translation badge width');
+assertEqual(winEnvelope.badgeHeight, 24, 'windows native input envelope tracks translation badge height');
+assertEqual(winEnvelope.badgeGap, 8, 'windows native input envelope tracks translation badge gap');
 
 const macMetrics = getCapsulePillMetrics('mac');
 assertEqual(macMetrics.width, 176, 'mac capsule keeps existing pill width');

--- a/openless-all/app/src/lib/capsuleLayout.ts
+++ b/openless-all/app/src/lib/capsuleLayout.ts
@@ -18,6 +18,16 @@ export interface CapsuleHostMetrics {
   boxSizing: 'border-box' | 'content-box';
 }
 
+export interface CapsuleInputEnvelopeMetrics {
+  width: number;
+  height: number;
+  radius: number;
+  bottomInset: number;
+  badgeWidth: number;
+  badgeHeight: number;
+  badgeGap: number;
+}
+
 export interface CapsuleMessageLayout {
   allowWrap: boolean;
   lineClamp: number;
@@ -27,7 +37,7 @@ export function getCapsulePillMetrics(os: OS): CapsulePillMetrics {
   if (os === 'win') {
     // Windows metrics describe the visible outer footprint of the pill.
     // 与 macOS pill 接近以保持视觉密度一致；保留 ~4-5% 余量适配 Windows 字体 metrics。
-    return { width: 180, height: 44, textWidth: 88, boxSizing: 'border-box' };
+    return { width: 196, height: 52, textWidth: 104, boxSizing: 'border-box' };
   }
 
   return { width: 176, height: 42, textWidth: 84, boxSizing: 'border-box' };
@@ -58,6 +68,31 @@ export function getCapsuleHostMetrics(
     bottomInset: 0,
     badgeGap: 8,
     boxSizing: 'border-box',
+  };
+}
+
+export function getCapsuleInputEnvelopeMetrics(os: OS): CapsuleInputEnvelopeMetrics {
+  if (os === 'win') {
+    return {
+      width: 196,
+      height: 52,
+      radius: 26,
+      bottomInset: 12,
+      badgeWidth: 132,
+      badgeHeight: 24,
+      badgeGap: 8,
+    };
+  }
+
+  const pill = getCapsulePillMetrics(os);
+  return {
+    width: pill.width,
+    height: pill.height,
+    radius: pill.height / 2,
+    bottomInset: 0,
+    badgeWidth: 132,
+    badgeHeight: 24,
+    badgeGap: 8,
   };
 }
 


### PR DESCRIPTION
Fixes #498.

Windows capsule contract PR.

What changed:
- Windows capsule DOM pill owns the visible surface.
- Windows native HWND is a transparent carrier and input envelope only.
- Removed Acrylic/Mica/DWM material from the capsule host to avoid gray carrier margins.
- Added rounded native SetWindowRgn envelope for the pill and translation badge.
- Transparent host margins pass through; visible pill and badge consume input.
- macOS/Linux behavior and macOS vibrancy remain untouched.

Evidence screenshots:

Recording capsule:
![Recording capsule host crop](https://raw.githubusercontent.com/Cooper-X-Oak/openless/5b6257cfade644698d5bc3936e0277897b549de9/windows-capsule-contract-498/recording-capsule-host-crop.png)

Translation badge capsule:
![Translation capsule host crop](https://raw.githubusercontent.com/Cooper-X-Oak/openless/5b6257cfade644698d5bc3936e0277897b549de9/windows-capsule-contract-498/translation-capsule-host-crop.png)

Accepted reference comparison:
![Accepted/reference/current comparison](https://raw.githubusercontent.com/Cooper-X-Oak/openless/5b6257cfade644698d5bc3936e0277897b549de9/windows-capsule-contract-498/accepted-recording-translation-comparison.png)

Evidence JSON:
- Recording JSON: https://raw.githubusercontent.com/Cooper-X-Oak/openless/5b6257cfade644698d5bc3936e0277897b549de9/windows-capsule-contract-498/recording-hit-test.json
- Translation JSON: https://raw.githubusercontent.com/Cooper-X-Oak/openless/5b6257cfade644698d5bc3936e0277897b549de9/windows-capsule-contract-498/translation-hit-test.json

Recording HITL summary:
- DPI 120, scale 1.25x
- Expected logical size 220x84, observed physical size 275x105
- Transparent top-left, left-middle, bottom-right all pass through
- Pill center hits OpenLess Capsule
- Screen pill captured
- allPassed true

Translation HITL summary:
- DPI 120, scale 1.25x
- Expected logical size 220x118, observed physical size 275x148
- Transparent top-left, left-middle, bottom-right all pass through
- Pill center hits OpenLess Capsule
- Badge center hits OpenLess Capsule
- Screen pill and badge captured
- allPassed true

Validation passed:
- node ./src/lib/capsuleLayout.test.ts
- node ./scripts/windows-capsule-contract.test.mjs
- PowerShell parse check for openless-all/app/scripts/windows-capsule-hitl.ps1
- npm run build
- cargo check --manifest-path ./openless-all/app/src-tauri/Cargo.toml --bin openless
- cargo build --manifest-path ./openless-all/app/src-tauri/Cargo.toml --bin openless
- cargo test --manifest-path ./openless-all/app/src-tauri/Cargo.toml capsule_container_region --no-run
- HITL recording pass with ExpectedWidth 220 ExpectedHeight 84
- HITL translation pass with ExpectedWidth 220 ExpectedHeight 118 TranslationActive

Known existing red outside this PR:
- node ./scripts/windows-ui-config.test.mjs still fails on the main-window native chrome/decorations assertion. I did not fold that #482-style main-window contract drift into this capsule PR.