### PR TITLE
perf(marketplace,localasr): 清理冗余定时器

### DIFF
--- a/openless-all/app/src/pages/LocalAsr.tsx
+++ b/openless-all/app/src/pages/LocalAsr.tsx
@@ -201,7 +201,8 @@ export function LocalAsr({ embedded = false }: LocalAsrProps = {}) {
     }
 
     const scheduleScrollGuardRestore = () => {
-        window.setTimeout(restoreScrollGuard, 0)
+        // issue #470：立即帧由下面的 rAF + 嵌套 rAF 覆盖（≈0~32ms），故移除等价的 setTimeout(…,0)；
+        // 80ms / 200ms 两枪保留，用于兜住 rAF 之后才发生的异步重排（如图片晚加载）。
         window.setTimeout(restoreScrollGuard, 80)
         window.setTimeout(restoreScrollGuard, 200)
         window.requestAnimationFrame(() => {

--- a/openless-all/app/src/pages/Marketplace.tsx
+++ b/openless-all/app/src/pages/Marketplace.tsx
@@ -386,8 +386,9 @@ export function Marketplace() {
       setUploadOriginPackId(null);
       setUploadTargetName(null);
       setSelectedUploadPackId(null);
-      // 后续 polling 用服务端真实数据校准（审核状态可能 pending→approved/rejected）。
-      window.setTimeout(() => { void refresh(); void refreshMyPacks(); }, 1500);
+      // issue #470：上传后给后端一点时间落库 + 跑审核，再用服务端真实数据校准一次
+      // （审核状态可能 pending→approved/rejected）。乐观更新已即时反映「我的发布」，
+      // 这里只需单次兜底刷新；取较长延时（5s）确保后端最终一致后能查到，去掉冗余的 1.5s 那次。
       window.setTimeout(() => { void refresh(); void refreshMyPacks(); }, 5000);
     } catch (error) {
       setActionMsg({ kind: 'err', text: t('marketplace.errors.upload', { err: errorMessage(error) }) });


### PR DESCRIPTION
### **User description**
源自 #470 Cloud 性能审查 #8/#9。

- **Marketplace**：上传后双重 `setTimeout(1.5s+5s)` 去重为单次 5s——乐观更新已即时反映「我的发布」，延时刷新仅做服务端状态校准，1.5s 那次纯冗余。
- **LocalAsr**：`scheduleScrollGuardRestore` 三连 `setTimeout(0/80/200ms)` 仅删等价的 0ms 那枪（已被紧随 rAF 覆盖），**保守保留 80/200ms** 兜住 rAF 之后的异步重排，避免滚动跳变回归。

**验证**：`npm run build` 通过。


___

### **PR Type**
Enhancement


___

### **Description**
- 移除 MarketPlace 上传后的冗余 1.5s 定时器，仅保留 5s 兜底刷新

- 移除 LocalAsr 滚动保护中的 setTimeout(…,0)，保留 80ms/200ms 兜住异步重排


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Marketplace upload"] --> B["Optimistic update (immediate)"]
  A --> C["Schedule refresh (5s)"]
  C --> D["Server state calibration"]
  A -.-> E["Removed: 1.5s refresh"]
  F["LocalAsr scroll guard"] --> G["rAF restore (0~32ms)"]
  F --> H["setTimeout(80ms) restore"]
  F --> I["setTimeout(200ms) restore"]
  G -.-> J["Removed: setTimeout(0ms)"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Performance optimization</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>LocalAsr.tsx</strong><dd><code>移除冗余的 setTimeout(…,0)</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src/pages/LocalAsr.tsx

<ul><li>移除 <code>setTimeout(restoreScrollGuard, 0)</code> 调用（被紧随的 rAF 覆盖）<br> <li> 保留 80ms 和 200ms 定时器，用于兜住 rAF 后可能发生的异步重排<br> <li> 添加注释说明 #470 原因</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/674/files#diff-35c7e3db3ea48b533df9bb63195bf0f2762ed382d681aee7f0da7e3a246e881d">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Marketplace.tsx</strong><dd><code>去除上传后双重 setTimeout，仅保留 5s</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src/pages/Marketplace.tsx

<ul><li>移除上传后的 1.5s 刷新定时器，仅保留 5s 定时器做服务端状态校准<br> <li> 乐观更新已即时反映「我的发布」，单次兜底刷新即可<br> <li> 添加注释说明 #470 变更原因</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/674/files#diff-99913f7adfcb885c62181b1429572f6eae311993ce2aa224fd2e9b0c20af2f23">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

