### PR TITLE
fix: guard qwen_engine std::Mutex poison + null ctx FFI calls

### DIFF
--- a/openless-all/app/src-tauri/src/asr/local/qwen_engine.rs
+++ b/openless-all/app/src-tauri/src/asr/local/qwen_engine.rs
@@ -59,7 +59,13 @@ impl QwenAsrEngine {
     where
         F: FnMut(&str) + Send + 'static,
     {
-        let mut slot = self.token_handler.lock().expect("token_handler poisoned");
+        // 用 std::sync::Mutex（非 parking_lot）是因为这个锁可能在 C FFI 回调
+        // token_trampoline 中被 handler 间接访问；若 handler panic，std Mutex
+        // 会 poison。此处用 into_inner() 恢复而非 panic，避免进程崩溃。
+        let mut slot = self
+            .token_handler
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
 
         // 先把 C 端那一侧切干净，再 drop 旧 Box，避免 C 在替换瞬间还持有旧指针。
         unsafe { qwen_set_token_callback(self.ctx, None, ptr::null_mut()) };
@@ -78,6 +84,9 @@ impl QwenAsrEngine {
 
     /// 批式转写：一次性给完整音频（mono f32 16kHz）。
     pub fn transcribe_audio(&self, samples: &[f32]) -> Result<String> {
+        if self.ctx.is_null() {
+            anyhow::bail!("engine already freed — cannot transcribe");
+        }
         // SAFETY: samples 在调用期间存活；返回是 C `malloc` 出的字符串。
         let raw =
             unsafe { qwen_transcribe_audio(self.ctx, samples.as_ptr(), samples.len() as i32) };
@@ -94,6 +103,9 @@ impl QwenAsrEngine {
     /// 流式转写：内部按 2s chunk 切片，token 通过 `set_token_handler` 注册的
     /// 回调实时吐出；返回值是最终完整文本。
     pub fn transcribe_stream(&self, samples: &[f32]) -> Result<String> {
+        if self.ctx.is_null() {
+            anyhow::bail!("engine already freed — cannot transcribe");
+        }
         let raw =
             unsafe { qwen_transcribe_stream(self.ctx, samples.as_ptr(), samples.len() as i32) };
         if raw.is_null() {


### PR DESCRIPTION
### **User description**
## 修复 dictation 热路径上的潜在崩溃

审计发现 \`src/asr/local/qwen_engine.rs\` 是整个 codebase 中**唯一**使用 \`std::sync::Mutex\`（会 poison）而非 \`parking_lot::Mutex\` 的锁，位于本地 ASR dictation 热路径上。

### 修复点

1. **\`set_token_handler\` — Mutex poison 防护**
   - 原代码: \`self.token_handler.lock().expect("token_handler poisoned")\`
   - 问题: \`token_trampoline\` 是 C FFI 回调，若 handler 在回调中 panic（即使当前 handler 是安全的，防御不能依赖当前安全），Mutex 会 poison，下次 dictation 调用 \`set_token_handler\` 时 \`.expect()\` 直接 panic 杀死进程
   - 修复: 改为 \`lock().unwrap_or_else(|poisoned| poisoned.into_inner())\` 安全恢复

2. **\`transcribe_audio\` / \`transcribe_stream\` — null ctx 防护**
   - 在调用 C FFI 前加 \`self.ctx.is_null()\` 检查，若引擎已被 drop 则返回错误而非 UB
   - defense-in-depth，正常 Arc 生命周期下不会触发

### 验证
- \`cargo check\` 通过
- \`cargo test\` 480 passed, 0 failed


___

### **PR Type**
Bug fix


___

### **Description**
- Recover from poisoned Mutex in token handler setter

- Guard null ctx before C FFI calls in transcribers


___

### Diagram Walkthrough


```mermaid
flowchart LR
    A["set_token_handler lock"] --> B["Recover from poison (unwrap_or_else)"]
    C["transcribe_audio/stream"] --> D["Return error if ctx is null"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>qwen_engine.rs</strong><dd><code>Guard Mutex poison and null ctx</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src-tauri/src/asr/local/qwen_engine.rs

<ul><li>Replace <code>lock().expect()</code> with <code>unwrap_or_else</code> for poisoned Mutex <br>recovery<br> <li> Add <code>is_null()</code> check before FFI calls to avoid undefined behavior</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/630/files#diff-983299174f88fae08767128a403bb2c235fa7c6ed5773ad0b01d28b0b2228d19">+13/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

