### PR TITLE
perf(local-asr): 引擎状态改后端事件驱动，前端零轮询

### DIFF
--- a/openless-all/app/src-tauri/src/commands/local_asr.rs
+++ b/openless-all/app/src-tauri/src/commands/local_asr.rs
@@ -270,7 +270,7 @@ pub async fn local_asr_test_model(
         .map_err(|e| format!("{e:#}"))
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct LocalAsrEngineStatus {
     pub loaded: bool,
@@ -305,5 +305,7 @@ pub fn local_asr_set_keep_loaded_secs(
 ) -> Result<(), String> {
     let mut prefs = coord.prefs().get();
     prefs.local_asr_keep_loaded_secs = seconds;
-    coord.prefs().set(prefs).map_err(|e| e.to_string())
+    coord.prefs().set(prefs).map_err(|e| e.to_string())?;
+    coord.emit_local_asr_engine_status();
+    Ok(())
 }

--- a/openless-all/app/src-tauri/src/coordinator.rs
+++ b/openless-all/app/src-tauri/src/coordinator.rs
@@ -529,6 +529,8 @@ impl Coordinator {
                     }
                 })
                 .await;
+                // 预热加载完后推一次状态，前端零轮询更新「已加载」。
+                emit_local_asr_engine_status(&inner);
             });
         }
         #[cfg(not(target_os = "macos"))]
