### PR TITLE
perf(onboarding,settings): 权限/热键状态纯事件驱动，去掉高频轮询

### DIFF
--- a/openless-all/app/src/components/Onboarding.tsx
+++ b/openless-all/app/src/components/Onboarding.tsx
@@ -301,10 +301,10 @@ function DesktopOnboarding({
   };
 
   useEffect(() => {
-    refresh();
+    void refresh();
     // issue #470：纯事件驱动，去掉每秒轮询。授权必经系统设置 App，切回 OpenLess 必触发 focus/visibilitychange。
-    const onFocus = () => refresh();
-    const onVisibility = () => { if (document.visibilityState === 'visible') refresh(); };
+    const onFocus = () => { void refresh(); };
+    const onVisibility = () => { if (document.visibilityState === 'visible') void refresh(); };
     window.addEventListener('focus', onFocus);
     document.addEventListener('visibilitychange', onVisibility);
     return () => {

--- a/openless-all/app/src/components/Onboarding.tsx
+++ b/openless-all/app/src/components/Onboarding.tsx
@@ -220,12 +220,14 @@ function AndroidMicrophoneStep() {
 
   useEffect(() => {
     void refresh();
-    const id = window.setInterval(refresh, 3000);
+    // issue #470：纯事件驱动，去掉高频轮询。窗口重新聚焦或重新可见时刷新（授权必经系统设置再切回）。
     const onFocus = () => { void refresh(); };
+    const onVisibility = () => { if (document.visibilityState === 'visible') void refresh(); };
     window.addEventListener('focus', onFocus);
+    document.addEventListener('visibilitychange', onVisibility);
     return () => {
-      window.clearInterval(id);
       window.removeEventListener('focus', onFocus);
+      document.removeEventListener('visibilitychange', onVisibility);
     };
   }, []);
 
@@ -300,12 +302,14 @@ function DesktopOnboarding({
 
   useEffect(() => {
     refresh();
-    const id = window.setInterval(refresh, 1000);
+    // issue #470：纯事件驱动，去掉每秒轮询。授权必经系统设置 App，切回 OpenLess 必触发 focus/visibilitychange。
     const onFocus = () => refresh();
+    const onVisibility = () => { if (document.visibilityState === 'visible') refresh(); };
     window.addEventListener('focus', onFocus);
+    document.addEventListener('visibilitychange', onVisibility);
     return () => {
-      window.clearInterval(id);
       window.removeEventListener('focus', onFocus);
+      document.removeEventListener('visibilitychange', onVisibility);
       if (refreshTimeoutRef.current) clearTimeout(refreshTimeoutRef.current);
     };
   }, [requiresAccessibility]);
@@ -318,6 +322,10 @@ function DesktopOnboarding({
     } finally {
       setBusy(false);
     }
+    // issue #470：与麦克风路径对称——授权动作返回后立即刷新，并挂一次 800ms 兜底覆盖 app 内按钮发起的授予。
+    void refresh();
+    if (refreshTimeoutRef.current) clearTimeout(refreshTimeoutRef.current);
+    refreshTimeoutRef.current = window.setTimeout(refresh, 800);
   };
 
   const onRequestMicrophone = async () => {

--- a/openless-all/app/src/pages/settings/PermissionsSection.tsx
+++ b/openless-all/app/src/pages/settings/PermissionsSection.tsx
@@ -80,13 +80,11 @@ export function PermissionsSection() {
       refreshWindowsIme();
     }
     refreshNetwork();
-    const hotkeyId = platformCaps?.supportsDesktopHotkey === true
-      ? window.setInterval(refreshHotkey, 1000)
-      : undefined;
+    // issue #470：热键状态改为纯事件驱动，去掉每秒轮询，靠下方 focus/visibilitychange 刷新。
     // 麦克风检查会短暂打开输入流，避免每秒探测导致隐私指示器频繁闪烁。
     const permissionId = window.setInterval(refreshPermissions, 10000);
     const networkId = window.setInterval(refreshNetwork, 30000);
-    const onFocus = () => {
+    const refreshAll = () => {
       refreshPermissions();
       if (platformCaps?.supportsDesktopHotkey === true) {
         refreshHotkey();
@@ -96,12 +94,15 @@ export function PermissionsSection() {
       }
       refreshNetwork();
     };
+    const onFocus = () => refreshAll();
+    const onVisibility = () => { if (document.visibilityState === 'visible') refreshAll(); };
     window.addEventListener('focus', onFocus);
+    document.addEventListener('visibilitychange', onVisibility);
     return () => {
-      if (hotkeyId !== undefined) window.clearInterval(hotkeyId);
       window.clearInterval(permissionId);
       window.clearInterval(networkId);
       window.removeEventListener('focus', onFocus);
+      document.removeEventListener('visibilitychange', onVisibility);
     };
   }, [platformCaps?.platform, platformCaps?.supportsDesktopHotkey]);
 


### PR DESCRIPTION
### **User description**
源自 #470 Cloud 性能审查 #3/#4/#5。引导页桌面(1s)/Android(3s)、设置页热键(1s) 的高频权限/热键 `setInterval` 轮询全部改为 `focus`/`visibilitychange` 事件驱动，连低频兜底也去掉（纯事件驱动）。

**覆盖论证**：麦克风前台原生弹窗授予由申请结果回调 + 800ms 兜底覆盖；辅助功能授予必经系统设置 App、切回必触发 focus/visibilitychange。并给 `onGrantAccessibility` 补对称的 `void refresh()` + 800ms 兜底。`refreshPermissions(10s)`/`refreshNetwork(30s)` 保留不动。

**验证**：`npm run build` 通过 + 对抗式复审（已修复其指出的 floating-promise）。


___

### **PR Type**
Enhancement


___

### **Description**
- 移除高频轮询，改用 focus/visibilitychange 事件驱动

- 添加 visibilitychange 事件监听，确保从系统设置返回后立即刷新

- 对称处理麦克风和辅助功能授权后的刷新逻辑

- 统一代码风格（void refresh()）消除 floating promise


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Performance improvement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Onboarding.tsx</strong><dd><code>事件驱动替代轮询 + 授权刷新对称处理</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src/components/Onboarding.tsx

<ul><li>AndroidMicrophoneStep: 移除 3 秒轮询，改为 focus + visibilitychange 事件<br> <li> DesktopOnboarding: 移除 1 秒轮询，添加同类事件监听<br> <li> onGrantAccessibility: 添加同步刷新 + 800ms 超时兜底<br> <li> 所有 refresh() 调用加 void（修复 floating promise）</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/673/files#diff-b268b8893cf3791067a27e6509d5721b260046fd4c7093f958697c09f3eeb5f7">+14/-6</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>PermissionsSection.tsx</strong><dd><code>Settings 页热键状态改为纯事件驱动</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src/pages/settings/PermissionsSection.tsx

<ul><li>移除热键 1 秒轮询（retain 10s/30s 低频轮询）<br> <li> 添加 focus + visibilitychange 事件驱动刷新所有状态<br> <li> 统一焦点事件处理逻辑</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/673/files#diff-2896b718081970bad5fcda36c960b1041fdfbd84fed2ea07fd500b7ff85ebffe">+6/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

