### PR TITLE
fix(macos): Beta 更新重启前重置 TCC 权限记录

### DIFF
--- a/openless-all/app/src-tauri/src/lib.rs
+++ b/openless-all/app/src-tauri/src/lib.rs
@@ -47,6 +47,8 @@ use std::sync::Arc;
 use std::time::Duration;
 
 const LOG_ROTATE_LIMIT_BYTES: u64 = 10 * 1024 * 1024;
+#[cfg(target_os = "macos")]
+const OPENLESS_BUNDLE_ID: &str = "com.openless.app";
 
 /// 第一次 show 时把 QA 浮窗摆到屏幕底部居中；之后的 show 不再 reposition，
 /// 让用户拖动后的位置在 hide → show 之间得以保持。详见 issue #118 v2。
@@ -820,7 +822,47 @@ fn restart_app(app: AppHandle) {
             log::info!("[updater] stripped xattr on {:?} before restart", bundle);
         }
     }
+    #[cfg(target_os = "macos")]
+    reset_tcc_for_beta_restart();
     app.restart();
+}
+
+#[cfg(target_os = "macos")]
+fn reset_tcc_for_beta_restart() {
+    if !is_beta_build() {
+        log::info!("[updater] skipping TCC reset before stable restart");
+        return;
+    }
+
+    // Beta builds are currently ad-hoc signed. Their code hash changes across builds, so
+    // old TCC rows can leave System Settings checked while AXIsProcessTrusted() is false.
+    reset_tcc_service_for_beta_restart("Accessibility");
+    reset_tcc_service_for_beta_restart("Microphone");
+}
+
+#[cfg(target_os = "macos")]
+fn is_beta_build() -> bool {
+    env!("CARGO_PKG_VERSION").contains('-')
+}
+
+#[cfg(target_os = "macos")]
+fn reset_tcc_service_for_beta_restart(service: &str) {
+    match std::process::Command::new("/usr/bin/tccutil")
+        .args(["reset", service, OPENLESS_BUNDLE_ID])
+        .status()
+    {
+        Ok(status) if status.success() => {
+            log::info!("[updater] reset TCC {service} before beta restart");
+        }
+        Ok(status) => {
+            log::warn!(
+                "[updater] reset TCC {service} before beta restart exited with {status}"
+            );
+        }
+        Err(e) => {
+            log::warn!("[updater] reset TCC {service} before beta restart failed: {e}");
+        }
+    }
 }
 
 /// 把日志同时写到 stderr + ~/Library/Logs/OpenLess/openless.log（match Swift `Log.swift`）。


### PR DESCRIPTION
### **User description**
fix(macos): 自动更新 Beta 后重置 ad-hoc TCC 记录

场景：
macOS 上安装 ad-hoc 签名的 OpenLess Beta 版本时，首次启动授权后，TCC
数据库记录的是当前构建的代码签名 hash。Beta 自动更新到新版本后，由于
ad-hoc 签名每次构建的 hash 不同，新版本无法复用旧版本的 TCC 授权记录。

复现步骤：
1. 安装并启动 ad-hoc 签名的 OpenLess Beta v1.3.4。
2. 按引导授予 Accessibility / Microphone 权限。
3. 在应用内检查更新并安装 Beta v1.3.5。
4. 更新完成后点击“现在重启”。
5. 新版启动后提示需要重新配置辅助功能权限。
6. 打开系统设置 → 隐私与安全性 → 辅助功能，可以看到 OpenLess 已存在且开关已勾选。
7. 反复关闭/打开该开关后，应用仍检测不到权限；只有删除旧的 OpenLess 条目并重新授权后才恢复。

原因：
ad-hoc 签名的 Beta 构建没有稳定的 Developer ID 身份，macOS TCC 会把旧版本
hash 对应的授权记录保留下来。系统设置界面显示的已勾选条目实际对应旧构建，
新版调用 AXIsProcessTrusted() 时仍返回 false。

修复思路：
在 macOS 更新重启路径中，仅对 Beta 构建执行 TCC reset。判断标准沿用项目现有
版本约定：版本号包含 prerelease 段（如 1.3.6-2）即视为 Beta 构建。

更新完成并点击重启时：
- Beta 构建：重置 Accessibility 和 Microphone 的旧 TCC 记录，让新版重新触发授权流程。
- Stable 构建：跳过 TCC reset，避免正式版更新后丢失用户已有授权。

这样可以修复 ad-hoc Beta 自动更新后的权限假勾选问题，同时不影响正式签名版本的权限继承体验。


___

### **PR Type**
Bug fix


___

### **Description**
- Reset TCC permissions for ad-hoc beta builds on macOS update restart

- Fixes false positive permission state in System Settings after update

- Only applies to beta builds (version contains '-') to avoid affecting stable releases


___

### Diagram Walkthrough


```mermaid
flowchart LR
    A["Start restart"] --> B{"is_beta_build?"}
    B -- yes --> C["reset_tcc_for_beta_restart"]
    C --> D["reset Accessibility"]
    D --> E["reset Microphone"]
    E --> F["app.restart()"]
    B -- no --> F
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>lib.rs</strong><dd><code>Add TCC reset logic for beta builds before restart</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src-tauri/src/lib.rs

<ul><li>Added <code>OPENLESS_BUNDLE_ID</code> constant for macOS<br> <li> Added <code>reset_tcc_for_beta_restart()</code> and helper functions<br> <li> Called <code>reset_tcc_for_beta_restart()</code> before <code>app.restart()</code> on macOS<br> <li> Only executes for beta builds to avoid impacting stable updates</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/588/files#diff-6b8eb1bbf8e378bab914f1a12962f7add5cc4ba9e013c37c9921a1032fa5e110">+42/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

