### PR TITLE
fix(asr): stabilize MiMo HTTP tests on macOS

### DIFF
--- a/openless-all/app/src-tauri/src/asr/mimo.rs
+++ b/openless-all/app/src-tauri/src/asr/mimo.rs
@@ -335,6 +335,7 @@ mod tests {
                     Err(err) => panic!("accept MiMo ASR test request failed: {err}"),
                 }
             };
+            stream.set_nonblocking(false).unwrap();
             stream
                 .set_read_timeout(Some(Duration::from_secs(5)))
                 .unwrap();
@@ -387,6 +388,7 @@ mod tests {
                         Err(err) => panic!("accept MiMo ASR chunk request failed: {err}"),
                     }
                 };
+                stream.set_nonblocking(false).unwrap();
                 stream
                     .set_read_timeout(Some(Duration::from_secs(5)))
                     .unwrap();


### PR DESCRIPTION
### **User description**
## Summary
- Fix the post-merge macOS CI failure in MiMo ASR tests.
- Explicitly switch accepted TCP streams back to blocking mode in the local HTTP test server.
- Keeps the nonblocking listener polling, but makes request-body reads deterministic across macOS/Linux.

## Root Cause
The failing `beta` push run was `27059512049`, job `macOS checks`, step `Run Rust backend unit tests`.
`mimo_splits_audio_before_base64_limit` panicked on macOS with `WouldBlock` while reading the large local HTTP request body because the accepted `TcpStream` behaved as nonblocking. The client then saw `Connection reset by peer`.

## Test Plan
- [x] `cargo test --manifest-path "openless-all/app/src-tauri/Cargo.toml" mimo_splits_audio_before_base64_limit -- --test-threads=1`
- [x] `cargo test --manifest-path "openless-all/app/src-tauri/Cargo.toml" --lib`
- [x] `git diff --check`
- [x] `git diff --cached --check`

Follow-up to #607 / Refs #600


___

### **PR Type**
Bug fix


___

### **Description**
- Fix MiMo ASR test failure on macOS by setting accepted TCP streams to blocking mode


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mimo.rs</strong><dd><code>Add blocking mode to test HTTP streams</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src-tauri/src/asr/mimo.rs

<ul><li>Added <code>stream.set_nonblocking(false)</code> to two test helper functions after <br>accepting connections<br> <li> Prevents <code>WouldBlock</code> error on macOS when reading request body from <br>nonblocking streams</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/608/files#diff-481b30666a6e2e3b9296ac0cdba16c17d3da9051f59032aa810a2f02db80376c">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

