### PR TITLE
Pace Windows streaming SendInput

### DIFF
--- a/openless-all/app/src-tauri/src/unicode_keystroke.rs
+++ b/openless-all/app/src-tauri/src/unicode_keystroke.rs
@@ -313,11 +313,15 @@ mod macos_impl {
 #[cfg(target_os = "windows")]
 mod windows_impl {
     use super::{TisError, TypeError};
+    use std::time::Duration;
     use tauri::{AppHandle, Runtime};
     use windows::Win32::UI::Input::KeyboardAndMouse::{
         SendInput, INPUT, INPUT_0, INPUT_KEYBOARD, KEYBDINPUT, KEYBD_EVENT_FLAGS, KEYEVENTF_KEYUP,
         KEYEVENTF_UNICODE, VIRTUAL_KEY,
     };
+
+    const SENDINPUT_CHUNK_CHARS: usize = 16;
+    const SENDINPUT_CHUNK_DELAY: Duration = Duration::from_millis(12);
 
     /// Windows / Linux 上没有 input source 概念，token 留空。Send/Sync 自动派生。
     pub struct PreviousInputSource;
@@ -327,7 +331,9 @@ mod windows_impl {
             return Ok(0);
         }
         let mut typed_chars = 0;
-        for ch in text.chars() {
+        let mut sent_in_chunk = 0usize;
+        let mut chars = text.chars().peekable();
+        while let Some(ch) = chars.next() {
             let mut buf = [0u16; 2];
             for unit in ch.encode_utf16(&mut buf) {
                 if let Err(e) = send_utf16_unit(*unit, false) {
@@ -338,6 +344,11 @@ mod windows_impl {
                 }
             }
             typed_chars += 1;
+            sent_in_chunk += 1;
+            if sent_in_chunk >= SENDINPUT_CHUNK_CHARS && chars.peek().is_some() {
+                std::thread::sleep(SENDINPUT_CHUNK_DELAY);
+                sent_in_chunk = 0;
+            }
         }
         Ok(typed_chars)
     }


### PR DESCRIPTION
### **User description**
## Summary
- Add Windows streaming SendInput pacing to `unicode_keystroke::type_unicode_chunk`.
- Match the existing non-streaming Windows pacing: 16 chars per chunk, 12ms between chunks.
- Keep the fix scoped to Claude's high-risk #491 finding; no IME, clipboard, or hotkey behavior changes.

## Test Plan
- `git diff --check`
- `cargo test --manifest-path "/home/chris233/openless/openless-all/app/src-tauri/Cargo.toml" unicode_keystroke`
- `cargo test --manifest-path "/home/chris233/openless/openless-all/app/src-tauri/Cargo.toml" streaming_insert`
- `cargo check --manifest-path "/home/chris233/openless/openless-all/app/src-tauri/Cargo.toml" --target "x86_64-pc-windows-gnu"`

Refs #491


___

### **PR Type**
Bug fix


___

### **Description**
- Pace Windows `SendInput` batches

- Insert short delays between chunks

- Reduce post-recording input stalls


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Windows unicode typing"] -- "processes characters" --> B["Chunked SendInput batches"]
  B -- "sleep after 16 chars" --> C["Reduced input contention"]
  C -- "prevents" --> D["Post-recording UI freeze"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>unicode_keystroke.rs</strong><dd><code>Add paced Windows Unicode input sending</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src-tauri/src/unicode_keystroke.rs

<ul><li>Adds Windows-specific pacing constants for <code>SendInput</code> chunk size and <br>delay.<br> <li> Switches Unicode typing to track chunk progress while iterating <br>characters.<br> <li> Sleeps briefly after every 16 characters when more input remains.</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/513/files#diff-8cc0a36519da475e8ea9bfa356414bd11b70aa1f656da9f841c004ded6a338d2">+12/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

