### PR TITLE
Fix Zhipu ASR endpoint handling

### DIFF
--- a/openless-all/app/src-tauri/src/asr/whisper.rs
+++ b/openless-all/app/src-tauri/src/asr/whisper.rs
@@ -101,8 +101,7 @@ impl WhisperBatchASR {
             .map(|chunk| i16::from_le_bytes([chunk[0], chunk[1]]))
             .collect();
         let wav = encode_wav_16k_mono(&samples);
-        let base_url = self.base_url.trim_end_matches('/');
-        let url = format!("{}/audio/transcriptions", base_url);
+        let url = transcription_url(&self.base_url)?;
 
         let wav_part = reqwest::multipart::Part::bytes(wav)
             .file_name("audio.wav")
@@ -171,6 +170,23 @@ fn split_pcm_by_duration(pcm: &[u8], max_chunk_duration_ms: Option<u64>) -> Vec<
     }
 
     pcm.chunks(bytes_per_chunk).collect()
+}
+
+fn transcription_url(base_url: &str) -> Result<String> {
+    let parsed = reqwest::Url::parse(base_url.trim()).context("parse Whisper base URL")?;
+    let mut url = parsed.clone();
+    let path = parsed.path().trim_end_matches('/');
+    let next_path = if path.ends_with("/audio/transcriptions") {
+        path.to_string()
+    } else if path.ends_with("/audio") {
+        format!("{path}/transcriptions")
+    } else if let Some(prefix) = path.strip_suffix("/chat/completions") {
+        format!("{prefix}/audio/transcriptions")
+    } else {
+        format!("{path}/audio/transcriptions")
+    };
+    url.set_path(&next_path);
+    Ok(url.to_string())
 }
 
 fn join_transcript_chunks(chunks: &[String]) -> String {
@@ -463,6 +479,29 @@ mod tests {
     }
 
     #[test]
+    fn transcription_url_accepts_base_audio_or_full_endpoint() {
+        assert_eq!(
+            transcription_url("https://open.bigmodel.cn/api/paas/v4").unwrap(),
+            "https://open.bigmodel.cn/api/paas/v4/audio/transcriptions"
+        );
+        assert_eq!(
+            transcription_url("https://open.bigmodel.cn/api/paas/v4/audio").unwrap(),
+            "https://open.bigmodel.cn/api/paas/v4/audio/transcriptions"
+        );
+        assert_eq!(
+            transcription_url("https://open.bigmodel.cn/api/paas/v4/audio/transcriptions").unwrap(),
+            "https://open.bigmodel.cn/api/paas/v4/audio/transcriptions"
+        );
+        assert_eq!(
+            transcription_url(
+                "https://open.bigmodel.cn/api/paas/v4/audio/transcriptions?api-version=2026-01-01"
+            )
+            .unwrap(),
+            "https://open.bigmodel.cn/api/paas/v4/audio/transcriptions?api-version=2026-01-01"
+        );
+    }
+
+    #[test]
     fn join_transcript_chunks_skips_empty_chunks() {
         let chunks = vec![" hello ".to_string(), "".to_string(), "world".to_string()];
         assert_eq!(join_transcript_chunks(&chunks), "hello world");
@@ -571,6 +610,7 @@ mod tests {
                         Err(err) => panic!("accept ASR test request failed: {err}"),
                     }
                 };
+                stream.set_nonblocking(false).unwrap();
                 stream
                     .set_read_timeout(Some(Duration::from_secs(5)))
                     .unwrap();


### PR DESCRIPTION
### **User description**
## Summary
- Refs #507.
- Normalize Whisper/Zhipu ASR transcription URLs so `/v4`, `/v4/audio`, and full `/v4/audio/transcriptions` endpoints all post to the correct endpoint without doubling the path.
- Preserve query parameters on custom transcription endpoints.
- Fix a macOS CI-only test-server race by returning accepted test sockets to blocking mode before reading the multipart request.

## Not Included
- This PR intentionally does not change Linux ASR error visibility/UI behavior.

## Test Plan
- `cargo test --manifest-path \"/home/chris233/openless/openless-all/app/src-tauri/Cargo.toml\" transcription_url_accepts_base_audio_or_full_endpoint -- --test-threads=1`
- `cargo test --manifest-path \"/home/chris233/openless/openless-all/app/src-tauri/Cargo.toml\" asr::whisper::tests::transcribe_posts_single_request_without_chunk_limit -- --test-threads=1`
- `git diff --check upstream/beta`

## Review
- Subagent review: APPROVE


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Normalize Zhipu ASR transcription URLs

- Avoid doubled `/audio/transcriptions` paths

- Preserve query strings on custom endpoints

- Fix macOS ASR test socket blocking


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["ASR base URL"] -- "normalize" --> B["transcription_url()"]
  B -- "used by" --> C["Whisper transcription request"]
  B -- "verified by" --> D["URL normalization tests"]
  E["Accepted test socket"] -- "set blocking" --> F["Multipart request reader"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>whisper.rs</strong><dd><code>Normalize ASR URLs and strengthen tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src-tauri/src/asr/whisper.rs

<ul><li>Replaces manual URL concatenation with <code>transcription_url()</code><br> <li> Prevents duplicated <code>/audio/transcriptions</code> for Zhipu endpoints<br> <li> Preserves query parameters when rebuilding transcription URLs<br> <li> Adds regression coverage and fixes test socket blocking</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/510/files#diff-cf6696a6b96bc9f0fb12aeb6e3934ad2668e3595f06ad10652604887f9794d2b">+42/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

