### PR TITLE
perf(coordinator): 可选热键 supervisor 注册成功即退出，消除稳态轮询

### DIFF
--- a/openless-all/app/src-tauri/src/coordinator.rs
+++ b/openless-all/app/src-tauri/src/coordinator.rs
@@ -2142,22 +2142,22 @@ fn combo_hotkey_supervisor_loop(inner: Arc<Inner>) {
         // 读当前 prefs
         let prefs = inner.prefs.get();
         if crate::shortcut_binding::legacy_modifier_trigger(&prefs.dictation_hotkey).is_some() {
-            // 不是 Custom → 睡着等 prefs 改动
+            // 不是 Custom → 卸载后退出守护
             take_combo_hotkey_on_main_thread(&inner);
-            std::thread::sleep(std::time::Duration::from_secs(5));
-            continue;
+            // 对齐主 supervisor 的 exit-on-success：装/卸交给 update_combo_hotkey_binding 主动路径，issue #470
+            return;
         }
 
         let binding = prefs.dictation_hotkey.clone();
         if is_unconfigured_shortcut(&binding) {
             take_combo_hotkey_on_main_thread(&inner);
-            std::thread::sleep(std::time::Duration::from_secs(5));
-            continue;
+            // 对齐主 supervisor 的 exit-on-success：装/卸交给 update_combo_hotkey_binding 主动路径，issue #470
+            return;
         }
 
         if inner.combo_hotkey.lock().is_some() {
-            std::thread::sleep(std::time::Duration::from_secs(5));
-            continue;
+            // 对齐主 supervisor 的 exit-on-success：装/卸交给 update_combo_hotkey_binding 主动路径，issue #470
+            return;
         }
 
         let app = inner.app.lock().clone();
@@ -2255,13 +2255,13 @@ fn translation_hotkey_supervisor_loop(inner: Arc<Inner>) {
                 let (qa_trigger, translation_trigger) = modifier_shortcut_triggers(&inner);
                 monitor.update_modifier_shortcuts(qa_trigger, translation_trigger);
             }
-            std::thread::sleep(std::time::Duration::from_secs(5));
-            continue;
+            // 对齐主 supervisor 的 exit-on-success：装/卸交给 try_update_translation_hotkey_binding 主动路径，issue #470
+            return;
         }
 
         if inner.translation_hotkey.lock().is_some() {
-            std::thread::sleep(std::time::Duration::from_secs(5));
-            continue;
+            // 对齐主 supervisor 的 exit-on-success：装/卸交给 try_update_translation_hotkey_binding 主动路径，issue #470
+            return;
         }
 
         let app = match inner.app.lock().clone() {
@@ -2348,21 +2348,21 @@ fn action_hotkey_supervisor_loop(inner: Arc<Inner>, kind: ActionHotkeyKind) {
         if inner.shutdown.load(Ordering::SeqCst) {
             return;
         }
-        // None = 用户主动停用：反注册并睡着等 prefs 改动（由 update 路径唤醒）。
+        // None = 用户主动停用：反注册后退出守护（由 update_action_hotkey_binding 主动路径重装）。
         let Some(binding) = action_hotkey_binding(&inner, kind) else {
             take_action_hotkey_on_main_thread(&inner, kind);
-            std::thread::sleep(std::time::Duration::from_secs(5));
-            continue;
+            // 对齐主 supervisor 的 exit-on-success：装/卸交给 update_action_hotkey_binding 主动路径，issue #470
+            return;
         };
         if is_modifier_only_shortcut(&binding) {
             take_action_hotkey_on_main_thread(&inner, kind);
-            std::thread::sleep(std::time::Duration::from_secs(5));
-            continue;
+            // 对齐主 supervisor 的 exit-on-success：装/卸交给 update_action_hotkey_binding 主动路径，issue #470
+            return;
         }
 
         if action_hotkey_slot(&inner, kind).lock().is_some() {
-            std::thread::sleep(std::time::Duration::from_secs(5));
-            continue;
+            // 对齐主 supervisor 的 exit-on-success：装/卸交给 update_action_hotkey_binding 主动路径，issue #470
+            return;
         }
 
         let app = match inner.app.lock().clone() {


### PR DESCRIPTION
### **User description**
源自 #470 Cloud 性能审查 #2。combo/translation/action 三类可选热键 supervisor 原本注册成功后不退出，稳态每 5s 醒来读 prefs，多线程常驻空转。

**改动**：对齐主 `hotkey_supervisor_loop` 的 exit-on-success 模式——到达「已安装」或「已主动停用」稳态即 `return` 退出，零稳态轮询。仅改控制流（`sleep+continue`→`return`），无新增锁。

**安全前提（已逐函数确认）**：用户启用/改/停这些热键时 `set_*_hotkey` 命令与 `persist_settings` diff 都会调 `update_*_hotkey_binding`，其覆盖「monitor 为 None → 从零 start+spawn」安装路径 → 退出后启停改键无需重启即时生效；ComboHotkeyMonitor 注册后驻留、无运行中自注销 → monitor 不会自己死，无需守护。有界路径（失败重试 3s / recv_timeout 5s / app未就绪 1s）全部保留。

**验证**：macOS `cargo check` 通过 + 对抗式复审 pass。Windows/Linux cfg 分支靠 CI（控制流三端等价，无 cfg 分歧）。


___

### **PR Type**
Enhancement


___

### **Description**
- 消除 combo/translation/action 可选热键 supervisor 的稳态轮询

- 对齐主 supervisor 的 exit-on-success 模式：注册成功即 return 退出

- 依赖 update_*_hotkey_binding 主动路径确保启停即时生效，无需守护


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Before("之前") --> Loop("loop {}") --> Check1["检查 prefs"] --> Decision1{"已安装/已禁用?"}
  Decision1 -->|是| Uninstall["卸载热键"] --> Sleep["sleep 5s"] --> Loop
  Decision1 -->|否| Decision2{"Monitor 已存在?"}
  Decision2 -->|是| Sleep
  Decision2 -->|否| Install["安装热键"] --> ReturnBefore["保持 loop"]
  After("之后") --> Loop2["loop {}"] --> Check2["检查 prefs"] --> Decision3{"已安装/已禁用?"}
  Decision3 -->|是| Uninstall2["卸载热键"] --> ReturnAfter1["return"]
  Decision3 -->|否| Decision4{"Monitor 已存在?"}
  Decision4 -->|是| ReturnAfter2["return"]
  Decision4 -->|否| Install2["安装热键"] --> ReturnAfter3["return"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>coordinator.rs</strong><dd><code>supervisor loop exit-on-success</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src-tauri/src/coordinator.rs

<ul><li>在 combo_hotkey_supervisor_loop 中将三个稳定状态分支从 sleep+continue 改为 return<br> <li> 在 translation_hotkey_supervisor_loop 中将两个稳定状态分支改为 return<br> <li> 在 action_hotkey_supervisor_loop 中将三个稳定状态分支改为 return<br> <li> 添加注释说明对齐主 supervisor 的 exit-on-success 模式，依赖 update_*_hotkey_binding <br>主动路径</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/671/files#diff-73d8c004670b27293f74f0f3991b9a6fc28f0ff0b883214de2b078b1e09797ca">+18/-18</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

