### PR TITLE
ci: @claude 审核默认改用 Opus 4.8，复杂时主 Agent 自行派发子 Agent

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -3,8 +3,11 @@ name: Claude Code
 # 触发策略：
 # - 默认不主动 review；任何 PR 打开 / 同步都不会自动调用模型，避免烧 OAuth token 额度。
 # - 评论 / review / issue 中出现 `@claude` 才触发，且发起者必须是 Open-Less 组织成员（OWNER 或 MEMBER）。
-# - 模型默认 claude-sonnet-4-6（量大、成本低）；评论里写 `--opus` 或包含 `claude-opus`
-#   字样会切到 claude-opus-4-7（用于需要更深推理的任务）。
+# - 模型默认 claude-opus-4-8（深推理；复杂时可自行派发子 Agent）；评论里写 `--sonnet` 或包含 `claude-sonnet`
+#   字样会降级到 claude-sonnet-4-6（量大、成本低，用于简单任务省 OAuth token 额度）。
+# - 默认单个主 Agent 审核；仅当改动较大 / 较复杂时，主 Agent 可自行用 Task 派发子 Agent 协助再汇总。
+#   --allowedTools 放行 Task 及读码所需的 Read/Grep/Glob（不放行 Bash，保持只读、不执行 PR 代码）。
+#   注意：Opus 4.8 token 消耗高于 sonnet，简单提问写 `--sonnet` 降级即可。
 
 on:
   issue_comment:
@@ -50,7 +53,7 @@ jobs:
       - name: Detach HEAD to free local branch ref
         run: git checkout --detach
 
-      - name: Pick model (default sonnet, opt-in opus)
+      - name: Pick model (default opus-4-8, opt-down sonnet)
         id: pick_model
         env:
           COMMENT_BODY: ${{ github.event.comment.body }}
@@ -60,10 +63,11 @@ jobs:
         run: |
           set -eu
           body="${COMMENT_BODY}${REVIEW_BODY}${ISSUE_BODY}${ISSUE_TITLE}"
-          if [[ "$body" == *"--opus"* ]] || [[ "$body" == *"claude-opus"* ]]; then
-            echo "model=claude-opus-4-7" >> "$GITHUB_OUTPUT"
-          else
+          # 默认 opus-4-8（深推理；复杂时可自行派发子 Agent）；评论里写 --sonnet 或 claude-sonnet 才降级省额度
+          if [[ "$body" == *"--sonnet"* ]] || [[ "$body" == *"claude-sonnet"* ]]; then
             echo "model=claude-sonnet-4-6" >> "$GITHUB_OUTPUT"
+          else
+            echo "model=claude-opus-4-8" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Run Claude Code
@@ -76,5 +80,13 @@ jobs:
           additional_permissions: |
             actions: read
 
-          # 模型策略：默认 sonnet，评论里 --opus 才升级到 opus
-          claude_args: '--model ${{ steps.pick_model.outputs.model }}'
+          # 模型策略：默认 opus-4-8，评论里 --sonnet 才降级到 sonnet。
+          # 单主 Agent：默认自己审；仅当改动较大 / 复杂时主 Agent 才用 Task 自行派发子 Agent。
+          # --allowedTools 放行 Task + Read/Grep/Glob（不放行 Bash，保持只读、不执行 PR 代码）。
+          # append-system-prompt 内置「全平台适配性」审核要求：本仓库 macOS/Windows/Linux 三端、
+          # 大量 #[cfg(target_os=...)] 分支，根目录带跨平台告警的 CLAUDE.md 不在本 git 仓库内，
+          # 云端 action 看不到，故把该约束直接写进 system prompt 保证生效。
+          claude_args: |
+            --model ${{ steps.pick_model.outputs.model }}
+            --allowedTools "Task,Read,Grep,Glob"
+            --append-system-prompt "默认以单个主 Agent 完成审核与回答；仅当本次改动较大或较复杂时，你可自行用 Task 工具派发子 Agent 协助并汇总其结论。本仓库 OpenLess 是 macOS / Windows / Linux 跨平台桌面应用，大量代码按 #[cfg(target_os = ...)] 分平台，插入法 / IME / ASR / 依赖在三端各有独立实现（Linux 在多处为 allow(dead_code)，最易被漏）。扫描与审核代码时务必考虑全平台适配性：改动跨平台符号时核对 macOS / Windows / Linux 三个 cfg 分支是否同步，识别仅在单一平台生效、或会破坏其他平台编译与行为的问题。审核为只读，不要修改代码，输出简洁的中文结论。"


