### PR TITLE
fix(polish): 上下文感知润色限最近 4 轮，消除历史堆积导致的首字延迟 (#678)

### DIFF
--- a/openless-all/app/src-tauri/src/coordinator/dictation.rs
+++ b/openless-all/app/src-tauri/src/coordinator/dictation.rs
@@ -2505,6 +2505,12 @@ fn append_typed_prefix(target: &mut String, delta: &str, typed_chars: usize) -> 
     appended
 }
 
+/// 上下文感知润色最多回看的历史轮数。`sessions` 为 newest-first，故 take 保留最近 N 轮。
+/// 这是对「5 分钟窗口内不限条数」的硬上限：不限条数时历史堆积会无限拉长 LLM 请求、抬高
+/// 首 token 时间（流式插入下 = 「出第一个字」的时刻），拖慢全体用户的转写（见 issue #678）。
+/// 取值偏小以优先延迟；若要更长的多轮连续性可上调。
+const MAX_POLISH_CONTEXT_TURNS: usize = 4;
+
 fn eligible_polish_context_turns(
     sessions: Vec<DictationSession>,
     active_style_pack_id: &str,
@@ -2533,6 +2539,8 @@ fn eligible_polish_context_turns(
                 Some((s.raw_transcript, s.final_text))
             }
         })
+        // 最近 N 轮上限：newest-first，take 保留最近的，杜绝历史堆积拖慢首字延迟（#678）。
+        .take(MAX_POLISH_CONTEXT_TURNS)
         .collect()
 }
 
@@ -2541,7 +2549,7 @@ mod tests {
     use super::{
         append_typed_prefix, batch_asr_chunk_limit_ms, default_done_message,
         drain_streaming_insert_deltas_with, eligible_polish_context_turns, finalize_polished_text,
-        flush_streaming_insert_buffer_with, streaming_insert_eligible,
+        flush_streaming_insert_buffer_with, streaming_insert_eligible, MAX_POLISH_CONTEXT_TURNS,
     };
     use crate::types::{
         ChineseScriptPreference, CorrectionRule, DictationSession, InsertStatus, PolishMode,
@@ -2583,6 +2591,37 @@ mod tests {
             translation_active,
             polish_source: polish_source.map(str::to_string),
         }
+    }
+
+    #[test]
+    fn polish_context_is_capped_to_most_recent_turns() {
+        // newest-first：堆积多于上限的历史时，只保留最近 MAX_POLISH_CONTEXT_TURNS 轮，
+        // 避免无限拼接拖慢首字延迟（issue #678）。
+        let sessions: Vec<DictationSession> = (0..MAX_POLISH_CONTEXT_TURNS + 3)
+            .map(|i| {
+                history_session(
+                    &format!("s{i}"),
+                    &format!("raw {i}"),
+                    &format!("final {i}"),
+                    Some("pack.new"),
+                    false,
+                    None,
+                )
+            })
+            .collect();
+
+        let turns = eligible_polish_context_turns(sessions, "pack.new", false);
+
+        assert_eq!(turns.len(), MAX_POLISH_CONTEXT_TURNS);
+        // 保留的是最近的（newest-first 输入的前 N 条）。
+        assert_eq!(turns[0], ("raw 0".to_string(), "final 0".to_string()));
+        assert_eq!(
+            turns[MAX_POLISH_CONTEXT_TURNS - 1],
+            (
+                format!("raw {}", MAX_POLISH_CONTEXT_TURNS - 1),
+                format!("final {}", MAX_POLISH_CONTEXT_TURNS - 1)
+            )
+        );
     }
 
     #[test]


### PR DESCRIPTION
### **User description**
## 关联 issue

Closes #678

## 问题

1.3.6 起非 Raw 润色默认把**最近 5 分钟内的全部历史轮**前置进 LLM 请求：
- `types.rs:828` 默认窗口 5 分钟（开箱即开）；
- `coordinator/dictation.rs::eligible_polish_context_turns` 末尾直接 `.collect()`，**不限条数**。

历史越多 → 输入 token 越多 → 首 token 时间越长。在默认流式插入下，TTFT 就是「光标出现第一个字」的时刻 → 面向**全体用户**表现为转写变慢（约 +1s 量级，越重度越明显）。

## 改动（单一职责）

- 新增常量 `MAX_POLISH_CONTEXT_TURNS = 4`。
- `eligible_polish_context_turns` 在 `.collect()` 前加 `.take(MAX_POLISH_CONTEXT_TURNS)`。`sessions` 为 newest-first（`recent_within_minutes` 保证），take 保留**最近 4 轮**；`build_polish_history_messages` 再 `.rev()` 成时序——顺序正确。
- 把无界的上下文拼接收敛为常数量级，仍保留多轮连续性。

取值 4 偏向延迟优先、可调；未改时间窗口、未动其他逻辑。

## 测试

```
cargo test --lib coordinator::dictation
  polish_context_is_capped_to_most_recent_turns ... ok
  （其余 15 个 dictation 单测全绿，未受影响）
```
新测断言：堆积 7 条历史时只返回最近 4 轮（newest-first 的前 4 条）。

> 来源：2026-06-16 全仓多 Agent 审计（延迟专项）。注：另有一条仅影响 Windows 本地 sherpa 在线模型的冷加载延迟，单独跟进。


___

### **PR Type**
Bug fix


___

### **Description**
- Limit polish context turns to 4 (MAX_POLISH_CONTEXT_TURNS).

- Add unit test to verify capping behavior.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  HistoricalSessions["Historical Sessions (newest-first)"] -- ".take(4)" --> Capped["4 most recent turns"] --> BuildMessages["build_polish_history_messages .rev()"] --> LLMRequest["LLM request (capped tokens)"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>dictation.rs</strong><dd><code>Cap polish context turns to 4, add test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src-tauri/src/coordinator/dictation.rs

<ul><li>Added constant <code>MAX_POLISH_CONTEXT_TURNS = 4</code>.<br> <li> Applied <code>.take(MAX_POLISH_CONTEXT_TURNS)</code> before <code>collect()</code> in <br><code>eligible_polish_context_turns</code>.<br> <li> Added unit test <code>polish_context_is_capped_to_most_recent_turns</code> to <br>verify capping.</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/682/files#diff-4cf79887f41f4811eb2b1ef682c62ee34c14a0ab969362a9ba1046de59c8578b">+40/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

