### PR TITLE
fix(overview): ASR 状态在凭据保存后未刷新仍显示「未配置」

### DIFF
--- a/openless-all/app/src-tauri/src/commands.rs
+++ b/openless-all/app/src-tauri/src/commands.rs
@@ -695,10 +695,13 @@ pub fn set_credential(window: Window, account: String, value: String) -> Result<
     ensure_main_window(&window)?;
     let acc = parse_account(&account)?;
     if value.is_empty() {
-        CredentialsVault::remove(acc).map_err(|e| e.to_string())
+        CredentialsVault::remove(acc).map_err(|e| e.to_string())?;
     } else {
-        CredentialsVault::set(acc, &value).map_err(|e| e.to_string())
+        CredentialsVault::set(acc, &value).map_err(|e| e.to_string())?;
     }
+    // 通知前端凭据已变更（如 Overview 页需要刷新 asrConfigured 状态）。
+    let _ = window.emit("credentials:changed", ());
+    Ok(())
 }
 
 #[tauri::command]

--- a/openless-all/app/src/pages/Overview.tsx
+++ b/openless-all/app/src/pages/Overview.tsx
@@ -87,6 +87,42 @@ export function Overview({ onOpenHistory }: OverviewProps) {
       });
   }, [refreshHistory]);
 
+  // 凭据被保存后重新拉取状态（issue #532：在 Settings 中填写/更新凭据
+  // 但不切换提供商时，原有的 useEffect 不会重跑，导致概览页的状态仍停留在「未配置」）。
+  useEffect(() => {
+    let cancelled = false;
+    let unlisten: (() => void) | undefined;
+    (async () => {
+      try {
+        const { listen } = await import('@tauri-apps/api/event');
+        const handle = await listen('credentials:changed', () => {
+          getCredentials()
+            .then(status => {
+              if (cancelled) return;
+              setCreds(status);
+              setCredsError(false);
+            })
+            .catch(error => {
+              if (cancelled) return;
+              console.error('[overview] failed to load credentials status', error);
+              setCredsError(true);
+            });
+        });
+        if (cancelled) {
+          handle();
+        } else {
+          unlisten = handle;
+        }
+      } catch {
+        // browser dev mock — 没有 Tauri event bridge
+      }
+    })();
+    return () => {
+      cancelled = true;
+      unlisten?.();
+    };
+  }, []);
+
   const metrics = useMemo(() => {
     const today = new Date();
     today.setHours(0, 0, 0, 0);


### PR DESCRIPTION
### **User description**
修复 issue #532 — 概览页 ASR 语音状态在 Settings 中保存凭据后仍显示「未配置」。

**根因：** Overview 页的 `refreshCredentials()` 只在 `prefs?.activeAsrProvider` 变化时触发。当用户在 Settings 中填写/更新 ASR 凭据（如 volcengine 的 APP ID、Access Token、Resource ID）但不切换提供商时，该依赖不变，凭据状态不会被重新拉取。

**修复：**
1. Rust `set_credential` 命令保存凭据后 emit `credentials:changed` Tauri 事件
2. Overview 新增 `useEffect` 监听该事件，收到后调用 `refreshCredentials()`

**Test plan:**
- 在 Settings → 服务 中配置 volcengine ASR（填写 APP ID、Access Token、Resource ID），保存后切回 Overview，验证「ASR 语音」卡片显示「已配置」
- 在 Settings 中切换 ASR 提供商（如切换到 siliconflow），验证 Overview 状态正确更新
- 在 Settings 中清空凭据，验证 Overview 状态变为「未配置」
- 验证 LLM 配置状态不受影响


___

### **PR Type**
Bug fix


___

### **Description**
- Refresh ASR status after credential saves

- Emit `credentials:changed` from backend

- Listen for credential updates on Overview

- Keep LLM status behavior unchanged


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["set_credential saves credentials"] -- "emit `credentials:changed`" --> B["Overview listens for credential updates"]
  B -- "call `getCredentials()`" --> C["Refresh ASR configured status"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>commands.rs</strong><dd><code>Emit credential change event after save</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src-tauri/src/commands.rs

<ul><li>Returns <code>Ok(())</code> after credential writes complete.<br> <li> Emits <code>credentials:changed</code> on every save or removal.<br> <li> Notifies the frontend that credential state changed.<br> <li> Supports Overview refresh without provider switching.</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/538/files#diff-8215873d09604b1dbb99088131ba7fc2fd6c537e67588cba5bd9160c2138b035">+5/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Overview.tsx</strong><dd><code>Listen for credential updates in Overview</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src/pages/Overview.tsx

<ul><li>Adds a Tauri event listener for <code>credentials:changed</code>.<br> <li> Re-fetches credentials when the event is received.<br> <li> Updates credential status and clears errors after refresh.<br> <li> Cleans up the listener on unmount.</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/538/files#diff-87ea690f4abf573183a65635bee8aae0f788da0bc4b4f030f53756fa16f8aae2">+36/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

