### PR TITLE
fix(capsule): 终态/空闲让胶囊点击穿透，修复贴近输入框误触弹主界面 (#631)

### DIFF
--- a/openless-all/app/src-tauri/src/coordinator/capsule.rs
+++ b/openless-all/app/src-tauri/src/coordinator/capsule.rs
@@ -29,6 +29,9 @@ pub(crate) fn capsule_show_strategy_for_platform() -> CapsuleShowStrategy {
 static CAPSULE_NO_ACTIVATE_FALLBACK_WARNED: AtomicBool = AtomicBool::new(false);
 static CAPSULE_SUPPRESSED_BY_TOGGLE_LOGGED: AtomicBool = AtomicBool::new(false);
 static CAPSULE_FIRST_SHOW_LOGGED: AtomicBool = AtomicBool::new(false);
+// issue #631：上一次应用到胶囊窗口的点击穿透值。初始 false 与窗口创建时一致
+// （tauri.conf.json 未设 ignore），按变化去重，避免录音中 ~30Hz 电平帧重复调系统 API。
+static CAPSULE_IGNORE_CURSOR_APPLIED: AtomicBool = AtomicBool::new(false);
 // #470 诊断 v2：capsule webview 句柄取不到时的一次性门，区分「窗口压根没创建」(A0)。
 static CAPSULE_WINDOW_MISSING_LOGGED: AtomicBool = AtomicBool::new(false);
 
@@ -67,6 +70,18 @@ pub(crate) fn show_capsule_window_for_recording<R: tauri::Runtime>(
             log::warn!("[capsule] show fallback failed: {e}");
         }
     }
+}
+
+/// issue #631：该状态下胶囊窗口是否应忽略鼠标事件（点击穿透到下层应用）。
+/// 胶囊窗口 220×110 远大于可见 pill，贴近输入框时透明区域会吃掉用户点击并激活
+/// OpenLess（误触弹出主界面）。终态（Done/Cancelled/Error）与 Idle 没有可交互
+/// 按钮——包括 2s toast 停留和离场动画期间——让点击穿透；录音/转写/润色态有
+/// ✕/✓ 按钮，保持可点。
+pub(crate) fn capsule_ignore_cursor_for_state(state: CapsuleState) -> bool {
+    !matches!(
+        state,
+        CapsuleState::Recording | CapsuleState::Transcribing | CapsuleState::Polishing
+    )
 }
 
 /// 终止态（Done / Cancelled / Error）后延迟 N ms 把胶囊改回 Idle，让浮窗自动消失。
@@ -241,6 +256,13 @@ pub(crate) fn emit_capsule(
         }
         #[cfg(not(target_os = "linux"))]
         {
+
+        // issue #631：终态/空闲让胶囊点击穿透，录音完成后用户点击贴近的输入框
+        // 不再误触胶囊激活 OpenLess。状态变化时才真正调系统 API。
+        let ignore_cursor = capsule_ignore_cursor_for_state(state);
+        if CAPSULE_IGNORE_CURSOR_APPLIED.swap(ignore_cursor, Ordering::SeqCst) != ignore_cursor {
+            let _ = window.set_ignore_cursor_events(ignore_cursor);
+        }
 
         // 三平台统一：Done / Cancelled / Error 状态保留 ~1.5s toast
         // （schedule_capsule_idle 之后会回 Idle 隐藏）。

--- a/openless-all/app/src-tauri/src/coordinator/tests.rs
+++ b/openless-all/app/src-tauri/src/coordinator/tests.rs
@@ -811,6 +811,19 @@ fn window_hotkey_fallback_is_disabled_when_no_explicit_fallback_is_advertised() 
 }
 
 #[test]
