### PR TITLE
fix(polish): Traditional 模式强制中文字形转换，不再只靠 prompt (#622)

### DIFF
--- a/openless-all/app/src-tauri/src/coordinator/dictation.rs
+++ b/openless-all/app/src-tauri/src/coordinator/dictation.rs
@@ -341,7 +341,48 @@ mod tests {
             false,
             PolishMode::Light,
             false,
+            crate::types::ChineseScriptPreference::Auto,
         ));
+    }
+
+    // issue #622：非 Auto 字形偏好必须关闭流式，改走会做字形转换的一次性路径。
+    #[test]
+    fn streaming_insert_ineligible_when_chinese_script_forced() {
+        for pref in [
+            crate::types::ChineseScriptPreference::Traditional,
+            crate::types::ChineseScriptPreference::Simplified,
+        ] {
+            assert!(!streaming_insert_eligible(
+                true,
+                false,
+                PolishMode::Light,
+                false,
+                pref,
+            ));
+        }
+    }
+
+    // issue #622：非 Auto + 成功 LLM 润色（非流式、无 error）时，最终插入文字
+    // 必须套用字形转换，不能只靠 prompt 指示。覆盖 issue 给出的两个验收用例。
+    #[test]
+    fn finalize_forces_traditional_even_on_successful_polish() {
+        let cases = [
+            ("你知道你今天想要做什么吗？", "你知道你今天想要做什麼嗎？"),
+            ("所以你已经考过了吗？", "所以你已經考過了嗎？"),
+        ];
+        for (input, expected) in cases {
+            let out = finalize_polished_text(
+                input.to_string(),
+                false,             // translation_active
+                true,              // raw_uses_llm
+                PolishMode::Light, // 成功润色路径（非 Raw、非 error）
+                &None,             // 无 polish_error
+                crate::types::ChineseScriptPreference::Traditional,
+                &[],   // 无 correction rules
+                false, // already_streamed
+            );
+            assert_eq!(out, expected);
+        }
     }
 
     #[test]

