### PR TITLE
perf(tray): 托盘麦克风设备监听改 OS 原生通知，空闲零唤醒 + 60s 兜底

### DIFF
--- a/openless-all/app/src-tauri/Cargo.toml
+++ b/openless-all/app/src-tauri/Cargo.toml
@@ -104,6 +104,10 @@ minisign-verify = "0.2"
 block2 = "0.5"
 core-foundation = "0.10"
 core-graphics = "0.24"
+# issue #470：托盘麦克风设备变更改用 CoreAudio AudioObjectAddPropertyListener 原生通知
+# （替代 10s 轮询，空闲零唤醒）。符号本就在依赖树（cpal → coreaudio-sys 0.2），提升为
+# 直接依赖零额外编译成本。
+coreaudio-sys = "0.2"
 objc2 = "0.5"
 objc2-foundation = "0.2"
 objc2-app-kit = "0.2"

--- a/openless-all/app/src-tauri/src/device_watch.rs
+++ b/openless-all/app/src-tauri/src/device_watch.rs
@@ -3,11 +3,11 @@
 //! 目的：替代「每 10s 轮询 `list_input_devices()`」这条空闲唤醒。改用各平台原生的设备
 //! 变更通知，空闲时零唤醒，设备插拔/默认设备切换时由 OS 回调实时触发刷新。
 //!
-//! 严格按平台分流：
+//! 平台分流：
 //! - macOS：CoreAudio `AudioObjectAddPropertyListener` 监听
 //!   `kAudioHardwarePropertyDevices`，专用线程跑 `CFRunLoop` 常驻。
-//! - Windows：`IMMNotificationClient` 经 `IMMDeviceEnumerator` 注册端点通知回调。
-//! - Linux：无原生路径，返回 `false`，由 `lib.rs` 的慢速兜底轮询负责。
+//! - Windows / Linux：暂返回 `false`，由 `lib.rs` 的 60s 慢速兜底轮询负责。
+//!   （Windows 原生 `IMMNotificationClient` 通知留作后续，需 Windows 开发机验证。）
 //!
 //! 三平台共用契约：`spawn_native_watcher(app, on_change)`。`on_change` 是 `lib.rs` 提供
 //! 的去抖闭包（内部复用 `microphone_device_signature()`，真正变化才刷新+emit）。回调里
@@ -27,17 +27,9 @@ where
     macos::spawn(on_change)
 }
 
-/// Windows：经 MMDevice 端点通知注册。见模块内说明。
-#[cfg(target_os = "windows")]
-pub(crate) fn spawn_native_watcher<F>(_app: AppHandle, on_change: F) -> bool
-where
-    F: Fn() + Send + Sync + 'static,
-{
-    windows_impl::spawn(on_change)
-}
-
-/// Linux：无原生路径，纯靠 `lib.rs` 的慢速兜底轮询。
-#[cfg(not(any(target_os = "macos", target_os = "windows")))]
+/// 非 macOS（Windows / Linux）：暂无本地验证过的原生路径，返回 `false`，纯靠 `lib.rs`
+/// 的 60s 慢速兜底轮询。Windows 原生 `IMMNotificationClient` 留作后续（需 Windows 开发机验证）。
+#[cfg(not(target_os = "macos"))]
 pub(crate) fn spawn_native_watcher<F>(_app: AppHandle, _on_change: F) -> bool
 where
     F: Fn() + Send + Sync + 'static,
@@ -172,167 +164,3 @@ mod macos {
     }
 }
 
