### PR TITLE
Shorten Windows IME submit timeout

### DIFF
--- a/openless-all/app/src-tauri/src/windows_ime_ipc.rs
+++ b/openless-all/app/src-tauri/src/windows_ime_ipc.rs
@@ -3,8 +3,8 @@ use std::time::Duration;
 use crate::windows_ime_protocol::ImeSubmitStatus;
 
 pub const IME_CLIENT_WAIT_TIMEOUT: Duration = Duration::from_millis(700);
-const IME_OWNER_THREAD_MESSAGE_TIMEOUT_MS: u64 = 3000;
-const IME_ASYNC_EDIT_SESSION_TIMEOUT_MS: u64 = 3000;
+const IME_OWNER_THREAD_MESSAGE_TIMEOUT_MS: u64 = 2000;
+const IME_ASYNC_EDIT_SESSION_TIMEOUT_MS: u64 = 2000;
 const IME_SUBMIT_TIMEOUT_MARGIN_MS: u64 = 1000;
 const IME_NATIVE_ASYNC_COMMIT_TIMEOUT_MS: u64 =
     IME_OWNER_THREAD_MESSAGE_TIMEOUT_MS + IME_ASYNC_EDIT_SESSION_TIMEOUT_MS;
@@ -393,6 +393,11 @@ mod tests {
     #[test]
     fn submit_timeout_covers_native_async_commit_path() {
         assert!(IME_SUBMIT_TIMEOUT > Duration::from_millis(IME_NATIVE_ASYNC_COMMIT_TIMEOUT_MS));
+    }
+
+    #[test]
+    fn submit_timeout_stays_within_followup_stall_budget() {
+        assert_eq!(IME_SUBMIT_TIMEOUT, Duration::from_millis(5000));
     }
 
     #[test]

--- a/openless-all/app/windows-ime/src/text_service.cpp
+++ b/openless-all/app/windows-ime/src/text_service.cpp
@@ -12,7 +12,7 @@ namespace {
 
 constexpr wchar_t kMessageWindowClassName[] = L"OpenLessImeMessageWindow";
 constexpr UINT kSubmitTextMessage = WM_APP + 1;
-constexpr UINT kSubmitTextTimeoutMs = 3000;
+constexpr UINT kSubmitTextTimeoutMs = 2000;
 
 struct SubmitTextRequest {
   const std::wstring* session_id = nullptr;


### PR DESCRIPTION
### **User description**
## Summary
- Shorten the Windows IME native owner-thread and async edit-session waits from 3s to 2s each.
- Keep Rust-side `IME_SUBMIT_TIMEOUT` greater than the native total wait, reducing the worst-case submit stall from 7s to 5s without allowing late IME commits to race the fallback path.
- Leave clipboard restore timing unchanged because the current path already restores only when the clipboard still matches the inserted text and has delayed-terminal coverage.

## Test Plan
- `git diff --check`
- `cargo test --manifest-path "/home/chris233/openless/openless-all/app/src-tauri/Cargo.toml" windows_ime_ipc`
- `cargo check --manifest-path "/home/chris233/openless/openless-all/app/src-tauri/Cargo.toml" --target "x86_64-pc-windows-gnu"`

Notes: Native `OpenLessIme.dll` build still needs Windows/MSVC CI or real Windows validation.

Refs #491


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Shorten native IME wait times

- Cap Rust submit timeout at 5s

- Sync C++ submit timeout constant

- Add regression test for budget


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Windows IME native waits"] -- "2s + 2s" --> B["Rust submit timeout (5s)"]
  C["C++ submit timeout"] -- "2s" --> A
  B -- "verified by" --> D["Regression test"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>windows_ime_ipc.rs</strong><dd><code>Lower Rust IME timeout budget</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src-tauri/src/windows_ime_ipc.rs

<ul><li>Reduces native owner-thread and async edit-session waits from 3s to <br>2s.<br> <li> Keeps the Rust submit timeout at 5s, preserving the native wait <br>margin.<br> <li> Adds a regression test asserting the 5000ms follow-up stall budget.</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/514/files#diff-da94e55beee065f39ada5fecbf218dd760a7f41a4660876c32088ea6c889b8ab">+7/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>text_service.cpp</strong><dd><code>Match native IME timeout in C++</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/windows-ime/src/text_service.cpp

<ul><li>Lowers <code>kSubmitTextTimeoutMs</code> from 3000 to 2000.<br> <li> Aligns the Windows IME message timeout with the shorter native wait <br>path.</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/514/files#diff-5ba5fb59f6766fa5706c90c034af3975372658f4af9fbc9cdc26761e465d31a6">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

