### PR TITLE
fix: add 600ms activation cooldown after end_session for Toggle mode (#545)

### DIFF
--- a/openless-all/app/src-tauri/src/coordinator.rs
+++ b/openless-all/app/src-tauri/src/coordinator.rs
@@ -231,6 +231,10 @@ struct Inner {
     /// 与 `hotkey_trigger_held` 互补 —— held 防 press-without-release，本字段防
     /// press-release-press 三连过快。
     last_hotkey_dispatch_at: Mutex<Option<std::time::Instant>>,
+    /// end_session 成功收尾后将 phase 设为 Idle 时记录的时间戳 + POST_SESSION_COOLDOWN_MS。
+    /// handle_pressed 在 (Toggle, Idle) 分支检查此字段：未过期则忽略该次按键，
+    /// 防止胶囊离场动画期间误激活新听写（issue #545）。
+    session_cooldown_until: Mutex<Option<std::time::Instant>>,
     shortcut_recording_active: AtomicBool,
     /// 自定义组合键监听器（global-hotkey crate）。当 `prefs.hotkey.trigger == Custom` 时
     /// 代替 modifier-only 的 hotkey monitor。`None` 表示不使用自定义组合键或还没成功安装。
@@ -318,6 +322,7 @@ impl Coordinator {
                     hotkey_status: Mutex::new(HotkeyStatus::default()),
                     hotkey_trigger_held: AtomicBool::new(false),
                     last_hotkey_dispatch_at: Mutex::new(None),
+                    session_cooldown_until: Mutex::new(None),
                     shortcut_recording_active: AtomicBool::new(false),
                     combo_hotkey: Mutex::new(None),
                     translation_hotkey: Mutex::new(None),
@@ -379,6 +384,7 @@ impl Coordinator {
                 hotkey_status: Mutex::new(HotkeyStatus::default()),
                 hotkey_trigger_held: AtomicBool::new(false),
                 last_hotkey_dispatch_at: Mutex::new(None),
+                session_cooldown_until: Mutex::new(None),
                 shortcut_recording_active: AtomicBool::new(false),
                 combo_hotkey: Mutex::new(None),
                 translation_hotkey: Mutex::new(None),
@@ -4500,6 +4506,11 @@ fn enabled_phrases(inner: &Arc<Inner>) -> Vec<String> {
 /// 终止态（Done / Cancelled / Error）后延迟 N ms 把胶囊改回 Idle，让浮窗自动消失。
 /// 用户点 ✕ / ✓ / 中途出错 / 按 Esc 都走这里，统一 2 秒。
 const CAPSULE_AUTO_HIDE_DELAY_MS: u64 = 2000;
+
+/// Toggle 模式下，end_session 将 phase 设为 Idle 后在此时间内禁止新的 begin_session。
+/// 避免用户三连按时第 3 次按下误激活新听写（此时胶囊仍在离场动画周期内）。
+/// 值取 capsule EXIT_ANIM_MS (360ms) + 余量 ≈ 600ms。
+const POST_SESSION_COOLDOWN_MS: u64 = 600;
 
 /// Coordinator 全局超时保护：防止 ASR await_final_result() 永远挂起。
 /// 设置为 15 秒（比 ASR 的 12 秒 FINAL_RESULT_TIMEOUT 稍长），

--- a/openless-all/app/src-tauri/src/coordinator/dictation.rs
+++ b/openless-all/app/src-tauri/src/coordinator/dictation.rs
@@ -460,6 +460,20 @@ pub(super) async fn handle_pressed(inner: &Arc<Inner>) {
     log::info!("[coord] hotkey pressed (mode={mode:?}, phase={phase:?})");
     match (mode, phase) {
         (HotkeyMode::Toggle, SessionPhase::Idle) => {
+            // 冷却检查：end_session 刚收尾时禁止短时间内再次激活，
+            // 避免三连按第 3 次误触（此时胶囊仍在离场动画周期内，issue #545）。
+            let now = std::time::Instant::now();
+            let on_cooldown = inner
+                .session_cooldown_until
+                .lock()
+                .map(|deadline| now < deadline)
+                .unwrap_or(false);
+            if on_cooldown {
+                log::info!(
+                    "[coord] toggle activation blocked by cooldown (session still winding down)"
+                );
+                return;
+            }
             let _ = begin_session(inner).await;
         }
         (HotkeyMode::Toggle, SessionPhase::Listening) => {
@@ -1814,6 +1828,13 @@ pub(super) async fn end_session(inner: &Arc<Inner>) -> Result<(), String> {
         state.phase = SessionPhase::Idle;
         state.focus_target = None;
     }
+    // Toggle 模式冷却：设冷却时间戳，POST_SESSION_COOLDOWN_MS 内禁止新的 activate。
+    // 覆盖胶囊离场动画周期，避免三连按第 3 次误激活（issue #545）。
+    {
+        let now = std::time::Instant::now();
+        *inner.session_cooldown_until.lock() =
+            Some(now + std::time::Duration::from_millis(POST_SESSION_COOLDOWN_MS));
+    }
     schedule_capsule_idle(inner, CAPSULE_AUTO_HIDE_DELAY_MS);
 
     Ok(())
@@ -1861,6 +1882,10 @@ pub(super) fn cancel_session(inner: &Arc<Inner>) {
     if decision.phase != SessionPhase::Processing {
         let mut state = inner.state.lock();
         finish_cancel_session_state(&mut state, decision);
+        // 只有真正把 phase 设为 Idle 时才设冷却（避免离场动画期间误激活）。
+        let now = std::time::Instant::now();
+        *inner.session_cooldown_until.lock() =
+            Some(now + std::time::Duration::from_millis(POST_SESSION_COOLDOWN_MS));
     }
     emit_capsule(inner, CapsuleState::Cancelled, 0.0, 0, None, None);
     log::info!("[coord] session cancelled (was {:?})", decision.phase);


### PR DESCRIPTION
### **User description**
## 背景

Issue #545 报告 Toggle 模式下快速三连按时，第 3 次按键会在胶囊离场动画期间误激活新听写。

## 改动

在 coordinator 层增加 **timer-based busy gate**，冷却时长 **600ms**（覆盖胶囊 `EXIT_ANIM_MS` 360ms + 余量）：

| 文件 | 改动 |
|---|---|
| \`coordinator.rs\` | 新增 \`POST_SESSION_COOLDOWN_MS = 600\` 常量 + \`session_cooldown_until\` 字段 |
| \`coordinator/dictation.rs\` | \`handle_pressed\` 的 \`(Toggle, Idle)\` 分支增加冷却检查 |
| \`coordinator/dictation.rs\` | \`end_session\` 成功收尾时设置冷却 |
| \`coordinator/dictation.rs\` | \`cancel_session\` 将 phase 设为 Idle 时同步设置冷却 |

## 不受影响

- **Hold 模式**：冷却仅在 \`(Toggle, Idle)\` 分支检查，Hold 走 \`(Hold, Idle)\` 不受影响
- **错误/取消后的立即重试**：error 提前返回路径不设冷却，用户出错后可立即重试
- **Starting 阶段的连按**：已有 \`request_stop_during_starting\` 逻辑
- **现有 HOTKEY_DEBOUNCE (250ms)**：防抖与冷却互补，冷却占主导

## 验证

- \`cargo build\`: ✅ 成功
- \`cargo test\`: ✅ 358/358 通过
- Code review 子代理: ✅ 确认设计正确，修复了 \`cancel_session\` 遗漏的冷却

Closes #545


___

### **PR Type**
Bug fix


___

### **Description**
- Add 600ms activation cooldown after end_session/cancel_session

- Block toggle hotkey in Idle phase during cooldown

- Prevent triple-press Third key from starting new dictation


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Press["Hotkey Pressed (Toggle, Idle)"] --> Check{Cooldown expired?}
  Check -- Yes --> Begin["begin_session"]
  Check -- No --> Ignore["Ignore (blocked)"]
  Begin --> End["end_session / cancel_session"]
  End --> SetCooldown["Set POST_SESSION_COOLDOWN_MS"]
  SetCooldown --> CapsuleIdle["schedule_capsule_idle"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>coordinator.rs</strong><dd><code>Add cooldown constant and state field</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src-tauri/src/coordinator.rs

<ul><li>Added <code>POST_SESSION_COOLDOWN_MS</code> constant (600ms)<br> <li> Added <code>session_cooldown_until</code> field to <code>Inner</code> struct<br> <li> Initialized field in constructor</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/571/files#diff-73d8c004670b27293f74f0f3991b9a6fc28f0ff0b883214de2b078b1e09797ca">+11/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>dictation.rs</strong><dd><code>Implement cooldown check and set in session endpoints</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src-tauri/src/coordinator/dictation.rs

<ul><li>Added cooldown check in <code>handle_pressed</code> for <code>(Toggle, Idle)</code> branch<br> <li> Set cooldown timestamp in <code>end_session</code> after setting phase to Idle<br> <li> Set cooldown timestamp in <code>cancel_session</code> when phase set to Idle</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/571/files#diff-4cf79887f41f4811eb2b1ef682c62ee34c14a0ab969362a9ba1046de59c8578b">+25/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

