### PR TITLE
fix(macos): preserve capsule visibility in fullscreen spaces

### DIFF
--- a/openless-all/app/scripts/macos-capsule-spaces-contract.test.mjs
+++ b/openless-all/app/scripts/macos-capsule-spaces-contract.test.mjs
@@ -9,30 +9,73 @@ function assertMatch(source, pattern, name) {
 const coordinatorRs = (
   await readFile(new URL('../src-tauri/src/coordinator.rs', import.meta.url), 'utf-8')
 ).replace(/\r\n/g, '\n');
+const libRs = (await readFile(new URL('../src-tauri/src/lib.rs', import.meta.url), 'utf-8')).replace(
+  /\r\n/g,
+  '\n',
+);
 const functionMatch = coordinatorRs.match(
   /#\[cfg\(target_os = "macos"\)\]\s*fn show_capsule_window_no_activate[\s\S]*?\n}\n\n#\[cfg\(target_os = "linux"\)\]/,
+);
+const behaviorHelperMatch = coordinatorRs.match(
+  /#\[cfg\(target_os = "macos"\)\]\s*fn macos_capsule_collection_behavior[\s\S]*?\n}\n\n#\[cfg\(target_os = "macos"\)\]\s*fn macos_capsule_window_level/,
+);
+const styleHelperMatch = coordinatorRs.match(
+  /#\[cfg\(target_os = "macos"\)\]\s*fn macos_capsule_style_mask[\s\S]*?\n}\n\n#\[cfg\(target_os = "macos"\)\]\s*fn configure_macos_capsule_window_for_overlay/,
+);
+const hideHelperMatch = coordinatorRs.match(
+  /#\[cfg\(target_os = "macos"\)\]\s*pub\(crate\) fn hide_capsule_window_preserving_space[\s\S]*?\n}\n\n#\[cfg\(target_os = "macos"\)\]\s*fn show_capsule_window_no_activate/,
 );
 
 if (!functionMatch) {
   throw new Error('macOS capsule no-activate function not found');
 }
+if (!behaviorHelperMatch) {
+  throw new Error('macOS capsule collection behavior helper not found');
+}
+if (!styleHelperMatch) {
+  throw new Error('macOS capsule style helper not found');
+}
+if (!hideHelperMatch) {
+  throw new Error('macOS capsule hide helper not found');
+}
 
 const macosNoActivateFunction = functionMatch[0];
+const behaviorHelper = behaviorHelperMatch[0];
+const styleHelper = styleHelperMatch[0];
+const hideHelper = hideHelperMatch[0];
 const executableMacosNoActivateFunction = macosNoActivateFunction.replace(/\/\/.*$/gm, '');
 
 assertMatch(
-  macosNoActivateFunction,
-  /set_visible_on_all_workspaces\(true\)[\s\S]*?orderFrontRegardless/,
-  'macOS capsule should join all Spaces before showing without activation',
+  behaviorHelper,
+  /!MOVE_TO_ACTIVE_SPACE[\s\S]*?CAN_JOIN_ALL_SPACES[\s\S]*?TRANSIENT[\s\S]*?IGNORES_CYCLE[\s\S]*?FULL_SCREEN_AUXILIARY/,
+  'macOS capsule should clear MoveToActiveSpace and opt into the fullscreen HUD behaviors',
+);
+
+assertMatch(
+  styleHelper,
+  /NONACTIVATING_PANEL[\s\S]*?1 << 7/,
+  'macOS capsule should use the non-activating panel style bit',
 );
 
 assertMatch(
   macosNoActivateFunction,
-  /FULL_SCREEN_AUXILIARY[\s\S]*?1 << 8[\s\S]*?setCollectionBehavior[\s\S]*?orderFrontRegardless/,
-  'macOS capsule should join fullscreen Spaces as an auxiliary window before showing without activation',
+  /configure_macos_capsule_window_for_overlay\(window\)[\s\S]*?orderFrontRegardless/,
+  'macOS capsule should configure overlay behavior before showing without activation',
 );
 
-for (const forbidden of ['window.show()', 'set_focus', 'NSApp.activate', 'makeKeyAndOrderFront']) {
+assertMatch(
+  hideHelper,
+  /orderOut/,
+  'macOS capsule should hide with orderOut to preserve fullscreen Space association',
+);
+
+assertMatch(
+  libRs,
+  /prepare_capsule_window_for_overlay\(&capsule\)[\s\S]*?hide_capsule_window_preserving_space\(&capsule\)/,
+  'macOS startup should prepare and hide the capsule through the overlay-preserving path',
+);
+
+for (const forbidden of ['set_focus', 'NSApp.activate', 'makeKeyAndOrderFront']) {
   if (executableMacosNoActivateFunction.includes(forbidden)) {
     throw new Error(`macOS capsule no-activate path must not call ${forbidden}`);
   }

--- a/openless-all/app/src-tauri/src/coordinator.rs
+++ b/openless-all/app/src-tauri/src/coordinator.rs
@@ -4537,6 +4537,48 @@ mod tests {
     }
 
     #[test]
+    #[cfg(target_os = "macos")]
+    fn macos_capsule_collection_behavior_joins_spaces_without_conflicts() {
+        let behavior = macos_capsule_collection_behavior(0);
+
+        assert!(
+            behavior & (1 << 0) != 0,
+            "capsule HUD should join all Spaces"
+        );
+        assert_eq!(
+            behavior & (1 << 1),
+            0,
+            "MoveToActiveSpace keeps the HUD out of another app's fullscreen Space"
+        );
+        assert!(behavior & (1 << 3) != 0, "must be transient overlay");
+        assert_eq!(
+            behavior & (1 << 4),
+            0,
+            "Stationary can conflict with independent display Spaces"
+        );
+        assert!(behavior & (1 << 6) != 0, "must stay out of window cycling");
+        assert!(
+            behavior & (1 << 8) != 0,
+            "must appear over fullscreen Spaces"
+        );
+        assert!(
+            macos_capsule_window_level() >= 1500,
+            "capsule must use AssistiveTechHigh-level overlay stacking"
+        );
+    }
+
+    #[test]
+    #[cfg(target_os = "macos")]
+    fn macos_capsule_style_mask_is_nonactivating_panel_like() {
+        let style_mask = macos_capsule_style_mask(0);
+
+        assert!(
+            style_mask & (1 << 7) != 0,
+            "capsule should stay non-activating"
+        );
+    }
+
+    #[test]
     #[cfg(target_os = "windows")]
     fn prepared_windows_ime_slot_is_taken_only_for_matching_session() {
         let mut slots = vec![PreparedWindowsImeSessionSlot {
@@ -5127,37 +5169,122 @@ fn show_capsule_window_no_activate<R: tauri::Runtime>(
 }
 
 #[cfg(target_os = "macos")]
+fn macos_capsule_collection_behavior(current: usize) -> usize {
+    const CAN_JOIN_ALL_SPACES: usize = 1 << 0;
+    const MOVE_TO_ACTIVE_SPACE: usize = 1 << 1;
+    const TRANSIENT: usize = 1 << 3;
+    const STATIONARY: usize = 1 << 4;
+    const IGNORES_CYCLE: usize = 1 << 6;
+    const FULL_SCREEN_AUXILIARY: usize = 1 << 8;
+
+    // Mirror Electron's visibleOnAllWorkspaces/fullscreen auxiliary HUD path.
+    // `MoveToActiveSpace` keeps the ordinary Tauri NSWindow tied to the app's
+    // own Space instead of joining another app's native fullscreen Space.
+    let cleared = current & !MOVE_TO_ACTIVE_SPACE & !STATIONARY;
+    cleared | CAN_JOIN_ALL_SPACES | TRANSIENT | IGNORES_CYCLE | FULL_SCREEN_AUXILIARY
+}
+
+#[cfg(target_os = "macos")]
+fn macos_capsule_window_level() -> isize {
+    const K_CG_ASSISTIVE_TECH_HIGH_WINDOW_LEVEL_KEY: i32 = 20;
+
+    #[link(name = "ApplicationServices", kind = "framework")]
+    extern "C" {
+        fn CGWindowLevelForKey(key: i32) -> i32;
+    }
+
+    // Status-level windows can still be composited behind another app's native
+    // fullscreen Space. AssistiveTechHigh is the system overlay level used by
+    // transient accessibility HUDs.
+    unsafe { CGWindowLevelForKey(K_CG_ASSISTIVE_TECH_HIGH_WINDOW_LEVEL_KEY) as isize }
+}
+
+#[cfg(target_os = "macos")]
+fn macos_capsule_style_mask(current: usize) -> usize {
+    const NONACTIVATING_PANEL: usize = 1 << 7;
+
+    current | NONACTIVATING_PANEL
+}
+
+#[cfg(target_os = "macos")]
+fn configure_macos_capsule_window_for_overlay<R: tauri::Runtime>(
+    window: &tauri::WebviewWindow<R>,
+) -> Option<*mut objc2::runtime::AnyObject> {
+    use objc2::msg_send;
+    use objc2::runtime::AnyObject;
+
+    let Ok(handle) = window.ns_window() else {
+        log::warn!("[capsule] macOS overlay configure failed: ns_window unavailable");
+        return None;
+    };
+    let ns_window = handle as *mut AnyObject;
+    if ns_window.is_null() {
+        log::warn!("[capsule] macOS overlay configure failed: ns_window null");
+        return None;
+    }
+
+    unsafe {
+        let before_behavior: usize = msg_send![ns_window, collectionBehavior];
+        let before_style_mask: usize = msg_send![ns_window, styleMask];
+        let after_behavior = macos_capsule_collection_behavior(before_behavior);
+        let after_style_mask = macos_capsule_style_mask(before_style_mask);
+        let level = macos_capsule_window_level();
+        let _: () = msg_send![ns_window, setStyleMask: after_style_mask];
+        let _: () = msg_send![ns_window, setCollectionBehavior: after_behavior];
+        let _: () = msg_send![ns_window, setLevel: level];
+        let _: () = msg_send![ns_window, setCanHide: false];
+        let _: () = msg_send![ns_window, setHidesOnDeactivate: false];
+        let _: () = msg_send![ns_window, setReleasedWhenClosed: false];
+        let _: () = msg_send![ns_window, setIgnoresMouseEvents: true];
+        Some(ns_window)
+    }
+}
+
+#[cfg(target_os = "macos")]
+pub(crate) fn prepare_capsule_window_for_overlay<R: tauri::Runtime>(
+    window: &tauri::WebviewWindow<R>,
+) -> bool {
+    configure_macos_capsule_window_for_overlay(window).is_some()
+}
+
+#[cfg(target_os = "macos")]
+pub(crate) fn hide_capsule_window_preserving_space<R: tauri::Runtime>(
+    window: &tauri::WebviewWindow<R>,
+) -> bool {
+    use objc2::msg_send;
+
+    let Some(ns_window) = configure_macos_capsule_window_for_overlay(window) else {
+        return false;
+    };
+    unsafe {
+        let _: () = msg_send![ns_window, orderOut: std::ptr::null::<objc2::runtime::AnyObject>()];
+    }
+    true
+}
+
+#[cfg(target_os = "macos")]
 fn show_capsule_window_no_activate<R: tauri::Runtime>(
     _app: &AppHandle<R>,
     window: &tauri::WebviewWindow<R>,
 ) -> bool {
     use objc2::msg_send;
-    use objc2::runtime::AnyObject;
 
-    let Ok(handle) = window.ns_window() else {
+    // emit_capsule 已经把窗口操作 marshal 到 Tauri 主线程；这里不能调用
+    // set_focus()/NSApp.activate，否则 AeroSpace 会把 workspace 切回 OpenLess
+    // 主窗口所在空间。胶囊是 HUD，不是主窗口：通过 all-Spaces +
+    // fullscreen auxiliary 行为挂到用户当前 fullscreen Space。
+    let was_visible = window.is_visible().unwrap_or(false);
+    let Some(ns_window) = configure_macos_capsule_window_for_overlay(window) else {
         return false;
     };
-    let ns_window = handle as *mut AnyObject;
-    if ns_window.is_null() {
-        return false;
-    }
-
-    // emit_capsule 已经把窗口操作 marshal 到 Tauri 主线程；这里不能再调用
-    // window.show()/set_focus()/NSApp.activate，否则 AeroSpace 会把 workspace 切回
-    // OpenLess 主窗口所在空间。先让胶囊加入所有 Spaces，再用
-    // orderFrontRegardless 做无激活展示。
-    if let Err(e) = window.set_visible_on_all_workspaces(true) {
-        log::warn!("[capsule] set visible on all macOS Spaces failed: {e}");
-    }
 
     unsafe {
-        const NS_WINDOW_COLLECTION_BEHAVIOR_CAN_JOIN_ALL_SPACES: usize = 1 << 0;
-        const NS_WINDOW_COLLECTION_BEHAVIOR_FULL_SCREEN_AUXILIARY: usize = 1 << 8;
-        let behavior: usize = msg_send![ns_window, collectionBehavior];
-        let behavior = behavior
-            | NS_WINDOW_COLLECTION_BEHAVIOR_CAN_JOIN_ALL_SPACES
-            | NS_WINDOW_COLLECTION_BEHAVIOR_FULL_SCREEN_AUXILIARY;
-        let _: () = msg_send![ns_window, setCollectionBehavior: behavior];
+        if !was_visible {
+            if let Err(e) = window.show() {
+                log::warn!("[capsule] macOS no_activate pre-show failed: {e}");
+            }
+        }
+
         let _: () = msg_send![ns_window, orderFrontRegardless];
     }
     true
@@ -5396,6 +5523,13 @@ fn emit_capsule(
                 );
             }
             hide_capsule_window_if_present();
+            #[cfg(target_os = "macos")]
+            {
+                if !hide_capsule_window_preserving_space(&window) {
+                    let _ = window.hide();
+                }
+            }
+            #[cfg(not(target_os = "macos"))]
             let _ = window.hide();
         }
         }

--- a/openless-all/app/src-tauri/src/lib.rs
+++ b/openless-all/app/src-tauri/src/lib.rs
@@ -146,7 +146,15 @@ pub fn run() {
                 if let Err(e) = position_capsule_bottom_center(&capsule, false) {
                     log::warn!("[capsule] position failed: {e}");
                 }
-                let _ = capsule.hide();
+                #[cfg(target_os = "macos")]
+                {
+                    crate::coordinator::prepare_capsule_window_for_overlay(&capsule);
+                    let _ = crate::coordinator::hide_capsule_window_preserving_space(&capsule);
+                }
+                #[cfg(not(target_os = "macos"))]
+                {
+                    let _ = capsule.hide();
+                }
             }
 
             // QA 浮窗（issue #118）：紧贴胶囊上方 8pt、屏幕底部居中、380×440。


### PR DESCRIPTION
### **User description**
## Summary
- follow up the existing macOS Spaces/fullscreen capsule fixes by keeping the capsule window in its overlay configuration after startup and after hide
- replace macOS `window.hide()` on the capsule path with an AppKit `orderOut` helper so the window does not get rebound to a regular Space
- harden the static macOS capsule contract test around the new overlay behavior

## Why the current implementation still breaks
Previous fixes in #549 and #556 taught the capsule how to join all Spaces and fullscreen Spaces at show time. That helps for the first show, but the Tauri window still goes through the regular `hide()` path:

- startup hides the capsule with `window.hide()`
- idle/hidden transitions also call `window.hide()`

On macOS, that means the next show is starting from a normal hidden `NSWindow` state again, so the overlay can still fall back to the app's own desktop Space instead of the current fullscreen Space.

This patch keeps the existing webview capsule, but treats its `NSWindow` more like a non-activating HUD overlay:

- clear `MoveToActiveSpace` and `Stationary`
- keep `CanJoinAllSpaces` + `FullScreenAuxiliary`
- add `Transient`, `IgnoresCycle`, and the non-activating panel style bit
- hide with `orderOut` instead of the regular Tauri `hide()` path

## Verification
- `npm --prefix "openless-all/app" run check:macos-capsule-spaces`
- `git diff --check`

## Notes
- I could not run `cargo test` in this fork clone because the checkout is missing the `vendor/qwen-asr` C sources required by `build.rs`.
- The behavior itself was smoke-tested separately on a local macOS build while narrowing this patch down from a larger self-use branch.


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Overlay capsule on fullscreen macOS Spaces

- Configure NSWindow with proper collection behavior, style mask, and window level

- Hide capsule with orderOut instead of window.hide() to keep space association

- Add unit tests and update contract test for new helpers


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["show_capsule_window_no_activate"] --> B["configure_macos_capsule_window_for_overlay"]
  B --> C["setCAN_JOIN_ALL_SPACES, TRANSIENT, IGNORES_CYCLE, FULL_SCREEN_AUXILIARY"]
  B --> D["setNONACTIVATING_PANEL"]
  B --> E["setAssistiveTechHigh level"]
  B --> F["orderFrontRegardless"]
  G["hide_capsule_window_preserving_space"] --> H["configure_macos_capsule_window_for_overlay"]
  H --> I["orderOut"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>coordinator.rs</strong><dd><code>Refactor macOS capsule overlay configuration and hide</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src-tauri/src/coordinator.rs

<ul><li>Added helper functions for macOS capsule overlay configuration: <br><code>macos_capsule_collection_behavior</code>, <code>macos_capsule_style_mask</code>, <br><code>macos_capsule_window_level</code><br> <li> Refactored <code>show_capsule_window_no_activate</code> to apply overlay settings <br>before <code>orderFrontRegardless</code><br> <li> Added <code>prepare_capsule_window_for_overlay</code> and <br><code>hide_capsule_window_preserving_space</code> functions<br> <li> Added unit tests for collection behavior and style mask</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/642/files#diff-73d8c004670b27293f74f0f3991b9a6fc28f0ff0b883214de2b078b1e09797ca">+152/-18</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>lib.rs</strong><dd><code>Use overlay-preserving hide on macOS startup</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src-tauri/src/lib.rs

<ul><li>On macOS startup, use <code>prepare_capsule_window_for_overlay</code> and <br><code>hide_capsule_window_preserving_space</code> instead of <code>capsule.hide()</code></ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/642/files#diff-6b8eb1bbf8e378bab914f1a12962f7add5cc4ba9e013c37c9921a1032fa5e110">+9/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>macos-capsule-spaces-contract.test.mjs</strong><dd><code>Update contract test for new overlay helpers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/scripts/macos-capsule-spaces-contract.test.mjs

<ul><li>Updated assertions for new helpers: behavior helper, style helper, <br>hide helper<br> <li> Removed check for <code>window.show()</code> from forbidden list<br> <li> Added check for <code>orderOut</code> in hide helper</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/642/files#diff-f246fa613cf2c504b2b8dc1b7826d521871b382825e13724daed2831f2118f91">+49/-6</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

