### PR TITLE
Avoid activating Windows TSF during dictation start

### DIFF
--- a/openless-all/app/src-tauri/src/coordinator.rs
+++ b/openless-all/app/src-tauri/src/coordinator.rs
@@ -1905,7 +1905,7 @@ fn spawn_qa_recorder_error_monitor(inner: &Arc<Inner>, rx: mpsc::Receiver<Record
         .ok();
 }
 
-#[cfg(target_os = "windows")]
+#[cfg(all(target_os = "windows", test))]
 fn store_prepared_windows_ime_session(
     slots: &mut Vec<PreparedWindowsImeSessionSlot>,
     session_id: SessionId,
@@ -1972,20 +1972,21 @@ async fn insert_with_windows_ime_first(
     paste_shortcut: PasteShortcut,
     ime_target: Option<ImeSubmitTarget>,
 ) -> InsertStatus {
+    if allow_non_tsf_insertion_fallback {
+        log::info!("[windows-ime] non-TSF insertion enabled; skipping TSF activation");
+        return insert_via_non_tsf_fallback(inner, polished, restore_clipboard, paste_shortcut);
+    }
+
     let prepared = {
         let mut slot = inner.prepared_windows_ime_session.lock();
         take_matching_prepared_windows_ime_session(&mut slot, session_id)
     };
-    let Some(prepared) = prepared else {
-        log::warn!("[windows-ime] no prepared TSF session for this dictation");
-        if should_try_non_tsf_insertion_fallback(
-            allow_non_tsf_insertion_fallback,
-            InsertStatus::Failed,
-        ) {
-            return insert_via_non_tsf_fallback(inner, polished, restore_clipboard, paste_shortcut);
+    let prepared = match prepared {
+        Some(prepared) => prepared,
+        None => {
+            log::info!("[windows-ime] preparing TSF session for required TSF insert");
+            inner.windows_ime.prepare_session()
         }
-        log::warn!("[windows-ime] non-TSF insertion fallback is disabled; failing insert");
-        return InsertStatus::Failed;
     };
 
     let request = crate::windows_ime_ipc::ImeSubmitRequest {
@@ -2036,19 +2037,13 @@ fn insert_via_non_tsf_fallback(
 
     match status {
         InsertStatus::Inserted => {
-            log::warn!(
-                "[windows-ime] TSF unavailable; inserted via paced Unicode SendInput fallback"
-            );
+            log::info!("[windows-ime] inserted via paced Unicode SendInput");
         }
         InsertStatus::CopiedFallback => {
-            log::warn!(
-                "[windows-ime] TSF unavailable; Unicode SendInput failed, left text on clipboard"
-            );
+            log::warn!("[windows-ime] Unicode SendInput failed, left text on clipboard");
         }
         InsertStatus::PasteSent | InsertStatus::Failed => {
-            log::warn!(
-                "[windows-ime] TSF unavailable; Unicode SendInput fallback failed and copy fallback failed"
-            );
+            log::warn!("[windows-ime] Unicode SendInput failed and copy fallback failed");
         }
     }
 

--- a/openless-all/app/src-tauri/src/coordinator/dictation.rs
+++ b/openless-all/app/src-tauri/src/coordinator/dictation.rs
@@ -535,12 +535,6 @@ pub(super) async fn begin_session(inner: &Arc<Inner>) -> Result<(), String> {
         }
         session_id
     };
-    #[cfg(target_os = "windows")]
-    {
-        let prepared = inner.windows_ime.prepare_session();
-        let mut slots = inner.prepared_windows_ime_session.lock();
-        store_prepared_windows_ime_session(&mut slots, current_session_id, prepared);
-    }
     // 翻译模式标志重置；hotkey 监听器在 Shift down 时再 set true。
     inner
         .translation_modifier_seen


### PR DESCRIPTION
### **User description**
This avoids activating the OpenLess TSF IME when a dictation session starts.

On Windows, starting dictation previously called `prepare_session()`, which can activate the OpenLess TSF profile and cause host processes such as Explorer to load `OpenLessIme.dll`. In some cases Explorer crashes with `ntdll.dll` / `0xc0000374` around dictation start.

The default Windows insertion path already supports paced Unicode `SendInput`, so this change skips TSF activation when non-TSF insertion is enabled. TSF is now prepared lazily only when non-TSF fallback is disabled and TSF insertion is explicitly required.

Verified with:
- `npm run build`
- `cargo check`
- `git diff --check`


___

### **PR Type**
Bug fix


___

### **Description**
- Skip TSF activation at dictation start

- Use non-TSF insertion immediately

- Lazily prepare TSF only when needed

- Adjust Windows IME logging and helpers


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Dictation session starts"] -- "no eager TSF prep" --> B["Non-TSF insertion path"]
  B -- "Unicode SendInput" --> C["Text inserted without TSF"]
  A -- "TSF required later" --> D["Lazy TSF session preparation"]
  D -- "submit through TSF" --> E["Windows IME insertion"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>coordinator.rs</strong><dd><code>Defer Windows TSF preparation until needed</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src-tauri/src/coordinator.rs

<ul><li>Skip TSF activation when non-TSF fallback is allowed.<br> <li> Lazily call <code>prepare_session()</code> only for required TSF inserts.<br> <li> Update fallback logging to reflect actual insertion outcomes.<br> <li> Restrict prepared-session storage helper to tests.</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/516/files#diff-73d8c004670b27293f74f0f3991b9a6fc28f0ff0b883214de2b078b1e09797ca">+14/-19</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>dictation.rs</strong><dd><code>Stop preparing TSF on session begin</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src-tauri/src/coordinator/dictation.rs

<ul><li>Remove eager Windows IME preparation from <code>begin_session()</code>.<br> <li> Prevent dictation start from activating the TSF profile.<br> <li> Keep session initialization focused on state setup.</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/516/files#diff-4cf79887f41f4811eb2b1ef682c62ee34c14a0ab969362a9ba1046de59c8578b">+0/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