-// ===================================================================================
-// Windows — IMMNotificationClient via IMMDeviceEnumerator
-// ===================================================================================
-//
-// 注意：开发机是 macOS，本分支无法本地编译验证，正确性靠 CI + 真机。严格 cfg-gate，
-// 写法保守稳妥。关键约束：
-//   1. enumerator 必须在监听期间一直存活，否则回调停止——故由常驻线程持有，退出时才
-//      `UnregisterEndpointNotificationCallback` + drop。
-//   2. COM 在本线程 `CoInitializeEx(MULTITHREADED)`，退出时 `CoUninitialize`。
-//   3. 只关心 capture（输入）设备的增删/状态/默认变化；render 设备变化忽略。回调里只调
-//      `on_change`（其内部去抖会过滤掉无关变化），故即使偶尔多触发也只是多一次零副作用
-//      的签名比较。
-#[cfg(target_os = "windows")]
-mod windows_impl {
-    use std::sync::atomic::Ordering;
-    use std::time::Duration;
-
-    use windows::core::Result as WinResult;
-    use windows::core::PCWSTR;
-    use windows::Win32::Media::Audio::{
-        eCapture, EDataFlow, ERole, IMMDeviceEnumerator, IMMNotificationClient,
-        IMMNotificationClient_Impl, MMDeviceEnumerator, DEVICE_STATE,
-    };
-    use windows::Win32::System::Com::{
-        CoCreateInstance, CoInitializeEx, CoUninitialize, CLSCTX_ALL, COINIT_MULTITHREADED,
-    };
-    use windows::Win32::UI::Shell::PropertiesSystem::PROPERTYKEY;
-
-    use super::super::TRAY_MICROPHONE_WATCHER_STOPPING;
-
-    /// IMMNotificationClient 实现：相关回调都转交 `on_change`（其内部去抖）。
-    /// 拥有 `on_change` 的所有权（'static Box），故 client 自包含、不借用外部生命周期。
-    #[windows::core::implement(IMMNotificationClient)]
-    struct DeviceNotificationClient {
-        on_change: Box<dyn Fn() + Send + Sync>,
-    }
-
-    impl DeviceNotificationClient {
-        fn notify(&self) {
-            (self.on_change)();
-        }
-    }
-
-    // IMMNotificationClient 的全部方法都必须实现（COM 接口契约）。
-    #[allow(non_snake_case)]
-    impl IMMNotificationClient_Impl for DeviceNotificationClient_Impl {
-        fn OnDeviceStateChanged(
-            &self,
-            _pwstrDeviceId: &PCWSTR,
-            _dwNewState: DEVICE_STATE,
-        ) -> WinResult<()> {
-            // 设备启用/禁用/拔出。无法在此廉价判断 data-flow，统一交给签名去抖过滤。
-            self.notify();
-            Ok(())
-        }
-
-        fn OnDeviceAdded(&self, _pwstrDeviceId: &PCWSTR) -> WinResult<()> {
-            self.notify();
-            Ok(())
-        }
-
-        fn OnDeviceRemoved(&self, _pwstrDeviceId: &PCWSTR) -> WinResult<()> {
-            self.notify();
-            Ok(())
-        }
-
-        fn OnDefaultDeviceChanged(
-            &self,
-            flow: EDataFlow,
-            _role: ERole,
-            _pwstrDefaultDeviceId: &PCWSTR,
-        ) -> WinResult<()> {
-            // 默认设备变化：只关心 capture（输入）。render 变化忽略，减少无谓刷新。
-            if flow == eCapture {
-                self.notify();
-            }
-            Ok(())
-        }
-
-        fn OnPropertyValueChanged(
-            &self,
-            _pwstrDeviceId: &PCWSTR,
-            _key: &PROPERTYKEY,
-        ) -> WinResult<()> {
-            // 属性变化噪声大（音量等），不触发刷新。
-            Ok(())
-        }
-    }
-
-    /// 在专用线程注册 MMDevice 端点通知并常驻直到退出 flag 置位。
-    /// 成功返回 `true`；COM/注册失败返回 `false`。
-    pub(super) fn spawn<F>(on_change: F) -> bool
-    where
-        F: Fn() + Send + Sync + 'static,
-    {
-        // 闭包提前装箱：client 直接拥有它，全程不借用外部生命周期，无裸指针 hack。
-        let on_change: Box<dyn Fn() + Send + Sync> = Box::new(on_change);
-        let (tx, rx) = std::sync::mpsc::channel::<bool>();
-        let spawn_result = std::thread::Builder::new()
-            .name("openless-mic-mmdevice".into())
-            .spawn(move || {
-                // SAFETY: 在本专用线程初始化 COM（MTA）。失败则不注册，直接报失败退出。
-                let hr = unsafe { CoInitializeEx(None, COINIT_MULTITHREADED) };
-                if hr.is_err() {
-                    log::warn!("[device_watch] CoInitializeEx failed: {hr:?}");
-                    let _ = tx.send(false);
-                    return;
-                }
-
-                let registered = register_and_run(on_change);
-                let _ = tx.send(registered);
-
-                // SAFETY: 与上面的 CoInitializeEx 配对。register_and_run 返回时所有 COM 对象
-                // 已 drop（enumerator/client 在其作用域内），此处可安全反初始化 COM。
-                unsafe { CoUninitialize() };
-            });
-
-        if let Err(err) = spawn_result {
-            log::warn!("[device_watch] spawn MMDevice watcher thread failed: {err}");
-            return false;
-        }
-        rx.recv().unwrap_or(false)
-    }
-
-    /// 创建 enumerator、注册回调、常驻轮转检查退出 flag、退出前注销。注册成功返回 `true`。
-    ///
-    /// 关键：本函数返回前 `enumerator` 与 `client` 一直在作用域内存活 → 满足「监听期间
-    /// enumerator 必须存活，否则回调停」。`client` 拥有 `on_change` 的所有权，自包含。
-    fn register_and_run(on_change: Box<dyn Fn() + Send + Sync>) -> bool {
-        // SAFETY: 标准 MMDevice enumerator 实例化。CLSCTX_ALL 允许进程内/外服务器。
-        let enumerator: IMMDeviceEnumerator =
-            match unsafe { CoCreateInstance(&MMDeviceEnumerator, None, CLSCTX_ALL) } {
-                Ok(e) => e,
-                Err(err) => {
-                    log::warn!(
-                        "[device_watch] CoCreateInstance(MMDeviceEnumerator) failed: {err:?}"
-                    );
-                    return false;
-                }
-            };
-
-        let client: IMMNotificationClient = DeviceNotificationClient { on_change }.into();
-
-        // SAFETY: enumerator 有效；client 是合法 IMMNotificationClient。注册后系统持有 client
-        // 的引用计数，回调将从 MMDevice 线程进入。client 拥有 on_change，生命周期自洽。
-        if let Err(err) = unsafe { enumerator.RegisterEndpointNotificationCallback(&client) } {
-            log::warn!("[device_watch] RegisterEndpointNotificationCallback failed: {err:?}");
-            return false;
-        }
-
-        // 常驻：MMDevice 回调由系统线程驱动，本线程只需保持 enumerator/client 存活并周期
-        // 检查退出 flag。1s 一片，退出最多 1s 内生效。
-        while !TRAY_MICROPHONE_WATCHER_STOPPING.load(Ordering::Relaxed) {
-            std::thread::sleep(Duration::from_secs(1));
-        }
-
-        // SAFETY: 注销同一 client。enumerator 仍有效。注销后系统不再回调。
-        if let Err(err) = unsafe { enumerator.UnregisterEndpointNotificationCallback(&client) } {
-            log::warn!("[device_watch] UnregisterEndpointNotificationCallback failed: {err:?}");
-        }
-        // enumerator 与 client 在此 drop（COM 引用计数归还，on_change 随 client 释放）。
-        true
-    }
-}

