### PR TITLE
fix: Linux Wayland 改用应用级自定义标题栏，绕过 GTK CSD 点击无响应问题

### DIFF
--- a/openless-all/app/src-tauri/src/lib.rs
+++ b/openless-all/app/src-tauri/src/lib.rs
@@ -204,8 +204,50 @@ pub fn run() {
                 let suppress_show = !force_show && coordinator.prefs().get().start_minimized;
                 if suppress_show {
                     log::info!("[main] start_minimized=true → 跳过初始 show，等用户点托盘");
-                } else if let Err(e) = main.show() {
-                    log::warn!("[main] initial show failed: {e}");
+                } else {
+                    #[cfg(target_os = "linux")]
+                    {
+                        // Workaround for Linux Wayland WebKitGTK compositing bugs:
+                        // `visible:false` → `show()` can leave the webview surface
+                        // without a valid input region, making the entire window
+                        // (including CSD titlebar buttons) unresponsive to clicks.
+                        //
+                        // The fix: after show(), async-delay for webview realize,
+                        // then set_focus() + ±1px pseudo-resize to force GTK's
+                        // size-allocate → input surface reattach.
+                        // Ref: tauri#9394, cc-switch linux_fix.rs
+                        let main_clone = main.clone();
+                        let _ = main_clone.set_focus();
+                        tauri::async_runtime::spawn(async move {
+                            tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+                            let _ = main_clone.set_focus();
+                            if let Ok(orig) = main_clone.inner_size() {
+                                let bumped = tauri::PhysicalSize::new(
+                                    orig.width.saturating_add(1),
+                                    orig.height,
+                                );
+                                let _ = main_clone.set_size(bumped);
+                                tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+                                let _ = main_clone.set_size(orig);
+                                log::info!("[main] Linux nudge: focus + surface reactivation done");
+                                // Reconcile: compositor may have coalesced the two
+                                // set_size calls, leaving the window at width+1.
+                                tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+                                if let Ok(after) = main_clone.inner_size() {
+                                    if after.width != orig.width || after.height != orig.height {
+                                        log::info!(
+                                            "[main] Linux nudge drift detected: {}x{} → {}x{}, correcting",
+                                            orig.width, orig.height, after.width, after.height
+                                        );
+                                        let _ = main_clone.set_size(orig);
+                                    }
+                                }
+                            }
+                        });
+                    }
+                    if let Err(e) = main.show() {
+                        log::warn!("[main] initial show failed: {e}");
+                    }
                 }
             }
 

