### PR TITLE
Pr/windows ime whisper fixes

### DIFF
--- a/openless-all/app/src-tauri/src/asr/whisper.rs
+++ b/openless-all/app/src-tauri/src/asr/whisper.rs
@@ -616,8 +616,9 @@ mod tests {
                     .unwrap();
                 let request = read_http_request(&mut stream);
                 let request_text = String::from_utf8_lossy(&request);
+                let request_text_lower = request_text.to_ascii_lowercase();
                 assert!(request_text.starts_with("POST /audio/transcriptions HTTP/1.1"));
-                assert!(request_text.contains("authorization: Bearer key"));
+                assert!(request_text_lower.contains("authorization: bearer key"));
                 assert!(request_text.contains("model"));
                 write_json_response(&mut stream, &format!(r#"{{"text":"{}"}}"#, text));
             }

--- a/openless-all/app/src-tauri/wix/openless-ime.wxs
+++ b/openless-all/app/src-tauri/wix/openless-ime.wxs
@@ -9,7 +9,12 @@
           </Component>
         </Directory>
         <Directory Id="OpenLessImeX86Directory" Name="x86">
-          <Component Id="OpenLessImeDllX86Component" Guid="{A2E61B9A-4034-4ABF-A42F-964A9B1F08BB}" Win64="no">
+          <!-- The x86 TSF DLL is intentionally packaged inside the x64 MSI
+               under INSTALLDIR\windows-ime\x86 and registered with
+               SysWOW64\regsvr32 below. Mark the MSI component as 64-bit so
+               WiX accepts it under the x64 INSTALLDIR; this does not change
+               the architecture of the DLL payload. -->
+          <Component Id="OpenLessImeDllX86Component" Guid="{A2E61B9A-4034-4ABF-A42F-964A9B1F08BB}" Win64="yes">
             <File Id="OpenLessImeDllX86" Name="OpenLessIme.dll" Source="src-tauri\target\windows-ime-msvc\x86\Release\OpenLessIme.dll" KeyPath="yes" />
           </Component>
         </Directory>


### PR DESCRIPTION
### **User description**
## Summary
- Mark the bundled x86 IME DLL component as 64-bit for the x64 MSI layout while preserving the x86 payload path and SysWOW64 registration behavior.
- Make the Whisper request test tolerate lowercase `authorization` headers.

## Tests
- cargo test --manifest-path src-tauri/Cargo.toml --lib whisper


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Fix x64 MSI acceptance for x86 IME payload

- Keep x86 DLL path and registration intact

- Normalize Whisper test headers to lowercase


___

### Diagram Walkthrough


```mermaid
flowchart LR
  P["Windows IME and Whisper fixes"]
  W["WiX component metadata"]
  T["Whisper test header check"]
  P -- "package x86 DLL as Win64" --> W
  P -- "accept lowercase authorization" --> T
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>whisper.rs</strong><dd><code>Make Whisper header check case-insensitive</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src-tauri/src/asr/whisper.rs

<ul><li>Lowercase captured request text before asserting<br> <li> Accept <code>authorization: bearer key</code> variants<br> <li> Keep transcription request path and model checks</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/533/files#diff-cf6696a6b96bc9f0fb12aeb6e3934ad2668e3595f06ad10652604887f9794d2b">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>openless-ime.wxs</strong><dd><code>Mark x86 IME component as Win64</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src-tauri/wix/openless-ime.wxs

<ul><li>Add explanatory comment for MSI layout<br> <li> Set x86 component <code>Win64="yes"</code><br> <li> Preserve x86 DLL source path and registration</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/533/files#diff-985611b7c97c134e8b9b96c56b3ae223a35460cbe5da351cdbfa6fd1151b7f76">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

