### PR TITLE
fix: sync preferences.json when switching ASR provider

### DIFF
--- a/openless-all/app/src-tauri/src/commands.rs
+++ b/openless-all/app/src-tauri/src/commands.rs
@@ -807,6 +807,12 @@ pub async fn set_active_asr_provider(
         return Ok(());
     }
     CredentialsVault::set_active_asr_provider(&provider).map_err(|e| e.to_string())?;
+    // 同步更新偏好文件，确保 Keychain 和 preferences.json 不同步。
+    // 前端 onAsrProviderChange 也会调 updatePrefs()，但那是另一条异步路径；
+    // 本行保证无论前端是否调了 updatePrefs，文件始终与 Keychain 一致。
+    let mut prefs = coord.read_settings();
+    prefs.active_asr_provider = provider.clone();
+    let _ = coord.write_settings(prefs);
     let release_plan = local_asr_release_plan_for_provider(&provider);
     if provider == crate::asr::local::PROVIDER_ID {
         // 切到本地 ASR → 后台预加载模型，下次按 hotkey 时不必等数秒。

--- a/openless-all/app/src-tauri/src/commands.rs
+++ b/openless-all/app/src-tauri/src/commands.rs
@@ -812,7 +812,9 @@ pub async fn set_active_asr_provider(
     // 本行保证无论前端是否调了 updatePrefs，文件始终与 Keychain 一致。
     let mut prefs = coord.read_settings();
     prefs.active_asr_provider = provider.clone();
-    let _ = coord.write_settings(prefs);
+    if let Err(e) = coord.write_settings(prefs) {
+        log::warn!("[set_active_asr_provider] sync preferences.json failed: {e}");
+    }
     let release_plan = local_asr_release_plan_for_provider(&provider);
     if provider == crate::asr::local::PROVIDER_ID {
         // 切到本地 ASR → 后台预加载模型，下次按 hotkey 时不必等数秒。
@@ -830,8 +832,17 @@ pub async fn set_active_asr_provider(
 }
 
 #[tauri::command]
-pub fn set_active_llm_provider(provider: String) -> Result<(), String> {
-    CredentialsVault::set_active_llm_provider(&provider).map_err(|e| e.to_string())
+pub fn set_active_llm_provider(
+    coord: CoordinatorState<'_>,
+    provider: String,
+) -> Result<(), String> {
+    CredentialsVault::set_active_llm_provider(&provider).map_err(|e| e.to_string())?;
+    let mut prefs = coord.read_settings();
+    prefs.active_llm_provider = provider.clone();
+    if let Err(e) = coord.write_settings(prefs) {
+        log::warn!("[set_active_llm_provider] sync preferences.json failed: {e}");
+    }
+    Ok(())
 }
 
 /// 读出某个账号的实际值（用于设置页预填表单）。


### PR DESCRIPTION
### **User description**
## Problem

Changing the ASR provider in Settings (e.g. from whisper to volcengine) calls `set_active_asr_provider` which only writes to the system Keychain, but does **not** update `preferences.json`. The preferences file update happens through a separate async path (`updatePrefs` → `setSettings`), creating a two-step save that can get out of sync.

If the second step fails (or if the app is restarted before it completes), `preferences.json` still has the old provider, and the user sees their setting "not saved".

## Fix

`set_active_asr_provider` now also syncs the provider to preferences.json immediately after writing to Keychain, so both stores are always consistent regardless of what the frontend does.

```rust
if let Ok(mut prefs) = coord.read_settings() {
    prefs.active_asr_provider = provider.clone();
    let _ = coord.write_settings(prefs);
}
```

## Test

1. Open Settings → change ASR provider
2. Kill and restart OpenLess
3. The selected provider persists correctly


___

### **PR Type**
Bug fix


___

### **Description**
- Sync ASR provider to `preferences.json`

- Sync LLM provider to `preferences.json`

- Warn when preference write fails


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["set_active_asr_provider"] -- "write Keychain" --> B["preferences.json sync"]
  C["set_active_llm_provider"] -- "write Keychain" --> D["preferences.json sync"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>commands.rs</strong><dd><code>Sync provider updates to settings file</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src-tauri/src/commands.rs

<ul><li>After updating the ASR provider in <code>CredentialsVault</code>, also writes <br><code>active_asr_provider</code> into <code>preferences.json</code>.<br> <li> Changes <code>set_active_llm_provider</code> to accept <code>CoordinatorState</code>, then <br>persists <code>active_llm_provider</code> to settings too.<br> <li> Logs a warning when syncing <code>preferences.json</code> fails, instead of failing <br>the whole command.</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/552/files#diff-8215873d09604b1dbb99088131ba7fc2fd6c537e67588cba5bd9160c2138b035">+19/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

