### PR TITLE
feat: 新增 MediaPlayPause HotkeyTrigger 支持有线耳机线控录音 (#477)

### DIFF
--- a/openless-all/app/src-tauri/src/coordinator.rs
+++ b/openless-all/app/src-tauri/src/coordinator.rs
@@ -1963,6 +1963,8 @@ fn window_key_matches_trigger(trigger: crate::types::HotkeyTrigger, key: &str, c
         HotkeyTrigger::LeftOption => (key == "Alt" || key == "AltGraph") && code == "AltLeft",
         HotkeyTrigger::RightCommand => key == "Meta" && code == "MetaRight",
         HotkeyTrigger::Fn => key == "Control" && code == "ControlRight",
+        // MediaPlayPause 走 WH_KEYBOARD_LL，不走 window hotkey fallback
+        HotkeyTrigger::MediaPlayPause => false,
         // Custom 走 global-hotkey crate，不走 window hotkey fallback
         HotkeyTrigger::Custom => false,
     }

--- a/openless-all/app/src-tauri/src/hotkey.rs
+++ b/openless-all/app/src-tauri/src/hotkey.rs
@@ -621,6 +621,7 @@ mod platform {
             HotkeyTrigger::RightOption | HotkeyTrigger::RightAlt => 61,
             HotkeyTrigger::RightCommand => 54,
             HotkeyTrigger::Fn => 63,
+            HotkeyTrigger::MediaPlayPause => 0,
             HotkeyTrigger::Custom => unreachable!("custom combo hotkeys use ComboHotkeyMonitor"),
         }
     }
@@ -633,6 +634,7 @@ mod platform {
                 FLAG_MASK_ALTERNATE
             }
             HotkeyTrigger::Fn => FLAG_MASK_SECONDARY_FN,
+            HotkeyTrigger::MediaPlayPause => 0,
             HotkeyTrigger::Custom => unreachable!("custom combo hotkeys use ComboHotkeyMonitor"),
         }
     }
@@ -766,6 +768,7 @@ mod platform {
     const VK_LMENU: u32 = 0xA4;
     const VK_RMENU: u32 = 0xA5;
     const VK_RWIN: u32 = 0x5C;
+    const VK_MEDIA_PLAY_PAUSE: u32 = 0xB3;
     const LLKHF_INJECTED: u32 = 0x0000_0010;
     const ACCEPT_INJECTED_ENV: &str = "OPENLESS_ACCEPT_SYNTHETIC_HOTKEY_EVENTS";
 
@@ -1024,6 +1027,7 @@ mod platform {
             HotkeyTrigger::RightCommand => VK_RWIN,
             HotkeyTrigger::LeftOption => VK_LMENU,
             HotkeyTrigger::Fn => VK_RCONTROL,
+            HotkeyTrigger::MediaPlayPause => VK_MEDIA_PLAY_PAUSE,
             HotkeyTrigger::Custom => unreachable!("custom combo hotkeys use ComboHotkeyMonitor"),
         }
     }

--- a/openless-all/app/src-tauri/src/linux_fcitx.rs
+++ b/openless-all/app/src-tauri/src/linux_fcitx.rs
@@ -100,6 +100,7 @@ fn trigger_to_keysym(trigger: crate::types::HotkeyTrigger) -> u32 {
         crate::types::HotkeyTrigger::LeftOption => KEYSYM_ALT_L,
         crate::types::HotkeyTrigger::RightCommand => KEYSYM_SUPER_R,
         crate::types::HotkeyTrigger::Fn => KEYSYM_CONTROL_R,
+        crate::types::HotkeyTrigger::MediaPlayPause => unreachable!("Windows-only"),
         crate::types::HotkeyTrigger::Custom => unreachable!(),
     }
 }
@@ -112,13 +113,16 @@ fn trigger_name(trigger: crate::types::HotkeyTrigger) -> &'static str {
         crate::types::HotkeyTrigger::LeftOption => "Alt_L",
         crate::types::HotkeyTrigger::RightCommand => "Super_R",
         crate::types::HotkeyTrigger::Fn => "Control_R",