--- a/openless-all/app/src-tauri/src/lib.rs
+++ b/openless-all/app/src-tauri/src/lib.rs
@@ -207,14 +207,10 @@ pub fn run() {
                 } else {
                     #[cfg(target_os = "linux")]
                     {
-                        // Workaround for Linux Wayland WebKitGTK compositing bugs:
+                        // Workaround for Linux Wayland WebKitGTK compositing:
                         // `visible:false` → `show()` can leave the webview surface
-                        // without a valid input region, making the entire window
-                        // (including CSD titlebar buttons) unresponsive to clicks.
-                        //
-                        // The fix: after show(), async-delay for webview realize,
-                        // then set_focus() + ±1px pseudo-resize to force GTK's
-                        // size-allocate → input surface reattach.
+                        // without a valid input region. The ±1px nudge forces
+                        // GTK size-allocate → input surface reattach.
                         // Ref: tauri#9394, cc-switch linux_fix.rs
                         let main_clone = main.clone();
                         let _ = main_clone.set_focus();
@@ -234,11 +230,12 @@ pub fn run() {
                                 // set_size calls, leaving the window at width+1.
                                 tokio::time::sleep(std::time::Duration::from_millis(500)).await;
                                 if let Ok(after) = main_clone.inner_size() {
-                                    if after.width != orig.width || after.height != orig.height {
-                                        log::info!(
-                                            "[main] Linux nudge drift detected: {}x{} → {}x{}, correcting",
-                                            orig.width, orig.height, after.width, after.height
-                                        );
+                                    // Only correct the ±1px nudge artifact — if the
+                                    // compositor or user resized the window significantly
+                                    // during this window, don't clobber that change.
+                                    let dw = if after.width > orig.width { after.width - orig.width } else { orig.width - after.width };
+                                    let dh = if after.height > orig.height { after.height - orig.height } else { orig.height - after.height };
+                                    if dw <= 1 && dh <= 1 && (dw > 0 || dh > 0) {
                                         let _ = main_clone.set_size(orig);
                                     }
                                 }

--- a/openless-all/app/src-tauri/src/main.rs
+++ b/openless-all/app/src-tauri/src/main.rs
@@ -2,5 +2,20 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
 fn main() {
+    // Work around WebKitGTK compositing bugs on Linux Wayland:
+    // - WEBKIT_DISABLE_COMPOSITING_MODE=1 fixes "whole window unresponsive
+    //   to clicks until maximize/restore" (tauri#9394)
+    // - WEBKIT_DISABLE_DMABUF_RENDERER=1 fixes white/black screen on some
+    //   GPU/driver combos (e.g. Nvidia + Debian)
+    #[cfg(target_os = "linux")]
+    {
+        if std::env::var("WEBKIT_DISABLE_DMABUF_RENDERER").is_err() {
+            std::env::set_var("WEBKIT_DISABLE_DMABUF_RENDERER", "1");
+        }
+        if std::env::var("WEBKIT_DISABLE_COMPOSITING_MODE").is_err() {
+            std::env::set_var("WEBKIT_DISABLE_COMPOSITING_MODE", "1");
+        }
+    }
+
     openless_lib::run();
 }

--- a/openless-all/app/src-tauri/tauri.linux.conf.json
+++ b/openless-all/app/src-tauri/tauri.linux.conf.json
@@ -10,8 +10,8 @@
         "minWidth": 980,
         "minHeight": 640,
         "resizable": true,
-        "decorations": true,
-        "transparent": false,
+        "decorations": false,
+        "transparent": true,
         "shadow": true,
         "visible": false,
         "acceptFirstMouse": true

--- a/openless-all/app/src/components/WindowChrome.tsx
+++ b/openless-all/app/src/components/WindowChrome.tsx
@@ -31,10 +31,15 @@ export function WindowChrome({
   children,
   height = 800,
 }: WindowChromeProps) {
+  // Windows: decorations:true 时外层不画圆角/边框/阴影/标题栏，避免与原生窗口重叠。
+  // Linux: decorations:false 时外层画 14px 圆角 + 自定义标题栏。
   const shellRadius = os === 'mac' ? 0 : os === 'win' ? 0 : 14;
   const consoleRadius = os === 'mac' ? 20 : os === 'win' ? WIN_CONSOLE_RADIUS : 14;
   const titlebarHeight = os === 'mac' ? MAC_TITLEBAR_HEIGHT : os === 'linux' ? LINUX_TITLEBAR_HEIGHT : 0;
 
+  // 三个平台共用半透明玻璃 background + backdropFilter。
+  // macOS: NSVisualEffectView 提供材质；Windows: Tauri apply_mica 提供 Mica；
+  // Linux: decorations:false 后 CSS 磨砂玻璃自成背景。
   const background = `
     radial-gradient(120% 80% at 0% 0%, rgba(255,255,255,0.55) 0%, rgba(255,255,255,0) 60%),
     radial-gradient(100% 70% at 100% 100%, rgba(37,99,235,0.07) 0%, rgba(37,99,235,0) 55%),
@@ -78,6 +83,9 @@ export function WindowChrome({
         />
       )}
       {os === 'linux' && <LinuxTitlebar />}
+      {os === 'linux' && (
+        <style>{`.ol-linux-close-btn:hover{background:rgba(220,38,38,0.12)!important;color:rgb(220,38,38)!important}`}</style>
+      )}
       <div style={{ flex: 1, minHeight: 0, display: 'flex', position: 'relative' }}>
         {children}
       </div>
@@ -87,21 +95,36 @@ export function WindowChrome({
 
 // ── Linux custom titlebar — mirrors cc-switch's approach ──
 
+type TauriWindow = import('@tauri-apps/api/window').Window;
+
 function LinuxTitlebar() {
   const [maximized, setMaximized] = useState(false);
-  const winRef = useRef<any>(null);
+  const winRef = useRef<TauriWindow | null>(null);
 
   useEffect(() => {
     let cancelled = false;
+    let unlisten: (() => void) | undefined;
     import('@tauri-apps/api/window').then(({ getCurrentWindow }) => {
       if (cancelled) return;
       const w = getCurrentWindow();
       winRef.current = w;
-      w.isMaximized().then((m: boolean) => {
+      w.isMaximized().then((m) => {
         if (!cancelled) setMaximized(m);
       }).catch(() => {});
+      // Keep icon in sync when user maximizes via double-click / keyboard shortcut
+      w.listen('tauri://resize', () => {
+        if (cancelled) return;
+        w.isMaximized().then((m) => {
+          if (!cancelled) setMaximized(m);
+        }).catch(() => {});
+      }).then((fn) => {
+        if (!cancelled) unlisten = fn;
+      }).catch(() => {});
     }).catch(() => {});
-    return () => { cancelled = true; };
+    return () => {
+      cancelled = true;
+      unlisten?.();
+    };
   }, []);
 
   const onMinimize = useCallback(() => {
@@ -109,8 +132,13 @@ function LinuxTitlebar() {
   }, []);
 
   const onToggleMaximize = useCallback(() => {
-    winRef.current?.toggleMaximize().catch(() => {});
-    setMaximized((m) => !m);
+    const w = winRef.current;
+    if (!w) return;
+    w.toggleMaximize().catch(() => {});
+    // Re-query after window manager processes the toggle, in case WM rejects it
+    setTimeout(() => {
+      w.isMaximized().then(setMaximized).catch(() => {});
+    }, 300);
   }, []);
 
   const onClose = useCallback(() => {
@@ -154,17 +182,11 @@ function LinuxTitlebar() {
           onClick={onClose}
           aria-label="Close"
           className="ol-linux-close-btn"
-          style={closeBtn}
+          style={ctrlBtn}
         >
           <CloseSvg />
         </button>
       </div>
-      <style>{`
-        .ol-linux-close-btn:hover {
-          background: rgba(220,38,38,0.12) !important;
-          color: rgb(220,38,38) !important;
-        }
-      `}</style>
     </div>
   );
 }
@@ -179,9 +201,6 @@ const ctrlBtn: CSSProperties = {
   background: 'transparent', color: 'var(--ol-ink-3)',
   fontFamily: 'inherit', cursor: 'default',
   transition: 'background 0.12s, color 0.12s',
-};
-const closeBtn: CSSProperties = {
-  ...ctrlBtn,
 };
 
 function MinimizeSvg() {

--- a/openless-all/app/src/components/WindowChrome.tsx
+++ b/openless-all/app/src/components/WindowChrome.tsx
@@ -1,4 +1,4 @@
-import { type CSSProperties, type ReactNode } from 'react';
+import { type CSSProperties, type ReactNode, useCallback, useEffect, useRef, useState } from 'react';
 
 export type OS = 'mac' | 'win' | 'linux';
 
@@ -16,6 +16,7 @@ export function detectOS(): OS {
 
 const MAC_TITLEBAR_HEIGHT = 28;
 const MAC_SYSTEM_CONTROLS_RESERVED_WIDTH = 76;
+const LINUX_TITLEBAR_HEIGHT = 36;
 const WIN_CONSOLE_RADIUS = 10;
 
 interface WindowChromeProps {
@@ -30,17 +31,10 @@ export function WindowChrome({
   children,
   height = 800,
 }: WindowChromeProps) {
-  // Windows 下交还原生外壳（decorations:true）：外层不画圆角 / 边框 / 阴影 / 标题栏，
-  // 避免与原生窗口的角和关闭按钮重叠。内层卡片保留 10px 圆角，跟整体设计对齐。
   const shellRadius = os === 'mac' ? 0 : os === 'win' ? 0 : 14;
   const consoleRadius = os === 'mac' ? 20 : os === 'win' ? WIN_CONSOLE_RADIUS : 14;
-  const titlebarHeight = os === 'mac' ? MAC_TITLEBAR_HEIGHT : 0;
+  const titlebarHeight = os === 'mac' ? MAC_TITLEBAR_HEIGHT : os === 'linux' ? LINUX_TITLEBAR_HEIGHT : 0;
 
-  // 两个平台用同一份半透明玻璃 background + backdropFilter，让 sidebar 透明地坐在
-  // 磨砂底板上时有可见的玻璃感。
-  // Windows: Tauri transparent:true + lib.rs apply_mica 提供 Win11 Mica 透出来；
-  // macOS: NSVisualEffectView 提供材质。
-  // alpha 0.92：和原生 Win11 caption（lib.rs 设为 rgb(245,245,247)）色差最小，玻璃感仍可见。
   const background = `
     radial-gradient(120% 80% at 0% 0%, rgba(255,255,255,0.55) 0%, rgba(255,255,255,0) 60%),
     radial-gradient(100% 70% at 100% 100%, rgba(37,99,235,0.07) 0%, rgba(37,99,235,0) 55%),
@@ -83,9 +77,142 @@ export function WindowChrome({
           }}
         />
       )}
+      {os === 'linux' && <LinuxTitlebar />}
       <div style={{ flex: 1, minHeight: 0, display: 'flex', position: 'relative' }}>
         {children}
       </div>
     </div>
+  );
+}
+
+// ── Linux custom titlebar — mirrors cc-switch's approach ──
+
+function LinuxTitlebar() {
+  const [maximized, setMaximized] = useState(false);
+  const winRef = useRef<any>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    import('@tauri-apps/api/window').then(({ getCurrentWindow }) => {
+      if (cancelled) return;
+      const w = getCurrentWindow();
+      winRef.current = w;
+      w.isMaximized().then((m: boolean) => {
+        if (!cancelled) setMaximized(m);
+      }).catch(() => {});
+    }).catch(() => {});
+    return () => { cancelled = true; };
+  }, []);
+
+  const onMinimize = useCallback(() => {
+    winRef.current?.minimize().catch(() => {});
+  }, []);
+
+  const onToggleMaximize = useCallback(() => {
+    winRef.current?.toggleMaximize().catch(() => {});
+    setMaximized((m) => !m);
+  }, []);
+
+  const onClose = useCallback(() => {
+    winRef.current?.close().catch(() => {});
+  }, []);
+
+  return (
+    <div
+      data-tauri-drag-region
+      style={{
+        height: LINUX_TITLEBAR_HEIGHT,
+        flexShrink: 0,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+        padding: '0 6px 0 14px',
+        background: 'rgba(245,245,247,0.85)',
+        backdropFilter: 'blur(12px) saturate(180%)',
+        WebkitBackdropFilter: 'blur(12px) saturate(180%)',
+        borderBottom: '0.5px solid rgba(0,0,0,0.08)',
+        color: 'var(--ol-ink-3)',
+        fontSize: 13,
+        fontWeight: 500,
+        cursor: 'default',
+        userSelect: 'none',
+        zIndex: 50,
+      }}
+    >
+      <span style={{ color: 'var(--ol-ink-2)' }}>OpenLess</span>
+      <div
+        style={{ display: 'flex', gap: 4, pointerEvents: 'auto' }}
+        onMouseDown={(e) => e.stopPropagation()}
+      >
+        <button onClick={onMinimize} aria-label="Minimize" style={ctrlBtn}>
+          <MinimizeSvg />
+        </button>
+        <button onClick={onToggleMaximize} aria-label={maximized ? 'Restore' : 'Maximize'} style={ctrlBtn}>
+          {maximized ? <RestoreSvg /> : <MaximizeSvg />}
+        </button>
+        <button
+          onClick={onClose}
+          aria-label="Close"
+          className="ol-linux-close-btn"
+          style={closeBtn}
+        >
+          <CloseSvg />
+        </button>
+      </div>
+      <style>{`
+        .ol-linux-close-btn:hover {
+          background: rgba(220,38,38,0.12) !important;
+          color: rgb(220,38,38) !important;
+        }
+      `}</style>
+    </div>
+  );
+}
+
+// ── inline SVG icons (no lucide-react dep) ──
+
+const svgWrap: CSSProperties = { width: 12, height: 12, display: 'block' };
+const ctrlBtn: CSSProperties = {
+  width: 30, height: 24,
+  display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
+  borderRadius: 5, border: 0, padding: 0,
+  background: 'transparent', color: 'var(--ol-ink-3)',
+  fontFamily: 'inherit', cursor: 'default',
+  transition: 'background 0.12s, color 0.12s',
+};
+const closeBtn: CSSProperties = {
+  ...ctrlBtn,
+};
+
+function MinimizeSvg() {
+  return (
+    <svg width="12" height="12" viewBox="0 0 12 12" fill="none" style={svgWrap}>
+      <rect x="2" y="5.5" width="8" height="1" rx="0.5" fill="currentColor" />
+    </svg>
+  );
+}
+
+function MaximizeSvg() {
+  return (
+    <svg width="12" height="12" viewBox="0 0 12 12" fill="none" style={svgWrap}>
+      <rect x="2" y="2" width="8" height="8" rx="1.5" stroke="currentColor" strokeWidth="1.1" />
+    </svg>
+  );
+}
+
+function RestoreSvg() {
+  return (
+    <svg width="12" height="12" viewBox="0 0 12 12" fill="none" style={svgWrap}>
+      <rect x="3.6" y="0.6" width="7.2" height="7.2" rx="1.3" stroke="currentColor" strokeWidth="1.1" />
+      <rect x="0.6" y="3.6" width="7.2" height="7.2" rx="1.3" fill="var(--ol-surface, #fff)" stroke="currentColor" strokeWidth="1.1" />
+    </svg>
+  );
+}
+
+function CloseSvg() {
+  return (
+    <svg width="12" height="12" viewBox="0 0 12 12" fill="none" style={svgWrap}>
+      <path d="M2.8 2.8l6.4 6.4M9.2 2.8l-6.4 6.4" stroke="currentColor" strokeWidth="1.25" strokeLinecap="round" />
+    </svg>
   );
 }