--- a/openless-all/app/src-tauri/src/device_watch.rs
+++ b/openless-all/app/src-tauri/src/device_watch.rs
@@ -1,0 +1,338 @@
+//! 托盘麦克风设备变更的 OS 原生监听（issue #470）。
+//!
+//! 目的：替代「每 10s 轮询 `list_input_devices()`」这条空闲唤醒。改用各平台原生的设备
+//! 变更通知，空闲时零唤醒，设备插拔/默认设备切换时由 OS 回调实时触发刷新。
+//!
+//! 严格按平台分流：
+//! - macOS：CoreAudio `AudioObjectAddPropertyListener` 监听
+//!   `kAudioHardwarePropertyDevices`，专用线程跑 `CFRunLoop` 常驻。
+//! - Windows：`IMMNotificationClient` 经 `IMMDeviceEnumerator` 注册端点通知回调。
+//! - Linux：无原生路径，返回 `false`，由 `lib.rs` 的慢速兜底轮询负责。
+//!
+//! 三平台共用契约：`spawn_native_watcher(app, on_change)`。`on_change` 是 `lib.rs` 提供
+//! 的去抖闭包（内部复用 `microphone_device_signature()`，真正变化才刷新+emit）。回调里
+//! 只调用 `on_change`，不做别的。注册失败一律返回 `false`（只 warn 不 panic），交由
+//! 兜底轮询兜底，保证三平台都「永远能检测到设备」。
+
+use tauri::AppHandle;
+
+/// 注册 OS 原生设备变更监听。成功返回 `true`，平台不支持或注册失败返回 `false`。
+///
+/// `on_change` 在 OS 回调线程上被调用（可能并发/重复），其内部负责去抖与线程派发。
+#[cfg(target_os = "macos")]
+pub(crate) fn spawn_native_watcher<F>(_app: AppHandle, on_change: F) -> bool
+where
+    F: Fn() + Send + Sync + 'static,
+{
+    macos::spawn(on_change)
+}
+
+/// Windows：经 MMDevice 端点通知注册。见模块内说明。
+#[cfg(target_os = "windows")]
+pub(crate) fn spawn_native_watcher<F>(_app: AppHandle, on_change: F) -> bool
+where
+    F: Fn() + Send + Sync + 'static,
+{
+    windows_impl::spawn(on_change)
+}
+
+/// Linux：无原生路径，纯靠 `lib.rs` 的慢速兜底轮询。
+#[cfg(not(any(target_os = "macos", target_os = "windows")))]
+pub(crate) fn spawn_native_watcher<F>(_app: AppHandle, _on_change: F) -> bool
+where
+    F: Fn() + Send + Sync + 'static,
+{
+    false
+}
+
+// ===================================================================================
+// macOS — CoreAudio AudioObjectAddPropertyListener
+// ===================================================================================
+#[cfg(target_os = "macos")]
+mod macos {
+    use coreaudio_sys::{
+        kAudioHardwarePropertyDevices, kAudioObjectPropertyElementMain,
+        kAudioObjectPropertyScopeGlobal, kAudioObjectSystemObject, AudioObjectAddPropertyListener,
+        AudioObjectID, AudioObjectPropertyAddress, AudioObjectRemovePropertyListener, OSStatus,
+        UInt32,
+    };
+    use std::ffi::c_void;
+    use std::sync::atomic::Ordering;
+    use std::time::Duration;
+
+    use core_foundation::runloop::{kCFRunLoopDefaultMode, CFRunLoop, CFRunLoopRunResult};
+
+    use super::super::TRAY_MICROPHONE_WATCHER_STOPPING;
+
+    /// 把用户闭包（胖指针）经单个 `*mut c_void` 传进 C 回调的双重间接封装。
+    /// 照抄 cpal 的 `PropertyListenerCallbackWrapper` 模式
+    /// (cpal-0.15.3/src/host/coreaudio/macos/property_listener.rs)。
+    struct ListenerWrapper(Box<dyn Fn() + Send + Sync>);
+
+    /// CoreAudio 属性监听回调 shim：把 `*mut c_void` 还原成用户闭包并调用。
+    /// 照抄 cpal 的 `property_listener_handler_shim`。
+    ///
+    /// # Safety
+    /// `user_data` 必须是 `spawn` 里 `AudioObjectAddPropertyListener` 注册时传入、且在监听
+    /// 存活期间一直有效的 `*const ListenerWrapper`（由常驻线程持有，不会提前释放）。
+    unsafe extern "C" fn listener_shim(
+        _object: AudioObjectID,
+        _num_addresses: UInt32,
+        _addresses: *const AudioObjectPropertyAddress,
+        user_data: *mut c_void,
+    ) -> OSStatus {
+        // SAFETY: user_data 是注册时传入的 &ListenerWrapper（见下方 SAFETY 注释），
+        // 监听存活期间常驻线程一直持有它，故此处解引用有效。
+        let wrapper = &*(user_data as *const ListenerWrapper);
+        (wrapper.0)();
+        0
+    }
+
+    /// 在专用线程注册 CoreAudio 设备变更监听并跑 CFRunLoop 常驻。
+    /// 成功返回 `true`（线程已起且监听已注册）；注册失败返回 `false`。
+    pub(super) fn spawn<F>(on_change: F) -> bool
+    where
+        F: Fn() + Send + Sync + 'static,
+    {
+        let (tx, rx) = std::sync::mpsc::channel::<bool>();
+        let spawn_result = std::thread::Builder::new()
+            .name("openless-mic-coreaudio".into())
+            .spawn(move || {
+                // wrapper 必须活过整个监听期，故 leak/常驻在本线程栈上直到 runloop 退出。
+                let wrapper = ListenerWrapper(Box::new(on_change));
+                let address = AudioObjectPropertyAddress {
+                    mSelector: kAudioHardwarePropertyDevices,
+                    mScope: kAudioObjectPropertyScopeGlobal,
+                    mElement: kAudioObjectPropertyElementMain,
+                };
+
+                // SAFETY: kAudioObjectSystemObject 是合法的系统级 AudioObjectID；address 指向
+                // 本栈上有效结构；listener_shim 是 'static extern "C" 回调；&wrapper 在整个
+                // runloop 期间存活（直到本线程退出），满足 CoreAudio 对 user_data 生命周期的
+                // 要求。返回值是 OSStatus，0 表示成功。
+                let status: OSStatus = unsafe {
+                    AudioObjectAddPropertyListener(
+                        kAudioObjectSystemObject as AudioObjectID,
+                        &address as *const _,
+                        Some(listener_shim),
+                        &wrapper as *const _ as *mut c_void,
+                    )
+                };
+
+                if status != 0 {
+                    log::warn!(
+                        "[device_watch] AudioObjectAddPropertyListener failed: OSStatus={status}"
+                    );
+                    let _ = tx.send(false);
+                    return;
+                }
+                let _ = tx.send(true);
+
+                // CFRunLoop 常驻。用 `run_in_mode` 短超时轮转代替 `CFRunLoopRun()`，
+                // 每 1s 醒来一次检查退出 flag——避免跨线程 CFRunLoopStop 的竞态与线程泄漏。
+                // CoreAudio 回调照常在 run_in_mode 内被派发（属于 default mode）。
+                while !TRAY_MICROPHONE_WATCHER_STOPPING.load(Ordering::Relaxed) {
+                    // SAFETY: kCFRunLoopDefaultMode 是 CoreFoundation 提供的 'static 常量字符串。
+                    let mode = unsafe { kCFRunLoopDefaultMode };
+                    let result = CFRunLoop::run_in_mode(mode, Duration::from_secs(1), false);
+                    // Finished 表示 runloop 立即返回（没有任何 input source）。CoreAudio 监听
+                    // 本身会给 default mode 装上 source，正常不会走到这里；但极端情况下用一小段
+                    // sleep 避免空转 busy loop，再回到顶部按退出 flag 判断。
+                    if matches!(result, CFRunLoopRunResult::Finished) {
+                        std::thread::sleep(Duration::from_millis(200));
+                    }
+                }
+
+                // SAFETY: 与注册时同一组 (object, address, shim, user_data)，且 wrapper 仍存活。
+                // 退出前移除监听，避免 CoreAudio 持有悬垂指针。
+                let remove_status: OSStatus = unsafe {
+                    AudioObjectRemovePropertyListener(
+                        kAudioObjectSystemObject as AudioObjectID,
+                        &address as *const _,
+                        Some(listener_shim),
+                        &wrapper as *const _ as *mut c_void,
+                    )
+                };
+                if remove_status != 0 {
+                    log::warn!(
+                        "[device_watch] AudioObjectRemovePropertyListener failed: OSStatus={remove_status}"
+                    );
+                }
+                // wrapper 在此 drop——此时监听已移除，C 侧不再回调，安全。
+                let _ = &wrapper;
+            });
+
+        if let Err(err) = spawn_result {
+            log::warn!("[device_watch] spawn CoreAudio watcher thread failed: {err}");
+            return false;
+        }
+
+        // 等线程报告注册结果（注册是同步的、瞬时的）。线程崩溃/通道断开按失败处理。
+        rx.recv().unwrap_or(false)
+    }
+}
+
+// ===================================================================================
+// Windows — IMMNotificationClient via IMMDeviceEnumerator
+// ===================================================================================
+//
+// 注意：开发机是 macOS，本分支无法本地编译验证，正确性靠 CI + 真机。严格 cfg-gate，
+// 写法保守稳妥。关键约束：
+//   1. enumerator 必须在监听期间一直存活，否则回调停止——故由常驻线程持有，退出时才
+//      `UnregisterEndpointNotificationCallback` + drop。
+//   2. COM 在本线程 `CoInitializeEx(MULTITHREADED)`，退出时 `CoUninitialize`。
+//   3. 只关心 capture（输入）设备的增删/状态/默认变化；render 设备变化忽略。回调里只调
+//      `on_change`（其内部去抖会过滤掉无关变化），故即使偶尔多触发也只是多一次零副作用
+//      的签名比较。
+#[cfg(target_os = "windows")]
+mod windows_impl {
+    use std::sync::atomic::Ordering;
+    use std::time::Duration;
+
+    use windows::core::Result as WinResult;
+    use windows::core::PCWSTR;
+    use windows::Win32::Media::Audio::{
+        eCapture, EDataFlow, ERole, IMMDeviceEnumerator, IMMNotificationClient,
+        IMMNotificationClient_Impl, MMDeviceEnumerator, DEVICE_STATE,
+    };
+    use windows::Win32::System::Com::{
+        CoCreateInstance, CoInitializeEx, CoUninitialize, CLSCTX_ALL, COINIT_MULTITHREADED,
+    };
+    use windows::Win32::UI::Shell::PropertiesSystem::PROPERTYKEY;
+
+    use super::super::TRAY_MICROPHONE_WATCHER_STOPPING;
+
+    /// IMMNotificationClient 实现：相关回调都转交 `on_change`（其内部去抖）。
+    /// 拥有 `on_change` 的所有权（'static Box），故 client 自包含、不借用外部生命周期。
+    #[windows::core::implement(IMMNotificationClient)]
+    struct DeviceNotificationClient {
+        on_change: Box<dyn Fn() + Send + Sync>,
+    }
+
+    impl DeviceNotificationClient {
+        fn notify(&self) {
+            (self.on_change)();
+        }
+    }
+
+    // IMMNotificationClient 的全部方法都必须实现（COM 接口契约）。
+    #[allow(non_snake_case)]
+    impl IMMNotificationClient_Impl for DeviceNotificationClient_Impl {
+        fn OnDeviceStateChanged(
+            &self,
+            _pwstrDeviceId: &PCWSTR,
+            _dwNewState: DEVICE_STATE,
+        ) -> WinResult<()> {
+            // 设备启用/禁用/拔出。无法在此廉价判断 data-flow，统一交给签名去抖过滤。
+            self.notify();
+            Ok(())
+        }
+
+        fn OnDeviceAdded(&self, _pwstrDeviceId: &PCWSTR) -> WinResult<()> {
+            self.notify();
+            Ok(())
+        }
+
+        fn OnDeviceRemoved(&self, _pwstrDeviceId: &PCWSTR) -> WinResult<()> {
+            self.notify();
+            Ok(())
+        }
+
+        fn OnDefaultDeviceChanged(
+            &self,
+            flow: EDataFlow,
+            _role: ERole,
+            _pwstrDefaultDeviceId: &PCWSTR,
+        ) -> WinResult<()> {
+            // 默认设备变化：只关心 capture（输入）。render 变化忽略，减少无谓刷新。
+            if flow == eCapture {
+                self.notify();
+            }
+            Ok(())
+        }
+
+        fn OnPropertyValueChanged(
+            &self,
+            _pwstrDeviceId: &PCWSTR,
+            _key: &PROPERTYKEY,
+        ) -> WinResult<()> {
+            // 属性变化噪声大（音量等），不触发刷新。
+            Ok(())
+        }
+    }
+
+    /// 在专用线程注册 MMDevice 端点通知并常驻直到退出 flag 置位。
+    /// 成功返回 `true`；COM/注册失败返回 `false`。
+    pub(super) fn spawn<F>(on_change: F) -> bool
+    where
+        F: Fn() + Send + Sync + 'static,
+    {
+        // 闭包提前装箱：client 直接拥有它，全程不借用外部生命周期，无裸指针 hack。
+        let on_change: Box<dyn Fn() + Send + Sync> = Box::new(on_change);
+        let (tx, rx) = std::sync::mpsc::channel::<bool>();
+        let spawn_result = std::thread::Builder::new()
+            .name("openless-mic-mmdevice".into())
+            .spawn(move || {
+                // SAFETY: 在本专用线程初始化 COM（MTA）。失败则不注册，直接报失败退出。
+                let hr = unsafe { CoInitializeEx(None, COINIT_MULTITHREADED) };
+                if hr.is_err() {
+                    log::warn!("[device_watch] CoInitializeEx failed: {hr:?}");
+                    let _ = tx.send(false);
+                    return;
+                }
+
+                let registered = register_and_run(on_change);
+                let _ = tx.send(registered);
+
+                // SAFETY: 与上面的 CoInitializeEx 配对。register_and_run 返回时所有 COM 对象
+                // 已 drop（enumerator/client 在其作用域内），此处可安全反初始化 COM。
+                unsafe { CoUninitialize() };
+            });
+
+        if let Err(err) = spawn_result {
+            log::warn!("[device_watch] spawn MMDevice watcher thread failed: {err}");
+            return false;
+        }
+        rx.recv().unwrap_or(false)
+    }
+
+    /// 创建 enumerator、注册回调、常驻轮转检查退出 flag、退出前注销。注册成功返回 `true`。
+    ///
+    /// 关键：本函数返回前 `enumerator` 与 `client` 一直在作用域内存活 → 满足「监听期间
+    /// enumerator 必须存活，否则回调停」。`client` 拥有 `on_change` 的所有权，自包含。
+    fn register_and_run(on_change: Box<dyn Fn() + Send + Sync>) -> bool {
+        // SAFETY: 标准 MMDevice enumerator 实例化。CLSCTX_ALL 允许进程内/外服务器。
+        let enumerator: IMMDeviceEnumerator =
+            match unsafe { CoCreateInstance(&MMDeviceEnumerator, None, CLSCTX_ALL) } {
+                Ok(e) => e,
+                Err(err) => {
+                    log::warn!(
+                        "[device_watch] CoCreateInstance(MMDeviceEnumerator) failed: {err:?}"
+                    );
+                    return false;
+                }
+            };
+
+        let client: IMMNotificationClient = DeviceNotificationClient { on_change }.into();
+
+        // SAFETY: enumerator 有效；client 是合法 IMMNotificationClient。注册后系统持有 client
+        // 的引用计数，回调将从 MMDevice 线程进入。client 拥有 on_change，生命周期自洽。
+        if let Err(err) = unsafe { enumerator.RegisterEndpointNotificationCallback(&client) } {
+            log::warn!("[device_watch] RegisterEndpointNotificationCallback failed: {err:?}");
+            return false;
+        }
+
+        // 常驻：MMDevice 回调由系统线程驱动，本线程只需保持 enumerator/client 存活并周期
+        // 检查退出 flag。1s 一片，退出最多 1s 内生效。
+        while !TRAY_MICROPHONE_WATCHER_STOPPING.load(Ordering::Relaxed) {
+            std::thread::sleep(Duration::from_secs(1));
+        }
+
+        // SAFETY: 注销同一 client。enumerator 仍有效。注销后系统不再回调。
+        if let Err(err) = unsafe { enumerator.UnregisterEndpointNotificationCallback(&client) } {
+            log::warn!("[device_watch] UnregisterEndpointNotificationCallback failed: {err:?}");
+        }
+        // enumerator 与 client 在此 drop（COM 引用计数归还，on_change 随 client 释放）。
+        true
+    }
+}

