### PR TITLE
fix(linux): fcitx5 auxDown 持久化 + 热键模式保存修复 + 隐藏剪贴板/胶囊设置

### DIFF
--- a/openless-all/app/src-tauri/src/coordinator.rs
+++ b/openless-all/app/src-tauri/src/coordinator.rs
@@ -4608,21 +4608,17 @@ fn emit_capsule(
 
         let mut last = LAST_AUX.lock().unwrap();
         if aux != last.as_deref() {
-            let was_none = last.is_none();
             *last = aux.map(String::from);
             // 代数计数器：每次状态变化 +1，retry 线程只在自己代数仍为最新时生效。
             // 避免 Recording→Idle→Recording 快速切换时多个 retry 重复触发。
             static RETRY_GEN: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+            // fetch_add 返回旧值，所以 latest_gen > gen+1 才表示"在我之后又发生了变更"。
             let gen = RETRY_GEN.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
             match aux {
                 Some(t) => {
                     log::info!("[capsule] set_aux_down: {t} gen={gen}");
-                    // 把 DBus I/O 移到独立线程：emit_capsule 会被音频回调线程
-                    // (cpal) 调用，同步阻塞可能导致录音卡顿或可闻杂音。
                     let text = t.to_string();
                     std::thread::spawn(move || {
-                        // 状态检查：发送前确认 LAST_AUX 未变，避免在快速状态切换时
-                        // 旧 set_aux_down 跑到 clear_aux_down 后面，旧文字覆盖新状态。
                         let current = LAST_AUX.lock().unwrap().clone();
                         if current.as_deref() != Some(&text) {
                             log::info!("[capsule] set_aux_down skipped: state changed to {current:?}");
@@ -4632,42 +4628,31 @@ fn emit_capsule(
                             log::warn!("[capsule] set_aux_down failed: {e}");
                         }
                     });
-                    // 首次设置（从 None 转为有值）时，fcitx5 可能还在处理触发
-                    // 快捷键的按键事件（press/release），这些事件可能覆盖 auxDown。
-                    // 延迟 300ms 重设一次确保状态不被竞态覆盖。
-                    // retry 使用 gen 去重：状态已变则不再发送旧文字。
-                    if was_none {
+                    // 终态（Done/Cancelled/Error）3 秒后自动清除，避免一直跟随焦点。
+                    if matches!(state, CapsuleState::Done | CapsuleState::Cancelled | CapsuleState::Error) {
                         let text = t.to_string();
                         std::thread::spawn(move || {
-                            std::thread::sleep(std::time::Duration::from_millis(300));
-                            // 检查代数：新的状态变化已发生则跳过。
+                            std::thread::sleep(std::time::Duration::from_secs(3));
                             let latest_gen = RETRY_GEN.load(std::sync::atomic::Ordering::SeqCst);
-                            if gen != latest_gen {
-                                log::info!("[capsule] set_aux_down retry skipped: gen {gen} < {latest_gen}");
+                            if latest_gen > gen + 1 {
                                 return;
                             }
                             let current = LAST_AUX.lock().unwrap().clone();
                             if current.as_deref() != Some(&text) {
-                                log::info!("[capsule] set_aux_down retry skipped: state changed to {current:?}");
                                 return;
                             }
-                            log::info!("[capsule] set_aux_down retry: {text}");
-                            if let Err(e) = crate::linux_fcitx::set_aux_down(&text) {
-                                log::warn!("[capsule] set_aux_down retry failed: {e}");
-                            }
+                            log::info!("[capsule] auto-clear terminal state: {text}");
+                            let _ = crate::linux_fcitx::set_aux_down("");
+                            *LAST_AUX.lock().unwrap() = None;
                         });
                     }
                 }
                 None => {
                     log::info!("[capsule] clear_aux_down gen={gen}");
-                    // 同样从音频线程挪走，避免阻塞。
-                    // 状态守卫：发送前确认 LAST_AUX 仍是 None，避免快速状态切换时
-                    // 旧 clear_aux_down 跑到新 set_aux_down 后面，把新文字清掉。
                     std::thread::spawn(move || {
-                        // 检查代数：新的状态变化已发生则跳过。
                         let latest_gen = RETRY_GEN.load(std::sync::atomic::Ordering::SeqCst);
-                        if gen != latest_gen {
-                            log::info!("[capsule] clear_aux_down skipped: gen {gen} < {latest_gen}");
+                        if latest_gen > gen + 1 {
+                            log::info!("[capsule] clear_aux_down skipped: gen {gen}, latest {latest_gen}");
                             return;
                         }
                         let current = LAST_AUX.lock().unwrap().clone();

--- a/openless-all/app/src/pages/settings/RecordingInputSection.tsx
+++ b/openless-all/app/src/pages/settings/RecordingInputSection.tsx
@@ -17,6 +17,7 @@ import { SelectLite } from '../../components/ui/SelectLite';
 import { Card, Collapsible } from '../_atoms';
 import { SettingRow, Toggle, inputStyle } from './shared';
 import { MicrophoneSelect } from './MicrophoneSelect';
+import { detectOS } from '../../components/WindowChrome';
 
 async function autostartIsEnabled(): Promise<boolean> {
   const { invoke } = await import('@tauri-apps/api/core');
@@ -35,6 +36,7 @@ async function autostartDisable(): Promise<void> {
 
 export function RecordingInputSection() {
   const { t } = useTranslation();
+  const os = detectOS();
   const { prefs, capability, updatePrefs: savePrefs } = useHotkeySettings();
   const [microphoneDevices, setMicrophoneDevices] = useState<MicrophoneDevice[]>([]);
   const [microphoneDevicesLoaded, setMicrophoneDevicesLoaded] = useState(false);
@@ -205,15 +207,18 @@ export function RecordingInputSection() {
             )}
           </div>
         </SettingRow>
+        {os !== 'linux' && (
         <SettingRow label={t('settings.recording.capsuleLabel')}>
           <Toggle on={prefs.showCapsule} onToggle={onShowCapsuleChange} />
         </SettingRow>
+        )}
         <SettingRow label={t('settings.recording.muteDuringRecordingLabel')}>
           <Toggle on={prefs.muteDuringRecording} onToggle={onMuteDuringRecordingChange} />
         </SettingRow>
       </Card>
 
-      {/* ─── 插入与剪贴板（折叠） ──────────────────────────────────── */}
+      {/* ─── 插入与剪贴板（折叠，仅 macOS / Windows） ──────────────── */}
+      {os !== 'linux' && (
       <Collapsible title={t('settings.recording.insertGroupTitle')}>
         <SettingRow label={t('settings.recording.restoreClipboardLabel')}>
           <Toggle on={prefs.restoreClipboardAfterPaste} onToggle={onRestoreClipboardChange} />
@@ -256,6 +261,18 @@ export function RecordingInputSection() {
           />
         </SettingRow>
       </Collapsible>
+      )}
+      {/* ─── 流式输入（Linux） ────────────────────────────────────────── */}
+      {os === 'linux' && (
+      <Card>
+        <SettingRow label={t('settings.advanced.streamingInsertLabel')}>
+          <Toggle
+            on={!!prefs.streamingInsert}
+            onToggle={(next) => void savePrefs({ ...prefs, streamingInsert: next })}
+          />
+        </SettingRow>
+      </Card>
+      )}
 
       {/* ─── 启动（折叠） ──────────────────────────────────────────── */}
       <Collapsible title={t('settings.recording.startupGroupTitle')}>

--- a/openless-all/app/src/pages/settings/RecordingInputSection.tsx
+++ b/openless-all/app/src/pages/settings/RecordingInputSection.tsx
@@ -215,6 +215,14 @@ export function RecordingInputSection() {
         <SettingRow label={t('settings.recording.muteDuringRecordingLabel')}>
           <Toggle on={prefs.muteDuringRecording} onToggle={onMuteDuringRecordingChange} />
         </SettingRow>
+        {os === 'linux' && (
+        <SettingRow label={t('settings.advanced.streamingInsertLabel')}>
+          <Toggle
+            on={!!prefs.streamingInsert}
+            onToggle={(next) => void savePrefs({ ...prefs, streamingInsert: next })}
+          />
+        </SettingRow>
+        )}
       </Card>
 
       {/* ─── 插入与剪贴板（折叠，仅 macOS / Windows） ──────────────── */}
@@ -262,18 +270,6 @@ export function RecordingInputSection() {
         </SettingRow>
       </Collapsible>
       )}
-      {/* ─── 流式输入（Linux） ────────────────────────────────────────── */}
-      {os === 'linux' && (
-      <Card>
-        <SettingRow label={t('settings.advanced.streamingInsertLabel')}>
-          <Toggle
-            on={!!prefs.streamingInsert}
-            onToggle={(next) => void savePrefs({ ...prefs, streamingInsert: next })}
-          />
-        </SettingRow>
-      </Card>
-      )}
-
       {/* ─── 启动（折叠） ──────────────────────────────────────────── */}
       <Collapsible title={t('settings.recording.startupGroupTitle')}>
         <AutostartRow />

--- a/openless-all/app/src/pages/settings/ShortcutsSection.tsx
+++ b/openless-all/app/src/pages/settings/ShortcutsSection.tsx
@@ -13,9 +13,11 @@ import {
 import { useHotkeySettings } from '../../state/HotkeySettingsContext';
 import { Card } from '../_atoms';
 import { SettingRow } from './shared';
+import { detectOS } from '../../components/WindowChrome';
 
 export function ShortcutsSection() {
   const { t } = useTranslation();
+  const os = detectOS();
   const { prefs, hotkey, capability, updatePrefs: savePrefs } = useHotkeySettings();
 
   if (!prefs || !hotkey || !capability) {
@@ -28,7 +30,7 @@ export function ShortcutsSection() {
 
   const readonlyRows: Array<[string, string]> = [
     [t('settings.shortcuts.cancel'), 'Esc'],
-    [t('settings.shortcuts.confirm'), t('settings.shortcuts.confirmHint')],
+    ...(os !== 'linux' ? [[t('settings.shortcuts.confirm'), t('settings.shortcuts.confirmHint')]] as Array<[string, string]> : []),
   ];
   return (
     <Card>

--- a/openless-all/app/src/state/HotkeySettingsContext.tsx
+++ b/openless-all/app/src/state/HotkeySettingsContext.tsx
@@ -88,15 +88,11 @@ export function HotkeySettingsProvider({ children }: { children: ReactNode }) {
     }, [])
 
     const queueSetSettings = useCallback(
-        (resolveNext: (current: UserPreferences) => UserPreferences) => {
+        (resolved: UserPreferences) => {
             const task = persistQueueRef.current
                 .catch(() => undefined)
                 .then(async () => {
-                    const current = latestPrefsRef.current
-                    if (!current) return
-                    const next = resolveNext(current)
-                    if (next === current) return
-                    await setSettings(next)
+                    await setSettings(resolved)
                 })
             persistQueueRef.current = task
             return task
@@ -176,10 +172,7 @@ export function HotkeySettingsProvider({ children }: { children: ReactNode }) {
         const merged = { ...currentPrefs, ...nextLocalePrefs }
         latestPrefsRef.current = merged
         setPrefs(merged)
-        void queueSetSettings((current) => ({
-            ...current,
-            ...nextLocalePrefs,
-        })).catch((error) => {
+        void queueSetSettings(merged).catch((error) => {
             console.warn(
                 "[settings] sync locale output preferences failed",
                 error,
@@ -199,7 +192,7 @@ export function HotkeySettingsProvider({ children }: { children: ReactNode }) {
             if (resolved === current) return
             setPrefs(resolved)
             latestPrefsRef.current = resolved
-            await queueSetSettings(() => resolved)
+            await queueSetSettings(resolved)
         },
         [queueSetSettings],
     )

--- a/openless-all/scripts/linux-fcitx5-plugin/openless.cpp
+++ b/openless-all/scripts/linux-fcitx5-plugin/openless.cpp
@@ -222,6 +222,21 @@ public:
                     instance_->flushUI();
                 }));
 
+        // 6. PostInputMethod 阶段恢复 lastAuxText_：fcitx5 在处理按键后可能
+        //    清掉 auxDown（如 enter/backspace 触发内联模式），此钩子自动补回。
+        eventHandlers_.push_back(
+            instance_->watchEvent(
+                EventType::InputContextKeyEvent,
+                EventWatcherPhase::PostInputMethod,
+                [this](Event &event) {
+                    if (lastAuxText_.empty()) return;
+                    auto &keyEvent = static_cast<KeyEvent &>(event);
+                    auto *ic = keyEvent.inputContext();
+                    if (!ic) return;
+                    ic->inputPanel().setAuxDown(Text(lastAuxText_));
+                    ic->updateUserInterface(UserInterfaceComponent::InputPanel, true);
+                }));
+
         FCITX_LOGC(openless, Info) << "OpenLess plugin loaded";
     }
 


### PR DESCRIPTION
### **User description**
## 变更

### fcitx5 插件
- `openless.cpp`：新增 `PostInputMethod` 事件钩子，fcitx5 按键处理后自动恢复 auxDown 文字，解决状态提示被键盘事件覆盖的问题

### 后端
- `coordinator.rs`：终态（✅已插入/❌出错/—已取消）3 秒后自动清除 auxDown；修复 `RETRY_GEN` 代数比较（`fetch_add` 返回旧值，改为 `latest_gen > gen+1`）；移除无效的 300ms 重试

### 前端
- `HotkeySettingsContext.tsx`：修复 `queueSetSettings` 永久跳过 `setSettings()` 的 bug（`latestPrefsRef` 在 microtask 执行前已被同步更新为新对象，导致 `next === current`）
- `RecordingInputSection.tsx`：Linux 隐藏剪贴板/粘贴/胶囊设置组，流式输入开关移入录音卡片内
- `ShortcutsSection.tsx`：Linux 隐藏"胶囊确认插入"快捷键提示

## 已知问题（Linux）

| 问题 | 现状 |
|------|------|
| fcitx5 输入法状态弹窗在浏览器内不显示 | 待解决 |
| fcitx5 插件在浏览器中 alt+a 热键导致字母 a 被输入 | 待解决 |
| 主程序网络异常时可能触发奇怪行为 | 待解决 |

## Linux / Wayland 使用说明

在 Wayland 下使用 fcitx5 时，需要在系统设置中开启 **允许 X11 应用**（兼容性 → X11 应用监测快捷键），否则 fcitx5 插件在部分应用中可能无法捕获热键。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fix Linux fcitx5 auxDown persistence

- Restore saved hotkey settings reliably

- Hide Linux-only settings clutter

- Auto-clear terminal capsule states


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Linux settings UI"] -- "hide / move options" --> B["Cleaner recording & shortcuts panels"]
  C["Hotkey settings queue"] -- "persist resolved prefs" --> D["Settings saved reliably"]
  E["fcitx5 plugin PostInputMethod"] -- "restore auxDown" --> F["auxDown survives key handling"]
  G["Capsule coordinator"] -- "gen guard / auto-clear" --> H["Terminal states clear after 3s"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>coordinator.rs</strong><dd><code>Fix capsule state timing and retries</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src-tauri/src/coordinator.rs

<ul><li>Removes the old 300ms retry path for <code>set_aux_down</code>.<br> <li> Fixes generation comparison for retry/cancel guards.<br> <li> Auto-clears terminal capsule states after 3 seconds.<br> <li> Keeps async DBus updates guarded against stale state.</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/554/files#diff-73d8c004670b27293f74f0f3991b9a6fc28f0ff0b883214de2b078b1e09797ca">+10/-25</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>HotkeySettingsContext.tsx</strong><dd><code>Fix queued settings persistence</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src/state/HotkeySettingsContext.tsx

<ul><li>Changes <code>queueSetSettings</code> to persist a resolved preference object.<br> <li> Stops relying on <code>latestPrefsRef</code> inside the queued microtask.<br> <li> Fixes the bug where <code>setSettings()</code> could be skipped permanently.<br> <li> Updates locale sync to enqueue the merged preferences directly.</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/554/files#diff-e62674662a221b573ac2fb80bbe6aa101479533cce21f3d9414ad6c08642d614">+4/-11</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>openless.cpp</strong><dd><code>Restore auxDown after key handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/scripts/linux-fcitx5-plugin/openless.cpp

<ul><li>Adds a <code>PostInputMethod</code> key event watcher.<br> <li> Restores <code>lastAuxText_</code> after fcitx5 processes key events.<br> <li> Prevents <code>auxDown</code> from being cleared by enter/backspace handling.<br> <li> Improves Linux IME status persistence in the plugin.</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/554/files#diff-4e4cff4f87c85d6635f0b30fb7007d3bf9a94b72bb872716ca01859f5f8847bd">+15/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>RecordingInputSection.tsx</strong><dd><code>Rework Linux recording settings layout</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src/pages/settings/RecordingInputSection.tsx

<ul><li>Detects Linux with <code>detectOS()</code> and branches UI rendering.<br> <li> Hides capsule and insert-group settings on Linux.<br> <li> Moves streaming insert toggle into the recording card on Linux.<br> <li> Keeps the original grouped layout for macOS and Windows.</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/554/files#diff-8ff75c44c63ba78f0cb6c2b6de2dd3429c3100e5df700a9221fba0069904859e">+15/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ShortcutsSection.tsx</strong><dd><code>Hide Linux-only shortcut hint</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src/pages/settings/ShortcutsSection.tsx

<ul><li>Detects Linux platform in the shortcuts settings page.<br> <li> Removes the capsule confirm shortcut hint on Linux.<br> <li> Leaves the confirm shortcut visible on other platforms.</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/554/files#diff-2278f6bf152693f76255e52340adc9558f3da4764473c2682fd0eef36dcb83de">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