### PR DESCRIPTION
### **User description**
## Summary
- KDE/Wayland 下 GTK CSD 标题栏按钮无法响应点击（tao#1218, tauri#9394），WebKit 环境变量 + nudge resize 均不能可靠修复
- 参考 cc-switch 方案，设置 `decorations: false` + `transparent: true`，用 React 组件绘制应用级标题栏
- 36px 拖拽栏 + 最小化/最大化/关闭三键，通过 `@tauri-apps/api/window` 的 `getCurrentWindow()` 控制窗口
- 同时保留 `WEBKIT_DISABLE_COMPOSITING_MODE` / `DMABUF_RENDERER` 环境变量和 async nudge 作为辅助修复

## Changes
| File | Change |
|------|--------|
| `tauri.linux.conf.json` | 主窗口 `decorations: false` + `transparent: true` |
| `WindowChrome.tsx` | 新增 `LinuxTitlebar` 组件（动态 import Tauri API + 内联 SVG 图标） |
| `main.rs` | WebKit 合成模式环境变量（GTK 初始化前设置） |
| `lib.rs` | async nudge（set_focus + ±1px resize）辅助修复 webview surface 输入区域 |

## Test plan
- [x] KDE Wayland 下窗口控制按钮可点击（最小化/最大化/关闭）
- [x] 拖拽标题栏可移动窗口
- [x] 双击标题栏切换最大化/还原
- [x] macOS/Windows 不受影响（OS 条件渲染隔离）

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Add Linux custom titlebar controls

