### PR TITLE
fix(linux): restore clipboard fallback after fcitx failure

### DIFF
--- a/openless-all/app/src-tauri/src/insertion.rs
+++ b/openless-all/app/src-tauri/src/insertion.rs
@@ -30,24 +30,21 @@ impl TextInserter {
         Self
     }
 
-    /// Linux 路径：仅走 fcitx5 CommitText 直写。无剪贴板 fallback。
+    /// Linux 路径：优先走 fcitx5 CommitText；插件不可用或提交失败时回退剪贴板粘贴。
     #[cfg(target_os = "linux")]
     pub fn insert(
         &self,
         text: &str,
-        _restore_clipboard_after_paste: bool,
-        _paste_shortcut: PasteShortcut,
+        restore_clipboard_after_paste: bool,
+        paste_shortcut: PasteShortcut,
     ) -> InsertStatus {
-        if text.is_empty() {
-            return InsertStatus::CopiedFallback;
-        }
-        match crate::linux_fcitx::commit_text(text) {
-            Ok(()) => InsertStatus::Inserted,
-            Err(e) => {
-                log::warn!("[insertion] fcitx commit_text failed: {e}");
-                InsertStatus::Failed
-            }
-        }
+        insert_with_fcitx_or_clipboard_fallback(
+            text,
+            restore_clipboard_after_paste,
+            paste_shortcut,
+            crate::linux_fcitx::commit_text,
+            insert_with_clipboard_restore,
+        )
     }
 
     /// Windows 路径：写剪贴板 + 模拟 `paste_shortcut`。
@@ -73,7 +70,10 @@ impl TextInserter {
         restore_clipboard_after_paste: bool,
         paste_shortcut: PasteShortcut,
     ) -> InsertStatus {
-        self.insert(text, restore_clipboard_after_paste, paste_shortcut)
+        if text.is_empty() {
+            return InsertStatus::CopiedFallback;
+        }
+        insert_with_clipboard_restore(text, restore_clipboard_after_paste, paste_shortcut)
     }
 
     #[cfg(target_os = "windows")]
@@ -116,6 +116,32 @@ impl TextInserter {
             InsertStatus::CopiedFallback
         } else {
             InsertStatus::Failed
+        }
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn insert_with_fcitx_or_clipboard_fallback<C, F>(
+    text: &str,
+    restore_clipboard_after_paste: bool,
+    paste_shortcut: PasteShortcut,
+    commit_text: C,
+    clipboard_fallback: F,
+) -> InsertStatus
+where
+    C: FnOnce(&str) -> Result<(), String>,
+    F: FnOnce(&str, bool, PasteShortcut) -> InsertStatus,
+{
+    if text.is_empty() {
+        return InsertStatus::CopiedFallback;
+    }
+    match commit_text(text) {
+        Ok(()) => InsertStatus::Inserted,
+        Err(err) => {
+            log::warn!(
+                "[insertion] fcitx commit_text failed, falling back to clipboard paste: {err}"
+            );
+            clipboard_fallback(text, restore_clipboard_after_paste, paste_shortcut)
         }
     }
 }
@@ -587,6 +613,81 @@ mod tests {
             );
         }
         assert_eq!(inserter.copy_fallback(""), InsertStatus::CopiedFallback);
+    }
+
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn linux_commit_text_success_skips_clipboard_fallback() {
+        let mut fallback_called = false;
+
+        let status = insert_with_fcitx_or_clipboard_fallback(
+            "dictated text",
+            true,
+            PasteShortcut::CtrlV,
+            |text| {
+                assert_eq!(text, "dictated text");
+                Ok(())
+            },
+            |_, _, _| {
+                fallback_called = true;
+                InsertStatus::CopiedFallback
+            },
+        );
+
+        assert_eq!(status, InsertStatus::Inserted);
+        assert!(!fallback_called);
+    }
+
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn linux_commit_text_failure_uses_clipboard_fallback() {
+        let mut fallback_args = None;
+
+        let status = insert_with_fcitx_or_clipboard_fallback(
+            "dictated text",
+            true,
+            PasteShortcut::CtrlShiftV,
+            |_| Err("plugin unavailable".to_string()),
+            |text, restore_clipboard_after_paste, paste_shortcut| {
+                fallback_args = Some((
+                    text.to_string(),
+                    restore_clipboard_after_paste,
+                    paste_shortcut,
+                ));
+                InsertStatus::CopiedFallback
+            },
+        );
+
+        assert_eq!(status, InsertStatus::CopiedFallback);
+        assert_eq!(
+            fallback_args,
+            Some(("dictated text".to_string(), true, PasteShortcut::CtrlShiftV))
+        );
+    }
+
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn linux_empty_insert_skips_commit_text_and_clipboard_fallback() {
+        let mut commit_called = false;
+        let mut fallback_called = false;
+
+        let status = insert_with_fcitx_or_clipboard_fallback(
+            "",
+            true,
+            PasteShortcut::CtrlV,
+            |_| {
+                commit_called = true;
+                Ok(())
+            },
+            |_, _, _| {
+                fallback_called = true;
+                InsertStatus::CopiedFallback
+            },
+        );
+
+        assert_eq!(status, InsertStatus::CopiedFallback);
+        assert!(!commit_called);
+        assert!(!fallback_called);
     }
 
     #[test]


### PR DESCRIPTION
### **User description**
## Summary
- keep Linux fcitx5 CommitText as the first insert path
- fall back to the existing clipboard paste path when fcitx commit_text fails
- make insert_via_clipboard_fallback bypass fcitx and exercise the real clipboard fallback directly
- add Linux branch tests for commit success, commit failure, and empty input

## Verification
- rustfmt --edition 2021 "openless-all/app/src-tauri/src/insertion.rs"
- cargo test --manifest-path "openless-all/app/src-tauri/Cargo.toml" insertion -- --test-threads=1
- cargo check --manifest-path "openless-all/app/src-tauri/Cargo.toml"
- git diff --check


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Refactor Linux insertion with clipboard fallback on fcitx failure

- Direct clipboard fallback for explicit fallback path

- Add Linux branch tests for key scenarios


___

### Diagram Walkthrough


```mermaid
flowchart LR
  insert["insert() call"] --> fcitx["fcitx commit_text"]
  fcitx -- success --> Inserted["InsertStatus::Inserted"]
  fcitx -- failure --> clipboard["clipboard paste fallback"]
  clipboard --> status["CopiedFallback / Failed"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>insertion.rs</strong><dd><code>Restructure Linux insertion with clipboard fallback</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src-tauri/src/insertion.rs

<ul><li>Restructured Linux <code>insert()</code> to use <br><code>insert_with_fcitx_or_clipboard_fallback</code><br> <li> <code>insert_via_clipboard_fallback</code> now bypasses fcitx and calls <br><code>insert_with_clipboard_restore</code> directly<br> <li> Added three unit tests for Linux: commit success skips fallback, <br>commit failure uses fallback, empty input returns CopiedFallback</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/610/files#diff-7babc246552969ca4ebaeedf3274ad6d1708d47fd4e699a1e70ba0395b11384d">+115/-14</a></td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