### PR DESCRIPTION
### **User description**
## 背景

`@claude` 云端审核(`.github/workflows/claude.yml`)原来默认用 `claude-sonnet-4-6`,只在评论写 `--opus` 时升级。本次按需求把**默认审核模型改为 Opus 4.8**,并保留主 Agent 在复杂改动时**自行派发子 Agent**的能力(不强制多 Agent 架构)。

## 改动(仅 `claude.yml`,+17/-8)

1. **默认模型 `claude-sonnet-4-6` → `claude-opus-4-8`**。开关反转:原 `--opus` 升级开关改成 `--sonnet` 降级开关 —— 评论写 `--sonnet`(或含 `claude-sonnet`)才降回 sonnet,作为简单任务的省额度逃生通道。
2. **单主 Agent 为默认**:`--append-system-prompt` 指示默认由单个主 Agent 完成审核;仅当改动较大/复杂时,主 Agent 才用 `Task` 工具自行派发子 Agent 协助并汇总。
3. **放行派发能力**:`--allowedTools "Task,Read,Grep,Glob"` —— 允许派发子 Agent 及只读审码。**不放行 `Bash`**,审核保持只读、不执行 PR 代码。

## 为什么 base 是 `main` 而不是 `beta`

`claude.yml` 由 `issue_comment` / `issues` / `pull_request_review` 等事件触发,GitHub Actions 对这类事件**一律使用默认分支(main)上的 workflow 文件**。所以此改动必须落到 `main` 才会真正改变 `@claude` 的行为;合并到 `beta` 不会生效。本 PR 为纯 CI 配置改动,不含应用代码,直接进 main 安全。

## 取舍

Opus 4.8 的 token 消耗高于 sonnet。但触发面未变 —— 仍是只有组织成员主动 `@claude` 才跑、不自动 review,总量可控;急用省钱时评论带 `--sonnet` 即可降级。

## 测试计划

- [x] `ruby -ryaml` 校验 YAML 合法,`claude_args` 三个 flag(`--model` / `--allowedTools` / `--append-system-prompt`)解析正确(append-system-prompt 为单行、双引号包裹、内部无双引号)
- [x] `pick_model` 逻辑:默认输出 `claude-opus-4-8`,命中 `--sonnet`/`claude-sonnet` 时输出 `claude-sonnet-4-6`
- [ ] 合并后,在某 issue / PR 评论 `@claude` 跑一次,确认用 Opus 4.8、单主 Agent 正常出审核结论;再用 `@claude --sonnet` 确认能降级


___

### **PR Type**
Enhancement


___

### **Description**
- Default model switched to claude-opus-4-8 with opt-down via --sonnet comment

- Allowed Task, Read, Grep, Glob tools for complex sub-agent dispatch

- Added cross-platform compatibility checks in system prompt


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Comment contains --sonnet?"] -->|Yes| B["Use claude-sonnet-4-6"]
  A -->|No| C["Use claude-opus-4-8"]
  C --> D["Single main agent; can dispatch sub-agents if complex"]
  D --> E["System prompt: cross-platform checks"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>claude.yml</strong><dd><code>Switch default model and enhance agent capabilities</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/claude.yml

<ul><li>Changed default model from sonnet-4-6 to opus-4-8 with opt-down via <br>comment<br> <li> Added allowedTools: Task, Read, Grep, Glob (no Bash) for sub-agent <br>dispatch<br> <li> Added append-system-prompt with cross-platform compatibility and <br>single-agent guidance</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/669/files#diff-53fec9c265fdba82268df5cd90315b8da57cce43d8e20efbf5c0bdcd1de1342e">+20/-8</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

