### PR TITLE
fix(overview): 凭据保存后状态不刷新仍显示「未配置」 (#573)

### DIFF
--- a/openless-all/app/src-tauri/src/commands.rs
+++ b/openless-all/app/src-tauri/src/commands.rs
@@ -783,10 +783,15 @@ pub fn set_credential(window: Window, account: String, value: String) -> Result<
     ensure_main_window(&window)?;
     let acc = parse_account(&account)?;
     if value.is_empty() {
-        CredentialsVault::remove(acc).map_err(|e| e.to_string())
+        CredentialsVault::remove(acc).map_err(|e| e.to_string())?;
     } else {
-        CredentialsVault::set(acc, &value).map_err(|e| e.to_string())
+        CredentialsVault::set(acc, &value).map_err(|e| e.to_string())?;
     }
+    // 通知前端凭据已变更（如 Overview 页需要刷新 asrConfigured 状态）。
+    // issue #532 / #573：在 Settings 填写凭据但不切换提供商时，Overview 不会重拉状态，
+    // 仍显示「未配置」。该修复曾随 #538 合入 main，但被 beta→main 合并覆盖，beta 上缺失。
+    let _ = window.emit("credentials:changed", ());
+    Ok(())
 }
 
 #[tauri::command]

--- a/openless-all/app/src/pages/Overview.tsx
+++ b/openless-all/app/src/pages/Overview.tsx
@@ -101,6 +101,34 @@ export function Overview({ onOpenHistory }: OverviewProps) {
     refreshCredentials();
   }, [refreshCredentials, prefs?.activeAsrProvider, prefs?.activeLlmProvider]);
 
+  // 凭据被保存后重新拉取状态（issue #532 / #573：在 Settings 中填写/更新凭据
+  // 但不切换提供商时，上面的 useEffect 不会重跑，导致概览页的状态仍停留在「未配置」）。
+  // 复用 refreshCredentials() 以带上 credentialsRequestSeq 防竞态。
+  useEffect(() => {
+    let cancelled = false;
+    let unlisten: (() => void) | undefined;
+    (async () => {
+      try {
+        const { listen } = await import('@tauri-apps/api/event');
+        const handle = await listen('credentials:changed', () => {
+          if (cancelled) return;
+          refreshCredentials();
+        });
+        if (cancelled) {
+          handle();
+        } else {
+          unlisten = handle;
+        }
+      } catch {
+        // browser dev mock — 没有 Tauri event bridge
+      }
+    })();
+    return () => {
+      cancelled = true;
+      unlisten?.();
+    };
+  }, [refreshCredentials]);
+
   const metrics = useMemo(() => {
     const today = new Date();
     today.setHours(0, 0, 0, 0);


### PR DESCRIPTION
### **User description**
## 问题

Closes #573 (亦覆盖 #532 在 beta 上的复现)

用户（如 Ubuntu 24.04）配好火山引擎 ASR 后，概览页仍显示「未配置」。

## 根因

在 Settings 中填写/更新凭据但**不切换提供商**时，`Overview` 原有的两个刷新触发点都不会触发：
- 首次挂载的 `useEffect`
- 依赖 `prefs?.activeAsrProvider / activeLlmProvider` 的 `useEffect`（保存凭据不会改 active provider）

所以 `asrConfigured` 状态卡在初始的「未配置」，直到手动切换 provider 或重启 App。

这个修复曾随 **#538** 合入 `main`，但随后被 `beta → main` 合并覆盖，**开发主分支 `beta` 上完全缺失**（`git grep credentials:changed origin/beta` 为空）。维护者此前在 issue 回复「更新最新版应该已修了」其实对 beta 用户不成立。

## 改动（单一职责，2 文件 ~35 行）

- `commands.rs`：`set_credential` 保存/删除成功后 `emit("credentials:changed")`
- `Overview.tsx`：新增 `useEffect` 监听该事件并调用 `refreshCredentials()`

相比 #538 原版的改进：监听回调复用既有的 `refreshCredentials()`（带 `credentialsRequestSeq` 防竞态），而非裸 `getCredentials().then(...)`，避免并发刷新乱序。

## 验证

- [x] `tsc --noEmit` 通过
- [x] `cargo check` 通过
- [ ] 真机：火山引擎填三件套不切 provider，Overview 立即变「已配置」

## 备注

⚠️ 提醒：下次 `Merge branch beta into main` 时请确保 `set_credential` 的 emit 不再被丢，否则会第三次回退此修复。

@claude 请审核。


___

### **PR Type**
Bug fix


___

### **Description**
- Emit "credentials:changed" event from backend on credential save/remove

- Listen for credential updates in Overview to refresh ASR status

- Fixes ASR status not updating after saving credentials without switching provider


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Backend: set_credential saves/removes credentials"] -- "emit `credentials:changed`" --> B["Frontend: Overview listens for event"]
  B -- "calls refreshCredentials()" --> C["ASR configured status updated"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>commands.rs</strong><dd><code>Emit credential change event from backend</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src-tauri/src/commands.rs

<ul><li>After credential set or remove, emit "credentials:changed" Tauri event<br> <li> Added comment referencing issues #532 and #573</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/590/files#diff-8215873d09604b1dbb99088131ba7fc2fd6c537e67588cba5bd9160c2138b035">+7/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Overview.tsx</strong><dd><code>Listen for credential updates in Overview</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src/pages/Overview.tsx

<ul><li>Added useEffect to listen for "credentials:changed" event<br> <li> On event, call refreshCredentials() with existing abort-controller <br>safety<br> <li> Clean up listener on unmount</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/590/files#diff-87ea690f4abf573183a65635bee8aae0f788da0bc4b4f030f53756fa16f8aae2">+28/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

