### PR TITLE
fix(asr): validate MiMo credentials as ASR provider

### DIFF
--- a/openless-all/app/src-tauri/src/coordinator/asr_setup.rs
+++ b/openless-all/app/src-tauri/src/coordinator/asr_setup.rs
@@ -8,6 +8,25 @@
 
 use super::*;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CloudAsrCredentialRequirement {
+    AsrApiKey,
+    Volcengine,
+}
+
+pub(crate) fn cloud_asr_credential_requirement(
+    active_asr: &str,
+) -> CloudAsrCredentialRequirement {
+    if is_whisper_compatible_provider(active_asr)
+        || is_bailian_provider(active_asr)
+        || is_mimo_provider(active_asr)
+    {
+        CloudAsrCredentialRequirement::AsrApiKey
+    } else {
+        CloudAsrCredentialRequirement::Volcengine
+    }
+}
+
 pub(crate) fn ensure_microphone_permission(_inner: &Arc<Inner>) -> Result<(), String> {
     use crate::permissions::{self, PermissionStatus};
 
@@ -78,22 +97,25 @@ pub(crate) fn ensure_asr_credentials() -> Result<(), String> {
         }
     }
 
-    if is_whisper_compatible_provider(&active_asr) || is_bailian_provider(&active_asr) {
-        let api_key = CredentialsVault::get(CredentialAccount::AsrApiKey)
-            .ok()
-            .flatten()
-            .unwrap_or_default();
-        if api_key.trim().is_empty() {
-            return Err("请先在设置中填写 ASR 服务商 API Key".to_string());
+    match cloud_asr_credential_requirement(&active_asr) {
+        CloudAsrCredentialRequirement::AsrApiKey => {
+            let api_key = CredentialsVault::get(CredentialAccount::AsrApiKey)
+                .ok()
+                .flatten()
+                .unwrap_or_default();
+            if api_key.trim().is_empty() {
+                return Err("请先在设置中填写 ASR 服务商 API Key".to_string());
+            }
+            Ok(())
         }
-        return Ok(());
-    }
-
-    let creds = read_volc_credentials();
-    if creds.app_id.trim().is_empty() || creds.access_token.trim().is_empty() {
-        Err("请先在设置中填写火山引擎 ASR App Key 和 Access Key".to_string())
-    } else {
-        Ok(())
+        CloudAsrCredentialRequirement::Volcengine => {
+            let creds = read_volc_credentials();
+            if creds.app_id.trim().is_empty() || creds.access_token.trim().is_empty() {
+                Err("请先在设置中填写火山引擎 ASR App Key 和 Access Key".to_string())
+            } else {
+                Ok(())
+            }
+        }
     }
 }
 

--- a/openless-all/app/src-tauri/src/coordinator/tests.rs
+++ b/openless-all/app/src-tauri/src/coordinator/tests.rs
@@ -212,6 +212,14 @@ fn windows_local_providers_are_keyless_and_not_whisper_compatible() {
 }
 
 #[test]
+fn credential_gate_classifies_mimo_as_api_key_asr_provider() {
+    assert_eq!(
+        cloud_asr_credential_requirement(crate::asr::mimo::PROVIDER_ID),
+        CloudAsrCredentialRequirement::AsrApiKey
+    );
+}
+
+#[test]
 fn verbose_json_enabled_only_for_whisper_family() {
     // verbose_json + 幻听过滤只对返回完整 Whisper 指标的 provider 开启。
     assert!(whisper_supports_verbose_json("whisper"));


### PR DESCRIPTION
### **User description**
## 摘要

修复小米 MiMo ASR 已选中后，快捷键启动听写仍误提示检查火山引擎 ASR 凭据的问题。
<img width="309" height="111" alt="image" src="https://github.com/user-attachments/assets/eda428a7-8f2c-4200-9499-9b38de48c69a" />


## 修复 / 新增 / 改进

- 修复 `ensure_asr_credentials()` 对 `xiaomi-mimo-asr` 的凭据分类。
- 将小米 MiMo ASR 归入 ASR API Key 类型校验，而不是默认落入火山引擎 App Key / Access Key 校验。
- 新增回归测试，确保 MiMo ASR 不会再被误分类为火山引擎凭据路径。

## 兼容

- 不包含：不修改 MiMo ASR 请求协议、不修改设置页字段、不修改火山 / Whisper / 百炼 / 本地 ASR 的运行协议。
- 对现有用户 / 本地环境 / 构建流程的影响：已选择小米 MiMo ASR 的用户会按 `asr.api_key` 校验启动听写，不再要求填写火山引擎凭据；其他 ASR provider 行为保持不变。

## 测试计划

- [x] 命令：`cargo test credential_gate_classifies_mimo_as_api_key_asr_provider --lib`
- [x] 结果：通过，`1 passed; 0 failed`
- [x] 证据路径：`openless-all/app/src-tauri/src/coordinator/tests.rs`

- [x] 命令：`cargo test mimo --lib`
- [x] 结果：通过，`7 passed; 0 failed`
- [x] 证据路径：`openless-all/app/src-tauri/src/asr/mimo.rs`


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Fix MiMo ASR credential classification

- Add explicit credential requirement enum

- Add regression test for MiMo provider


___

### Diagram Walkthrough


```mermaid
flowchart LR
  active_asr["Active ASR Provider"]
  requirement["Credential Requirement"]
  credential_check["Credential Check"]
  active_asr -- "cloud_asr_credential_requirement" --> requirement
  requirement -- "AsrApiKey" --> credential_check
  requirement -- "Volcengine" --> credential_check
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>asr_setup.rs</strong><dd><code>Refactor credential gate with enum for providers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src-tauri/src/coordinator/asr_setup.rs

<ul><li>Add <code>CloudAsrCredentialRequirement</code> enum and <br><code>cloud_asr_credential_requirement</code> function<br> <li> Refactor <code>ensure_asr_credentials</code> to use enum matching<br> <li> Include MiMo provider in AsrApiKey requirement</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/635/files#diff-068416c8b4a026817964894c929d939122c3e2fb11ebc9327b8c38809aad9a52">+37/-15</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>tests.rs</strong><dd><code>Add test for MiMo credential classification</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src-tauri/src/coordinator/tests.rs

<ul><li>Add test <code>credential_gate_classifies_mimo_as_api_key_asr_provider</code><br> <li> Verify MiMo provider returns AsrApiKey requirement</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/635/files#diff-1e84f126ceab7983130eeaa6f9c2983c6d131078e48e3549e3c6f52116266982">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