+        crate::types::HotkeyTrigger::MediaPlayPause => unreachable!("Windows-only"),
         crate::types::HotkeyTrigger::Custom => unreachable!(),
     }
 }
 
 /// 将 OpenLess 的主听写热键绑定同步到 fcitx5 插件。
 pub fn sync_binding_to_plugin(binding: &crate::types::HotkeyBinding) {
-    if binding.trigger == crate::types::HotkeyTrigger::Custom {
+    if binding.trigger == crate::types::HotkeyTrigger::Custom
+        || binding.trigger == crate::types::HotkeyTrigger::MediaPlayPause
+    {
         return;
     }
     let sym = trigger_to_keysym(binding.trigger);
@@ -185,6 +189,9 @@ pub fn sync_qa_binding(trigger: Option<crate::types::HotkeyTrigger>) {
         let _ = set_qa_hotkey_raw(0, 0);
         return;
     };
+    if trigger == crate::types::HotkeyTrigger::MediaPlayPause {
+        return;
+    }
     let sym = trigger_to_keysym(trigger);
     let name = trigger_name(trigger);
     match set_qa_hotkey_raw(sym, 0) {
@@ -199,6 +206,9 @@ pub fn sync_translation_binding(trigger: Option<crate::types::HotkeyTrigger>) {
         let _ = set_translation_hotkey_raw(0, 0);
         return;
     };
+    if trigger == crate::types::HotkeyTrigger::MediaPlayPause {
+        return;
+    }
     let sym = trigger_to_keysym(trigger);
     let name = trigger_name(trigger);
     match set_translation_hotkey_raw(sym, 0) {

--- a/openless-all/app/src-tauri/src/shortcut_binding.rs
+++ b/openless-all/app/src-tauri/src/shortcut_binding.rs
@@ -54,6 +54,7 @@ pub fn legacy_modifier_trigger(binding: &ShortcutBinding) -> Option<HotkeyTrigge
             Some(HotkeyTrigger::RightCommand)
         }
         "fn" | "function" => Some(HotkeyTrigger::Fn),
+        "mediaplaypause" | "mediaplay" | "playpause" => Some(HotkeyTrigger::MediaPlayPause),
         _ => None,
     }
 }
@@ -66,6 +67,7 @@ pub fn binding_from_legacy_trigger(trigger: HotkeyTrigger) -> ShortcutBinding {
         HotkeyTrigger::LeftControl => "LeftControl",
         HotkeyTrigger::RightCommand => "RightCommand",
         HotkeyTrigger::Fn => "Fn",
+        HotkeyTrigger::MediaPlayPause => "MediaPlayPause",
         HotkeyTrigger::Custom => "RightOption",
     };
     ShortcutBinding {

--- a/openless-all/app/src-tauri/src/types.rs
+++ b/openless-all/app/src-tauri/src/types.rs
@@ -1847,6 +1847,7 @@ pub enum HotkeyTrigger {
     RightCommand,
     Fn,
     RightAlt, // Windows synonym for RightOption
+    MediaPlayPause,
     Custom,
 }
 
@@ -1860,6 +1861,7 @@ impl HotkeyTrigger {
             HotkeyTrigger::RightCommand => "右 Command",
             HotkeyTrigger::Fn => "Fn (地球键)",
             HotkeyTrigger::RightAlt => "右 Alt",
+            HotkeyTrigger::MediaPlayPause => "⏯ Media 播放/暂停",
             HotkeyTrigger::Custom => "自定义组合键",
         }
     }
@@ -1951,6 +1953,7 @@ fn legacy_trigger_code(trigger: HotkeyTrigger) -> &'static str {
         HotkeyTrigger::Fn => "ControlRight",
         #[cfg(not(target_os = "windows"))]
         HotkeyTrigger::Fn => "Fn",
+        HotkeyTrigger::MediaPlayPause => "MediaPlayPause",
         HotkeyTrigger::Custom => "",
     }
 }
@@ -2071,6 +2074,7 @@ impl HotkeyCapability {
                     HotkeyTrigger::RightAlt,
                     HotkeyTrigger::LeftControl,
                     HotkeyTrigger::RightCommand,
+                    HotkeyTrigger::MediaPlayPause,
                     HotkeyTrigger::Custom,
                 ],
                 requires_accessibility_permission: false,

