### PR TITLE
fix(ci): Release Notes 里的注意事项只输出一次

### DIFF
--- a/.github/workflows/release-tauri.yml
+++ b/.github/workflows/release-tauri.yml
@@ -572,6 +572,38 @@ jobs:
           if-no-files-found: error
 
       # ── tag 推送时,同步上传到 GitHub Release ──
+      # 只有 leader job (darwin/aarch64) 把 release body 写到文件,其余 matrix job
+      # 的 body_path 留空,softprops/action-gh-release@v2 在 body 为空时会保留
+      # existing release body 不动,避免每个 matrix job 都 append 一遍同样的 prelude
+      # 导致 release notes 重复 N 次 (v1.3.4-tauri 出现 4 次的 root cause:
+      # 4 个 matrix job × append_body=true × 共享同一份 body)。
+      - name: Prepare release body prelude
+        if: matrix.updater-target == 'darwin' && matrix.updater-arch == 'aarch64' && startsWith(github.ref, 'refs/tags/v') && endsWith(github.ref, '-tauri')
+        shell: bash
+        run: |
+          cat > "$RUNNER_TEMP/release-body.md" << 'EOF'
+          ### macOS 用户首次安装提示
+
+          下载 DMG 拖入 `/Applications` 后，**必须**在终端运行：
+
+          ```bash
+          xattr -cr /Applications/OpenLess.app
+          ```
+
+          否则 Gatekeeper 会提示「OpenLess 已损坏」——这是因为当前 build 用 ad-hoc 签名、没做 Apple 公证。
+
+          ### 渠道说明
+
+          - 以 `-tauri` 结尾的 tag 是**正式版**（自动推送给所有 in-app 检查更新的用户）。
+          - 以 `-beta-tauri` 结尾的 tag 是 **Beta 版**（GitHub 标 pre-release，**不**通过 in-app updater 推送给正式版用户；只对在「设置 → 关于 → 加入 Beta 渠道」开关切到 Beta 的用户可见，且需要手动从此页面下载安装）。
+
+          ### 行为变更提示
+
+          - 流式输入默认开启；不兼容场景会自动回落到一次性插入。可在「设置 → 高级」关闭。
+          - 流式输入成功后默认把最终文本同步到剪贴板，方便再次粘贴；可在「设置 → 高级」关闭。
+          EOF
+          echo "OPENLESS_RELEASE_BODY_PATH=$RUNNER_TEMP/release-body.md" >> "$GITHUB_ENV"
+
       - name: Create / update release
         if: startsWith(github.ref, 'refs/tags/v') && endsWith(github.ref, '-tauri')
         uses: softprops/action-gh-release@v2
@@ -583,33 +615,14 @@ jobs:
           # 普通用户看不到；同时只上传 latest-*-beta.json，正式版用户的
           # endpoint（latest-*.json）永远不会被覆盖，保证 Beta 不溢出正式版。
           prerelease: ${{ env.OPENLESS_RELEASE_CHANNEL == 'beta' }}
