### PR TITLE
Fix Linux main window controls

### DIFF
--- a/openless-all/app/src-tauri/tauri.linux.conf.json
+++ b/openless-all/app/src-tauri/tauri.linux.conf.json
@@ -1,0 +1,55 @@
+{
+  "$schema": "https://schema.tauri.app/config/2",
+  "app": {
+    "windows": [
+      {
+        "label": "main",
+        "title": "OpenLess",
+        "width": 1240,
+        "height": 800,
+        "minWidth": 980,
+        "minHeight": 640,
+        "resizable": true,
+        "decorations": true,
+        "transparent": false,
+        "shadow": true,
+        "visible": false,
+        "acceptFirstMouse": true
+      },
+      {
+        "label": "capsule",
+        "url": "index.html?window=capsule",
+        "title": "OpenLess Capsule",
+        "width": 220,
+        "height": 110,
+        "decorations": false,
+        "transparent": true,
+        "shadow": false,
+        "alwaysOnTop": true,
+        "skipTaskbar": true,
+        "resizable": false,
+        "focus": false,
+        "visible": false,
+        "center": false,
+        "acceptFirstMouse": true
+      },
+      {
+        "label": "qa",
+        "url": "index.html?window=qa",
+        "title": "OpenLess QA",
+        "width": 380,
+        "height": 440,
+        "decorations": false,
+        "transparent": true,
+        "shadow": true,
+        "alwaysOnTop": true,
+        "skipTaskbar": true,
+        "resizable": false,
+        "focus": false,
+        "visible": false,
+        "center": false,
+        "acceptFirstMouse": true
+      }
+    ]
+  }
+}


### PR DESCRIPTION
### **User description**
## Summary
- add Linux-specific Tauri config for the main window
- disable main-window transparency on Linux while keeping native decorations
- keep capsule and QA window definitions in the Linux override because Tauri merge patch replaces the windows array

Closes #517

## Validation
- npm --prefix "openless-all/app" run build
- cargo check --manifest-path "openless-all/app/src-tauri/Cargo.toml"
- git diff --check HEAD~1 HEAD

## Notes
- Needs Ubuntu real-desktop validation for native window-control hit testing; current environment has no DISPLAY/WAYLAND_DISPLAY.


___

### **PR Type**
Bug fix


___

### **Description**
- Add Linux-specific Tauri window config

- Disable main-window transparency on Ubuntu

- Keep capsule and QA windows intact


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Linux Tauri config"] -- "defines" --> B["main window"]
  A -- "includes" --> C["capsule window"]
  A -- "includes" --> D["QA window"]
  B -- "transparent: false, decorations: true" --> E["clickable window controls"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>tauri.linux.conf.json</strong><dd><code>Add Linux window configuration override</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src-tauri/tauri.linux.conf.json

<ul><li>Defines a Linux-only Tauri <code>app.windows</code> override<br> <li> Sets the main window to non-transparent with native decorations<br> <li> Preserves the <code>capsule</code> and <code>qa</code> window definitions in the override</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/518/files#diff-38361037cc4b8090b8810871778327344aa9bfd0ae0ac243e26826474a9aa738">+55/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

