### PR TITLE
fix(popup): 跨端弹窗一致性 — capsule 四边 clamp + Windows 句柄重试(#470) + qa 焦点契约(#466)

### DIFF
--- a/openless-all/app/src-tauri/src/coordinator/ime_insertion.rs
+++ b/openless-all/app/src-tauri/src/coordinator/ime_insertion.rs
@@ -515,6 +515,9 @@ pub(crate) fn show_capsule_window_no_activate<R: tauri::Runtime>(
             }
         }
     }
+    // 走到这里 hwnd 必为 Some：上面循环要么在 Win32 分支 break（hwnd 已赋值），
+    // 要么提前 return false。此 else 仅是 HANDLE_RETRY_ATTEMPTS == 0（循环体一次都不跑）
+    // 时的防御性兜底，当前常量为 5 时不可达，保留以防后续把次数改 0。
     let Some(hwnd) = hwnd else {
         return false;
     };

--- a/openless-all/app/src-tauri/src/coordinator/ime_insertion.rs
+++ b/openless-all/app/src-tauri/src/coordinator/ime_insertion.rs
@@ -479,19 +479,45 @@ pub(crate) fn show_capsule_window_no_activate<R: tauri::Runtime>(
         SWP_SHOWWINDOW, SW_SHOWNOACTIVATE,
     };
 