--- a/openless-all/app/src-tauri/src/lib.rs
+++ b/openless-all/app/src-tauri/src/lib.rs
@@ -28,6 +28,10 @@ mod commands;
 mod coordinator;
 mod coordinator_state;
 mod correction;
+// 托盘麦克风设备变更监听：macOS CoreAudio / Windows MMDevice 原生通知（空闲零唤醒），
+// Linux 退化为纯轮询兜底。仅桌面端。详见 issue #470。
+#[cfg(not(mobile))]
+mod device_watch;
 mod external_url;
 #[cfg(not(mobile))]
 mod global_hotkey_runtime;
@@ -902,21 +906,74 @@ fn microphone_device_signature() -> Option<Vec<(String, bool)>> {
     }
 }
 
+/// 在主线程上刷新托盘麦克风子菜单并通知前端。供 OS 原生设备变更回调与慢速兜底轮询
+/// 共用同一条收尾路径。已在主线程或被 `run_on_main_thread` 派发后调用。
+#[cfg(not(mobile))]
+fn refresh_microphone_on_main(app: &AppHandle) {
+    if let Err(err) = refresh_tray_microphone_menu(app) {
+        log::warn!("[tray] refresh microphone menu after device change failed: {err}");
+    }
+    let _ = app.emit("microphone:devices-changed", serde_json::json!({}));
+}
+
+/// 设备变更去抖闭包：被 OS 原生通知回调（macOS CoreAudio / Windows MMDevice）调用。
+/// 复用 `microphone_device_signature()` 去抖——签名没变就零副作用直接返回；变了才
+/// `run_on_main_thread` 派发刷新+emit。OS 通知可能合并/重复触发，去抖确保只在真正
+/// 变化时刷新。`last_signature` 用 `Mutex` 保护，因为回调可能从不同的 CoreAudio/COM
+/// 线程并发进入。
+#[cfg(not(mobile))]
+fn make_microphone_change_handler(app: AppHandle) -> impl Fn() + Send + Sync + 'static {
+    let last_signature = parking_lot::Mutex::new(microphone_device_signature());
+    move || {
+        let signature = microphone_device_signature();
+        {
+            let mut guard = last_signature.lock();
+            if signature == *guard {
+                return;
+            }
+            *guard = signature;
+        }
+        let refresh_app = app.clone();
+        let _ = app.run_on_main_thread(move || refresh_microphone_on_main(&refresh_app));
+    }
+}
+
 #[cfg(not(mobile))]
 fn start_tray_microphone_watcher(app: AppHandle) {
     TRAY_MICROPHONE_WATCHER_STOPPING.store(false, Ordering::Relaxed);
+
+    // 1) OS 原生设备变更通知（issue #470 的最优方案）：空闲零唤醒。
+    //    macOS → CoreAudio AudioObjectAddPropertyListener；Windows → IMMNotificationClient。
+    //    Linux 无原生路径，返回 false，纯靠下面的慢速兜底。
+    //    注册失败（OSStatus≠0 / RegisterEndpoint Err）只 warn，不 panic——兜底轮询保证
+    //    三平台都「永远能检测到设备」。
+    let native_registered =
+        device_watch::spawn_native_watcher(app.clone(), make_microphone_change_handler(app.clone()));
+    if native_registered {
+        log::info!("[tray] OS native microphone device watcher registered");
+    } else {
+        log::info!(
+            "[tray] no OS native microphone device watcher (unsupported platform or registration failed); relying on slow poll fallback"
+        );
+    }
+
+    // 2) 全平台慢速兜底：60s 无条件轮询，复用 signature 去抖（签名没变就 continue，零
+    //    副作用）。原生通知失败时由它保证设备变更最终被检测到；原生通知正常时它只是
+    //    极低频的安全网，几乎从不真正刷新。
     if let Err(err) = std::thread::Builder::new()
-        .name("openless-tray-mic-watch".into())
+        .name("openless-tray-mic-poll".into())
         .spawn(move || {
             let mut last_signature = microphone_device_signature();
             while !TRAY_MICROPHONE_WATCHER_STOPPING.load(Ordering::Relaxed) {
-                // 10s, not 1.5s. `list_input_devices()` is a relatively costly
-                // CoreAudio/WASAPI enumeration and this ran every 1.5s forever —
-                // the single biggest idle wakeup. The tray menu refreshes on hover
-                // and the settings page reacts to `microphone:devices-changed`, so
-                // ~10s detection latency is fine. (Proper fix: subscribe to an OS
-                // device-change notification instead of polling.)
-                std::thread::sleep(Duration::from_millis(10_000));
+                // 60s（而非 10s）：原生通知承担实时检测，这条线程只是兜底，把它拉到 60s
+                // 进一步压低空闲唤醒。1s 一片的睡眠让退出 flag 最多 1s 内生效，避免退出时
+                // 长时间挂起线程。
+                for _ in 0..60 {
+                    if TRAY_MICROPHONE_WATCHER_STOPPING.load(Ordering::Relaxed) {
+                        return;
+                    }
+                    std::thread::sleep(Duration::from_secs(1));
+                }
                 if TRAY_MICROPHONE_WATCHER_STOPPING.load(Ordering::Relaxed) {
                     break;
                 }
@@ -925,20 +982,12 @@ fn start_tray_microphone_watcher(app: AppHandle) {
                     continue;
                 }
                 last_signature = signature;
-                let app = app.clone();
                 let refresh_app = app.clone();
-                let _ = app.run_on_main_thread(move || {
-                    if let Err(err) = refresh_tray_microphone_menu(&refresh_app) {
-                        log::warn!(
-                            "[tray] refresh microphone menu after device change failed: {err}"
-                        );
-                    }
-                    let _ = refresh_app.emit("microphone:devices-changed", serde_json::json!({}));
-                });
+                let _ = app.run_on_main_thread(move || refresh_microphone_on_main(&refresh_app));
             }
         })
     {
-        log::warn!("[tray] start microphone watcher failed: {err}");
+        log::warn!("[tray] start microphone poll fallback failed: {err}");
     }
 }
 