-          # body 在 generated notes 之前 prepend——所有 matrix job 设同一份字符串，
-          # 多次调用 action 时内容一致、idempotent。提示 macOS Gatekeeper 绕过指令 +
-          # 渠道说明，每个 release 自动带上，用户不用回项目 README 翻就能看到。
-          body: |
-            ### macOS 用户首次安装提示
-
-            下载 DMG 拖入 `/Applications` 后，**必须**在终端运行：
-
-            ```bash
-            xattr -cr /Applications/OpenLess.app
-            ```
-
-            否则 Gatekeeper 会提示「OpenLess 已损坏」——这是因为当前 build 用 ad-hoc 签名、没做 Apple 公证。
-
-            ### 渠道说明
-
-            - 以 `-tauri` 结尾的 tag 是**正式版**（自动推送给所有 in-app 检查更新的用户）。
-            - 以 `-beta-tauri` 结尾的 tag 是 **Beta 版**（GitHub 标 pre-release，**不**通过 in-app updater 推送给正式版用户；只对在「设置 → 关于 → 加入 Beta 渠道」开关切到 Beta 的用户可见，且需要手动从此页面下载安装）。
-
-            ### 行为变更提示
-
-            - 流式输入默认开启；不兼容场景会自动回落到一次性插入。可在「设置 → 高级」关闭。
-            - 流式输入成功后默认把最终文本同步到剪贴板，方便再次粘贴；可在「设置 → 高级」关闭。
-
-          append_body: true
-          # Matrix jobs all upload assets to the same release. Generate notes once
-          # so macOS, Windows, and Linux jobs do not duplicate the release body.
+          # 非 leader job 的 OPENLESS_RELEASE_BODY_PATH 是空字符串,softprops 在
+          # body 为空时走 `body || existing.body` 分支保留既有内容,不会覆盖。
+          # leader job 用默认 append_body=false,每次完整覆盖 release body 为
+          # "prelude + generated notes",re-run 同一 tag 时也保持 idempotent
+          # (append_body=true 会让 re-run 把上轮 body 拼到前面、再次复制)。
+          body_path: ${{ env.OPENLESS_RELEASE_BODY_PATH }}
+          # generate_release_notes 也只在 leader 跑:避免 4 个 matrix jobs
+          # 产生 4 份相同的 What's Changed 段。
           generate_release_notes: ${{ matrix.updater-target == 'darwin' && matrix.updater-arch == 'aarch64' }}
           files: |
             openless-all/app/src-tauri/target/release/bundle/dmg/*.dmg


### PR DESCRIPTION
### **User description**
## 摘要

让 GitHub Release notes 的注意事项（macOS 安装提示 / 及其渠道说明 / 行为变更提示）只出现一次，不再随 matrix job 数量重复追加。
例如：`v1.3.4-tauri` 的 release 里这段出现了 4 次，因为 4 个 matrix job 各调一次 `softprops/action-gh-release@v2` 并共享同一份 `body:` + `append_body: true`。

## 修复

- 把 release body prelude 从内联 `body:` 改成 leader job（darwin/aarch64）写到 `$RUNNER_TEMP/release-body.md`，release step 通过 `body_path` 引用；其他 matrix job 的 `OPENLESS_RELEASE_BODY_PATH` 为空，softprops 走 `body || existing.body` 分支保留既有内容
- 去掉 `append_body: true`，leader 用默认 `append_body=false` 每次完整覆盖 body，同一 tag re-run 也保持 idempotent（旧实现 re-run 一次会把上一轮 body 再拼到前面）

## 兼容

- 不包含：发版 tag 命名、artifact 文件列表、`generate_release_notes` 的 gate 条件、Beta 渠道行为、in-app updater manifest——全部未改
- 对现有用户 / 本地环境 / 构建流程的影响：仅影响下一个 `v*-tauri` tag 发版后 GitHub Release 页面的 notes 文本；in-app updater（`latest-*.json` 文件名 / 内容 / 推送渠道）、artifact 下载链接、本地 dev build 不受影响

## 测试计划

1. 
  - [ ] 命令：触发 release workflow
  - [ ] 结果：release 页面注意事项只出现一次，后面跟一份自动生成的 "What's Changed"；`prerelease=true` 标记仍正确；4 个平台的 artifact（.dmg / .app.tar.gz / .exe / .msi / .deb / .rpm / .AppImage / latest-*.json）齐全
  - [ ] 证据路径：https://github.com/Open-Less/openless/releases/tag/vX.Y.Z-beta-tauri
2. 
  - [ ] 命令：在 Actions 页面重跑该 tag 的任一 matrix job
  - [ ] 结果：release notes body 与首次发版后完全一致，prelude 不被再次复制
  - [ ] 证据路径：同上 release 页面 + 对应 workflow run log


___

### **PR Type**
Bug fix


___

### **Description**
- Write release prelude once

- Use `body_path` for leader job

- Preserve existing body on other jobs

- Generate notes only on leader


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Leader matrix job"] -- "writes prelude file" --> B["$RUNNER_TEMP/release-body.md"]
  B -- "passed via `body_path`" --> C["softprops/action-gh-release"]
  D["Other matrix jobs"] -- "leave body path empty" --> C
  C -- "append generated notes once" --> E["GitHub Release notes"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>release-tauri.yml</strong><dd><code>Move release body to leader-only file</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/release-tauri.yml

<ul><li>Adds a leader-only step to write the release prelude into <br><code>$RUNNER_TEMP/release-body.md</code>.<br> <li> Exports <code>OPENLESS_RELEASE_BODY_PATH</code> so only the leader job passes <br><code>body_path</code> to the release action.<br> <li> Removes the inline <code>body</code> and <code>append_body: true</code> usage to avoid repeated <br>prelude appends.<br> <li> Keeps <code>generate_release_notes</code> on the leader job, preventing duplicate <br><code>What's Changed</code> sections.</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/558/files#diff-cac78cd4d340dc05703d65bee14ea766337499de655e15553ceb8181eef097cb">+40/-27</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