--- a/openless-all/app/src/i18n/en.ts
+++ b/openless-all/app/src/i18n/en.ts
@@ -883,6 +883,7 @@ export const en: typeof zhCN = {
       rightCommand: 'Right Command',
       fn: 'Fn (Globe key)',
       rightAlt: 'Right Alt',
+      mediaPlayPause: '⏯ Media Play/Pause',
       custom: 'Custom combination\u2026',
     },
     fallback: 'Global hotkey',

--- a/openless-all/app/src/i18n/ja.ts
+++ b/openless-all/app/src/i18n/ja.ts
@@ -885,6 +885,7 @@ export const ja: typeof zhCN = {
       rightCommand: '右 Command',
       fn: 'Fn (地球キー)',
       rightAlt: '右 Alt',
+      mediaPlayPause: '⏯ メディア再生/一時停止',
       custom: 'カスタム組み合わせ…',
     },
     fallback: 'グローバルショートカット',

--- a/openless-all/app/src/i18n/ko.ts
+++ b/openless-all/app/src/i18n/ko.ts
@@ -885,6 +885,7 @@ export const ko: typeof zhCN = {
       rightCommand: '오른쪽 Command',
       fn: 'Fn (지구본 키)',
       rightAlt: '오른쪽 Alt',
+      mediaPlayPause: '⏯ 미디어 재생/일시정지',
       custom: '사용자 지정 조합…',
     },
     fallback: '전역 단축키',

--- a/openless-all/app/src/i18n/zh-CN.ts
+++ b/openless-all/app/src/i18n/zh-CN.ts
@@ -881,6 +881,7 @@ export const zhCN = {
       rightCommand: '右 Command',
       fn: 'Fn (地球键)',
       rightAlt: '右 Alt',
+      mediaPlayPause: '⏯ 媒体播放/暂停',
       custom: '自定义组合键…',
     },
     fallback: '全局快捷键',

--- a/openless-all/app/src/i18n/zh-TW.ts
+++ b/openless-all/app/src/i18n/zh-TW.ts
@@ -883,6 +883,7 @@ export const zhTW: typeof zhCN = {
       rightCommand: '右 Command',
       fn: 'Fn (地球鍵)',
       rightAlt: '右 Alt',
+      mediaPlayPause: '⏯ 媒體播放/暫停',
       custom: '自訂組合…',
     },
     fallback: '全局快捷鍵',

--- a/openless-all/app/src/lib/hotkey.ts
+++ b/openless-all/app/src/lib/hotkey.ts
@@ -169,6 +169,8 @@ function legacyTriggerCode(trigger: HotkeyTrigger | null | undefined): string | 
       return 'MetaRight';
     case 'fn':
       return 'Fn';
+    case 'mediaPlayPause':
+      return 'MediaPlayPause';
     default:
       return null;
   }
@@ -259,6 +261,7 @@ function formatPrimary(primary: string): string {
     case 'leftcontrol': return isMac ? 'Left ⌃' : 'Left Ctrl';
     case 'rightcommand': return isMac ? 'Right ⌘' : (currentPlatform().isWindows ? 'Right Win' : 'Right Super');
     case 'fn': return 'Fn';
+    case 'mediaplaypause': return '⏯ Media';
     case 'shift': return isMac ? '⇧' : 'Shift';
   }
   return trimmed;

--- a/openless-all/app/src/lib/types.ts
+++ b/openless-all/app/src/lib/types.ts
@@ -60,6 +60,7 @@ export type HotkeyTrigger =
   | 'rightCommand'
   | 'fn'
   | 'rightAlt'
+  | 'mediaPlayPause'
   | 'custom';
 
 export type HotkeyMode = 'toggle' | 'hold' | 'doubleClick';


### PR DESCRIPTION
### **User description**
Closes #477

## 改动

在 HotkeyTrigger 枚举中新增 MediaPlayPause 变体，Windows WH_KEYBOARD_LL 钩子捕获 VK_MEDIA_PLAY_PAUSE（0xB3），使 EarPods 线控按钮可作为录音触发键。

### Rust 后端
- types.rs — 枚举变体、display_name、legacy_trigger_code、Windows available_triggers
- hotkey.rs — Windows trigger_to_vk_code → 0xB3，macOS 占位
- shortcut_binding.rs — legacy_modifier_trigger 字符串映射
- coordinator.rs — window_key_matches_trigger → false
- linux_fcitx.rs — 三处 sync 函数添加 MediaPlayPause 守卫避免配置迁移 panic

