### PR TITLE
fix(history): 历史页搜索框可点击、可搜索 (#612)

### DIFF
--- a/openless-all/app/src/i18n/en.ts
+++ b/openless-all/app/src/i18n/en.ts
@@ -265,6 +265,8 @@ export const en: typeof zhCN = {
     desc: 'Locally stored transcripts.',
     filterAll: 'All',
     summary: '{{total}} total · showing {{shown}}',
+    searchPlaceholder: 'Search transcripts… ({{shortcut}})',
+    searchNoMatch: 'No entries match “{{query}}”.',
     empty: 'No history yet. Press {{trigger}} to record one.',
     loadFailed: 'Failed to load history: {{err}}',
     retry: 'Retry',

--- a/openless-all/app/src/i18n/ja.ts
+++ b/openless-all/app/src/i18n/ja.ts
@@ -267,6 +267,8 @@ export const ja: typeof zhCN = {
     desc: 'ローカルに保存された認識記録。',
     filterAll: 'すべて',
     summary: '合計 {{total}} 件 · 表示 {{shown}}',
+    searchPlaceholder: '文字起こしを検索…（{{shortcut}}）',
+    searchNoMatch: '「{{query}}」に一致する項目はありません。',
     empty: '履歴がありません。{{trigger}} を押して録音してみましょう。',
     loadFailed: '履歴の読み込みに失敗：{{err}}',
     retry: '再試行',

--- a/openless-all/app/src/i18n/ko.ts
+++ b/openless-all/app/src/i18n/ko.ts
@@ -267,6 +267,8 @@ export const ko: typeof zhCN = {
     desc: '로컬에 저장된 인식 기록.',
     filterAll: '전체',
     summary: '총 {{total}}건 · 표시 {{shown}}',
+    searchPlaceholder: '기록 검색…（{{shortcut}}）',
+    searchNoMatch: '“{{query}}”과(와) 일치하는 항목이 없습니다.',
     empty: '기록이 없습니다. {{trigger}} 를 눌러 한 번 녹음해 보세요.',
     loadFailed: '기록 로드 실패: {{err}}',
     retry: '다시 시도',

--- a/openless-all/app/src/i18n/zh-CN.ts
+++ b/openless-all/app/src/i18n/zh-CN.ts
@@ -263,6 +263,8 @@ export const zhCN = {
     desc: '本机保存的识别记录。',
     filterAll: '全部',
     summary: '共 {{total}} 条 · 显示 {{shown}}',
+    searchPlaceholder: '搜索转写内容…（{{shortcut}}）',
+    searchNoMatch: '没有匹配「{{query}}」的记录。',
     empty: '还没有历史记录。按 {{trigger}} 录一段试试。',
     loadFailed: '加载历史失败：{{err}}',
     retry: '重试',

--- a/openless-all/app/src/i18n/zh-TW.ts
+++ b/openless-all/app/src/i18n/zh-TW.ts
@@ -265,6 +265,8 @@ export const zhTW: typeof zhCN = {
     desc: '本機保存的識別記錄。',
     filterAll: '全部',
     summary: '共 {{total}} 條 · 顯示 {{shown}}',
+    searchPlaceholder: '搜尋轉寫內容…（{{shortcut}}）',
+    searchNoMatch: '沒有符合「{{query}}」的記錄。',
     empty: '還沒有歷史記錄。按 {{trigger}} 錄一段試試。',
     loadFailed: '加載歷史失敗：{{err}}',
     retry: '重試',

--- a/openless-all/app/src/pages/History.tsx
+++ b/openless-all/app/src/pages/History.tsx
@@ -1,7 +1,7 @@
 // History.tsx — 接 Tauri 后端 list_history / delete_history_entry / clear_history。
 // 真实数据来自 ~/Library/Application Support/OpenLess/history.json。
 
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Icon } from '../components/Icon';
 import { detectOS } from '../components/WindowChrome';
@@ -38,6 +38,9 @@ export function History() {
   const FILTERS = useFilters();
   const MODE_LABEL = useModeLabel();
   const [filter, setFilter] = useState<'all' | PolishMode>('all');
+  // issue #612：历史页顶部原为静态 div，只显示统计、不可输入。改为真实搜索框。
+  const [query, setQuery] = useState('');
+  const searchRef = useRef<HTMLInputElement>(null);
   const [items, setItems] = useState<DictationSession[]>([]);
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
@@ -80,10 +83,29 @@ export function History() {
     void refresh();
   }, [refresh]);
 
-  const filtered = useMemo(
-    () => (filter === 'all' ? items : items.filter(s => s.mode === filter)),
-    [items, filter],
-  );
+  // ⌘K / Ctrl+K 聚焦搜索框（issue #612 验收可选项）。
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && (e.key === 'k' || e.key === 'K')) {
+        e.preventDefault();
+        searchRef.current?.focus();
+      }
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, []);
+
+  const filtered = useMemo(() => {
+    const byMode = filter === 'all' ? items : items.filter(s => s.mode === filter);
+    const q = query.trim().toLowerCase();
+    if (!q) return byMode;
+    return byMode.filter(
+      s =>
+        s.finalText.toLowerCase().includes(q) ||
+        s.rawTranscript.toLowerCase().includes(q) ||
+        (s.appName ?? '').toLowerCase().includes(q),
+    );
+  }, [items, filter, query]);
   const item = useMemo(
     () => filtered.find(s => s.id === selectedId) || filtered[0],
     [filtered, selectedId],
@@ -181,12 +203,26 @@ export function History() {
           <div style={{ padding: '12px 14px', borderBottom: '0.5px solid var(--ol-line)' }}>
             <div style={{
               display: 'flex', alignItems: 'center', gap: 6,
-              padding: '6px 10px', fontSize: 12,
+              padding: '6px 10px',
               border: '0.5px solid var(--ol-line-strong)', borderRadius: 8,
               background: 'var(--ol-surface-2)', color: 'var(--ol-ink-3)',
             }}>
               <Icon name="search" size={12} />
-              <span style={{ flex: 1 }}>{t('history.summary', { total: items.length, shown: filtered.length })}</span>
+              <input
+                ref={searchRef}
+                type="search"
+                value={query}
+                onChange={e => setQuery(e.target.value)}
+                placeholder={t('history.searchPlaceholder', { shortcut: os === 'mac' ? '⌘K' : 'Ctrl+K' })}
+                style={{
+                  flex: 1, minWidth: 0, outline: 'none', border: 0,
+                  background: 'transparent', fontSize: 12, color: 'var(--ol-ink-2)',
+                  fontFamily: 'inherit',
+                }}
+              />
+            </div>
+            <div style={{ marginTop: 8, fontSize: 11, color: 'var(--ol-ink-4)' }}>
+              {t('history.summary', { total: items.length, shown: filtered.length })}
             </div>
             <div style={{ display: 'flex', gap: 4, flexWrap: 'wrap', marginTop: 10 }}>
               {FILTERS.map(f => (
@@ -220,7 +256,9 @@ export function History() {
             )}
             {!loading && !loadError && filtered.length === 0 && (
               <div style={{ padding: 16, fontSize: 12, color: 'var(--ol-ink-4)' }}>
-                {t('history.empty', { trigger: prefs ? formatComboLabel(prefs.dictationHotkey) : '' })}
+                {query.trim()
+                  ? t('history.searchNoMatch', { query: query.trim() })
+                  : t('history.empty', { trigger: prefs ? formatComboLabel(prefs.dictationHotkey) : '' })}
               </div>
             )}
             {!loadError && filtered.map(s => (


### PR DESCRIPTION
### **User description**
## 背景

issue #612：设置 → 历史记录页，顶部带搜索图标的区域无法点击、无法获得焦点、无法输入，只能看到「共 N 条 · 显示 M」统计文案，无法按关键词过滤历史条目。`History.tsx` 实现为静态 `div`，未使用 `input`，也无搜索逻辑。

## 改动（`History.tsx` + 5 个 i18n，单一职责）

- 把伪装成搜索框的静态 `<span>` 替换为真实 `<input type="search">`，可聚焦、可输入；原统计文案下移为独立小字行。
- 输入后**实时过滤**左侧列表：匹配 `finalText` / `rawTranscript` / `appName`（大小写不敏感、`trim`），与现有 mode 筛选叠加。
- 清空关键词恢复显示全部（受当前 mode 筛选）。
- **⌘K / Ctrl+K** 聚焦搜索框（设计稿 `pages.jsx` 预期）。
- 搜索无结果时显示专门提示 `history.searchNoMatch`，区别于「暂无历史」。
- 新增 i18n：`history.searchPlaceholder` / `history.searchNoMatch`（en / ja / ko / zh-CN / zh-TW）。

`type="search"` 在 WebKit 内提供原生清除按钮，无需自绘。

## 验收对照

- [x] 顶部搜索区域可点击并获得焦点、支持输入关键词
- [x] 实时按 rawTranscript / finalText 过滤左侧列表（额外含 appName）
- [x] 清空搜索词恢复显示全部
- [x] ⌘K / Ctrl+K 聚焦搜索框

## 验证

- `npm run build`（tsc 类型检查 + vite 构建）✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Bug fix


___

### **Description**
- Replace static div with real <input type="search">

- Add real-time filtering by finalText/rawTranscript/appName

- Add keyboard shortcut (⌘K/Ctrl+K) to focus search box

- Add i18n keys for search placeholder and no-match message


___

### Diagram Walkthrough


```mermaid
flowchart LR
  User["User types query"] --> Input["Search input (real <input>)"]
  Input --> Filter["Filter list by finalText/rawTranscript/appName"]
  Filter --> List["Show matching entries or no-match message"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Localization</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>en.ts</strong><dd><code>Add i18n keys for search placeholder and no-match (en)</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src/i18n/en.ts

<ul><li>Added <code>history.searchPlaceholder</code> with shortcut interpolation<br> <li> Added <code>history.searchNoMatch</code> for empty search results</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/627/files#diff-bb2f4fa05787923f8aeb23b6f11ad8705e02d9ff03a45790f9181e4615c79d83">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ja.ts</strong><dd><code>Add i18n keys for search placeholder and no-match (ja)</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src/i18n/ja.ts

<ul><li>Added <code>history.searchPlaceholder</code> translation<br> <li> Added <code>history.searchNoMatch</code> translation</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/627/files#diff-be57f0090cf34e3ff924cfa35f13d5d9e6514d3af5a1ebfdeb92bd7d36ed9cf4">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ko.ts</strong><dd><code>Add i18n keys for search placeholder and no-match (ko)</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src/i18n/ko.ts

<ul><li>Added <code>history.searchPlaceholder</code> translation<br> <li> Added <code>history.searchNoMatch</code> translation</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/627/files#diff-daf35bcb6a2f8a31565b83d119cb59b69c1dededbabfccfd0d56693fdb3726ca">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>zh-CN.ts</strong><dd><code>Add i18n keys for search placeholder and no-match (zh-CN)</code></dd></summary>
<hr>

openless-all/app/src/i18n/zh-CN.ts

<ul><li>Added <code>history.searchPlaceholder</code> translation<br> <li> Added <code>history.searchNoMatch</code> translation</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/627/files#diff-571576f3c7b6c4a78ae0f91accdccc5da5cbed00409955c9914c046fee6c80ea">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>zh-TW.ts</strong><dd><code>Add i18n keys for search placeholder and no-match (zh-TW)</code></dd></summary>
<hr>

openless-all/app/src/i18n/zh-TW.ts

<ul><li>Added <code>history.searchPlaceholder</code> translation<br> <li> Added <code>history.searchNoMatch</code> translation</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/627/files#diff-a8d5953f9c76bc3c90ec583270be04c852bd7540297500e6ff3260760fc61ea4">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>History.tsx</strong><dd><code>Implement search input and filtering logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src/pages/History.tsx

<ul><li>Imports <code>useRef</code> and <code>useState</code> for search query state<br> <li> Adds <code>query</code> state and <code>searchRef</code> ref<br> <li> Adds keyboard shortcut listener (⌘K/Ctrl+K) to focus search<br> <li> Updates <code>filtered</code> memo to include keyword matching on finalText, <br>rawTranscript, appName<br> <li> Replaces static <code><span></code> with real <code><input type="search"></code> element<br> <li> Moves summary text below the search bar<br> <li> Displays <code>searchNoMatch</code> text when query is non-empty and results empty</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/627/files#diff-46c1ec3909029ec66e43bf7cab4914b700aad500151f9ed7f569936df22d5528">+46/-8</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

