### PR TITLE
fix(macos): show capsule across Spaces

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,9 @@ jobs:
             }
           }
 
+      - name: Check macOS capsule Spaces contract
+        run: npm run check:macos-capsule-spaces
+
       - name: Build frontend (tsc + vite)
         run: npm run build
 

--- a/openless-all/app/package.json
+++ b/openless-all/app/package.json
@@ -8,6 +8,7 @@
     "build": "tsc && vite build",
     "preview": "vite preview",
     "tauri": "tauri",
+    "check:macos-capsule-spaces": "node scripts/macos-capsule-spaces-contract.test.mjs",
     "check:hotkey-injection": "node scripts/check-hotkey-injection.mjs"
   },
   "dependencies": {

--- a/openless-all/app/scripts/macos-capsule-spaces-contract.test.mjs
+++ b/openless-all/app/scripts/macos-capsule-spaces-contract.test.mjs
@@ -6,7 +6,9 @@ function assertMatch(source, pattern, name) {
   }
 }
 
-const coordinatorRs = await readFile(new URL('../src-tauri/src/coordinator.rs', import.meta.url), 'utf-8');
+const coordinatorRs = (
+  await readFile(new URL('../src-tauri/src/coordinator.rs', import.meta.url), 'utf-8')
+).replace(/\r\n/g, '\n');
 const functionMatch = coordinatorRs.match(
   /#\[cfg\(target_os = "macos"\)\]\s*fn show_capsule_window_no_activate[\s\S]*?\n}\n\n#\[cfg\(target_os = "linux"\)\]/,
 );

--- a/openless-all/app/scripts/macos-capsule-spaces-contract.test.mjs
+++ b/openless-all/app/scripts/macos-capsule-spaces-contract.test.mjs
@@ -1,0 +1,31 @@
+import { readFile } from 'node:fs/promises';
+
+function assertMatch(source, pattern, name) {
+  if (!pattern.test(source)) {
+    throw new Error(`${name}: pattern ${pattern} not found`);
+  }
+}
+
+const coordinatorRs = await readFile(new URL('../src-tauri/src/coordinator.rs', import.meta.url), 'utf-8');
+const functionMatch = coordinatorRs.match(
+  /#\[cfg\(target_os = "macos"\)\]\s*fn show_capsule_window_no_activate[\s\S]*?\n}\n\n#\[cfg\(target_os = "linux"\)\]/,
+);
+
+if (!functionMatch) {
+  throw new Error('macOS capsule no-activate function not found');
+}
+
+const macosNoActivateFunction = functionMatch[0];
+const executableMacosNoActivateFunction = macosNoActivateFunction.replace(/\/\/.*$/gm, '');
+
+assertMatch(
+  macosNoActivateFunction,
+  /set_visible_on_all_workspaces\(true\)[\s\S]*?orderFrontRegardless/,
+  'macOS capsule should join all Spaces before showing without activation',
+);
+
+for (const forbidden of ['window.show()', 'set_focus', 'NSApp.activate', 'makeKeyAndOrderFront']) {
+  if (executableMacosNoActivateFunction.includes(forbidden)) {
+    throw new Error(`macOS capsule no-activate path must not call ${forbidden}`);
+  }
+}

--- a/openless-all/app/src-tauri/src/coordinator.rs
+++ b/openless-all/app/src-tauri/src/coordinator.rs
@@ -4500,7 +4500,12 @@ fn show_capsule_window_no_activate<R: tauri::Runtime>(
 
     // emit_capsule 已经把窗口操作 marshal 到 Tauri 主线程；这里不能再调用
     // window.show()/set_focus()/NSApp.activate，否则 AeroSpace 会把 workspace 切回
-    // OpenLess 主窗口所在空间。orderFrontRegardless 只让胶囊可见，不成为 key window。
+    // OpenLess 主窗口所在空间。先让胶囊加入所有 Spaces，再用
+    // orderFrontRegardless 做无激活展示。
+    if let Err(e) = window.set_visible_on_all_workspaces(true) {
+        log::warn!("[capsule] set visible on all macOS Spaces failed: {e}");
+    }
+
     unsafe {
         let _: () = msg_send![ns_window, orderFrontRegardless];
     }


### PR DESCRIPTION
### **User description**
## Summary
- Make the macOS recording capsule visible across all Spaces before showing it.
- Keep the no-activation show path by continuing to use `orderFrontRegardless` and avoiding `window.show()` / focus APIs.
- Add a CI-covered static contract test for the macOS capsule Spaces/no-focus behavior.

Fixes #548

## Verification
- `npm --prefix "openless-all/app" run check:macos-capsule-spaces`
- `cargo test --manifest-path "openless-all/app/src-tauri/Cargo.toml" capsule_show_strategy_matches_platform_activation_contract`
- `npm --prefix "openless-all/app" run build`
- `git diff --check`

## Notes
- I could not live-smoke-test macOS Spaces behavior from this Linux environment.


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Show capsule across all Spaces

- Keep no-activation display behavior

- Add macOS contract verification

- Run contract in CI


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["macOS capsule show path"] -- "set visible on all workspaces" --> B["orderFrontRegardless"]
  C["CI workflow"] -- "runs" --> D["macOS Spaces contract test"]
  D -- "verifies" --> A
  E["package.json script"] -- "invokes" --> D
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>coordinator.rs</strong><dd><code>Show capsule on all macOS Spaces</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src-tauri/src/coordinator.rs

<ul><li>Calls <code>set_visible_on_all_workspaces(true)</code> before showing the capsule.<br> <li> Keeps <code>orderFrontRegardless</code> as the no-activation display path.<br> <li> Logs a warning if enabling all-workspace visibility fails.</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/549/files#diff-73d8c004670b27293f74f0f3991b9a6fc28f0ff0b883214de2b078b1e09797ca">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ci.yml</strong><dd><code>Run capsule Spaces check in CI</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/ci.yml

<ul><li>Adds a CI step to run the macOS capsule Spaces contract check.<br> <li> Ensures the visibility contract is validated during automated builds.</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/549/files#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03f">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>package.json</strong><dd><code>Add macOS capsule contract script</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/package.json

<ul><li>Adds the <code>check:macos-capsule-spaces</code> npm script.<br> <li> Links the script to the new contract test file.</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/549/files#diff-2650f8aa2f7ec97aa8af47f1f8a7c9ae4677fb69754b20d554e1d542507cf4ea">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>macos-capsule-spaces-contract.test.mjs</strong><dd><code>Add macOS Spaces contract test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/scripts/macos-capsule-spaces-contract.test.mjs

<ul><li>Adds a static contract test for the macOS capsule show path.<br> <li> Verifies <code>set_visible_on_all_workspaces(true)</code> happens before <br><code>orderFrontRegardless</code>.<br> <li> Guards against focus or activation APIs in the no-activate path.</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/549/files#diff-f246fa613cf2c504b2b8dc1b7826d521871b382825e13724daed2831f2118f91">+33/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

