### PR TITLE
feat(asr): 支持 OpenRouter 作为 ASR 提供商 (#582)

### DIFF
--- a/openless-all/app/src-tauri/Cargo.lock
+++ b/openless-all/app/src-tauri/Cargo.lock
@@ -3680,6 +3680,7 @@ version = "1.3.6-2"
 dependencies = [
  "anyhow",
  "arboard",
+ "base64 0.22.1",
  "block2 0.5.1",
  "bytes",
  "bzip2 0.4.4",

--- a/openless-all/app/src-tauri/Cargo.toml
+++ b/openless-all/app/src-tauri/Cargo.toml
@@ -26,6 +26,8 @@ tauri-plugin-autostart = "2"
 tauri-plugin-dialog = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+# OpenRouter ASR 把音频以标准 base64（带 padding）放进 JSON body（issue #582）。
+base64 = "0.22"
 sha2 = "0.10"
 bzip2 = "0.4"
 tar = "0.4"

--- a/openless-all/app/src-tauri/src/asr/whisper.rs
+++ b/openless-all/app/src-tauri/src/asr/whisper.rs
@@ -2,6 +2,7 @@
 //! to any OpenAI-compatible `/audio/transcriptions` endpoint on session end.
 
 use anyhow::{Context, Result};
+use base64::Engine;
 use parking_lot::Mutex;
 
 use crate::asr::wav::encode_wav_16k_mono;
@@ -21,6 +22,19 @@ pub const PROMPT_CHAR_BUDGET: usize = 240;
 /// 区切り文字（ASCII）。Whisper のトークナイザはどの言語でも安定して扱える。
 const PROMPT_SEPARATOR: &str = ", ";
 
+/// `/audio/transcriptions` 请求体编码方式。
+///
+/// OpenAI 官方及多数兼容厂商用 `multipart/form-data`（file + model）。
+/// OpenRouter 虽路径相同、也走 Bearer，但请求体是 `application/json`：
+/// `{model, input_audio:{data:<base64 wav>, format:"wav"}}`（issue #582）。
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum AsrRequestFormat {
+    /// `multipart/form-data`（既有行为，默认）。
+    Multipart,
+    /// OpenRouter `application/json` + base64 音频。
+    OpenRouterJson,
+}
+
 pub struct WhisperBatchASR {
     api_key: String,
     base_url: String,
@@ -36,6 +50,8 @@ pub struct WhisperBatchASR {
     /// （SiliconFlow）は response_format 自体が無いので false にして従来の
     /// `json` のまま送る（壊さない）。
     verbose_json: bool,
+    /// 请求体编码方式。默认 `Multipart`，OpenRouter 走 `OpenRouterJson`。
+    request_format: AsrRequestFormat,
     buffer: Mutex<Vec<u8>>,
 }
 
@@ -55,8 +71,16 @@ impl WhisperBatchASR {
             prompt,
             max_chunk_duration_ms,
             verbose_json,
+            request_format: AsrRequestFormat::Multipart,
             buffer: Mutex::new(Vec::new()),
         }
+    }
+
+    /// 设置请求体编码方式（默认 `Multipart`）。OpenRouter 需 `OpenRouterJson`。
+    /// 用 builder 而非给 `new()` 加参数，避免改动既有 4 处构造点的签名。
+    pub fn with_request_format(mut self, request_format: AsrRequestFormat) -> Self {
+        self.request_format = request_format;
+        self
     }
 
     /// Stop collecting audio, encode the buffer as WAV, and POST to the
@@ -110,40 +134,62 @@ impl WhisperBatchASR {
             .collect();
         let wav = encode_wav_16k_mono(&samples);
         let url = transcription_url(&self.base_url)?;
-
-        let wav_part = reqwest::multipart::Part::bytes(wav)
-            .file_name("audio.wav")
-            .mime_str("audio/wav")
-            .context("set MIME type")?;
-        let mut form = reqwest::multipart::Form::new()
-            .part("file", wav_part)
-            .text("model", self.model.clone());
-
-        // verbose_json 対応プロバイダ（OpenAI / Groq）のときだけ、セグメント
-        // メタデータ付きの応答を要求し、temperature も 0 に固定する。非対応
-        // プロバイダ（SiliconFlow の SenseVoice / TeleSpeech 等）には送らず
-        // 従来どおりの応答にして、未知パラメータでの 4xx を避ける。
-        if self.verbose_json {
-            form = form
-                .text("response_format", "verbose_json")
-                .text("temperature", "0");
-        }
-
-        // `prompt` は空文字を送らない：OpenAI 互換実装によっては空文字でエラーに
-        // なるリスクがある（Groq は許容するが防御的にスキップ）。`trim()` で
-        // 空白のみのケースも除外。
-        if let Some(prompt) = self.prompt.as_ref() {
-            let trimmed = prompt.trim();
-            if !trimmed.is_empty() {
-                form = form.text("prompt", trimmed.to_string());
-            }
-        }
-
         let client = reqwest::Client::new();
-        let resp = client
-            .post(&url)
-            .header("Authorization", format!("Bearer {}", self.api_key))
-            .multipart(form)
+
+        let request = match self.request_format {
+            AsrRequestFormat::Multipart => {
+                let wav_part = reqwest::multipart::Part::bytes(wav)
+                    .file_name("audio.wav")
+                    .mime_str("audio/wav")
+                    .context("set MIME type")?;
+                let mut form = reqwest::multipart::Form::new()
+                    .part("file", wav_part)
+                    .text("model", self.model.clone());
+
+                // verbose_json 対応プロバイダ（OpenAI / Groq）のときだけ、セグメント
+                // メタデータ付きの応答を要求し、temperature も 0 に固定する。非対応
+                // プロバイダ（SiliconFlow の SenseVoice / TeleSpeech 等）には送らず
+                // 従来どおりの応答にして、未知パラメータでの 4xx を避ける。
+                if self.verbose_json {
+                    form = form
+                        .text("response_format", "verbose_json")
+                        .text("temperature", "0");
+                }
+
+                // `prompt` は空文字を送らない：OpenAI 互換実装によっては空文字でエラーに
+                // なるリスクがある（Groq は許容するが防御的にスキップ）。`trim()` で
+                // 空白のみのケースも除外。
+                if let Some(prompt) = self.prompt.as_ref() {
+                    let trimmed = prompt.trim();
+                    if !trimmed.is_empty() {
+                        form = form.text("prompt", trimmed.to_string());
+                    }
+                }
+
+                client
+                    .post(&url)
+                    .header("Authorization", format!("Bearer {}", self.api_key))
+                    .multipart(form)
+            }
+            AsrRequestFormat::OpenRouterJson => {
+                // OpenRouter /audio/transcriptions：application/json，音频走标准
+                // base64（带 padding）。不带 multipart 专属的 prompt/response_format
+                // 字段，避免未知字段导致 4xx；verbose_json 对该协议保持关闭。
+                let body = serde_json::json!({
+                    "model": self.model,
+                    "input_audio": {
+                        "data": base64::engine::general_purpose::STANDARD.encode(&wav),
+                        "format": "wav",
+                    },
+                });
+                client
+                    .post(&url)
+                    .header("Authorization", format!("Bearer {}", self.api_key))
+                    .json(&body)
+            }
+        };
+
+        let resp = request
             .send()
             .await
             .context("Whisper HTTP request failed")?;
@@ -722,6 +768,63 @@ mod tests {
 
         assert_eq!(transcript.text, "你好 world 尾");
         assert_eq!(transcript.duration_ms, 65_000);
+        server.join().unwrap();
+    }
+
+    #[tokio::test]
+    async fn openrouter_format_posts_json_with_base64_audio() {
+        // issue #582：OpenRouterJson 走 application/json + input_audio.data(base64)，
+        // 而非 multipart；响应仍按 {text} 解析。
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        listener.set_nonblocking(true).unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server = thread::spawn(move || {
+            let deadline = Instant::now() + Duration::from_secs(5);
+            let mut stream = loop {
+                match listener.accept() {
+                    Ok((stream, _)) => break stream,
+                    Err(err) if err.kind() == std::io::ErrorKind::WouldBlock => {
+                        assert!(
+                            Instant::now() < deadline,
+                            "timed out waiting for ASR test request"
+                        );
+                        thread::sleep(Duration::from_millis(10));
+                    }
+                    Err(err) => panic!("accept ASR test request failed: {err}"),
+                }
+            };
+            stream.set_nonblocking(false).unwrap();
+            stream
+                .set_read_timeout(Some(Duration::from_secs(5)))
+                .unwrap();
+            let request = read_http_request(&mut stream);
+            let request_text = String::from_utf8_lossy(&request);
+            let lower = request_text.to_ascii_lowercase();
+            assert!(request_text.starts_with("POST /audio/transcriptions HTTP/1.1"));
+            assert!(lower.contains("content-type: application/json"));
+            assert!(lower.contains("authorization: bearer key"));
+            // body 是 JSON：含 input_audio.data + format:"wav"，且不是 multipart。
+            assert!(request_text.contains("input_audio"));
+            assert!(request_text.contains(r#""format":"wav""#));
+            assert!(!lower.contains("multipart/form-data"));
+            write_json_response(&mut stream, r#"{"text":"openrouter ok"}"#);
+        });
+        let base_url = format!("http://{}", addr);
+
+        let asr = WhisperBatchASR::new(
+            "key".to_string(),
+            base_url,
+            "openai/whisper-large-v3-turbo".to_string(),
+            None,
+            None,
+            false,
+        )
+        .with_request_format(AsrRequestFormat::OpenRouterJson);
+        let pcm = vec![0u8; 32_000 * 2];
+        asr.consume_pcm_chunk(&pcm);
+
+        let transcript = asr.transcribe().await.unwrap();
+        assert_eq!(transcript.text, "openrouter ok");
         server.join().unwrap();
     }
 

--- a/openless-all/app/src-tauri/src/coordinator.rs
+++ b/openless-all/app/src-tauri/src/coordinator.rs
@@ -184,7 +184,9 @@ fn active_asr_provider_kind(id: &str) -> ActiveAsrProviderKind {
 
 fn batch_asr_chunk_limit_ms(provider_id: &str) -> Option<u64> {
     match provider_id {
-        "zhipu" => Some(30_000),
+        // OpenRouter 把音频 base64 进 JSON body，体积比二进制大 ~33%，长录音易撞
+        // body/时长上限，保守按 30s 切分（与 zhipu 同）。
+        "zhipu" | "openrouter" => Some(30_000),
         _ => None,
     }
 }
@@ -2489,7 +2491,16 @@ async fn build_local_qwen3(
 /// (messages=[{content:[{audio:...}]}]) 协议，不是 Whisper multipart，需要
 /// 单独 ASR 客户端，留给 V2。
 fn is_whisper_compatible_provider(id: &str) -> bool {
-    matches!(id, "whisper" | "siliconflow" | "zhipu" | "groq")
+    matches!(id, "whisper" | "siliconflow" | "zhipu" | "groq" | "openrouter")
+}
+
+/// 该 provider 的请求体编码方式。OpenRouter 的 `/audio/transcriptions` 是
+/// `application/json` + base64 音频（issue #582），其余兼容厂商沿用 multipart。
+fn whisper_request_format(provider_id: &str) -> crate::asr::whisper::AsrRequestFormat {
+    match provider_id {
+        "openrouter" => crate::asr::whisper::AsrRequestFormat::OpenRouterJson,
+        _ => crate::asr::whisper::AsrRequestFormat::Multipart,
+    }
 }
 
 /// 该 provider 的 `/audio/transcriptions` 是否支持 `response_format=verbose_json`
@@ -2665,14 +2676,17 @@ async fn build_qa_asr_start(inner: &Arc<Inner>, active_asr: &str) -> Result<QaAs
             let (api_key, base_url, model) = read_whisper_credentials();
             let whisper_prompt =
                 crate::asr::whisper::build_prompt_from_phrases(&enabled_phrases(inner));
-            let whisper = Arc::new(WhisperBatchASR::new(
-                api_key,
-                base_url,
-                model,
-                whisper_prompt,
-                batch_asr_chunk_limit_ms(active_asr),
-                whisper_supports_verbose_json(active_asr),
-            ));
+            let whisper = Arc::new(
+                WhisperBatchASR::new(
+                    api_key,
+                    base_url,
+                    model,
+                    whisper_prompt,
+                    batch_asr_chunk_limit_ms(active_asr),
+                    whisper_supports_verbose_json(active_asr),
+                )
+                .with_request_format(whisper_request_format(active_asr)),
+            );
             let active = ActiveAsr::Whisper(Arc::clone(&whisper));
             let consumer: Arc<dyn crate::recorder::AudioConsumer> = whisper;
             Ok(QaAsrStart::Ready { active, consumer })
@@ -4055,6 +4069,27 @@ mod tests {
         // SiliconFlow(SenseVoice/TeleSpeech) / Zhipu(GLM-ASR) 保持旧的 json 行为。
         assert!(!whisper_supports_verbose_json("siliconflow"));
         assert!(!whisper_supports_verbose_json("zhipu"));
+    }
+
+    #[test]
+    fn openrouter_is_whisper_compatible_json_provider() {
+        use crate::asr::whisper::AsrRequestFormat;
+        // issue #582：OpenRouter 走 whisper 兼容路由，但请求体是 JSON+base64。
+        assert!(is_whisper_compatible_provider("openrouter"));
+        assert_eq!(
+            whisper_request_format("openrouter"),
+            AsrRequestFormat::OpenRouterJson
+        );
+        // 其余兼容厂商保持 multipart。
+        assert_eq!(
+            whisper_request_format("whisper"),
+            AsrRequestFormat::Multipart
+        );
+        assert_eq!(whisper_request_format("groq"), AsrRequestFormat::Multipart);
+        // OpenRouter 的 JSON 协议不吃 response_format，verbose_json 保持关闭。
+        assert!(!whisper_supports_verbose_json("openrouter"));
+        // base64 膨胀，长录音保守按 30s 切分。
+        assert_eq!(batch_asr_chunk_limit_ms("openrouter"), Some(30_000));
     }
 
     #[test]

--- a/openless-all/app/src-tauri/src/coordinator/dictation.rs
+++ b/openless-all/app/src-tauri/src/coordinator/dictation.rs
@@ -811,14 +811,17 @@ pub(super) async fn begin_session(inner: &Arc<Inner>) -> Result<(), String> {
         // 互換プロバイダにも揃えるのが筋。
         let whisper_prompt =
             crate::asr::whisper::build_prompt_from_phrases(&enabled_phrases(inner));
-        let whisper = Arc::new(WhisperBatchASR::new(
-            api_key,
-            base_url,
-            model,
-            whisper_prompt,
-            batch_asr_chunk_limit_ms(&active_asr),
-            whisper_supports_verbose_json(&active_asr),
-        ));
+        let whisper = Arc::new(
+            WhisperBatchASR::new(
+                api_key,
+                base_url,
+                model,
+                whisper_prompt,
+                batch_asr_chunk_limit_ms(&active_asr),
+                whisper_supports_verbose_json(&active_asr),
+            )
+            .with_request_format(whisper_request_format(&active_asr)),
+        );
         store_asr_for_session(
             inner,
             current_session_id,
@@ -2166,6 +2169,7 @@ mod tests {
     #[test]
     fn batch_asr_chunk_limit_applies_only_to_zhipu() {
         assert_eq!(batch_asr_chunk_limit_ms("zhipu"), Some(30_000));
+        assert_eq!(batch_asr_chunk_limit_ms("openrouter"), Some(30_000));
         assert_eq!(batch_asr_chunk_limit_ms("whisper"), None);
         assert_eq!(batch_asr_chunk_limit_ms("siliconflow"), None);
         assert_eq!(batch_asr_chunk_limit_ms("groq"), None);

--- a/openless-all/app/src/i18n/en.ts
+++ b/openless-all/app/src/i18n/en.ts
@@ -618,6 +618,7 @@ export const en: typeof zhCN = {
         asrZhipu: 'Zhipu GLM-ASR',
         asrGroq: 'Groq Whisper-large-v3',
         asrWhisper: 'OpenAI Whisper (compatible)',
+        asrOpenrouter: 'OpenRouter Whisper',
         asrSherpaOnnxLocal: 'Local sherpa-onnx (experimental)',
         asrFoundryLocalWhisper: 'Local Whisper (Foundry Local)',
         asrLocalQwen3: 'Local Qwen3-ASR',

--- a/openless-all/app/src/i18n/ja.ts
+++ b/openless-all/app/src/i18n/ja.ts
@@ -620,6 +620,7 @@ export const ja: typeof zhCN = {
         asrZhipu: 'Zhipu GLM-ASR',
         asrGroq: 'Groq Whisper-large-v3',
         asrWhisper: 'OpenAI Whisper（互換）',
+        asrOpenrouter: 'OpenRouter Whisper',
         asrSherpaOnnxLocal: 'ローカル sherpa-onnx（実験的）',
         asrFoundryLocalWhisper: 'ローカル Whisper（Foundry Local）',
         asrLocalQwen3: 'ローカル Qwen3-ASR',

--- a/openless-all/app/src/i18n/ko.ts
+++ b/openless-all/app/src/i18n/ko.ts
@@ -620,6 +620,7 @@ export const ko: typeof zhCN = {
         asrZhipu: 'Zhipu GLM-ASR',
         asrGroq: 'Groq Whisper-large-v3',
         asrWhisper: 'OpenAI Whisper(호환)',
+        asrOpenrouter: 'OpenRouter Whisper',
         asrSherpaOnnxLocal: '로컬 sherpa-onnx(실험적)',
         asrFoundryLocalWhisper: '로컬 Whisper(Foundry Local)',
         asrLocalQwen3: '로컬 Qwen3-ASR',

--- a/openless-all/app/src/i18n/zh-CN.ts
+++ b/openless-all/app/src/i18n/zh-CN.ts
@@ -616,6 +616,7 @@ export const zhCN = {
         asrZhipu: '智谱 GLM-ASR',
         asrGroq: 'Groq Whisper-large-v3',
         asrWhisper: 'OpenAI Whisper（兼容）',
+        asrOpenrouter: 'OpenRouter Whisper',
         asrSherpaOnnxLocal: '本地 sherpa-onnx（实验性）',
         asrFoundryLocalWhisper: '本地 Whisper（Foundry Local）',
         asrLocalQwen3: '本地 Qwen3-ASR',

--- a/openless-all/app/src/i18n/zh-TW.ts
+++ b/openless-all/app/src/i18n/zh-TW.ts
@@ -618,6 +618,7 @@ export const zhTW: typeof zhCN = {
         asrZhipu: '智譜 GLM-ASR',
         asrGroq: 'Groq Whisper-large-v3',
         asrWhisper: 'OpenAI Whisper（兼容）',
+        asrOpenrouter: 'OpenRouter Whisper',
         asrSherpaOnnxLocal: '本地 sherpa-onnx（實驗性）',
         asrFoundryLocalWhisper: '本地 Whisper（Foundry Local）',
         asrLocalQwen3: '本地 Qwen3-ASR',

--- a/openless-all/app/src/pages/Overview.tsx
+++ b/openless-all/app/src/pages/Overview.tsx
@@ -30,6 +30,7 @@ const ASR_NAME_KEY_BY_ID: Record<string, string> = {
   zhipu: 'asrZhipu',
   groq: 'asrGroq',
   whisper: 'asrWhisper',
+  openrouter: 'asrOpenrouter',
   'foundry-local-whisper': 'asrFoundryLocalWhisper',
   'sherpa-onnx-local': 'asrSherpaOnnxLocal',
   'local-qwen3': 'asrLocalQwen3',

--- a/openless-all/app/src/pages/settings/ProvidersSection.tsx
+++ b/openless-all/app/src/pages/settings/ProvidersSection.tsx
@@ -142,6 +142,9 @@ const ASR_PRESETS: ReadonlyArray<{ id: AsrPresetId; nameKey: string; baseUrl: st
   { id: 'zhipu',        nameKey: 'asrZhipu',        baseUrl: 'https://open.bigmodel.cn/api/paas/v4',           model: 'glm-asr-2512'                },
   { id: 'groq',         nameKey: 'asrGroq',         baseUrl: 'https://api.groq.com/openai/v1',                 model: 'whisper-large-v3-turbo'      },
   { id: 'whisper',      nameKey: 'asrWhisper',      baseUrl: 'https://api.openai.com/v1',                      model: 'whisper-1'                   },
+  // OpenRouter 的 /audio/transcriptions 走 application/json + base64（issue #582），
+  // 后端 coordinator.rs::whisper_request_format 对该 id 切换到 OpenRouterJson 编码。
+  { id: 'openrouter',   nameKey: 'asrOpenrouter',   baseUrl: 'https://openrouter.ai/api/v1',                   model: 'openai/whisper-large-v3-turbo' },
   { id: 'foundry-local-whisper', nameKey: 'asrFoundryLocalWhisper', baseUrl: '',                              model: ''                              },
   // 本地引擎（Foundry / sherpa-onnx / Qwen3）：无 baseUrl/model 配置，
   // 模型在「高级 → 本地模型」里下载与切换。

--- a/openless-all/app/src/pages/settings/shared.tsx
+++ b/openless-all/app/src/pages/settings/shared.tsx
@@ -179,6 +179,7 @@ export type AsrPresetId =
     | "zhipu"
     | "groq"
     | "whisper"
+    | "openrouter"
     | "foundry-local-whisper"
     | "sherpa-onnx-local"
     | "local-qwen3"


### PR DESCRIPTION
### **User description**
## 需求

Closes #582

OpenRouter 的 `/audio/transcriptions` 与 OpenAI 路径相同、也走 Bearer 鉴权，但请求体格式不同：

| | OpenAI / 现有兼容厂商 | OpenRouter |
|---|---|---|
| Content-Type | `multipart/form-data` | `application/json` |
| 音频 | part `file` = WAV 二进制 | `input_audio.data` = base64(wav) |

所以直接把 OpenRouter 当 whisper 兼容 provider 加进预设，multipart 请求会被拒。

## 改动（单一职责：接入 OpenRouter ASR）

**后端**
- `whisper.rs`：新增 `AsrRequestFormat { Multipart, OpenRouterJson }`，`transcribe_chunk` 按格式分发。`OpenRouterJson` 发 `{model, input_audio:{data, format:"wav"}}`，用**标准 base64（带 padding）**，且不带 multipart 专属的 `prompt`/`response_format` 字段（避免未知字段 4xx）。用 `with_request_format` builder，**不改 `new()` 签名**（既有 4 处构造点零改动）。
- `coordinator.rs`：`is_whisper_compatible_provider` 注册 `openrouter`；新增 `whisper_request_format`；`verbose_json` 对 openrouter 保持关闭（其 JSON 协议不吃 `response_format`）；base64 膨胀 ~33%，长录音按 30s 切分（同 zhipu）。

**前端**
- `ASR_PRESETS` / `AsrPresetId` / `Overview` 名称映射 + 5 份 i18n 加 `openrouter`，默认 `baseUrl=https://openrouter.ai/api/v1`、`model=openai/whisper-large-v3-turbo`（报告人已验证的模型）。

**测试**
- `whisper.rs`：OpenRouterJson 发 JSON body（含 `input_audio` + `format:"wav"`、非 multipart）的单测；既有 multipart transcribe 测试不变。
- `coordinator.rs`：注册/格式/verbose_json/chunk-limit 断言。

## 验证

- [x] `tsc --noEmit` 通过
- [x] `cargo check` 通过
- [x] `cargo test --lib`（openrouter + transcribe 共 11 项）全过
- [ ] 真机：用真实 OpenRouter key 验证响应体字段 (`{text}`) 与长录音切分上限

## 依赖

新增直接依赖 `base64 = "0.22"`（此前已是传递依赖，未引入新 crate）。

## 备注

OpenRouter 官方文档已确认请求/响应格式（响应顶层 `text`，与 OpenAI 一致），故复用现有 `json["text"]` 解析。

@claude 请审核。


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Add OpenRouter ASR provider with JSON+base64 format

- Backend: new request format enum, chunk limit, base64 dependency

- Frontend: preset, i18n, type definitions

- Tests: verify JSON request and provider registration


___

### Diagram Walkthrough


```mermaid
flowchart LR
  User["User selects OpenRouter"] --> Frontend["ASR_PRESETS + i18n"]
  Frontend --> Coordinator["coordinator.rs: set request format"]
  Coordinator --> WhisperBatch["WhisperBatchASR"]
  WhisperBatch --> OpenRouterJson["OpenRouterJson encoding"]
  OpenRouterJson --> JSON["application/json body"]
  JSON --> Audio["input_audio.data: base64(wav)"]
  Audio --> Response["{ text }"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>6 files</summary><table>
<tr>
  <td><strong>whisper.rs</strong><dd><code>Add AsrRequestFormat enum and OpenRouterJson encoding</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/591/files#diff-cf6696a6b96bc9f0fb12aeb6e3934ad2668e3595f06ad10652604887f9794d2b">+133/-30</a></td>

</tr>

<tr>
  <td><strong>coordinator.rs</strong><dd><code>Register openrouter as whisper compatible provider and set format</code></dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/591/files#diff-73d8c004670b27293f74f0f3991b9a6fc28f0ff0b883214de2b078b1e09797ca">+45/-10</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>dictation.rs</strong><dd><code>Use with_request_format for dictation session</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/591/files#diff-4cf79887f41f4811eb2b1ef682c62ee34c14a0ab969362a9ba1046de59c8578b">+12/-8</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>Overview.tsx</strong><dd><code>Add openrouter to ASR name key mapping</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/591/files#diff-87ea690f4abf573183a65635bee8aae0f788da0bc4b4f030f53756fa16f8aae2">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ProvidersSection.tsx</strong><dd><code>Add OpenRouter preset with default model and baseUrl</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/591/files#diff-8fc332d1eb5b010583185b704ea439954650f6aff2d0195e00cd0cb76e526e7b">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>shared.tsx</strong><dd><code>Add openrouter to AsrPresetId union</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/591/files#diff-6e9d525a512046935216033f39bd85274b5eeb3d8bf5731e470deb019dcd7be8">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>en.ts</strong><dd><code>Add asrOpenrouter i18n key</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/591/files#diff-bb2f4fa05787923f8aeb23b6f11ad8705e02d9ff03a45790f9181e4615c79d83">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ja.ts</strong><dd><code>Add asrOpenrouter i18n key</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/591/files#diff-be57f0090cf34e3ff924cfa35f13d5d9e6514d3af5a1ebfdeb92bd7d36ed9cf4">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ko.ts</strong><dd><code>Add asrOpenrouter i18n key</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/591/files#diff-daf35bcb6a2f8a31565b83d119cb59b69c1dededbabfccfd0d56693fdb3726ca">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>zh-CN.ts</strong><dd><code>Add asrOpenrouter i18n key</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/591/files#diff-571576f3c7b6c4a78ae0f91accdccc5da5cbed00409955c9914c046fee6c80ea">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>zh-TW.ts</strong><dd><code>Add asrOpenrouter i18n key</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/591/files#diff-a8d5953f9c76bc3c90ec583270be04c852bd7540297500e6ff3260760fc61ea4">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Dependencies</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>Cargo.toml</strong><dd><code>Add base64 dependency</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/591/files#diff-334952ba03e62939865bbf0351f0916ea88c6457f8ea1259336e73ee4e2f088b">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

