### PR TITLE
fix(asr): allow HTTP endpoints with risk warning

### DIFF
--- a/openless-all/app/src-tauri/src/commands.rs
+++ b/openless-all/app/src-tauri/src/commands.rs
@@ -1150,11 +1150,6 @@ async fn validate_asr_transcription(config: &ProviderConfig, model: &str) -> Res
 
 fn asr_transcriptions_url(base_url: &str) -> Result<String, String> {
     let parsed = reqwest::Url::parse(base_url.trim()).map_err(|_| "endpointInvalid".to_string())?;
-    let host = parsed.host_str().unwrap_or_default();
-    let localhost = host.eq_ignore_ascii_case("localhost") || host == "127.0.0.1";
-    if parsed.scheme() != "https" && !localhost {
-        return Err("endpointMustUseHttps".to_string());
-    }
 
     // Work on the URL path only so we don't corrupt query parameters.
     let mut url = parsed.clone();
@@ -3755,6 +3750,10 @@ mod tests {
         assert_eq!(
             asr_transcriptions_url("https://api.openai.com/v1?api-version=2024-12-01").unwrap(),
             "https://api.openai.com/v1/audio/transcriptions?api-version=2024-12-01"
+        );
+        assert_eq!(
+            asr_transcriptions_url("http://192.168.1.10:8000/v1").unwrap(),
+            "http://192.168.1.10:8000/v1/audio/transcriptions"
         );
     }
 

--- a/openless-all/app/src/i18n/en.ts
+++ b/openless-all/app/src/i18n/en.ts
@@ -663,7 +663,7 @@ export const en: typeof zhCN = {
       validateSuccess: 'Connection check passed.',
       validateFailed: 'Connection check failed.',
       providerHttpStatus: 'Provider returned HTTP {{status}}. Check the API key permissions or endpoint.',
-      endpointMustUseHttps: 'Endpoint must use HTTPS (localhost/127.0.0.1 are allowed for local testing).',
+      endpointMustUseHttps: 'HTTP endpoints are allowed, but API keys and audio content may leak in transit.',
       endpointInvalid: 'Endpoint format is invalid.',
       responseTooLarge: 'Provider response is too large to validate safely.',
       asrInvalidJson: 'ASR response is not valid JSON.',

--- a/openless-all/app/src/i18n/ja.ts
+++ b/openless-all/app/src/i18n/ja.ts
@@ -665,7 +665,7 @@ export const ja: typeof zhCN = {
       validateSuccess: '接続チェックに合格しました。',
       validateFailed: '接続チェックに失敗しました。',
       providerHttpStatus: 'サプライヤーが {{status}} を返しました。API Key 権限またはエンドポイントを確認してください。',
-      endpointMustUseHttps: 'Endpoint は HTTPS を使用する必要があります（localhost/127.0.0.1 を除く）。',
+      endpointMustUseHttps: 'HTTP Endpoint も使用できますが、API Key と音声内容が通信中に漏えいする可能性があります。',
       endpointInvalid: 'Endpoint の形式が無効です。',
       responseTooLarge: 'サプライヤーの応答が大きすぎるため、安全のため検証を停止しました。',
       asrInvalidJson: 'ASR の応答が有効な JSON ではありません。',

--- a/openless-all/app/src/i18n/ko.ts
+++ b/openless-all/app/src/i18n/ko.ts
@@ -665,7 +665,7 @@ export const ko: typeof zhCN = {
       validateSuccess: '연결 확인을 통과했습니다.',
       validateFailed: '연결 확인에 실패했습니다.',
       providerHttpStatus: '공급자가 {{status}} 를 반환했습니다. API Key 권한 또는 Endpoint 를 확인해 주세요.',
-      endpointMustUseHttps: 'Endpoint 는 HTTPS 를 사용해야 합니다(localhost/127.0.0.1 제외).',
+      endpointMustUseHttps: 'HTTP Endpoint 를 사용할 수 있지만, API Key 와 음성 내용이 전송 중 유출될 수 있습니다.',
       endpointInvalid: 'Endpoint 형식이 올바르지 않습니다.',
       responseTooLarge: '공급자 응답이 너무 커서 안전을 위해 검증을 중단했습니다.',
       asrInvalidJson: 'ASR 응답이 유효한 JSON 이 아닙니다.',

--- a/openless-all/app/src/i18n/zh-CN.ts
+++ b/openless-all/app/src/i18n/zh-CN.ts
@@ -661,7 +661,7 @@ export const zhCN = {
       validateSuccess: '连接检查通过。',
       validateFailed: '连接检查未通过。',
       providerHttpStatus: '供应商接口返回 {{status}}，请检查 API Key 权限或 Endpoint。',
-      endpointMustUseHttps: 'Endpoint 必须使用 HTTPS（本地 localhost/127.0.0.1 测试除外）。',
+      endpointMustUseHttps: '允许使用 HTTP Endpoint，但请注意：API Key 和音频内容可能在传输中泄漏。',
       endpointInvalid: 'Endpoint 格式不合法。',
       responseTooLarge: '供应商响应过大，已停止验证以保证安全。',
       asrInvalidJson: 'ASR 响应不是有效 JSON。',

--- a/openless-all/app/src/i18n/zh-TW.ts
+++ b/openless-all/app/src/i18n/zh-TW.ts
@@ -663,7 +663,7 @@ export const zhTW: typeof zhCN = {
       validateSuccess: '連接檢查通過。',
       validateFailed: '連接檢查未通過。',
       providerHttpStatus: '供應商接口返回 {{status}}，請檢查 API Key 權限或 Endpoint。',
-      endpointMustUseHttps: 'Endpoint 必須使用 HTTPS（本地 localhost/127.0.0.1 測試除外）。',
+      endpointMustUseHttps: '允許使用 HTTP Endpoint，但請注意：API Key 和音訊內容可能在傳輸中外洩。',
       endpointInvalid: 'Endpoint 格式不合法。',
       responseTooLarge: '供應商響應過大，已停止驗證以保證安全。',
       asrInvalidJson: 'ASR 響應不是有效 JSON。',

--- a/openless-all/app/src/pages/settings/ProvidersSection.tsx
+++ b/openless-all/app/src/pages/settings/ProvidersSection.tsx
@@ -714,55 +714,64 @@ function CredentialField({ label, account, placeholder, mono, mask, defaultValue
 
   const inputType = mask && !revealed ? 'password' : 'text';
   const disabled = !loaded;
+  const showInsecureAsrEndpointWarning = account === 'asr.endpoint'
+    && value.trim().toLowerCase().startsWith('http://');
 
   return (
     <SettingRow label={label}>
-      <div style={{ display: 'flex', gap: 6, alignItems: 'center', width: '100%', maxWidth: 420 }}>
-        <input
-          type={inputType}
-          value={value}
-          placeholder={loaded ? placeholder : t('common.loading')}
-          onChange={handleChange}
-          onBlur={onBlur}
-          disabled={disabled}
-          style={{ ...inputStyle, fontFamily: mono ? 'var(--ol-font-mono)' : 'inherit' }}
-        />
-        {defaultValue && !value && loaded && (
-          <button onClick={fillDefault} title={t('settings.providers.fillDefault')} style={iconBtnStyle} disabled={!loaded}>
-            <Icon name="check" size={13} />
-          </button>
-        )}
-        {trailing}
-        {mask && (
-          <button
-            onClick={() => setRevealed(r => !r)}
-            title={revealed ? t('common.hide') : t('common.show')}
-            style={iconBtnStyle}
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 5, width: '100%', maxWidth: 420 }}>
+        <div style={{ display: 'flex', gap: 6, alignItems: 'center', width: '100%' }}>
+          <input
+            type={inputType}
+            value={value}
+            placeholder={loaded ? placeholder : t('common.loading')}
+            onChange={handleChange}
+            onBlur={onBlur}
             disabled={disabled}
+            style={{ ...inputStyle, fontFamily: mono ? 'var(--ol-font-mono)' : 'inherit' }}
+          />
+          {defaultValue && !value && loaded && (
+            <button onClick={fillDefault} title={t('settings.providers.fillDefault')} style={iconBtnStyle} disabled={!loaded}>
+              <Icon name="check" size={13} />
+            </button>
+          )}
+          {trailing}
+          {mask && (
+            <button
+              onClick={() => setRevealed(r => !r)}
+              title={revealed ? t('common.hide') : t('common.show')}
+              style={iconBtnStyle}
+              disabled={disabled}
+            >
+              <Icon name="eye" size={14} />
+            </button>
+          )}
+          <button
+            onClick={onCopy}
+            title={t('common.copy')}
+            style={iconBtnStyle}
+            disabled={!value || disabled}
           >
-            <Icon name="eye" size={14} />
+            <Icon name="copy" size={14} />
           </button>
-        )}
-        <button
-          onClick={onCopy}
-          title={t('common.copy')}
-          style={iconBtnStyle}
-          disabled={!value || disabled}
-        >
-          <Icon name="copy" size={14} />
-        </button>
-        {/* readError 是字段无法读取的持续错误，留在原位提示用户该字段不可用；
-            其它瞬态状态（saving / saved / saveError / copied / copyError）都通过
-            emitSaved 发到右上角统一 toast，不再内联占位。 */}
-        {status === 'readError' && (
-          <span
-            style={{
-              fontSize: 11,
-              color: 'var(--ol-warn)',
-              whiteSpace: 'nowrap',
-            }}
-          >
-            {t('settings.providers.readFailed')}
+          {/* readError 是字段无法读取的持续错误，留在原位提示用户该字段不可用；
+              其它瞬态状态（saving / saved / saveError / copied / copyError）都通过
+              emitSaved 发到右上角统一 toast，不再内联占位。 */}
+          {status === 'readError' && (
+            <span
+              style={{
+                fontSize: 11,
+                color: 'var(--ol-warn)',
+                whiteSpace: 'nowrap',
+              }}
+            >
+              {t('settings.providers.readFailed')}
+            </span>
+          )}
+        </div>
+        {showInsecureAsrEndpointWarning && (
+          <span style={{ fontSize: 11, color: 'var(--ol-warn)', lineHeight: 1.45 }}>
+            {t('settings.providers.endpointMustUseHttps')}
           </span>
         )}
       </div>


### PR DESCRIPTION
### **User description**
## Summary
- Remove the ASR validation-time HTTPS-only gate so HTTP endpoints such as LAN/self-hosted ASR services can be used.
- Show a non-blocking warning when the ASR endpoint starts with `http://`, noting API keys and audio content may leak in transit.
- Update provider warning text across locales.

Fixes #543

## Verification
- `cargo test --manifest-path "openless-all/app/src-tauri/Cargo.toml" asr_transcriptions_url_accepts_base_or_transcriptions_endpoint`
- `cargo test --manifest-path "openless-all/app/src-tauri/Cargo.toml" transcription_url_accepts_base_audio_or_full_endpoint`
- `cargo check --manifest-path "openless-all/app/src-tauri/Cargo.toml"`
- `npm --prefix "openless-all/app" run build`
- `git diff --check`

## Review
- Self-reviewed per maintainer request; no sub-agent review was used.


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Allow ASR HTTP endpoints

- Remove HTTPS-only validation gate

- Show insecure endpoint warning

- Update localized warning copy


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["ASR endpoint input"] -- "validate" --> B["HTTP accepted"]
  B -- "if http://" --> C["Show security warning"]
  B -- "used by" --> D["ASR request URL builder"]
  D -- "verified by" --> E["HTTP path test"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>commands.rs</strong><dd><code>Remove ASR HTTPS-only endpoint check</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/550/files#diff-8215873d09604b1dbb99088131ba7fc2fd6c537e67588cba5bd9160c2138b035">+4/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>6 files</summary><table>
<tr>
  <td><strong>en.ts</strong><dd><code>Rewrite insecure endpoint warning text</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/550/files#diff-bb2f4fa05787923f8aeb23b6f11ad8705e02d9ff03a45790f9181e4615c79d83">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ja.ts</strong><dd><code>Rewrite insecure endpoint warning text</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/550/files#diff-be57f0090cf34e3ff924cfa35f13d5d9e6514d3af5a1ebfdeb92bd7d36ed9cf4">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ko.ts</strong><dd><code>Rewrite insecure endpoint warning text</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/550/files#diff-daf35bcb6a2f8a31565b83d119cb59b69c1dededbabfccfd0d56693fdb3726ca">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>zh-CN.ts</strong><dd><code>Rewrite insecure endpoint warning text</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/550/files#diff-571576f3c7b6c4a78ae0f91accdccc5da5cbed00409955c9914c046fee6c80ea">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>zh-TW.ts</strong><dd><code>Rewrite insecure endpoint warning text</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/550/files#diff-a8d5953f9c76bc3c90ec583270be04c852bd7540297500e6ff3260760fc61ea4">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ProvidersSection.tsx</strong><dd><code>Add insecure ASR endpoint warning</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/550/files#diff-8fc332d1eb5b010583185b704ea439954650f6aff2d0195e00cd0cb76e526e7b">+51/-42</a>&nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

