### PR TITLE
fix(settings): 设置弹窗用 Portal 渲染避免被页面滚动条覆盖 (#580)

### DIFF
--- a/openless-all/app/src/components/SettingsModal.tsx
+++ b/openless-all/app/src/components/SettingsModal.tsx
@@ -8,6 +8,7 @@
 // 不在此弹窗出现。
 
 import { useLayoutEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
 import { useTranslation } from 'react-i18next';
 import { Icon } from './Icon';
 import { SavedToast } from './SavedToast';
@@ -69,11 +70,15 @@ export function SettingsModal({ os: _os, onClose, initialSettingsSection }: Sett
     setPillRect({ top: el.offsetTop, height: el.offsetHeight });
   }, [section]);
 
-  return (
+  // issue #580：用 Portal 渲染到 document.body，脱离页面 overflow:hidden 容器的
+  // stacking context。否则 WebKitGTK（Debian/KDE Wayland）下页面自绘滚动条
+  // (.ol-thinscroll) 不创建独立合成层，z-index 无法隔离，滚动时会盖在弹窗之上。
+  // 配合 position:fixed 覆盖整窗。
+  return createPortal(
     <div
       onClick={onClose}
       style={{
-        position: 'absolute', inset: 0,
+        position: 'fixed', inset: 0,
         background: 'rgba(15,17,22,0.32)',
         backdropFilter: 'blur(8px) saturate(140%)',
         WebkitBackdropFilter: 'blur(8px) saturate(140%)',
@@ -205,7 +210,8 @@ export function SettingsModal({ os: _os, onClose, initialSettingsSection }: Sett
           </div>
         </div>
       </div>
-    </div>
+    </div>,
+    document.body,
   );
 }
 


### PR DESCRIPTION
### **User description**
## 背景

issue #580：在历史记录页 / 风格页上下滑动后打开设置弹窗，页面的自定义滚动条（`.ol-thinscroll`）会覆盖在设置弹窗之上。报告者环境 Debian KDE Wayland（WebKitGTK），仅在滚动时出现。

## 根因

`SettingsModal` 遮罩层用 `position: absolute; z-index: 50`，但它和页面滚动条处在同一个 `overflow: hidden` 祖容器的 stacking context 内。WebKitGTK 下滚动条是元素自绘的一部分，不创建独立合成层，`z-index` 对其无效。issue 中已验证 `position: fixed`、主容器 `isolation: isolate` 均无效——因为问题不在 z-index 数值，而在于弹窗没有脱离那个 stacking context。

## 改动（仅 `SettingsModal.tsx`，单一职责）

- 用 `createPortal` 把弹窗渲染到 `document.body`，彻底脱离页面 DOM 树与 `overflow:hidden` 祖容器的 stacking context（与现有 `SelectLite` popover 同款做法）。
- 遮罩层 `position` 由 `absolute` 改为 `fixed`，覆盖整窗；视觉与交互（点遮罩关闭、毛玻璃背景、居中卡片动画）均不变。
- 设计 token 定义在 `:root`，`body` 下的 portal 正常继承，无样式丢失。

## 验证

- `npm run build`（tsc + vite）✅
- 平台验证：根因属 WebKitGTK 滚动条行为，建议在 Debian/KDE Wayland 上回归（reporter 环境）；Portal 脱离 stacking context 是该类问题的标准解法。

> 注：`MarketplaceModal` 用了同款 backdrop 结构，理论上有相同隐患；为保持单一职责本 PR 未一并改动，可后续跟进。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Bug fix


___

### **Description**
- 用 Portal 渲染设置弹窗，脱离 stacking context

- 遮罩层改为 fixed 覆盖整窗

- 修复 WebKitGTK 下滚动条覆盖问题


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>SettingsModal.tsx</strong><dd><code>设置弹窗使用 Portal 渲染</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src/components/SettingsModal.tsx

<ul><li>导入 <code>createPortal</code><br> <li> 使用 <code>createPortal</code> 将弹窗渲染到 <code>document.body</code><br> <li> 遮罩层 <code>position</code> 从 <code>absolute</code> 改为 <code>fixed</code><br> <li> 添加解释注释说明问题根因</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/628/files#diff-518aaa44065a9800e52b80d874e513ea210188d25cba2cff3e258b88c05c96cf">+9/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

