### PR TITLE
修复 Sherpa 本地 ASR 资产校验与部分下载状态

### DIFF
--- a/openless-all/app/src-tauri/src/asr/local/sherpa.rs
+++ b/openless-all/app/src-tauri/src/asr/local/sherpa.rs
@@ -142,7 +142,10 @@ fn required_path_is_dir(alias: &str, required: &str) -> bool {
 
 fn required_dir_is_valid(alias: &str, required: &str, path: &Path) -> bool {
     match (alias, required) {
-        ("qwen3-asr-0.6b-int8", "tokenizer") => path.join("tokenizer.json").is_file(),
+        ("qwen3-asr-0.6b-int8", "tokenizer") => {
+            path.join("tokenizer.json").is_file()
+                || (path.join("vocab.json").is_file() && path.join("merges.txt").is_file())
+        }
         _ => false,
     }
 }
@@ -345,7 +348,7 @@ mod tests {
     }
 
     #[test]
-    fn qwen3_tokenizer_requires_tokenizer_json() {
+    fn qwen3_tokenizer_accepts_supported_layouts() {
         let dir = std::env::temp_dir().join(format!(
             "openless-sherpa-tokenizer-{}",
             uuid::Uuid::new_v4()
@@ -359,6 +362,21 @@ mod tests {
         ));
 
         fs::write(dir.join("tokenizer.json"), b"{}").expect("write tokenizer json");
+        assert!(required_path_is_valid(
+            "qwen3-asr-0.6b-int8",
+            "tokenizer",
+            &dir
+        ));
+
+        fs::remove_file(dir.join("tokenizer.json")).expect("remove tokenizer json");
+        fs::write(dir.join("vocab.json"), b"{}").expect("write vocab json");
+        assert!(!required_path_is_valid(
+            "qwen3-asr-0.6b-int8",
+            "tokenizer",
+            &dir
+        ));
+
+        fs::write(dir.join("merges.txt"), b"#version: 0.2").expect("write merges txt");
         assert!(required_path_is_valid(
             "qwen3-asr-0.6b-int8",
             "tokenizer",

--- a/openless-all/app/src/pages/LocalAsr.tsx
+++ b/openless-all/app/src/pages/LocalAsr.tsx
@@ -976,8 +976,11 @@ export function LocalAsr({ embedded = false }: LocalAsrProps = {}) {
         if (!sherpaAvailable) return
         const modelAlias = selectedSherpaAlias
         const remoteSize = sherpaRemoteSizes[modelAlias]
+        const model = sherpaCatalog.find((item) => item.alias === modelAlias)
         const initialDownloaded =
-            sherpaDownloadProgress[modelAlias]?.bytesDownloaded ?? 0
+            sherpaDownloadProgress[modelAlias]?.bytesDownloaded ??
+            model?.downloadedBytes ??
+            0
         setSherpaBusy("download")
         setSherpaDownloadCancelRequested(false)
         setSherpaDownloadProgress((prev) => ({
@@ -1236,21 +1239,44 @@ export function LocalAsr({ embedded = false }: LocalAsrProps = {}) {
     const selectedSherpaRemoteSize = sherpaRemoteSizes[selectedSherpaAlias]
     const selectedSherpaDownloadProgress =
         sherpaDownloadProgress[selectedSherpaAlias]
+    const selectedSherpaDownloadedBytes =
+        selectedSherpaCatalog?.downloadedBytes ?? 0
+    const selectedSherpaProgressBytes =
+        selectedSherpaDownloadProgress?.bytesDownloaded ?? 0
+    const selectedSherpaPartialBytes = Math.max(
+        selectedSherpaProgressBytes,
+        selectedSherpaDownloadedBytes,
+    )
     const isSherpaDownloading =
         selectedSherpaDownloadProgress?.phase === "started" ||
         selectedSherpaDownloadProgress?.phase === "progress"
     const hasSherpaPartial =
         selectedSherpaCatalog?.cached !== true &&
         selectedSherpaDownloadProgress?.phase !== "finished" &&
-        (selectedSherpaDownloadProgress?.bytesDownloaded ?? 0) > 0
-    const canDeleteSelectedSherpa =
+        selectedSherpaPartialBytes > 0
+    const selectedSherpaHasLocalFiles =
         selectedSherpaCatalog?.cached === true ||
-        hasSherpaPartial ||
-        (selectedSherpaCatalog?.downloadedBytes ?? 0) > 0
+        selectedSherpaDownloadedBytes > 0
+    const canDeleteSelectedSherpa =
+        selectedSherpaHasLocalFiles || hasSherpaPartial
     const showSherpaDownloadProgress =
         isSherpaDownloading ||
         selectedSherpaDownloadProgress?.phase === "failed" ||
         hasSherpaPartial
+    const selectedSherpaDownloadProgressForDisplay =
+        selectedSherpaDownloadProgress ??
+        (hasSherpaPartial
+            ? {
+                  modelId: selectedSherpaAlias,
+                  file: "",
+                  fileIndex: 0,
+                  fileCount: selectedSherpaRemoteSize?.fileCount ?? 0,
+                  bytesDownloaded: selectedSherpaDownloadedBytes,
+                  bytesTotal: selectedSherpaRemoteSize?.totalBytes ?? 0,
+                  phase: "progress" as const,
+                  error: null,
+              }
+            : undefined)
     const selectedSherpaSizeMb = formatFoundrySizeMb(
         selectedSherpaCatalog?.fileSizeMb,
     )
@@ -2033,7 +2059,7 @@ export function LocalAsr({ embedded = false }: LocalAsrProps = {}) {
 
                         {showSherpaDownloadProgress && (
                             <DownloadProgressBlock
-                                progress={selectedSherpaDownloadProgress}
+                                progress={selectedSherpaDownloadProgressForDisplay}
                                 remoteSize={selectedSherpaRemoteSize}
                                 cancelRequested={sherpaDownloadCancelRequested}
                             />
@@ -2063,8 +2089,7 @@ export function LocalAsr({ embedded = false }: LocalAsrProps = {}) {
                                 size="sm"
                                 disabled={
                                     sherpaBusy !== null ||
-                                    !sherpaAvailable ||
-                                    selectedSherpaCatalog?.cached !== true
+                                    !sherpaAvailable
                                 }
                                 onClick={() => void handlePrepareSherpa()}
                             >


### PR DESCRIPTION
### **User description**
## 概要

修复 Sherpa 本地 ASR 在 Qwen3-ASR 模型资产校验和部分下载状态展示上的问题。

主要改动：

- 放宽 Qwen3-ASR tokenizer 目录校验，支持两种合法布局：
  - `tokenizer.json`
  - `vocab.json` + `merges.txt`
- Sherpa catalog 增加 `downloadedBytes`，用于前端恢复本地部分下载状态。
- catalog / prepare 阶段统一使用 required path 校验，避免目录存在但内容不完整时被误判为可用。
- Local ASR 页面根据 `downloadedBytes`、`fileSizeMb` 和实时下载 progress 综合判断本地文件状态。
- 修复页面刷新后部分下载状态丢失的问题，使继续下载、删除按钮和进度展示能正确反映本地文件状态。
- Sherpa 准备按钮不再强依赖 `cached === true`，允许在本地文件存在但缓存状态未完整识别时尝试准备。

## 背景

Qwen3-ASR 的 tokenizer 资产可能不是单一的 `tokenizer.json` 文件，而是 `vocab.json` + `merges.txt` 的组合布局。此前校验逻辑无法识别这种合法布局，可能导致模型已经下载/解压后仍被判定为未缓存或不可用。

另外，Sherpa 下载状态主要依赖前端实时 progress。页面刷新后，如果本地已经存在部分下载或部分解压文件，但没有实时下载事件，UI 可能无法正确显示继续下载、删除和进度状态。

## Foundry 检查结论

本次同时检查了 Foundry Local Whisper 的类似风险。

Foundry 当前模型资产仍是固定文件布局，没有发现类似 Qwen3 tokenizer 这种目录型、多布局资产校验需求。因此本 PR 不修改 Foundry 的后端模型校验逻辑。

## 验证

- `node node_modules\typescript\bin\tsc --noEmit --pretty false`
- `cargo test qwen3_tokenizer_accepts_supported_layouts --lib`
- `git diff --check`


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Support dual Qwen3 tokenizer layouts

- Restore Sherpa partial download state

- Enable prepare without cached flag

- Add regression coverage for tokenizer assets


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Qwen3 tokenizer assets"] -- "accept multiple layouts" --> B["Sherpa asset validation"]
  B -- "preserve partial bytes" --> C["Local ASR UI state"]
  C -- "show progress and delete" --> D["User actions"]
  B -- "regression test" --> E["Rust tests"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>sherpa.rs</strong><dd><code>Accept supported Qwen3 tokenizer layouts</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src-tauri/src/asr/local/sherpa.rs

<ul><li>Expands Qwen3 tokenizer validation to accept <code>tokenizer.json</code> or <br><code>vocab.json</code> plus <code>merges.txt</code>.<br> <li> Keeps <code>required_path_is_dir</code> logic aligned with the tokenizer directory <br>requirement.<br> <li> Updates the unit test to verify both supported layouts and the invalid <br>intermediate state.</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/527/files#diff-1d5fe100dd3dc159e55d82e687d86497460f3eeac462e680ccbab5ab6d861552">+20/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>LocalAsr.tsx</strong><dd><code>Restore Sherpa download state from catalog</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src/pages/LocalAsr.tsx

<ul><li>Seeds download progress with stored <code>downloadedBytes</code> when no live <br>progress exists.<br> <li> Derives partial-download UI state from both cached catalog data and <br>active progress.<br> <li> Allows delete and prepare actions when local files exist even if <br><code>cached</code> is unset.<br> <li> Synthesizes display progress so the UI can render resumed downloads <br>after refresh.</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/527/files#diff-35c7e3db3ea48b533df9bb63195bf0f2762ed382d681aee7f0da7e3a246e881d">+33/-8</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