### PR DESCRIPTION
### **User description**
源自 #470 Cloud 性能审查 P0。原 watcher 每 10s 轮询 `list_input_devices()`（CoreAudio/WASAPI 全枚举）永不停歇。

**改动**：新增 `device_watch` 模块用 OS 原生设备变更通知替代轮询——macOS `AudioObjectAddPropertyListener(kAudioHardwarePropertyDevices)` 专用 CFRunLoop 线程常驻；Windows `IMMNotificationClient` 经 `IMMDeviceEnumerator` 注册端点通知。回调复用现有去抖 + `refresh_tray_microphone_menu` + emit。

**works 保证**：保留一条 60s 全平台慢速兜底轮询无条件运行——原生注册失败 / Linux 无原生路径时退化到它，三平台永远能检测到设备。`coreaudio-sys` 提升为 macOS 直接依赖（本就在依赖树）。

**验证**：macOS `cargo check` 通过。⚠️ Windows `IMMNotificationClient` 分支开发机(macOS)无法本地编译，**请 CI 三平台 cargo check + Windows 真机验证**；60s 兜底保证即使该分支失效也不漏检设备。Cargo.lock 未含本次 dep（macOS check 会引入大量无关环境性条目），cargo 构建自愈。


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Replace 10s polling with OS-native device notifications (macOS CoreAudio) for zero idle wake-ups

