### PR TITLE
fix(polish): retry 不再重发「请求体写出超时」请求，杜绝重复计费 (#680)

### DIFF
--- a/openless-all/app/src-tauri/src/polish.rs
+++ b/openless-all/app/src-tauri/src/polish.rs
@@ -1250,6 +1250,14 @@ pub(crate) fn http_client_builder(base_url: &str, timeout_secs: u64) -> reqwest:
     }
 }
 
+/// 是否对一次发送失败做「网络抖动」重试。**只**对「服务端必然没收到」的 connect /
+/// request 类失败重试；任何 `is_timeout()` 都不重试——非幂等的 LLM completion 在请求体
+/// 写出阶段超时时（reqwest 会把这类错误同时标记成 `is_request()` + `is_timeout()`），服务端
+/// 可能已收到并计费，重试会导致重复 billing + 重复 completion。抽成纯函数便于穷举单测。
+fn should_retry_transient(is_connect: bool, is_request: bool, is_timeout: bool) -> bool {
+    (is_connect || is_request) && !is_timeout
+}
+
 /// 发请求 + 网络抖动 retry：**只**对 `is_connect()` / `is_request()` 这两类「服务端
 /// 必然没收到」的失败重试一次。`is_timeout()` 故意**不**重试——超时时服务端可能已经
 /// 在处理请求并扣计费（LLM completion 是非幂等动作），重试会导致重复 billing + 重复
@@ -1277,7 +1285,7 @@ async fn send_with_transient_retry(
     };
     match initial.send().await {
         Ok(r) => Ok(r),
-        Err(e) if e.is_connect() || e.is_request() => {
+        Err(e) if should_retry_transient(e.is_connect(), e.is_request(), e.is_timeout()) => {
             log::warn!(
                 "[llm] send transient failure, retry in {}ms: {}",
                 RETRY_DELAY_MS,
@@ -2463,6 +2471,30 @@ mod tests {
 
     static CODEX_AUTH_FIXTURE_COUNTER: AtomicU64 = AtomicU64::new(0);
     static ENV_LOCK: StdMutex<()> = StdMutex::new(());
+
+    #[test]
+    fn retries_connect_and_request_failures_without_timeout() {
+        // 纯 connect / 纯 request 失败（服务端必然没收到）→ 重试一次。
+        assert!(should_retry_transient(true, false, false));
+        assert!(should_retry_transient(false, true, false));
+        assert!(should_retry_transient(true, true, false));
+    }
+
+    #[test]
+    fn never_retries_when_timeout_flagged() {
+        // 关键回归：请求体写出阶段超时，reqwest 同时标记 is_request + is_timeout——
+        // 服务端可能已收到并对非幂等 LLM completion 计费，绝不能重试（否则重复扣费）。
+        assert!(!should_retry_transient(false, true, true));
+        assert!(!should_retry_transient(true, false, true));
+        assert!(!should_retry_transient(true, true, true));
+        // 纯超时同样不重试。
+        assert!(!should_retry_transient(false, false, true));
+    }
+
+    #[test]
+    fn does_not_retry_unrelated_failures() {
+        assert!(!should_retry_transient(false, false, false));
+    }
 
     struct EnvSnapshot {
         values: Vec<(&'static str, Option<OsString>)>,


### PR DESCRIPTION
### **User description**
## 关联 issue

Closes #680

## 问题

`polish.rs::send_with_transient_retry` 的重试 match 臂顺序问题：
```rust
Err(e) if e.is_connect() || e.is_request() => { /* retry */ }  // 先命中
Err(e) => { if e.is_timeout() { Timeout } }                    // 到不了
```
reqwest 会把**请求体写出阶段的超时**同时标记为 `is_request()` + `is_timeout()`。这类错误先命中第一个臂被重试，与该函数文档「`is_timeout()` 故意不重试——超时时服务端可能已收到并对非幂等 LLM completion 计费」相悖，也与共享的 `net.rs::send_with_retry`（仅 `is_connect()`）矛盾。后果：body 写出期超时可能重发请求 → 重复 completion + 重复插入文本 + 双重计费。

## 改动（单一职责）

- 抽出纯函数 `should_retry_transient(is_connect, is_request, is_timeout) -> bool`，逻辑 `(is_connect || is_request) && !is_timeout`，让「任何带 timeout 标记的失败都不重试」。
- `send_with_transient_retry` 改为调用该函数判定。
- 新增穷举真值表单测。

未触碰流式插入、缓存 HTTP client、provider 逻辑。

## 测试

```
cargo test --lib retr
  retries_connect_and_request_failures_without_timeout ... ok
  never_retries_when_timeout_flagged ... ok
  does_not_retry_unrelated_failures ... ok
```
`npm run build` + `cargo test --lib` 全绿（434 其余单测未受影响）。

> 来源：2026-06-16 全仓多 Agent 审计（polish 专项）。


___

### **PR Type**
Bug fix


___

### **Description**
- Prevent retries on timeout-flagged errors to avoid duplicate billing

- Extract retry decision into pure function should_retry_transient

- Add exhaustive unit tests for retry logic


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A[send request] --> B{error?}
  B -->|Ok| C[success]
  B -->|Err| D{is_timeout?}
  D -->|yes| E[don't retry]
  D -->|no| F{is_connect or is_request?}
  F -->|yes| G[retry once]
  F -->|no| H[don't retry]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>polish.rs</strong><dd><code>Refine retry logic and add tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src-tauri/src/polish.rs

<ul><li>Added pure function <code>should_retry_transient(is_connect, is_request, </code><br><code>is_timeout) -> bool</code> that returns true only if (is_connect || <br>is_request) && !is_timeout<br> <li> Modified <code>send_with_transient_retry</code> to use the function instead of the <br>previous match arm<br> <li> Added three unit tests covering all combinations of flags</ul>


</details>


  </td>
  <td><a href=""></a></td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

