### PR TITLE
fix(linux): fallback from backdrop-filter when WEBKIT_DISABLE_COMPOSITING_MODE=1

### DIFF
--- a/openless-all/app/src-tauri/src/commands.rs
+++ b/openless-all/app/src-tauri/src/commands.rs
@@ -3523,6 +3523,12 @@ pub async fn github_device_flow_poll(
     Ok(GithubDevicePollResult::Error { message: msg })
 }
 
+#[tauri::command]
+pub fn is_no_compositing_mode() -> bool {
+    // Linux WebKitGTK: WEBKIT_DISABLE_COMPOSITING_MODE=1 时 backdrop-filter 不可用
+    std::env::var("WEBKIT_DISABLE_COMPOSITING_MODE").as_deref() == Ok("1")
+}
+
 #[cfg(test)]
 mod tests {
     use super::{

--- a/openless-all/app/src-tauri/src/lib.rs
+++ b/openless-all/app/src-tauri/src/lib.rs
@@ -465,6 +465,7 @@ pub fn run() {
             #[cfg(target_os = "windows")]
             commands::sherpa_onnx_asr_reveal_model_dir,
             commands::export_error_log,
+            commands::is_no_compositing_mode,
             restart_app,
         ])
         .build(tauri::generate_context!())

--- a/openless-all/app/src/App.tsx
+++ b/openless-all/app/src/App.tsx
@@ -17,6 +17,7 @@ import {
   windowMouseHotkeyCode,
 } from './lib/windowHotkeyFallback';
 import { QaPanel } from './pages/QaPanel';
+import { invoke } from '@tauri-apps/api/core';
 import { HotkeySettingsProvider } from './state/HotkeySettingsContext';
 
 interface AppProps {
@@ -168,6 +169,18 @@ export function App({ isCapsule, isQa, forcedOs }: AppProps) {
       window.removeEventListener('mouseup', forwardMouse, true);
     };
   }, [os]);
