### PR TITLE
Scale Cloud Whisper timeout for long recordings

### DIFF
--- a/openless-all/app/src-tauri/src/coordinator.rs
+++ b/openless-all/app/src-tauri/src/coordinator.rs
@@ -25,7 +25,7 @@ use crate::asr::local::{
     foundry, sherpa, FoundryLocalRuntime, FoundryLocalWhisperAsr, SherpaOnnxAsr, SherpaOnnxRuntime,
 };
 use crate::asr::{
-    BailianCredentials, BailianRealtimeASR, DictionaryHotword, MimoBatchASR, RawTranscript,
+    pcm, BailianCredentials, BailianRealtimeASR, DictionaryHotword, MimoBatchASR, RawTranscript,
     VolcengineCredentials, VolcengineStreamingASR, WhisperBatchASR,
 };
 use crate::combo_hotkey::{ComboHotkeyError, ComboHotkeyEvent, ComboHotkeyMonitor};
@@ -874,7 +874,7 @@ impl Coordinator {
     /// 用**当前配置的** ASR provider 对一段已归档的 16k/mono/16-bit PCM 重新转录
     /// （issue #613「重新转录」）。复用 `build_qa_asr_start`，对所有 provider 统一：
     /// 流式 provider 先 open_session 再灌音并取 final，批处理 provider 直接灌音后
-    /// transcribe。整段超时走 COORDINATOR_GLOBAL_TIMEOUT_SECS 兜底，防止挂死。
+    /// transcribe。整段转写按 provider 设置超时，防止挂死。
     ///
     /// 只做 ASR，不做润色/落字/写历史 —— 回写历史由 command 层完成，保持本方法纯粹。
     pub async fn retranscribe_pcm(&self, pcm: Vec<u8>) -> Result<String, String> {
@@ -884,6 +884,7 @@ impl Coordinator {
         start.open_streaming_session().await?;
         let consumer = start.recorder_consumer();
         consumer.consume_pcm_chunk(&pcm);
+        let audio_secs = (pcm::pcm_duration_ms(&pcm) as f64) / 1000.0;
         let timeout = std::time::Duration::from_secs(COORDINATOR_GLOBAL_TIMEOUT_SECS);
         let raw = match start.active_asr() {
             ActiveAsr::Volcengine(asr) => {
@@ -900,10 +901,13 @@ impl Coordinator {
                     .map_err(|_| "重新转录超时".to_string())?
                     .map_err(|e| e.to_string())?
             }
-            ActiveAsr::Whisper(w) => tokio::time::timeout(timeout, w.transcribe())
-                .await
-                .map_err(|_| "重新转录超时".to_string())?
-                .map_err(|e| e.to_string())?,
+            ActiveAsr::Whisper(w) => {
+                let timeout = cloud_whisper_transcribe_timeout(audio_secs);
+                tokio::time::timeout(timeout, w.transcribe())
+                    .await
+                    .map_err(|_| "重新转录超时".to_string())?
+                    .map_err(|e| e.to_string())?
+            }
             ActiveAsr::Mimo(m) => tokio::time::timeout(timeout, m.transcribe())
                 .await
                 .map_err(|_| "重新转录超时".to_string())?

--- a/openless-all/app/src-tauri/src/coordinator.rs
+++ b/openless-all/app/src-tauri/src/coordinator.rs
@@ -935,6 +935,14 @@ impl Coordinator {
                 asr_setup::schedule_local_asr_release(inner);
                 out
             }
+            #[cfg(target_os = "macos")]
+            ActiveAsr::AppleSpeech(local) => {
+                let dur = asr_setup::local_qwen_transcribe_timeout(audio_secs);
+                tokio::time::timeout(dur, local.transcribe())
+                    .await
+                    .map_err(|_| "重新转录超时".to_string())?
+                    .map_err(|e| e.to_string())?
+            }
         };
         Ok(raw.text)
     }

--- a/openless-all/app/src-tauri/src/coordinator/asr_setup.rs
+++ b/openless-all/app/src-tauri/src/coordinator/asr_setup.rs
@@ -467,6 +467,8 @@ pub(crate) async fn build_qa_asr_start(
 /// 设置为 15 秒（比 ASR 的 12 秒 FINAL_RESULT_TIMEOUT 稍长），
 /// 只在 ASR 超时机制失效时作为最后的防线触发。
 pub(crate) const COORDINATOR_GLOBAL_TIMEOUT_SECS: u64 = 15;
+pub(crate) const CLOUD_WHISPER_MIN_TIMEOUT_SECS: u64 = 30;
+pub(crate) const CLOUD_WHISPER_MAX_TIMEOUT_SECS: u64 = 300;
 
 #[cfg(target_os = "windows")]
 pub(crate) fn foundry_audio_transcribe_timeout_duration() -> std::time::Duration {
@@ -481,6 +483,17 @@ pub(crate) fn local_qwen_transcribe_timeout(audio_secs: f64) -> std::time::Durat
     let secs = ((audio_secs * 0.6).ceil() as u64)
         .saturating_add(10)
         .max(COORDINATOR_GLOBAL_TIMEOUT_SECS);
+    std::time::Duration::from_secs(secs)
+}
+
+/// Cloud Whisper/Groq ASR 的批量转写超时。短录音给 30s 余量；长录音按音频长度
+/// 扩展，避免数分钟录音被 15s coordinator guard 提前丢弃。5 分钟上限仍保留为
+/// 外部 API 卡死时的最后防线。
+pub(crate) fn cloud_whisper_transcribe_timeout(audio_secs: f64) -> std::time::Duration {
+    let scaled = ((audio_secs * 0.5).ceil() as u64).saturating_add(15);
+    let secs = scaled
+        .max(CLOUD_WHISPER_MIN_TIMEOUT_SECS)
+        .min(CLOUD_WHISPER_MAX_TIMEOUT_SECS);
     std::time::Duration::from_secs(secs)
 }
 

--- a/openless-all/app/src-tauri/src/coordinator/dictation_end.rs
+++ b/openless-all/app/src-tauri/src/coordinator/dictation_end.rs
@@ -106,8 +106,13 @@ pub(crate) async fn end_session(inner: &Arc<Inner>) -> Result<(), String> {
         }
         ActiveAsr::Whisper(w) => {
             debug_assert!(uses_global_timeout);
-            // Whisper 也添加类似的超时保护
-            let timeout_duration = std::time::Duration::from_secs(COORDINATOR_GLOBAL_TIMEOUT_SECS);
+            let audio_secs = elapsed as f64 / 1000.0;
+            let timeout_duration = cloud_whisper_transcribe_timeout(audio_secs);
+            log::info!(
+                "[coord] whisper transcribe: audio={:.2}s timeout={}s",
+                audio_secs,
+                timeout_duration.as_secs()
+            );
             match tokio::time::timeout(timeout_duration, w.transcribe()).await {
                 Ok(Ok(r)) => r,
                 Ok(Err(e)) => {
@@ -129,7 +134,7 @@ pub(crate) async fn end_session(inner: &Arc<Inner>) -> Result<(), String> {
                 Err(_) => {
                     log::error!(
                         "[coord] whisper 全局超时 {} 秒",
-                        COORDINATOR_GLOBAL_TIMEOUT_SECS
+                        timeout_duration.as_secs()
                     );
                     write_transcribe_failed_history(inner, current_session_id, elapsed);
                     emit_capsule(

--- a/openless-all/app/src-tauri/src/coordinator/tests.rs
+++ b/openless-all/app/src-tauri/src/coordinator/tests.rs
@@ -343,6 +343,48 @@ fn local_qwen_timeout_handles_zero_duration() {
     );
 }
 
+#[test]
+fn cloud_whisper_timeout_has_longer_floor_than_global_guard() {
+    assert_eq!(
+        cloud_whisper_transcribe_timeout(5.0),
+        std::time::Duration::from_secs(CLOUD_WHISPER_MIN_TIMEOUT_SECS)
+    );
+}
+
+#[test]
+fn cloud_whisper_timeout_handles_zero_duration() {
+    assert_eq!(
+        cloud_whisper_transcribe_timeout(0.0),
+        std::time::Duration::from_secs(CLOUD_WHISPER_MIN_TIMEOUT_SECS)
+    );
+}
+
+#[test]
+fn cloud_whisper_timeout_scales_for_long_recordings() {
+    // 422s recording: ceil(422 * 0.5) + 15 = 226s. Do not drop it at 15s.
+    assert_eq!(
+        cloud_whisper_transcribe_timeout(422.0),
+        std::time::Duration::from_secs(226)
+    );
+}
+
+#[test]
+fn cloud_whisper_timeout_is_capped() {
+    assert_eq!(
+        cloud_whisper_transcribe_timeout(1_000.0),
+        std::time::Duration::from_secs(CLOUD_WHISPER_MAX_TIMEOUT_SECS)
+    );
+}
+
+#[test]
+fn cloud_whisper_timeout_preserves_exact_cap_boundary() {
+    // ceil(570 * 0.5) + 15 = 300s, exactly at the cap.
+    assert_eq!(
+        cloud_whisper_transcribe_timeout(570.0),
+        std::time::Duration::from_secs(CLOUD_WHISPER_MAX_TIMEOUT_SECS)
+    );
+}
+
 #[cfg(target_os = "windows")]
 #[test]
 fn foundry_release_uses_foundry_keep_loaded_preference() {


### PR DESCRIPTION
### **User description**
## Summary
- replace the fixed 15s coordinator timeout for Cloud Whisper-compatible dictation with an audio-duration-aware timeout
- apply the same timeout to the existing history retranscription path using the archived PCM duration
- add timeout boundary tests for short, zero-length, long, capped, and exact-cap recordings

## Why
Long Cloud Whisper-compatible recordings can take longer than the existing 15s coordinator guard to transcribe. In that case the recording is marked as a timeout even though the provider may still be working. This is especially visible for multi-minute recordings.

The new timeout is:
- floor: 30s
- scaled: `ceil(audio_secs * 0.5) + 15`
- cap: 300s

For example, a 422s recording now gets a 226s timeout instead of 15s.

The same timeout is also used when retranscribing an archived recording, where the exact PCM duration is available.

## Validation
- `cargo test cloud_whisper_timeout --lib` passed: 5 tests
- `cargo test` passed: 521 tests
- `cargo build --release` passed
- Claude review: no blockers, ready for PR
- Codex review: no blockers, ready for PR

Note: `cargo fmt --check` currently reports unrelated existing formatting diffs in upstream files outside this PR, so I did not apply broad formatting changes.


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Replace fixed 15s coordinator timeout with audio-duration-aware timeout for Cloud Whisper

- Apply same timeout to retranscription path and add Apple Speech retranscription support

- Add boundary tests for short, zero, long, capped, and exact-cap recordings


___

### Diagram Walkthrough


```mermaid
flowchart LR
  AudioLength["Audio length (seconds)"]
  ComputeTime["Compute timeout: ceil(len*0.5)+15, clamped [30,300]"]
  Transcribe["Cloud Whisper transcribe with timeout"]
  Retranscribe["Retranscribe archived PCM with same timeout"]
  AudioLength --> ComputeTime
  ComputeTime --> Transcribe
  ComputeTime --> Retranscribe
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>coordinator.rs</strong><dd><code>Use dynamic timeout in retranscribe_pcm and add Apple Speech</code></dd></summary>
<hr>

openless-all/app/src-tauri/src/coordinator.rs

<ul><li>Added import of <code>pcm</code> module to compute audio duration<br> <li> Modified <code>retranscribe_pcm</code> to use <code>cloud_whisper_transcribe_timeout</code> for <br>Whisper provider<br> <li> Added Apple Speech retranscription timeout using <br><code>local_qwen_transcribe_timeout</code></ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/646/files#diff-73d8c004670b27293f74f0f3991b9a6fc28f0ff0b883214de2b078b1e09797ca">+18/-6</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>asr_setup.rs</strong><dd><code>Add timeout constants and scaling function for Cloud Whisper</code></dd></summary>
<hr>

openless-all/app/src-tauri/src/coordinator/asr_setup.rs

<ul><li>Defined <code>CLOUD_WHISPER_MIN_TIMEOUT_SECS</code> (30) and <br><code>CLOUD_WHISPER_MAX_TIMEOUT_SECS</code> (300)<br> <li> Implemented <code>cloud_whisper_transcribe_timeout</code> function with formula <br><code>ceil(audio_secs * 0.5) + 15</code>, clamped between min and max</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/646/files#diff-068416c8b4a026817964894c929d939122c3e2fb11ebc9327b8c38809aad9a52">+13/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>dictation_end.rs</strong><dd><code>Use audio-aware timeout in Cloud Whisper end_session</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src-tauri/src/coordinator/dictation_end.rs

<ul><li>Replaced fixed <code>COORDINATOR_GLOBAL_TIMEOUT_SECS</code> with dynamic <br><code>cloud_whisper_transcribe_timeout</code> in <code>end_session</code> for Whisper provider<br> <li> Added logging of audio duration and computed timeout</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/646/files#diff-0e8cdeea12e9c66a55f566d065b4cb98193dd58e4fdf677c7a6a3a22c273353b">+8/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>tests.rs</strong><dd><code>Add unit tests for cloud_whisper_transcribe_timeout</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src-tauri/src/coordinator/tests.rs

<ul><li>Added 5 test cases: floor for short recordings, zero duration, scaling <br>for 422s, cap at 1000s, exact cap boundary at 570s</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/646/files#diff-1e84f126ceab7983130eeaa6f9c2983c6d131078e48e3549e3c6f52116266982">+42/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