@@ -540,10 +542,16 @@ impl Coordinator {
     /// 释放当前缓存的本地 ASR 引擎（用户主动点 / 或 删除模型时调）。
     pub fn release_local_asr_engine(&self) {
         self.inner.local_asr_cache.release_now();
+        emit_local_asr_engine_status(&self.inner);
     }
 
     pub fn local_asr_loaded_model(&self) -> Option<String> {
         self.inner.local_asr_cache.loaded_model_id()
+    }
+
+    /// 主动把当前本地 ASR 引擎状态推给前端（keepLoadedSecs 变更等命令侧调用）。
+    pub fn emit_local_asr_engine_status(&self) {
+        emit_local_asr_engine_status(&self.inner);
     }
 
     pub fn bind_app(&self, handle: AppHandle) {
@@ -3222,6 +3230,23 @@ fn ensure_local_qwen3_model_ready() -> Result<(), String> {
     Ok(())
 }
 
+/// 引擎加载/释放/keepLoadedSecs 变化时主动推给前端，前端 listen
+/// `local-asr:engine-changed` 即可零轮询同步 UI（issue #470 / #6）。
+/// 只反映 Qwen3 这一路（loaded_model_id / prefs），不碰 Foundry / Sherpa。
+/// 仅用跨平台符号，保证 Windows / Linux 也能编译。
+fn emit_local_asr_engine_status(inner: &Arc<Inner>) {
+    let model_id = inner.local_asr_cache.loaded_model_id();
+    let keep_loaded_secs = inner.prefs.get().local_asr_keep_loaded_secs;
+    let status = crate::commands::LocalAsrEngineStatus {
+        loaded: model_id.is_some(),
+        model_id,
+        keep_loaded_secs,
+    };
+    if let Some(app) = inner.app.lock().clone() {
+        let _ = app.emit("local-asr:engine-changed", &status);
+    }
+}
+
 /// 一次 dictation 结束后，按 prefs.local_asr_keep_loaded_secs 决定何时释放
 /// 内存里的 Qwen3-ASR 引擎。0 = 立即释放；其它值 = sleep N 秒后看 last_used。
 /// 多次会话叠加多个 sleep 任务，每个独立 check：只要中间又被使用过就跳过释放。
@@ -3230,12 +3255,16 @@ fn schedule_local_asr_release(inner: &Arc<Inner>) {
     let cache = Arc::clone(&inner.local_asr_cache);
     if keep_secs == 0 {
         cache.release_now();
+        emit_local_asr_engine_status(inner);
         return;
     }
     let dur = std::time::Duration::from_secs(keep_secs as u64);
+    let inner = Arc::clone(inner);
     tauri::async_runtime::spawn(async move {
         tokio::time::sleep(dur).await;
-        cache.release_if_idle(dur);
+        if cache.release_if_idle(dur) {
+            emit_local_asr_engine_status(&inner);
+        }
     });
 }
 
@@ -3322,6 +3351,8 @@ async fn build_local_qwen3(
     let engine = tauri::async_runtime::spawn_blocking(move || cache.get_or_load(&mid, &dir))
         .await
         .map_err(|e| anyhow::anyhow!("spawn_blocking join failed: {e:#}"))??;
+    // 加载完成（含缓存命中刷新 last_used）后推一次状态，前端零轮询更新「已加载」。
+    emit_local_asr_engine_status(inner);
     Ok(Arc::new(crate::asr::local::LocalQwenAsr::new(app, engine)))
 }
 

--- a/openless-all/app/src-tauri/src/coordinator.rs
+++ b/openless-all/app/src-tauri/src/coordinator.rs
@@ -3233,7 +3233,9 @@ fn ensure_local_qwen3_model_ready() -> Result<(), String> {
 /// 引擎加载/释放/keepLoadedSecs 变化时主动推给前端，前端 listen
 /// `local-asr:engine-changed` 即可零轮询同步 UI（issue #470 / #6）。
 /// 只反映 Qwen3 这一路（loaded_model_id / prefs），不碰 Foundry / Sherpa。
-/// 仅用跨平台符号，保证 Windows / Linux 也能编译。
+/// 仅用桌面端跨平台符号；Android 无本地 ASR 引擎（LocalAsrEngineStatus 不在该 target
+/// 编译），单独给 no-op stub（见下），让各调用点在所有平台统一编译。
+#[cfg(not(target_os = "android"))]
 fn emit_local_asr_engine_status(inner: &Arc<Inner>) {
     let model_id = inner.local_asr_cache.loaded_model_id();
     let keep_loaded_secs = inner.prefs.get().local_asr_keep_loaded_secs;
@@ -3246,6 +3248,10 @@ fn emit_local_asr_engine_status(inner: &Arc<Inner>) {
         let _ = app.emit("local-asr:engine-changed", &status);
     }
 }
+
+/// Android no-op：该 target 不编译 LocalAsrEngineStatus / 本地 ASR 引擎。issue #470 / #6。
+#[cfg(target_os = "android")]
+fn emit_local_asr_engine_status(_inner: &Arc<Inner>) {}
 
 /// 一次 dictation 结束后，按 prefs.local_asr_keep_loaded_secs 决定何时释放
 /// 内存里的 Qwen3-ASR 引擎。0 = 立即释放；其它值 = sleep N 秒后看 last_used。

--- a/openless-all/app/src/pages/LocalAsr.tsx
+++ b/openless-all/app/src/pages/LocalAsr.tsx
@@ -180,7 +180,6 @@ export function LocalAsr({ embedded = false }: LocalAsrProps = {}) {
     const foundryRefreshTimer = useRef<number | null>(null)
     const sherpaRefreshTimer = useRef<number | null>(null)
     const sherpaDownloadRefreshTimer = useRef<number | null>(null)
-    const engineStatusTimer = useRef<number | null>(null)
     const foundrySelectionDirty = useRef(false)
     const selectedFoundryAliasRef =
         useRef<FoundryLocalAsrModelAlias>("whisper-small")
@@ -506,15 +505,39 @@ export function LocalAsr({ embedded = false }: LocalAsrProps = {}) {
 
     useEffect(() => {
         void refresh()
-        // 引擎状态每 5s 轮询一次，让 UI 能看到 release 计时器到点后的状态变化
-        engineStatusTimer.current = window.setInterval(() => {
-            void refreshEngineStatus()
-        }, 5000)
         return () => {
-            if (engineStatusTimer.current !== null) {
-                window.clearInterval(engineStatusTimer.current)
-            }
             if (scrollGuardCleanup.current) scrollGuardCleanup.current()
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [])
+
+    // 引擎状态改由后端主动 emit（加载/释放/keepLoadedSecs 变更），前端零轮询。
+    // 挂载时仍拉一次初值，之后 listen `local-asr:engine-changed` 增量更新。
+    // 仅 Tauri 环境（浏览器 dev mock 无事件）。
+    useEffect(() => {
+        if (!isTauri) return
+        void refreshEngineStatus()
+        let unlisten: undefined | (() => void)
+        let cancelled = false
+        ;(async () => {
+            const { listen } = await import("@tauri-apps/api/event")
+            const off = await listen<LocalAsrEngineStatus>(
+                "local-asr:engine-changed",
+                (e) => {
+                    setEngineStatus(e.payload)
+                },
+            )
+            if (cancelled) {
+                off()
+            } else {
+                unlisten = off
+            }
+        })().catch((err) =>
+            console.warn("[localAsr] engine status subscribe failed", err),
+        )
+        return () => {
+            cancelled = true
+            if (unlisten) unlisten()
         }
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [])
@@ -1363,9 +1386,8 @@ export function LocalAsr({ embedded = false }: LocalAsrProps = {}) {
 
     const handlePreload = async () => {
         try {
+            // 加载完成后后端会 emit `local-asr:engine-changed`，前端零轮询更新状态。
             await preloadLocalAsr()
-            // 触发预加载后给后端几秒，再查状态
-            window.setTimeout(() => void refreshEngineStatus(), 1500)
         } catch (e) {
             setError(e instanceof Error ? e.message : String(e))
         }


### PR DESCRIPTION
### **User description**
源自 #470 Cloud 性能审查 #6。LocalAsr 前端原本 `setInterval` 每 5s 轮询 `refreshEngineStatus`。

**改动**：后端在每个状态转换点主动 emit `local-asr:engine-changed`（load、idle 释放 `release_if_idle==true`、手动释放汇聚点、keepLoadedSecs 变更），前端 `listen` 增量更新、删掉 5s 轮询与 `engineStatusTimer`。挂载时仍拉一次初值，cleanup `unlisten`。`LocalAsrEngineStatus` 加 `Clone`。helper 只用跨平台符号，不碰 Foundry/Sherpa。

**验证**：macOS `cargo check` + `npm run build` 通过。


___

### **PR Type**
Enhancement


___

### **Description**
- 后端主动推送引擎状态事件

- 前端零轮询，监听事件更新

- 跨平台兼容（Android 空实现）


___

### Diagram Walkthrough


```mermaid
flowchart LR
    subgraph Backend [Backend Rust]
        coordinator["coordinator.rs"]
    end
    subgraph Frontend [Frontend React]
        localAsr["LocalAsr.tsx"]
    end
    coordinator -- "emit 'local-asr:engine-changed'" --> localAsr
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>local_asr.rs</strong><dd><code>派生 Clone 并触发状态推送</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src-tauri/src/commands/local_asr.rs

<ul><li>为 LocalAsrEngineStatus 添加 Clone 派生<br> <li> local_asr_set_keep_loaded_secs 执行后调用 emit 通知前端</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/672/files#diff-0e580c32448bda30fa2e02bfb96254df14f96b5f073555d15c74a4d1d39505d3">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>coordinator.rs</strong><dd><code>实现事件发射函数与跨平台适配</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src-tauri/src/coordinator.rs

<ul><li>新增 emit_local_asr_engine_status 函数<br> <li> 在引擎加载/释放/keepLoadedSecs 变更时调用<br> <li> 添加 Android 编译空实现（no-op stub）</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/672/files#diff-73d8c004670b27293f74f0f3991b9a6fc28f0ff0b883214de2b078b1e09797ca">+38/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>LocalAsr.tsx</strong><dd><code>前端零轮询监听引擎状态</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src/pages/LocalAsr.tsx

<ul><li>移除 engineStatusTimer 轮询及清理代码<br> <li> 添加 useEffect 监听 local-asr:engine-changed 事件<br> <li> 预加载后不再手动延迟刷新状态</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/672/files#diff-35c7e3db3ea48b533df9bb63195bf0f2762ed382d681aee7f0da7e3a246e881d">+32/-10</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

