### PR TITLE
perf(less-computer-glow): 隐藏时卸载全屏发光层，消除空闲 GPU 占用

### DIFF
--- a/openless-all/app/src-tauri/src/lib.rs
+++ b/openless-all/app/src-tauri/src/lib.rs
@@ -2181,6 +2181,8 @@ pub(crate) fn show_less_computer_glow<R: tauri::Runtime>(app: &AppHandle<R>) {
     }
     // 点击穿透：纯视觉浮层，绝不拦截鼠标。
     let _ = window.set_ignore_cursor_events(true);
+    // issue #470：通知 glow 前端「可见」，恢复发光动画（隐藏时会 emit(false) 卸载发光层以释放 GPU）。
+    let _ = window.emit("less-computer-glow:active", true);
     let window_clone = window.clone();
     let _ = app.run_on_main_thread(move || {
         use objc2::msg_send;
@@ -2215,6 +2217,9 @@ pub(crate) fn show_less_computer_glow<R: tauri::Runtime>(_app: &AppHandle<R>) {}
 #[cfg(target_os = "macos")]
 pub(crate) fn hide_less_computer_glow<R: tauri::Runtime>(app: &AppHandle<R>) {
     if let Some(window) = app.get_webview_window("less-computer-glow") {
+        // issue #470：先通知前端「不可见」卸载全屏发光层(4 条无限动画)，webview 隐藏后即零 GPU；
+        // 否则 .hide() 后 webview 仍持续合成发光层（Windows 尤其不释放动画）。
+        let _ = window.emit("less-computer-glow:active", false);
         let _ = window.hide();
     }
 }

--- a/openless-all/app/src/pages/LessComputerGlow.tsx
+++ b/openless-all/app/src/pages/LessComputerGlow.tsx
@@ -2,6 +2,8 @@
 // 只画贴边光带，不铺暗场；彩色弧段沿边缘流动，模拟 Apple Intelligence 的粗细变化。
 // 纯视觉：pointer-events:none，后端再 set_ignore_cursor_events(true)。仅 macOS 显示。
 
+import { useEffect, useState } from 'react';
+
 const glowCss = `
 @property --lcg-angle { syntax: '<angle>'; initial-value: 0deg; inherits: false; }
 @keyframes lcg-spin    { to { --lcg-angle: 360deg; } }
@@ -93,6 +95,35 @@ if (typeof document !== 'undefined' && !document.getElementById('less-computer-g
 }
 
 export function LessComputerGlow() {
+  // issue #470：窗口 .hide() 后 webview 不会自动停掉这 4 条无限动画（Windows 尤其不释放），
+  // 全屏发光层持续占 GPU 合成。改由后端 show/hide 主动 emit 可见状态驱动：不可见时直接卸载
+  // 发光层（无元素 → 零 GPU），可见时原样渲染——显示时视觉零变化。
+  const [active, setActive] = useState(true);
+  useEffect(() => {
+    let cancelled = false;
+    let unlisten: (() => void) | undefined;
+    void import('@tauri-apps/api/event').then(({ listen }) => {
+      if (cancelled) return;
+      void listen<boolean>('less-computer-glow:active', (e) => {
+        setActive(Boolean(e.payload));
+      }).then((un) => {
+        if (cancelled) un();
+        else unlisten = un;
+      });
+    });
+    // 二级兜底：页面被标记为隐藏时也停（只停不启，绝不误关正在显示的发光）。
+    const onVisibility = () => {
+      if (document.hidden) setActive(false);
+    };
+    document.addEventListener('visibilitychange', onVisibility);
+    return () => {
+      cancelled = true;
+      unlisten?.();
+      document.removeEventListener('visibilitychange', onVisibility);
+    };
+  }, []);
+
+  if (!active) return null;
   return (
     <div className="lcg-root" aria-hidden>
       <span className="lcg-flow" />


### PR DESCRIPTION
### **User description**
源自 #470。彩虹描边 glow 是全屏 transparent 浮层 + 4 条无限动画。原组件无状态无监听，窗口 `.hide()` 后 webview 仍持续合成发光层、跑满 4 条动画，**GPU 永不释放（Windows 尤其不释放）**。

**改动**：后端 `show/hide_less_computer_glow` 主动 emit `less-computer-glow:active`（不依赖在隐藏窗口上失灵的 WebView2 visibilitychange）；前端可见时渲染与原来**完全一致**的 DOM（视觉零变化），不可见时返回 `null` 卸载发光层 → 零 GPU。另加 `document.hidden` 二级兜底（只停不启）。

**显示时视觉零变化**。glow 当前 macOS-only，本修复消除 macOS 隐藏态泄漏并让组件具备跨平台「隐藏即零 GPU」安全性。

**验证**：`cargo check` + `npm run build` 通过。


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- 后端 show/hide 主动 emit `less-computer-glow:active` 事件

- 前端根据事件驱动可见状态，隐藏时返回 null 卸载发光层

- 二级兜底：document.hidden 时停掉动画（只停不启）


___

### Diagram Walkthrough


```mermaid
flowchart LR
  BE["Backend (lib.rs)"] -- "emit less-computer-glow:active" --> FE["Frontend (LessComputerGlow.tsx)"]
  FE -- "active==true" --> Render["渲染发光层 (视觉零变化)"]
  FE -- "active==false" --> Null["返回 null (卸载发光层)"]
  Null -- "零 GPU 占用" --> GPU_Release["释放 GPU 合成资源"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>lib.rs</strong><dd><code>后端 emit 事件驱动发光层可见状态</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src-tauri/src/lib.rs

<ul><li>在 <code>show_less_computer_glow</code> 中 emit <code>less-computer-glow:active(true)</code><br> <li> 在 <code>hide_less_computer_glow</code> 中 emit <br><code>less-computer-glow:active(false)</code>，先通知前端再隐藏窗口</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/675/files#diff-6b8eb1bbf8e378bab914f1a12962f7add5cc4ba9e013c37c9921a1032fa5e110">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>LessComputerGlow.tsx</strong><dd><code>前端根据事件卸载发光层释放 GPU</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src/pages/LessComputerGlow.tsx

<ul><li>引入 <code>useState</code> 和 <code>useEffect</code> 管理 active 状态<br> <li> 监听 <code>less-computer-glow:active</code> 事件，不可见时组件返回 null 卸载发光层<br> <li> 二级兜底：<code>document.hidden</code> 时主动停掉动画</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/675/files#diff-07b0959143b2dfd139875e31f32a9e37ef28750254f17314e44b8f6784560741">+31/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