- Disable GTK decorations on Wayland

- Set WebKit Linux compatibility env vars

- Nudge WebView after initial show


___

### Diagram Walkthrough


```mermaid
flowchart LR
  cfg["tauri.linux.conf.json window config"] -- "decorations:false, transparent:true" --> chrome["WindowChrome.tsx LinuxTitlebar UI"]
  chrome -- "window controls and state sync" --> tauri["Tauri window API"]
  main["main.rs WebKit env vars"] -- "compositing compatibility" --> webkit["WebKitGTK"]
  lib["`lib.rs` post-show nudge" -- "focus + ±1px resize" --> webview["Webview input region"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>lib.rs</strong><dd><code>Add Linux post-show window nudge</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src-tauri/src/lib.rs

<ul><li>Adds a Linux-only workaround after <code>main.show()</code><br> <li> Forces focus and a small resize cycle<br> <li> Reconciles the window size after the nudge<br> <li> Avoids overwriting real user or compositor resizes</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/531/files#diff-6b8eb1bbf8e378bab914f1a12962f7add5cc4ba9e013c37c9921a1032fa5e110">+41/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main.rs</strong><dd><code>Set Linux WebKit compatibility variables</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src-tauri/src/main.rs

<ul><li>Sets <code>WEBKIT_DISABLE_DMABUF_RENDERER=1</code> on Linux<br> <li> Sets <code>WEBKIT_DISABLE_COMPOSITING_MODE=1</code> on Linux<br> <li> Preserves existing values when already configured<br> <li> Applies the workaround before app startup</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/531/files#diff-c734c0ec2e829f6001132adf9aa4356b38d40a4c8626466d7a0c97f759d5c409">+15/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>tauri.linux.conf.json</strong><dd><code>Switch Linux window to frameless mode</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src-tauri/tauri.linux.conf.json

<ul><li>Disables native window decorations on Linux<br> <li> Enables transparency for the custom shell<br> <li> Keeps the main window hidden at startup</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/531/files#diff-38361037cc4b8090b8810871778327344aa9bfd0ae0ac243e26826474a9aa738">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>WindowChrome.tsx</strong><dd><code>Add Linux custom window titlebar</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src/components/WindowChrome.tsx

<ul><li>Adds a Linux-only draggable titlebar<br> <li> Implements minimize, maximize, restore, and close actions<br> <li> Syncs maximize state from <code>tauri://resize</code><br> <li> Uses inline SVG icons and hover styling</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/531/files#diff-ca98272202276bc772e02f5bdd6dfd006d06a0da7bb6d9705d03e1da14edca4c">+155/-9</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