- Fallback 60s slow poll for Windows/Linux (6× lower wake-up rate than original)

- Extract common refresh and dedup logic for reusable device-change handling


___

### Diagram Walkthrough


```mermaid
flowchart LR
  subgraph start_tray_microphone_watcher
    A["macOS?"] -- yes --> B["spawn_native_watcher (CoreAudio)"]
    A -- "no (Windows / Linux)" --> C["return false"]
  end
  B -- "success?" --> D["native_registered = true"]
  B -- fail --> D
  D --> E["60s slow poll fallback unconditionally (1s sleep loop)"]
  E --> F["Check signature dedup (microphone_device_signature)"]
  F -- changed --> G["refresh_microphone_on_main (menu + emit)"]
  F -- unchanged --> E
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>device_watch.rs</strong><dd><code>Add device_watch module with macOS CoreAudio native listener</code></dd></summary>
<hr>

openless-all/app/src-tauri/src/device_watch.rs

<ul><li>New module for OS-native microphone device watching<br> <li> macOS: spawn CoreAudio AudioObjectAddPropertyListener with dedicated <br>CFRunLoop thread<br> <li> Windows/Linux: return false (delegate to 60s fallback)<br> <li> Handles registration failure gracefully with warning logs</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/670/files#diff-15b254919d5d8e93b7b7fca7f112f2a166a6efad4eb443b115e8b74c0b7d387b">+166/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>lib.rs</strong><dd><code>Integrate native watcher, reduce fallback poll to 60s, extract refresh </code><br><code>helper</code></dd></summary>
<hr>

openless-all/app/src-tauri/src/lib.rs

<ul><li>Integrate device_watch module via #[cfg(not(mobile))]<br> <li> Extract refresh_microphone_on_main helper for menu refresh & event <br>emit<br> <li> Implement make_microphone_change_handler with signature dedup (Mutex)<br> <li> Modify start_tray_microphone_watcher: attempt native watcher first, <br>then 60s poll (1s sleep slices)<br> <li> Reduce poll interval from 10s to 60s, making it true fallback</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/670/files#diff-6b8eb1bbf8e378bab914f1a12962f7add5cc4ba9e013c37c9921a1032fa5e110">+67/-18</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Cargo.toml</strong><dd><code>Add coreaudio-sys dependency for macOS native device watch</code></dd></summary>
<hr>

openless-all/app/src-tauri/Cargo.toml

<ul><li>Add coreaudio-sys as direct macOS dependency for CoreAudio API access</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/670/files#diff-334952ba03e62939865bbf0351f0916ea88c6457f8ea1259336e73ee4e2f088b">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