-    let Ok(handle) = window.window_handle() else {
-        // #470 诊断 v2：Win32 show 路径最可能的暗点之一。此前静默 return，
-        // 无法观测「胶囊完全不显示」是否卡在这里。
-        log::warn!(
-            "[capsule] no_activate failed: window_handle() unavailable — Win32 show skipped"
-        );
+    // #470：首帧 show 时 webview 句柄常常还没 realize（window_handle() 暂不可用），
+    // 此前一拿不到就 return false → 回落到会抢焦点的 window.show()，正是「胶囊不显示 /
+    // 焦点 churn」的主嫌。改为短暂有界重试：最多 5 次、每次 18ms（总 < 100ms），拿到
+    // Win32 句柄就走 no-activate 正常路径；全部失败才让调用方回落 show()。
+    // 本函数在 run_on_main_thread 闭包里同步执行（见 capsule.rs），短暂阻塞主线程是
+    // 可接受代价 —— 否则那一帧本就要走 show() 抢焦点。
+    const HANDLE_RETRY_ATTEMPTS: u32 = 5;
+    const HANDLE_RETRY_INTERVAL_MS: u64 = 18;
+    let mut hwnd: Option<HWND> = None;
+    for attempt in 0..HANDLE_RETRY_ATTEMPTS {
+        match window.window_handle() {
+            Ok(handle) => match handle.as_raw() {
+                RawWindowHandle::Win32(raw) => {
+                    hwnd = Some(HWND(raw.hwnd.get() as *mut _));
+                    break;
+                }
+                _ => {
+                    // 非 Win32 句柄不会随重试变化，直接放弃。
+                    log::warn!(
+                        "[capsule] no_activate failed: non-Win32 RawWindowHandle — Win32 show skipped"
+                    );
+                    return false;
+                }
+            },
+            Err(_) if attempt + 1 < HANDLE_RETRY_ATTEMPTS => {
+                std::thread::sleep(std::time::Duration::from_millis(HANDLE_RETRY_INTERVAL_MS));
+            }
+            Err(e) => {
+                // #470：重试耗尽仍拿不到句柄，记录后让调用方回落 show()。
+                log::warn!(
+                    "[capsule] no_activate failed: window_handle() unavailable after {HANDLE_RETRY_ATTEMPTS} retries ({e}) — Win32 show skipped"
+                );
+                return false;
+            }
+        }
+    }
+    let Some(hwnd) = hwnd else {
         return false;
     };
-    let RawWindowHandle::Win32(raw) = handle.as_raw() else {
-        log::warn!("[capsule] no_activate failed: non-Win32 RawWindowHandle — Win32 show skipped");
-        return false;
-    };
-    let hwnd = HWND(raw.hwnd.get() as *mut _);
 
     let _ = unsafe { ShowWindow(hwnd, SW_SHOWNOACTIVATE) };
     let _ = unsafe {

--- a/openless-all/app/src-tauri/src/lib.rs
+++ b/openless-all/app/src-tauri/src/lib.rs
@@ -1207,6 +1207,34 @@ fn bottom_visual_position(
     (x, y)
 }
 
+/// 把窗口左上角 `(x, y)`（同 area 同坐标系，physical px）夹到给定矩形内，
+/// **保证整窗（含自身 w×h）落在 area 内可见**。area 为工作区时即可避开任务栏。
+///
+/// 纯函数，无 Win32 依赖，便于单测多显示器 / 负原点 / 异常 DPI 输入。issue #470：
+/// 此前 Windows 分支只夹上边（`y.max(mon.top)`），左/右/下未夹，多屏负坐标下胶囊
+/// 可能被算到屏外却无任何观测。这里四边都夹。
+///
+/// area 比窗口还小时（`area_right - w < area_left`），`max_x` 退化为 `area_left`，
+/// `clamp` 把左上角收回 area 左上角，保证至少左上角可见、不溢出为负超界。
+#[cfg_attr(not(target_os = "windows"), allow(dead_code))]
+fn clamp_to_monitor(
+    x: i32,
+    y: i32,
+    w: i32,
+    h: i32,
+    area_left: i32,
+    area_top: i32,
+    area_right: i32,
+    area_bottom: i32,
+) -> (i32, i32) {
+    // 右/下边界 = area 右下角减去窗口自身尺寸，确保整窗可见。
+    let max_x = (area_right - w).max(area_left);
+    let max_y = (area_bottom - h).max(area_top);
+    let clamped_x = x.clamp(area_left, max_x);
+    let clamped_y = y.clamp(area_top, max_y);
+    (clamped_x, clamped_y)
+}
+
 /// 把 QA 浮窗放到屏幕底部居中、紧贴胶囊上方。tauri 启动期 + show 之前都会调一次，
 /// 防止用户切换显示器后位置错乱。
 fn position_qa_window<R: tauri::Runtime>(window: &tauri::WebviewWindow<R>) -> tauri::Result<()> {
@@ -1232,8 +1260,20 @@ fn position_qa_window<R: tauri::Runtime>(window: &tauri::WebviewWindow<R>) -> ta
 
 /// 显示 QA 窗口并发一条状态事件（前端订阅 `qa:state`）。
 /// `content_kind` 是不透明字符串（"loading" / "answer" / "idle" 等），
-/// 让前端 React 视图自行决定渲染哪一种。**不**抢前台 app 焦点（保证 Cmd+C
-/// fallback 仍能从原 app 拿到选区）。
+/// 让前端 React 视图自行决定渲染哪一种。
+///
+/// ## 跨端焦点契约（#164 / #466，三端**有意**不同，勿盲目对齐）
+/// - **macOS**：`orderFrontRegardless` —— 窗口可见但不成为 key window，frontmost
+///   始终是用户原 app，AX / Cmd+C fallback 能直接读到选区。**全程不抢焦点**。
+/// - **Windows**：`show_qa_window_no_activate` 实际是 `show()` + `set_focus()`，
+///   出现的那一帧会短暂抢前台。这是 #466 对 #164 的**有意取舍**：WebView2 子窗口有
+///   独立 focus 模型，不主动抓焦点则 QA webview 收不到键盘事件 → ESC 到不了 React
+///   监听、X 按钮 first-click 被 OS 当激活点击吃掉。代价由 `coordinator/qa.rs` 的
+///   focus-dance 补偿：抓选区前用 `qa_focus_target` 把焦点临时还给用户原 app，
+///   `simulate_copy` 跑完再 `refocus_qa_window` 收回。**移除 set_focus 会同时回归
+///   #164 的反面（ESC/X 失效），别删。** 详见 `show_qa_window_no_activate` 内注释。
+/// - **Linux**：`window.show()`。qa 窗口静态配置 `focus: false`（tauri.conf.json），
+///   Tauri 将其建成非激活窗口，因此 show() **不抢焦点**，与 macOS 契约一致。
 pub(crate) fn show_qa_window<R: tauri::Runtime>(app: &AppHandle<R>, content_kind: &str) {
     let Some(window) = app.get_webview_window("qa") else {
         log::info!("[qa] show 跳过：qa 窗口不存在 (content_kind={content_kind})");
@@ -1286,6 +1326,8 @@ pub(crate) fn show_qa_window<R: tauri::Runtime>(app: &AppHandle<R>, content_kind
             log::warn!("[qa] show fallback failed: {e}");
         }
     }
+    // Linux：qa 窗口静态配置 focus:false → Tauri 建成非激活窗口，window.show() 不抢
+    // 焦点，与 macOS「不抢焦点」契约一致（无需 Windows 那套 set_focus + focus-dance）。
     #[cfg(all(not(target_os = "macos"), not(target_os = "windows")))]
     if let Err(e) = window.show() {
         log::warn!("[qa] show failed: {e}");
@@ -1582,6 +1624,12 @@ pub(crate) struct ForegroundMonitor {
     pub(crate) top: i32,
     pub(crate) right: i32,
     pub(crate) bottom: i32,
+    /// 工作区矩形（physical px，去掉任务栏）。多端一致：胶囊优先夹到工作区内，
+    /// 避免压住任务栏。取不到时回退为整屏矩形。issue #470。
+    pub(crate) work_left: i32,
+    pub(crate) work_top: i32,
+    pub(crate) work_right: i32,
+    pub(crate) work_bottom: i32,
     /// 该显示器的有效 DPI 缩放（1.0 = 96dpi）。
     pub(crate) scale: f64,
 }
@@ -1619,6 +1667,10 @@ pub(crate) fn foreground_window_monitor() -> Option<ForegroundMonitor> {
             top: mi.rcMonitor.top,
             right: mi.rcMonitor.right,
             bottom: mi.rcMonitor.bottom,
+            work_left: mi.rcWork.left,
+            work_top: mi.rcWork.top,
+            work_right: mi.rcWork.right,
+            work_bottom: mi.rcWork.bottom,
             scale: (dpi_x as f64 / 96.0).max(0.1),
         })
     }
@@ -1651,15 +1703,24 @@ pub(crate) fn position_capsule_bottom_center<R: tauri::Runtime>(
             let offset_from_bottom =
                 (capsule_visual_height(translation_active) + 80.0 + bounds.bottom_inset) * scale;
             let y = ((mon.bottom as f64) - offset_from_bottom).round() as i32;
-            let clamped_y = y.max(mon.top);
-            // #470 诊断 v2：当前只夹了上边（.max(mon.top)），未夹下/左/右。多显示器、
-            // 负坐标或异常 DPI 下胶囊可能被算到屏幕外却无任何观测。记录显示器几何与
-            // 最终落点，用于证伪/证实「胶囊定位到屏幕外」(C 子嫌疑)。
+
+            // #470：四边都夹到「工作区」内（去掉任务栏），保证整窗可见。GetMonitorInfoW
+            // 取不到 rcWork 时（理论上不会，rcWork 总随 rcMonitor 一同填）退回整屏矩形。
+            let (work_l, work_t, work_r, work_b) =
+                if mon.work_right > mon.work_left && mon.work_bottom > mon.work_top {
+                    (mon.work_left, mon.work_top, mon.work_right, mon.work_bottom)
+                } else {
+                    (mon.left, mon.top, mon.right, mon.bottom)
+                };
+            let (clamped_x, clamped_y) =
+                clamp_to_monitor(x, y, phys_w, phys_h, work_l, work_t, work_r, work_b);
             log::debug!(
-                "[capsule] win position: mon=({},{})..({},{}) scale={:.2} size=({}x{}) -> x={} y={} clamped_y={}",
-                mon.left, mon.top, mon.right, mon.bottom, scale, phys_w, phys_h, x, y, clamped_y
+                "[capsule] win position: mon=({},{})..({},{}) work=({},{})..({},{}) scale={:.2} size=({}x{}) -> raw=({},{}) clamped=({},{})",
+                mon.left, mon.top, mon.right, mon.bottom,
+                work_l, work_t, work_r, work_b,
+                scale, phys_w, phys_h, x, y, clamped_x, clamped_y
             );
-            window.set_position(PhysicalPosition::new(x, clamped_y))?;
+            window.set_position(PhysicalPosition::new(clamped_x, clamped_y))?;
             return Ok(());
         }
         // 仅当 Win32 取不到前台显示器时，落回下面的 current_monitor 逻辑。
@@ -1740,7 +1801,7 @@ fn capsule_height_for_qa() -> f64 {
 mod tests {
     use super::{
         bottom_center_position, bottom_visual_position, capsule_height_for_qa,
-        capsule_visual_height, capsule_window_bounds, logical_monitor_frame,
+        capsule_visual_height, capsule_window_bounds, clamp_to_monitor, logical_monitor_frame,
         parse_tray_polish_mode_id, rotate_log_if_too_large, tray_polish_mode_menu_entries,
         tray_style_menu_enabled, LogicalMonitorFrame, LOG_ROTATE_LIMIT_BYTES,
     };
@@ -1887,6 +1948,54 @@ mod tests {
         let pos = bottom_visual_position(frame, 220.0, 96.0, 80.0, 0.0);
 
         assert_eq!(pos, (610.0, -176.0));
+    }
+
+    // ---- #470: capsule 四边 clamp（纯函数，合成多显示器 / 负原点 / 1.5x DPI 输入）----
+
+    #[test]
+    fn clamp_to_monitor_leaves_on_screen_position_untouched() {
+        // 1080p 主屏正中偏下，整窗本就可见 → 原样返回。
+        let (x, y) = clamp_to_monitor(800, 900, 264, 126, 0, 0, 1920, 1040);
+        assert_eq!((x, y), (800, 900));
+    }
+
+    #[test]
+    fn clamp_to_monitor_pulls_back_off_screen_right_and_bottom() {
+        // x/y 算到了屏幕右下外侧 → 收回到「右下角减去窗口尺寸」，整窗仍可见。
+        let (x, y) = clamp_to_monitor(2000, 1200, 264, 126, 0, 0, 1920, 1040);
+        assert_eq!((x, y), (1920 - 264, 1040 - 126));
+        // 整窗右/下边界都落在 area 内。
+        assert!(x + 264 <= 1920);
+        assert!(y + 126 <= 1040);
+    }
+
+    #[test]
+    fn clamp_to_monitor_pushes_into_negative_origin_left_monitor() {
+        // 副屏在主屏左侧（负 X 原点），落点算到了副屏左外侧 → 夹回 area_left。
+        // 1.5x DPI 下尺寸偏大，但 area 仍宽于窗口，左上角夹到 (-2560, top)。
+        let (x, y) = clamp_to_monitor(-3000, -100, 294, 138, -2560, 0, 0, 1440);
+        assert_eq!(x, -2560);
+        assert_eq!(y, 0);
+        // 右/下仍在 area 内。
+        assert!(x >= -2560 && x + 294 <= 0);
+        assert!(y >= 0 && y + 138 <= 1440);
+    }
+
+    #[test]
+    fn clamp_to_monitor_respects_work_area_above_taskbar() {
+        // 工作区底部 = 1040（任务栏占了 1040..1080）。落点本在任务栏区域（y=1030），
+        // 应被夹到「工作区底 - 窗口高」之上，胶囊整窗不压任务栏。
+        let (_x, y) = clamp_to_monitor(800, 1030, 264, 126, 0, 0, 1920, 1040);
+        assert_eq!(y, 1040 - 126);
+        assert!(y + 126 <= 1040);
+    }
+
+    #[test]
+    fn clamp_to_monitor_degrades_gracefully_when_window_wider_than_area() {
+        // 病态输入：area 比窗口还窄（罕见，但要保证不 panic、不溢出为负超界）。
+        // max_x 钳到 area_left，clamp 把左上角收回 area_left。
+        let (x, y) = clamp_to_monitor(500, 500, 800, 600, 0, 0, 400, 300);
+        assert_eq!((x, y), (0, 0));
     }
 
     #[test]

--- a/openless-all/app/src-tauri/src/lib.rs
+++ b/openless-all/app/src-tauri/src/lib.rs
@@ -1228,8 +1228,9 @@ fn clamp_to_monitor(
     area_bottom: i32,
 ) -> (i32, i32) {
     // 右/下边界 = area 右下角减去窗口自身尺寸，确保整窗可见。
-    let max_x = (area_right - w).max(area_left);
-    let max_y = (area_bottom - h).max(area_top);
+    // 用 saturating_sub 防 area_right/area_bottom 为极小（含 i32::MIN 近邻）时减法溢出。
+    let max_x = area_right.saturating_sub(w).max(area_left);
+    let max_y = area_bottom.saturating_sub(h).max(area_top);
     let clamped_x = x.clamp(area_left, max_x);
     let clamped_y = y.clamp(area_top, max_y);
     (clamped_x, clamped_y)
@@ -1967,6 +1968,15 @@ mod tests {
         // 整窗右/下边界都落在 area 内。
         assert!(x + 264 <= 1920);
         assert!(y + 126 <= 1040);
+    }
+
+    #[test]
+    fn clamp_to_monitor_pulls_back_when_right_edge_overflows_inside_area() {
+        // 左上角 x=1800 本在 area 内，但 x+w=2064 越过右边界 1920 →
+        // 应被左移到「右边界 - 窗口宽」，整窗右缘恰好贴住 area_right。
+        let (x, _y) = clamp_to_monitor(1800, 900, 264, 126, 0, 0, 1920, 1040);
+        assert_eq!(x, 1920 - 264);
+        assert!(x + 264 <= 1920);
     }
 
     #[test]


### PR DESCRIPTION
### **User description**
## 跨端弹窗一致性修复（task 1d 落地）

承接审计：Less Computer agent 弹窗设计上仅 macOS（trivially 一致）；真正的跨端分歧在 **capsule** 与 **qa**（均为既有 #470/#466 历史问题）。本 PR 修复之。

### 修复 1 — capsule 定位四边 clamp（`lib.rs`）
- 抽出纯函数 `clamp_to_monitor(x,y,w,h, area)`，保证整窗落在显示器内。
- Windows `position_capsule_bottom_center` 原**只夹顶边**（#470 飘屏根因之一）→ 改为**四边都夹**，优先夹到工作区 `rcWork`（避开任务栏）。`ForegroundMonitor` 加 work area 字段（复用 `GetMonitorInfoW` 已返回的 `rcWork`，无新 Win32 调用）。
- **5 个新单测**：屏内不动 / 右下越界回拉 / 负原点左副屏 / 工作区避任务栏 / 病态超宽输入。

### 修复 2 — Windows capsule 句柄重试（`coordinator/ime_insertion.rs`）
- `show_capsule_window_no_activate` 原「句柄一拿不到就回落抢焦点 `show()`」（#470 不显示/焦点churn）→ 改为**有界重试**（≤5×18ms，<100ms）拿 Win32 句柄；全失败才回落。

### 修复 3 — qa 焦点契约（**保守：仅文档化，不改运行时**）
- 查清 `set_focus()` 是 **#466 有意加的**（WebView2 子窗口不抓焦点则 ESC 到不了 React、X 按钮首击被吞），由 `qa.rs` 的 focus-dance 补偿。**移除会回归 #466**，故不动运行时，只把三端焦点契约差异写入 `show_qa_window` 文档注释。

### 验证
`cargo check` 0 error / `cargo test --lib` **424 passed**（419 基线 + 5 clamp）/ `npm build` 绿。

### ⚠️ 需 Windows 实测（mac 本机编不到）
修复 1 的 Windows 物理坐标分支、修复 2 的句柄重试整段——本机仅验证了纯函数 `clamp_to_monitor`（5 测）+ cargo check + cfg 完整；真实「多显示器+任务栏+WebView2」端到端表现需 CI + Windows 实测。

> base = `refactor/srp-split-dedup`（stacked，合并顺序：#597 → #615 → 本 PR）。


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fix Windows capsule handle retry with bounded retries (up to 5 attempts, ~100ms max)

- Fix capsule positioning: clamp all four edges to work area (avoid off-screen and taskbar)

- Add work area to ForegroundMonitor and update capsule position calculation

- Add comprehensive unit tests for clamp_to_monitor function

- Document qa focus contract across platforms (no runtime change)


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ime_insertion.rs</strong><dd><code>Add bounded retry for Windows capsule handle</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src-tauri/src/coordinator/ime_insertion.rs

<ul><li>Add bounded retry (max 5 attempts, ~18ms each) for Win32 handle in <br>show_capsule_window_no_activate<br> <li> If handle unavailable after retries, fall back to show() as before<br> <li> Handle non-Win32 handle early failure</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/616/files#diff-873e42cfbdd894ae7fe8e3bf0bd9ad88e32f013e3a2eadabc1b3c2dd47d694f6">+40/-11</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>lib.rs</strong><dd><code>Add clamp_to_monitor function and work area usage</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src-tauri/src/lib.rs

<ul><li>Extract clamp_to_monitor function to clamp window to rect (four edges)<br> <li> Use work area (rcWork) for capsule positioning to avoid taskbar<br> <li> Add work area fields to ForegroundMonitor struct<br> <li> Update capsule position calculation to clamp both x and y<br> <li> Add comprehensive unit tests for clamp_to_monitor<br> <li> Document qa focus contract across platforms (no runtime change)</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/616/files#diff-6b8eb1bbf8e378bab914f1a12962f7add5cc4ba9e013c37c9921a1032fa5e110">+129/-10</a></td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

