### PR TITLE
fix(ui): restore Windows capsule hitbox metrics

### DIFF
--- a/openless-all/app/src/lib/capsuleLayout.ts
+++ b/openless-all/app/src/lib/capsuleLayout.ts
@@ -25,9 +25,8 @@ export interface CapsuleMessageLayout {
 
 export function getCapsulePillMetrics(os: OS): CapsulePillMetrics {
   if (os === 'win') {
-    // Windows metrics describe the visible outer footprint of the pill.
-    // 与 macOS pill 接近以保持视觉密度一致；保留 ~4-5% 余量适配 Windows 字体 metrics。
-    return { width: 180, height: 44, textWidth: 88, boxSizing: 'border-box' };
+    // Windows metrics 必须与 src-tauri/src/lib.rs 的原生命中框合同保持一致。
+    return { width: 196, height: 52, textWidth: 104, boxSizing: 'border-box' };
   }
 
   return { width: 176, height: 42, textWidth: 84, boxSizing: 'border-box' };


### PR DESCRIPTION
### **User description**
## Summary
- restore Windows capsule pill metrics to 196x52 with text width 104
- keep frontend capsule layout aligned with the native hitbox contract in src-tauri/src/lib.rs

## Test Plan
- node "openless-all/app/src/lib/capsuleLayout.test.ts"
- cargo test --manifest-path "openless-all/app/src-tauri/Cargo.toml" capsule
- npm --prefix "openless-all/app" run build
- git diff --check


___

### **PR Type**
Bug fix


___

### **Description**
- Restore Windows capsule pill metrics

- Match native hitbox contract

- Update text width and outer dimensions


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Windows capsule layout"] -- "uses" --> B["Native hitbox contract"]
  B -- "requires" --> C["Updated pill metrics"]
  C -- "sets" --> D["196x52 size, 104 text width"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>capsuleLayout.ts</strong><dd><code>Restore Windows capsule sizing metrics</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src/lib/capsuleLayout.ts

<ul><li>Updates Windows pill metrics to <code>196x52</code><br> <li> Increases <code>textWidth</code> to <code>104</code><br> <li> Keeps <code>boxSizing</code> as <code>border-box</code><br> <li> Aligns frontend layout with native contract</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/541/files#diff-64a0fa382ce669f9eb4d0aa71205f37ecbc20817808cbc9f8fb792d7b8db9d7f">+2/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

