### PR TITLE
perf(capsule): 删除无效的 translation 徽章 backdrop-filter

### DIFF
--- a/openless-all/app/src/components/Capsule.tsx
+++ b/openless-all/app/src/components/Capsule.tsx
@@ -481,8 +481,8 @@ export function Capsule() {
             fontWeight: 600,
             color: 'var(--ol-blue)',
             background: 'var(--ol-capsule-badge-bg)',
-            backdropFilter: 'blur(20px) saturate(180%)',
-            WebkitBackdropFilter: 'blur(20px) saturate(180%)',
+            // issue #470：去掉无效的 backdrop-filter —— webview 模糊不了透明窗口背后的桌面
+            // （Tauri 上游限制，同本文件上方 pill 注释），纯空耗合成，删除零视觉变化。
             border: '0.5px solid var(--ol-capsule-badge-border)',
             boxShadow: '0 4px 12px -4px rgba(37, 99, 235, 0.25), 0 0 0 0.5px rgba(0,0,0,0.04)',
             letterSpacing: '0.02em',


### PR DESCRIPTION
### **User description**
源自 #470。该 `backdrop-filter: blur(20px)` 作用在浮于透明窗口之上的 translation 徽章 pill 上，背后只有透明窗口=桌面，而 webview 模糊不了窗口背后的桌面（Tauri 上游限制，本文件上方 pill 已有同款注释）。故它**不产生任何模糊效果、纯空耗一次合成**。删除**零视觉变化**。

**验证**：`npm run build` 通过。


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Remove invalid `backdrop-filter` on translation badge

- Fix voice capsule not showing on Windows (Tauri limitation)

- Zero visual change, pure performance improvement


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Capsule.tsx</strong><dd><code>Remove dead backdrop-filter on translation badge</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src/components/Capsule.tsx

<ul><li>Deleted <code>backdrop-filter: blur(20px) saturate(180%)</code> and vendor prefix <br>from translation badge styles<br> <li> Added explanatory comment referencing issue #470 (Tauri upstream <br>limitation)</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/676/files#diff-864fa6eaba61a50b436891d4a11265927947abf4d5447192368d26b12e9eaa67">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

