### PR TITLE
chore(capsule): #470 诊断 v2 — 暗点一次性日志（零行为改动）

### DIFF
--- a/openless-all/app/src-tauri/src/coordinator.rs
+++ b/openless-all/app/src-tauri/src/coordinator.rs
@@ -100,6 +100,8 @@ fn capsule_show_strategy_for_platform() -> CapsuleShowStrategy {
 static CAPSULE_NO_ACTIVATE_FALLBACK_WARNED: AtomicBool = AtomicBool::new(false);
 static CAPSULE_SUPPRESSED_BY_TOGGLE_LOGGED: AtomicBool = AtomicBool::new(false);
 static CAPSULE_FIRST_SHOW_LOGGED: AtomicBool = AtomicBool::new(false);
+// #470 诊断 v2：capsule webview 句柄取不到时的一次性门，区分「窗口压根没创建」(A0)。
+static CAPSULE_WINDOW_MISSING_LOGGED: AtomicBool = AtomicBool::new(false);
 
 /// 给 #470 诊断日志用的 capsule 状态短名。显式枚举每个变体到 &'static str，
 /// 不走 `Debug` —— 哪天 CapsuleState 加了 `String` 字段，`:?` 会把 ASR / polish
@@ -4989,9 +4991,13 @@ fn show_capsule_window_no_activate<R: tauri::Runtime>(
     };
 
     let Ok(handle) = window.window_handle() else {
+        // #470 诊断 v2：Win32 show 路径最可能的暗点之一。此前静默 return，
+        // 无法观测「胶囊完全不显示」是否卡在这里。
+        log::warn!("[capsule] no_activate failed: window_handle() unavailable — Win32 show skipped");
         return false;
     };
     let RawWindowHandle::Win32(raw) = handle.as_raw() else {
+        log::warn!("[capsule] no_activate failed: non-Win32 RawWindowHandle — Win32 show skipped");
         return false;
     };
     let hwnd = HWND(raw.hwnd.get() as *mut _);
@@ -5226,6 +5232,14 @@ fn emit_capsule(
     let app_for_main = app.clone();
     let _ = app.run_on_main_thread(move || {
         let Some(window) = app_for_main.get_webview_window("capsule") else {
+            // #470 诊断 v2：比 A/B/C 更靠前的暗点 A0 —— capsule webview 句柄取不到
+            // （窗口未创建/已销毁）。此前静默 return，无法观测。一次性 warn。
+            if !CAPSULE_WINDOW_MISSING_LOGGED.swap(true, Ordering::SeqCst) {
+                log::warn!(
+                    "[capsule] capsule webview window not found — emit_capsule show path skipped (state={})",
+                    capsule_state_log_name(state)
+                );
+            }
             return;
         };
         let show_capsule = inner_for_main.prefs.get().show_capsule;

--- a/openless-all/app/src-tauri/src/lib.rs
+++ b/openless-all/app/src-tauri/src/lib.rs
@@ -1376,7 +1376,15 @@ pub(crate) fn position_capsule_bottom_center<R: tauri::Runtime>(
             let offset_from_bottom =
                 (capsule_visual_height(translation_active) + 80.0 + bounds.bottom_inset) * scale;
             let y = ((mon.bottom as f64) - offset_from_bottom).round() as i32;
-            window.set_position(PhysicalPosition::new(x, y.max(mon.top)))?;
+            let clamped_y = y.max(mon.top);
+            // #470 诊断 v2：当前只夹了上边（.max(mon.top)），未夹下/左/右。多显示器、
+            // 负坐标或异常 DPI 下胶囊可能被算到屏幕外却无任何观测。记录显示器几何与
+            // 最终落点，用于证伪/证实「胶囊定位到屏幕外」(C 子嫌疑)。
+            log::debug!(
+                "[capsule] win position: mon=({},{})..({},{}) scale={:.2} size=({}x{}) -> x={} y={} clamped_y={}",
+                mon.left, mon.top, mon.right, mon.bottom, scale, phys_w, phys_h, x, y, clamped_y
+            );
+            window.set_position(PhysicalPosition::new(x, clamped_y))?;
             return Ok(());
         }
         // 仅当 Win32 取不到前台显示器时，落回下面的 current_monitor 逻辑。

--- a/openless-all/app/src/components/Capsule.tsx
+++ b/openless-all/app/src/components/Capsule.tsx
@@ -286,6 +286,9 @@ function Pill({ os, state, level, insertedChars, message, onCancel, onConfirm }:
 // 动画结束就 unmount → 用户看到半截动画被截断。
 // v1.3.1-6: 从 240ms 加到 360ms 让用户看清退出动画（240ms 太快感知不到）。
 const EXIT_ANIM_MS = 360;
+// #470 诊断 v2：模块级一次性门，只在 webview 收到第一个 capsule:state 事件时打 log。
+let capsuleStateFirstLogged = false;
+
 // 初始可见 state：Tauri 内运行从 idle 开始（等后端 capsule:state 事件），
 // 浏览器 dev 模式从 recording 开始以便直接看到胶囊。
 const INITIAL_VISIBLE_STATE: CapsuleState = isTauri ? 'idle' : 'recording';
@@ -321,6 +324,12 @@ export function Capsule() {
       const { listen } = await import('@tauri-apps/api/event');
       const handle = await listen<CapsulePayload>('capsule:state', event => {
         const p = event.payload;
+        if (!capsuleStateFirstLogged) {
+          capsuleStateFirstLogged = true;
+          // #470 诊断 v2：确认 capsule webview 确实收到了后端事件 —— 区分「后端没
+          // emit」与「emit 了但窗口没显示/没渲染」。配合后端 [capsule] 日志定位根因。
+          console.info('[capsule] first capsule:state received in webview, state=', p.state);
+        }
         setState(p.state);
         setLevel(p.level ?? 0);
         setMessage(p.message ?? undefined);


### PR DESCRIPTION
### **User description**
refs #470（**不 close**：这是诊断手段，不是修复）

## 背景

#470「Windows 语音输入看不到录音胶囊」根因至今未定：PR #471 已白纸黑字说明「只加诊断 log、不是真修复、需要真机日志」；byte92 报告 macOS 也复现，疑为跨平台共性。任何不基于真机日志的「修复」极可能修错对象，因此本 PR **不改任何 show/hide/position 行为**，只在几个**静默路径**补日志，把根因收敛到单一分支：

- **A**：后端没 emit / 状态机停在 Idle（两条既有 `[capsule]` 日志 + 前端是否收到事件）
- **B**：`show_capsule` 开关被关（既有 `suppressed by user toggle` 日志）
- **C**：Win32 show 跑了但 topmost 被拦 / 定位到屏幕外
- **A0**：capsule webview 窗口压根没创建/已销毁

## 改动（纯增量 log，零行为）

| 位置 | 此前 | 现在 |
|---|---|---|
| `coordinator.rs` `show_capsule_window_no_activate`（Win） | `window_handle()` / `RawWindowHandle::Win32` 取不到 → 静默 `return false` | 各补一条 `warn`（Win32 show 失败最可能的暗点） |
| `coordinator.rs` `emit_capsule` | `get_webview_window("capsule")` None → 静默 `return` | 一次性 `warn`（暗点 A0），`AtomicBool` 门避免 ~30Hz 刷屏 |
| `lib.rs` `position_capsule_bottom_center`（Win） | 只 `.max(mon.top)`，无观测 | 显示器几何 + 最终落点 `debug` log（证伪「定位到屏幕外」） |
| `Capsule.tsx` | — | 收到第一个 `capsule:state` 事件时一次性 `console.info`（区分「后端没 emit」vs「emit 了但没渲染/显示」） |

## 验证

- [x] 本机 `cargo check`（跨平台部分）+ `tsc --noEmit` 通过
- [ ] ⚠️ Windows-cfg 部分本机无法交叉编译（`ring` 的 C 代码需 MSVC），**依赖 Windows CI**。已逐行核对：no_activate 两处仅含字符串字面量；几何 log 的 10 个占位符对 10 个作用域内参数。

拿到真机含 `[capsule]` 的日志后，再据 A/B/C/A0 单独开修复 PR。

@claude 请审核（重点：一次性门是否正确、format 占位符/参数是否匹配、是否真的零行为改动）。


___

### **PR Type**
Other


___

### **Description**
- Add one-time warning logs when capsule window handle retrieval fails

- Add debug log for capsule positioning coordinates on Windows

- Add console.info on first capsule:state event in webview for frontend diagnostics


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Win32 show failed"] -- "log warn" --> B["Capsule window handle missing"]
  C["Capsule webview not found"] -- "log warn" --> D["emit_capsule skipped"]
  E["Position calculated"] -- "log debug" --> F["Monitor geometry + clamped_y"]
  G["Capsule:state received"] -- "console.info" --> H["First event in webview"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Diagnostic logging</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>coordinator.rs</strong><dd><code>Add capsule handle missing warnings</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src-tauri/src/coordinator.rs

<ul><li>Added one-time warning logs when <code>window_handle()</code> or <br><code>RawWindowHandle::Win32</code> fails in <code>show_capsule_window_no_activate</code><br> <li> Added one-time warning log when capsule webview window is not found <br>during <code>emit_capsule</code></ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/593/files#diff-73d8c004670b27293f74f0f3991b9a6fc28f0ff0b883214de2b078b1e09797ca">+14/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>lib.rs</strong><dd><code>Add capsule position debug log</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src-tauri/src/lib.rs

<ul><li>Added a debug log for capsule positioning coordinates and monitor <br>bounds on Windows</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/593/files#diff-6b8eb1bbf8e378bab914f1a12962f7add5cc4ba9e013c37c9921a1032fa5e110">+9/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Capsule.tsx</strong><dd><code>Add first capsule event log</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src/components/Capsule.tsx

<ul><li>Added a one-time console.info log on the first <code>capsule:state</code> event <br>received in the webview</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/593/files#diff-864fa6eaba61a50b436891d4a11265927947abf4d5447192368d26b12e9eaa67">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