--- a/openless-all/app/src-tauri/src/coordinator/dictation_end.rs
+++ b/openless-all/app/src-tauri/src/coordinator/dictation_end.rs
@@ -531,6 +531,7 @@ pub(crate) async fn end_session(inner: &Arc<Inner>) -> Result<(), String> {
         translation_active,
         mode,
         raw_uses_llm,
+        chinese_script_preference,
     );
     log::info!(
         "[coord] polish dispatch: translation={translation_active} mode={mode:?} streaming_eligible={streaming_eligible}"

--- a/openless-all/app/src-tauri/src/coordinator/dictation_streaming.rs
+++ b/openless-all/app/src-tauri/src/coordinator/dictation_streaming.rs
@@ -345,10 +345,10 @@ where
 
 pub(crate) fn finalize_polished_text(
     polished: String,
-    translation_active: bool,
+    _translation_active: bool,
     _raw_uses_llm: bool,
-    mode: PolishMode,
-    polish_error: &Option<String>,
+    _mode: PolishMode,
+    _polish_error: &Option<String>,
     chinese_script_preference: crate::types::ChineseScriptPreference,
     correction_rules: &[crate::types::CorrectionRule],
     already_streamed: bool,
@@ -356,16 +356,12 @@ pub(crate) fn finalize_polished_text(
     if already_streamed {
         return polished;
     }
-    let should_force_script = if translation_active {
-        polish_error.is_some()
-    } else {
-        mode == PolishMode::Raw || polish_error.is_some()
-    };
-    let polished = if should_force_script {
-        apply_chinese_script_preference(&polished, chinese_script_preference)
-    } else {
-        polished
-    };
+    // issue #622：无论是否经 LLM 润色成功，插入前都套用中文字形转换。
+    // apply_chinese_script_preference 对 Auto 是 no-op；非 Auto 时确保最终插入文字
+    // 不混简体——此前仅 Raw / 翻译 / 润色失败时强制转换，成功润色只靠 prompt 指示，
+    // 而部分 provider 会跟随简体 ASR 输入继续输出简体（流式路径已在上游回退为一次性，
+    // 见 streaming_insert_eligible）。
+    let polished = apply_chinese_script_preference(&polished, chinese_script_preference);
     if correction_rules.is_empty() {
         polished
     } else {
@@ -386,8 +382,14 @@ pub(crate) fn streaming_insert_eligible(
     translation_active: bool,
     mode: PolishMode,
     raw_uses_llm: bool,
+    chinese_script_preference: crate::types::ChineseScriptPreference,
 ) -> bool {
-    streaming_insert_enabled && !translation_active && (mode != PolishMode::Raw || raw_uses_llm)
+    streaming_insert_enabled
+        && !translation_active
+        && (mode != PolishMode::Raw || raw_uses_llm)
+        // issue #622：非 Auto 字形偏好需在插入前整体转换；流式逐字落字无法回退，
+        // 故关闭流式、走一次性路径（由 finalize_polished_text 套用字形转换）。
+        && chinese_script_preference == crate::types::ChineseScriptPreference::Auto
 }
 
 pub(crate) fn default_done_message(status: InsertStatus, polish_failed: bool) -> Option<String> {


### PR DESCRIPTION
### **User description**
## 背景

issue #622：当 Chinese Script Preference 设为 **Traditional** 时，OpenLess 最终插入的文字仍可能含简体中文（台湾繁体用户实测）。验收用例：

```
Input:  你知道你今天想要做什么吗？     →  Expected: 你知道你今天想要做什麼嗎？
Input:  所以你已经考过了吗？           →  Expected: 所以你已經考過了嗎？
```

## 根因

1. `finalize_polished_text` 只在 **Raw / 翻译 / 润色失败** 时强制 `apply_chinese_script_preference`；普通模式 LLM 润色**成功**时仅靠 system prompt 指示 LLM 输出繁体。但部分 provider 会跟随简体 ASR 输入继续输出简体——prompt-level 指示不可靠（issue 原文已指出）。
2. **流式插入**路径逐字落字到光标，`dictation_streaming.rs` 注释明确写着「不在流式路径里做 `apply_chinese_script_preference`」，已落的字符无法回退转换。

## 改动（`coordinator/` 三文件，单一职责）

- **`finalize_polished_text`**：非流式路径下**无条件**套用 `apply_chinese_script_preference`。该函数对 `Auto` 是 no-op（不影响自动模式），非 `Auto` 时保证 ASR/LLM 产生的简体在插入前被转成目标字形。
- **`streaming_insert_eligible`**：新增 `chinese_script_preference` 入参——非 `Auto` 时判定**不**走流式，转入会做字形转换的一次性路径。对应 issue 验收项「若流式无法安全套用转换，应 fallback 到 one-shot」。
- 单测：`finalize_forces_traditional_even_on_successful_polish` 覆盖 issue 两个验收用例；`streaming_insert_ineligible_when_chinese_script_forced` 验证非 Auto 关闭流式。

## 验收对照

- [x] Traditional 时最终插入文字输出繁体（成功润色路径也转换）
- [x] LLM polish 完成后、插入前再套用字形转换
- [x] 最终插入文字不含 ASR/LLM 产生的简体
- [x] Auto 模式保持现有行为（converter 对 Auto no-op）
- [x] 流式无法安全转换 → 自动 fallback 到一次性插入
- [x] 两个测试用例通过（单测断言）

## 验证

- `cargo check --manifest-path src-tauri/Cargo.toml` ✅
- `cargo test --lib`（新增 3 项断言全过）✅

> 说明：issue 还提到「ASR transcript 进 LLM 前先转换」。由于本 PR 保证**输出端**无条件转换（OpenCC 对混合文本只转简体字、保留繁体字），最终插入文字的繁体保证已成立；ASR 前置转换属冗余增强，为保持单一职责未纳入。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Bug fix


___

### **Description**
- Enforce Chinese script conversion for non-Auto preferences

- Force streaming insertion fallback when script preference is set

- Apply conversion unconditionally after successful polish


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["ASR Input (may be Simplified)"] --> B["Polish pipeline"]
  B --> C{"Script Preference?"}
  C -- "Auto" --> D["Streaming insertion allowed"]
  C -- "Traditional/Simplified" --> E["Fallback to one-shot insertion"]
  E --> F["apply_chinese_script_preference"]
  F --> G["Final output (forced to preferred script)"]
  D --> H["Streaming insertion (no conversion)"]
  H --> G
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>dictation.rs</strong><dd><code>Add tests for script conversion enforcement</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src-tauri/src/coordinator/dictation.rs

<ul><li>Added test verifying streaming_insert_ineligible when script <br>preference is Traditional or Simplified<br> <li> Added test finalize_forces_traditional_even_on_successful_polish <br>covering two acceptance cases</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/629/files#diff-4cf79887f41f4811eb2b1ef682c62ee34c14a0ab969362a9ba1046de59c8578b">+41/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>dictation_end.rs</strong><dd><code>Pass script preference to streaming eligibility</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src-tauri/src/coordinator/dictation_end.rs

<ul><li>Pass <code>chinese_script_preference</code> to <code>streaming_insert_eligible</code> call</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/629/files#diff-0e8cdeea12e9c66a55f566d065b4cb98193dd58e4fdf677c7a6a3a22c273353b">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>dictation_streaming.rs</strong><dd><code>Enforce script conversion and fallback streaming</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src-tauri/src/coordinator/dictation_streaming.rs

<ul><li>Remove conditional script conversion logic; always apply after polish<br> <li> Add check in streaming_insert_eligible: disable streaming when script <br>preference is not Auto</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/629/files#diff-c42201a31d01ae1176a359c3792d24201ebe6c308e78334592bcfd07feb75811">+16/-14</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