+fn capsule_ignore_cursor_only_in_non_interactive_states() {
+    // issue #631：有 ✕/✓ 按钮的三个状态必须可点；终态/空闲（含 toast 停留与
+    // 离场动画期间）点击穿透，避免误触激活 OpenLess 弹出主界面。
+    assert!(!capsule_ignore_cursor_for_state(CapsuleState::Recording));
+    assert!(!capsule_ignore_cursor_for_state(CapsuleState::Transcribing));
+    assert!(!capsule_ignore_cursor_for_state(CapsuleState::Polishing));
+    assert!(capsule_ignore_cursor_for_state(CapsuleState::Done));
+    assert!(capsule_ignore_cursor_for_state(CapsuleState::Cancelled));
+    assert!(capsule_ignore_cursor_for_state(CapsuleState::Error));
+    assert!(capsule_ignore_cursor_for_state(CapsuleState::Idle));
+}
+
+#[test]
 fn capsule_show_strategy_matches_platform_activation_contract() {
     // 平台列表必须与 capsule_show_strategy_for_platform 的 cfg 完全一致：
     // 改实现里的 #[cfg] 时，一并改这两个 #[cfg]，否则 Linux CI 直接红


### PR DESCRIPTION
### **User description**
## 问题 (#631)

录音胶囊窗口为 220×110，远大于可见 pill（约 42px 高）。录音完成后胶囊有 2s toast 停留 + 360ms 离场动画，期间整个透明窗口区域仍响应点击。胶囊贴近输入框（如微信聊天窗）时，用户录完点击输入框易误触胶囊 → 激活 OpenLess → 主界面被带到前台，打断操作流。

## 修复

在 `emit_capsule` 的主线程闭包中按状态切换 `set_ignore_cursor_events`（这是胶囊状态变更的唯一漏斗）：

- **Done / Cancelled / Error / Idle**（含 toast 停留与离场动画期间）→ 点击穿透到下层应用
- **Recording / Transcribing / Polishing** → 保持可点（✕/✓ 按钮）

按状态变化去重（`AtomicBool` swap），录音中 ~30Hz 电平帧不会重复调系统 API。Linux 分支本就不操作胶囊窗口（fcitx5 aux 文本），不受影响。

## 影响分析

GitNexus：`emit_capsule` 有 15 个直接调用方（dictation/QA/voice-agent 全部流程），hub 评级 CRITICAL。本改动**不动签名、不动现有 show/hide/定位行为**，仅附加一个状态驱动的窗口属性切换，对调用方透明。

## 验证

- 新增单测 `capsule_ignore_cursor_only_in_non_interactive_states`（穿透状态映射契约）
- `cargo test --lib`：479 passed, 0 failed

Closes #631


___

### **PR Type**
Bug fix


___

### **Description**
- Add state-based cursor ignore for capsule window

- Prevent misclick when capsule near input box

- Add deduplication to avoid redundant system API calls

- Add test for state mapping contract


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["CapsuleState"] --> B{"Interactive?"}
  B -- "Recording, Transcribing, Polishing" --> C["No ignore (clickable)"]
  B -- "Done, Cancelled, Error, Idle" --> D["Ignore cursor events (click-through)"]
  C --> E["User can tap ✕/✓"]
  D --> F["Click passes to underlying app"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>capsule.rs</strong><dd><code>Implement state-based cursor ignore for capsule window</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src-tauri/src/coordinator/capsule.rs

<ul><li>Added <code>capsule_ignore_cursor_for_state()</code> function to determine if <br>capsule should ignore cursor based on state<br> <li> Added static atomic <code>CAPSULE_IGNORE_CURSOR_APPLIED</code> for deduplication<br> <li> In <code>emit_capsule</code>, set <code>set_ignore_cursor_events</code> only when state changes</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/633/files#diff-ffff575ed610cb5cff61811f9b30bfee07d5fc9a868f00c64fbd6c59e73f159f">+22/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>tests.rs</strong><dd><code>Add unit test for cursor ignore state mapping</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src-tauri/src/coordinator/tests.rs

<ul><li>Added test <code>capsule_ignore_cursor_only_in_non_interactive_states</code> to <br>verify state to ignore mapping<br> <li> Ensures Recording/Transcribing/Polishing are clickable; others are not</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/633/files#diff-1e84f126ceab7983130eeaa6f9c2983c6d131078e48e3549e3c6f52116266982">+13/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