+
+  // Linux: 检测 WEBKIT_DISABLE_COMPOSITING_MODE → 禁用 backdrop-filter fallback
+  useEffect(() => {
+    if (!isTauri) return;
+    invoke<boolean>('is_no_compositing_mode').then((val) => {
+      if (val) {
+        document.documentElement.dataset.olNoCompositing = 'true';
+      }
+    }).catch((err) => {
+      console.warn('[startup] is_no_compositing_mode failed', err);
+    });
+  }, []);
 
   if (gate === 'checking') {
     return <StartupShell />;

--- a/openless-all/app/src/components/FloatingShell.tsx
+++ b/openless-all/app/src/components/FloatingShell.tsx
@@ -324,6 +324,7 @@ function FloatingShellBody({ os, initialTab, initialSettings }: { os: OS; initia
             一起坐在 WindowChrome 的磨砂底板上，整体一块连续玻璃。 */}
         <div style={{ flex: 1, minWidth: 0, padding: '4px 8px 6px 0', display: 'flex' }}>
           <main
+            className="ol-console-main"
             style={{
               flex: 1, minWidth: 0,
               overflow: 'hidden',

--- a/openless-all/app/src/components/WindowChrome.tsx
+++ b/openless-all/app/src/components/WindowChrome.tsx
@@ -40,6 +40,9 @@ export function WindowChrome({
   // 三个平台共用半透明玻璃 background + backdropFilter。
   // macOS: NSVisualEffectView 提供材质；Windows: Tauri apply_mica 提供 Mica；
   // Linux: decorations:false 后 CSS 磨砂玻璃自成背景。
+  //
+  // 注意：三层渐变的参数与 global.css 中 [data-ol-no-compositing] .ol-winchrome
+  // 的回退 background 同步（只 opacity 从 0.92 提到 0.96）。改这里时请同步更新 CSS。
   const background = `
     radial-gradient(120% 80% at 0% 0%, rgba(255,255,255,0.55) 0%, rgba(255,255,255,0) 60%),
     radial-gradient(100% 70% at 100% 100%, rgba(37,99,235,0.07) 0%, rgba(37,99,235,0) 55%),
@@ -48,6 +51,7 @@ export function WindowChrome({
 
   return (
     <div
+      className="ol-winchrome"
       style={{
         '--ol-window-shell-radius': `${shellRadius}px`,
         '--ol-window-console-radius': `${consoleRadius}px`,
@@ -148,6 +152,7 @@ function LinuxTitlebar() {
   return (
     <div
       data-tauri-drag-region
+      className="ol-linux-titlebar"
       style={{
         height: LINUX_TITLEBAR_HEIGHT,
         flexShrink: 0,

--- a/openless-all/app/src/styles/global.css
+++ b/openless-all/app/src/styles/global.css
@@ -163,3 +163,53 @@ a { color: inherit; text-decoration: none; }
   opacity: 0.32;
   pointer-events: none;
 }
+
+/* ── Linux no-compositing fallback ──────────────────────────────────────
+   WEBKIT_DISABLE_COMPOSITING_MODE=1 时 backdrop-filter 不可用，用噪点纹理
+   替代磨砂效果。data-ol-no-compositing 由 App.tsx 在初始化时设置。
+
+   !important 是因为三处目标的 backdrop-filter / background 均为 inline style
+   （WindowChrome.tsx / FloatingShell.tsx 的 style={...}），CSS class 必须
+   用 !important 才能覆盖。 */
+
+[data-ol-no-compositing] .ol-winchrome {
+  position: relative;
+  isolation: isolate;
+  /* !important 覆盖 WindowChrome.tsx inline backdropFilter */
+  backdrop-filter: none !important;
+  -webkit-backdrop-filter: none !important;
+  /* 提高透明梯度不透明度，补偿缺少模糊的视觉深度
+     注意：此三层的渐变参数与 WindowChrome.tsx 的 inline background 同步，
+     改动那边时请同步更新这里。 */
+  background:
+    radial-gradient(120% 80% at 0% 0%, rgba(255,255,255,0.55) 0%, rgba(255,255,255,0) 60%),
+    radial-gradient(100% 70% at 100% 100%, rgba(37,99,235,0.07) 0%, rgba(37,99,235,0) 55%),
+    linear-gradient(180deg, rgba(245,245,247,0.96) 0%, rgba(232,232,236,0.96) 100%) !important;
+}
+
+[data-ol-no-compositing] .ol-winchrome::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  z-index: -1;
+  border-radius: inherit;
+  /* 灰阶噪点颗粒，低 opacity 模拟磨砂质感 */
+  background-image: var(--ol-frost-grain);
+  background-size: 100px 100px;
+  opacity: 0.20;
+  pointer-events: none;
+}
+
+[data-ol-no-compositing] .ol-console-main {
+  /* !important 覆盖 FloatingShell.tsx inline backdropFilter */
+  backdrop-filter: none !important;
+  -webkit-backdrop-filter: none !important;
+  background: rgba(255, 255, 255, 0.80) !important;
+}
+
+[data-ol-no-compositing] .ol-linux-titlebar {
+  /* !important 覆盖 WindowChrome.tsx LinuxTitlebar inline backdropFilter */
+  backdrop-filter: none !important;
+  -webkit-backdrop-filter: none !important;
+  background: rgba(245, 245, 247, 0.95) !important;
+}


### PR DESCRIPTION
### **User description**
Closes #553

## 问题

Linux 上 `WEBKIT_DISABLE_COMPOSITING_MODE=1`（由 `main.rs` 设置，用于修复 tauri#9394 窗口点击无响应）会禁用 WebKitGTK 合成层，导致 CSS `backdrop-filter` 在 DOM 重排后失效。具体表现：
- 鼠标在历史词汇表上 hover → 磨砂消失
- 选中历史词汇表条目 → 右侧面板刷新 → 磨砂消失  
- 调整窗口大小后恢复

## 方案

前端初始化时通过 Tauri command 探测环境变量，检测到 `WEBKIT_DISABLE_COMPOSITING_MODE=1` 时用 CSS 数据属性切换三处 `backdrop-filter` 到渐变+噪点纹理的假磨砂方案：

| 元素 | 正常 | Fallback |
|------|------|----------|
| WindowChrome 底板 | 渐变 + blur(36px) | 渐变(opacity↑) + 噪点纹理(opacity 0.20) |
| 主面板 `<main>` | rgba(255,255,255,0.62) + blur(18px) | rgba(255,255,255,0.80) 不透明白底 |
| Linux 标题栏 | rgba(245,245,247,0.85) + blur(12px) | rgba(245,245,247,0.95) 不透明白底 |

## 文件改动

| 文件 | 改动 |
|------|------|
| `src-tauri/src/commands.rs` | 新增 `is_no_compositing_mode` command |
| `src-tauri/src/lib.rs` | 注册 command |
| `src/App.tsx` | 首屏 useEffect 调用 + 设 `data-ol-no-compositing` |
| `src/styles/global.css` | 3 条 `!important` 回退规则（带 `isolation: isolate`） |
| `src/components/WindowChrome.tsx` | 加 `ol-winchrome` / `ol-linux-titlebar` class |
| `src/components/FloatingShell.tsx` | `<main>` 加 `ol-console-main` class |

## 验证

- Rust `cargo check` ✅
- TypeScript `tsc --noEmit` ✅

## 测试

需要 Linux 用户拉本地编译验证。


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Add Rust command to detect WEBKIT_DISABLE_COMPOSITING_MODE

- Frontend sets data attribute on startup

- CSS fallback replaces backdrop-filter with gradient + noise texture

- Add class hooks to WindowChrome and FloatingShell components


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Rust: is_no_compositing_mode command"] --> B["App.tsx: invoke on startup"]
  B --> C["Set data-ol-no-compositing on <html>"]
  C --> D["CSS: !important fallback rules"]
  D --> E["WindowChrome backdrop-filter replaced"]
  D --> F["Linux-titlebar backdrop-filter replaced"]
  D --> G["Console-main backdrop-filter replaced"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>commands.rs</strong><dd><code>Add command to detect compositing mode</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src-tauri/src/commands.rs

<ul><li>Added <code>is_no_compositing_mode</code> command returning bool<br> <li> Checks <code>WEBKIT_DISABLE_COMPOSITING_MODE</code> env var</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/570/files#diff-8215873d09604b1dbb99088131ba7fc2fd6c537e67588cba5bd9160c2138b035">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>App.tsx</strong><dd><code>Initialize compositing detection on load</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src/App.tsx

<ul><li>Added import for <code>invoke</code><br> <li> Added useEffect to call command on startup for Linux<br> <li> Sets <code>data-ol-no-compositing</code> on document element when true</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/570/files#diff-de79c17c8d207a15e4b63b322a56e9f063721228677fe7e3c4a49813ab4c3576">+13/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>FloatingShell.tsx</strong><dd><code>Add class to main console area</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src/components/FloatingShell.tsx

- Added className `ol-console-main` to `<main>` element


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/570/files#diff-ef6d623d372a1cb87a4833f1435927fc2e2ceeedb75c18ea4064d45e1f44df38">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>WindowChrome.tsx</strong><dd><code>Add class hooks for CSS fallback</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src/components/WindowChrome.tsx

<ul><li>Added className <code>ol-winchrome</code> to outer container<br> <li> Added className <code>ol-linux-titlebar</code> to Linux titlebar</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/570/files#diff-ca98272202276bc772e02f5bdd6dfd006d06a0da7bb6d9705d03e1da14edca4c">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>lib.rs</strong><dd><code>Register new Tauri command</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src-tauri/src/lib.rs

- Registered `is_no_compositing_mode` command


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/570/files#diff-6b8eb1bbf8e378bab914f1a12962f7add5cc4ba9e013c37c9921a1032fa5e110">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>global.css</strong><dd><code>Add CSS fallback for no-compositing mode</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src/styles/global.css

<ul><li>Added fallback rules for <code>data-ol-no-compositing</code><br> <li> Override backdrop-filter with gradient+noise texture<br> <li> Applied to .ol-winchrome, .ol-console-main, .ol-linux-titlebar</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/570/files#diff-ba6dfef13673e14e7e2ae1888f48b081d20a99e6b5a93c451cff7096e80ea47f">+50/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

