### PR TITLE
fix(macos): show capsule in fullscreen Spaces

### DIFF
--- a/openless-all/app/scripts/macos-capsule-spaces-contract.test.mjs
+++ b/openless-all/app/scripts/macos-capsule-spaces-contract.test.mjs
@@ -28,7 +28,7 @@ assertMatch(
 
 assertMatch(
   macosNoActivateFunction,
-  /FullScreenAuxiliary[\s\S]*?setCollectionBehavior[\s\S]*?orderFrontRegardless/,
+  /FULL_SCREEN_AUXILIARY[\s\S]*?1 << 8[\s\S]*?setCollectionBehavior[\s\S]*?orderFrontRegardless/,
   'macOS capsule should join fullscreen Spaces as an auxiliary window before showing without activation',
 );
 

--- a/openless-all/app/scripts/macos-capsule-spaces-contract.test.mjs
+++ b/openless-all/app/scripts/macos-capsule-spaces-contract.test.mjs
@@ -26,6 +26,12 @@ assertMatch(
   'macOS capsule should join all Spaces before showing without activation',
 );
 
+assertMatch(
+  macosNoActivateFunction,
+  /FullScreenAuxiliary[\s\S]*?setCollectionBehavior[\s\S]*?orderFrontRegardless/,
+  'macOS capsule should join fullscreen Spaces as an auxiliary window before showing without activation',
+);
+
 for (const forbidden of ['window.show()', 'set_focus', 'NSApp.activate', 'makeKeyAndOrderFront']) {
   if (executableMacosNoActivateFunction.includes(forbidden)) {
     throw new Error(`macOS capsule no-activate path must not call ${forbidden}`);

--- a/openless-all/app/src-tauri/src/coordinator.rs
+++ b/openless-all/app/src-tauri/src/coordinator.rs
@@ -4489,7 +4489,6 @@ fn show_capsule_window_no_activate<R: tauri::Runtime>(
 ) -> bool {
     use objc2::msg_send;
     use objc2::runtime::AnyObject;
-    use objc2_app_kit::NSWindowCollectionBehavior;
 
     let Ok(handle) = window.ns_window() else {
         return false;
@@ -4508,10 +4507,12 @@ fn show_capsule_window_no_activate<R: tauri::Runtime>(
     }
 
     unsafe {
-        let behavior: NSWindowCollectionBehavior = msg_send![ns_window, collectionBehavior];
+        const NS_WINDOW_COLLECTION_BEHAVIOR_CAN_JOIN_ALL_SPACES: usize = 1 << 0;
+        const NS_WINDOW_COLLECTION_BEHAVIOR_FULL_SCREEN_AUXILIARY: usize = 1 << 8;
+        let behavior: usize = msg_send![ns_window, collectionBehavior];
         let behavior = behavior
-            | NSWindowCollectionBehavior::CanJoinAllSpaces
-            | NSWindowCollectionBehavior::FullScreenAuxiliary;
+            | NS_WINDOW_COLLECTION_BEHAVIOR_CAN_JOIN_ALL_SPACES
+            | NS_WINDOW_COLLECTION_BEHAVIOR_FULL_SCREEN_AUXILIARY;
         let _: () = msg_send![ns_window, setCollectionBehavior: behavior];
         let _: () = msg_send![ns_window, orderFrontRegardless];
     }

--- a/openless-all/app/src-tauri/src/coordinator.rs
+++ b/openless-all/app/src-tauri/src/coordinator.rs
@@ -4489,6 +4489,7 @@ fn show_capsule_window_no_activate<R: tauri::Runtime>(
 ) -> bool {
     use objc2::msg_send;
     use objc2::runtime::AnyObject;
+    use objc2_app_kit::NSWindowCollectionBehavior;
 
     let Ok(handle) = window.ns_window() else {
         return false;
@@ -4507,6 +4508,11 @@ fn show_capsule_window_no_activate<R: tauri::Runtime>(
     }
 
     unsafe {
+        let behavior: NSWindowCollectionBehavior = msg_send![ns_window, collectionBehavior];
+        let behavior = behavior
+            | NSWindowCollectionBehavior::CanJoinAllSpaces
+            | NSWindowCollectionBehavior::FullScreenAuxiliary;
+        let _: () = msg_send![ns_window, setCollectionBehavior: behavior];
         let _: () = msg_send![ns_window, orderFrontRegardless];
     }
     true


### PR DESCRIPTION
### **User description**
## Summary
- Add `NSWindowCollectionBehavior::FullScreenAuxiliary` to the macOS capsule no-activate show path.
- Keep `CanJoinAllSpaces` and `orderFrontRegardless` so the capsule remains visible without focusing OpenLess.
- Extend the macOS capsule Spaces contract test to cover fullscreen auxiliary behavior.

Fixes #548

## Test Plan
- [x] `npm --prefix "openless-all/app" run check:macos-capsule-spaces`
- [x] `cargo test --manifest-path "openless-all/app/src-tauri/Cargo.toml" capsule_show_strategy_matches_platform_activation_contract -- --test-threads=1`
- [x] `npm --prefix "openless-all/app" run build`
- [x] `git diff --check`

## Notes
- `cargo check --manifest-path "openless-all/app/src-tauri/Cargo.toml" --target x86_64-apple-darwin` cannot complete on this Linux machine because the macOS SDK is unavailable (`TargetConditionals.h` missing from the `ring` build). Real macOS fullscreen smoke testing is still required.


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Enable capsule in fullscreen Spaces

- Preserve no-activate display behavior

- Add contract coverage for auxiliary windows


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["show_capsule_window_no_activate"] -- "adds fullscreen auxiliary behavior" --> B["NSWindow.collectionBehavior"]
  B -- "keeps capsule visible" --> C["orderFrontRegardless"]
  D["macos-capsule-spaces-contract.test.mjs"] -- "verifies behavior contract" --> A
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>coordinator.rs</strong><dd><code>Add fullscreen auxiliary capsule behavior</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src-tauri/src/coordinator.rs

<ul><li>Defines AppKit collection behavior flags locally for macOS.<br> <li> Adds <code>CanJoinAllSpaces</code> and <code>FullScreenAuxiliary</code> to the capsule window.<br> <li> Keeps the existing <code>orderFrontRegardless</code> no-activate show path intact.</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/556/files#diff-73d8c004670b27293f74f0f3991b9a6fc28f0ff0b883214de2b078b1e09797ca">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>macos-capsule-spaces-contract.test.mjs</strong><dd><code>Extend macOS capsule spaces contract</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/scripts/macos-capsule-spaces-contract.test.mjs

<ul><li>Adds an assertion for <code>FULL_SCREEN_AUXILIARY</code> behavior.<br> <li> Verifies the capsule sets collection behavior before showing.<br> <li> Preserves the existing no-activate and forbidden-call checks.</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/556/files#diff-f246fa613cf2c504b2b8dc1b7826d521871b382825e13724daed2831f2118f91">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