### 前端
- types.ts — union 加 mediaPlayPause
- hotkey.ts — legacyTriggerCode + formatPrimary
- 5 个 i18n 文件加翻译

## 验证
- cargo check 通过
- 实测 EarPods 按钮在 Windows 11 上触发 0xB3

## 平台
- ✅ Windows — 完整支持 Toggle / Hold / DoubleClick
- ❌ macOS — 暂不支持（系统层拦截给 Siri）
- ❌ Linux — 暂不支持


___

### **PR Type**
Enhancement


___

### **Description**
- Add MediaPlayPause variant to HotkeyTrigger enum

- Capture VK_MEDIA_PLAY_PAUSE (0xB3) on Windows via WH_KEYBOARD_LL

- Frontend: extend types and i18n translations

- Guards in Linux fcitx sync to avoid panic on Windows-only trigger


___

### Diagram Walkthrough


```mermaid
flowchart LR
    MediaKey[EarPods Play/Pause Button] --> WH_KEYBOARD_LL[Windows Low Level Hook]
    WH_KEYBOARD_LL --> Trigger[HotkeyTrigger::MediaPlayPause]
    Trigger --> Recording[Toggle / Hold / DoubleClick Recording]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>coordinator.rs</strong><dd><code>Skip window key fallback for MediaPlayPause</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/568/files#diff-73d8c004670b27293f74f0f3991b9a6fc28f0ff0b883214de2b078b1e09797ca">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>hotkey.rs</strong><dd><code>Map MediaPlayPause to VK_MEDIA_PLAY_PAUSE on Windows</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/568/files#diff-f37b55b08938663b38e59e53ba8da02d59954d3f07dfbfa3a6c84aa7a43a3148">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>shortcut_binding.rs</strong><dd><code>Map legacy trigger strings and primary for MediaPlayPause</code></dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/568/files#diff-21d36207fa34a9d0d4fcedd89bdc48b26638579579d48054bf5998db1186719f">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>types.rs</strong><dd><code>Add MediaPlayPause variant and display name</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/568/files#diff-702c533512690147fd6f9342d29f6258530afc2c9ada765f4af3bd082080c952">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>hotkey.ts</strong><dd><code>Handle MediaPlayPause in legacy trigger and formatting</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/568/files#diff-bb6d4d21345ac72c5b6e71dbd0800d5a0f313a87ca2fa34042e6ca99126df24b">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>types.ts</strong><dd><code>Add mediaPlayPause to HotkeyTrigger union type</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/568/files#diff-f22942a2f6ef50f13345f6b2781790a4a99e38a1a39702ce4bca3b2b2eb95e5a">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Error handling</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>linux_fcitx.rs</strong><dd><code>Add guards for MediaPlayPause in fcitx sync functions</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/568/files#diff-c0fd61e3ff98e4627baaf32a3fc05c3dbb4884edd4f6d3c68836867ace70fe46">+11/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Internationalization</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>en.ts</strong><dd><code>Add MediaPlayPause translation for English</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/568/files#diff-bb2f4fa05787923f8aeb23b6f11ad8705e02d9ff03a45790f9181e4615c79d83">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ja.ts</strong><dd><code>Add MediaPlayPause translation for Japanese</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/568/files#diff-be57f0090cf34e3ff924cfa35f13d5d9e6514d3af5a1ebfdeb92bd7d36ed9cf4">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ko.ts</strong><dd><code>Add MediaPlayPause translation for Korean</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/568/files#diff-daf35bcb6a2f8a31565b83d119cb59b69c1dededbabfccfd0d56693fdb3726ca">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>zh-CN.ts</strong><dd><code>Add MediaPlayPause translation for Simplified Chinese</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/568/files#diff-571576f3c7b6c4a78ae0f91accdccc5da5cbed00409955c9914c046fee6c80ea">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>zh-TW.ts</strong><dd><code>Add MediaPlayPause translation for Traditional Chinese</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/568/files#diff-a8d5953f9c76bc3c90ec583270be04c852bd7540297500e6ff3260760fc61ea4">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

