### PR TITLE
fix(hotkey): 5 个快捷 setter 接入 Less Computer 键碰撞校验 (#684)

### DIFF
--- a/openless-all/app/src-tauri/src/commands/hotkeys.rs
+++ b/openless-all/app/src-tauri/src/commands/hotkeys.rs
@@ -23,6 +23,9 @@ pub fn set_dictation_hotkey(
     if let Some(open_app) = prefs.open_app_hotkey.as_ref() {
         reject_dictation_open_app_hotkey_overlap(&binding, open_app)?;
     }
+    if let Some(less_computer) = prefs.coding_agent_voice_hotkey.as_ref() {
+        reject_dictation_less_computer_hotkey_overlap(&binding, less_computer)?;
+    }
     prefs.dictation_hotkey = binding;
     sync_dictation_hotkey_legacy_fields(&mut prefs);
     coord.prefs().set(prefs).map_err(|e| e.to_string())?;
@@ -47,6 +50,9 @@ pub fn set_translation_hotkey(
     }
     if let Some(open_app) = previous.open_app_hotkey.as_ref() {
         reject_translation_open_app_hotkey_overlap(&binding, open_app)?;
+    }
+    if let Some(less_computer) = previous.coding_agent_voice_hotkey.as_ref() {
+        reject_translation_less_computer_hotkey_overlap(&binding, less_computer)?;
     }
     let mut prefs = previous.clone();
     prefs.translation_hotkey = binding;
@@ -82,6 +88,9 @@ pub fn set_switch_style_hotkey(
         if let Some(open_app) = prefs.open_app_hotkey.as_ref() {
             reject_switch_style_open_app_hotkey_overlap(binding, open_app)?;
         }
+        if let Some(less_computer) = prefs.coding_agent_voice_hotkey.as_ref() {
+            reject_less_computer_switch_style_hotkey_overlap(less_computer, binding)?;
+        }
     }
     prefs.switch_style_hotkey = binding;
     coord.prefs().set(prefs).map_err(|e| e.to_string())?;
@@ -108,6 +117,9 @@ pub fn set_open_app_hotkey(
         }
         if let Some(switch_style) = prefs.switch_style_hotkey.as_ref() {
             reject_switch_style_open_app_hotkey_overlap(switch_style, binding)?;
+        }
+        if let Some(less_computer) = prefs.coding_agent_voice_hotkey.as_ref() {
+            reject_less_computer_open_app_hotkey_overlap(less_computer, binding)?;
         }
     }
     prefs.open_app_hotkey = binding;
@@ -316,7 +328,7 @@ pub(crate) fn reject_qa_open_app_hotkey_overlap(
     reject_hotkey_overlap(qa, open_app, "打开应用快捷键不能和 QA 快捷键相同")
 }
 
-fn reject_qa_less_computer_hotkey_overlap(
+pub(crate) fn reject_qa_less_computer_hotkey_overlap(
     qa: &ShortcutBinding,
     less_computer: &ShortcutBinding,
 ) -> Result<(), String> {
@@ -404,5 +416,59 @@ fn shortcut_bindings_overlap(left: &ShortcutBinding, right: &ShortcutBinding) ->
             };
             left == right
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn key(primary: &str) -> ShortcutBinding {
+        ShortcutBinding {
+            primary: primary.into(),
+            modifiers: vec![],
+        }
+    }
+
+    /// 锁定碰撞矩阵：每个动作键与 Less Computer 键相同都必须被 reject_hotkey_collisions
+    /// 拒绝。5 个快捷 setter（set_dictation/translation/switch_style/open_app/qa_hotkey）
+    /// 此前漏校验 coding_agent_voice_hotkey，已接入对应的 less_computer 校验。
+    #[test]
+    fn each_action_hotkey_collides_with_less_computer() {
+        let lc = key("LeftControl");
+        let mut prefs = UserPreferences {
+            dictation_hotkey: key("A"),
+            translation_hotkey: key("B"),
+            qa_hotkey: Some(key("C")),
+            switch_style_hotkey: Some(key("D")),
+            open_app_hotkey: Some(key("E")),
+            coding_agent_voice_hotkey: Some(lc.clone()),
+            ..Default::default()
+        };
+        // 基线全不同 → 通过。
+        assert!(reject_hotkey_collisions(&prefs).is_ok());
+
+        prefs.dictation_hotkey = lc.clone();
+        assert!(reject_hotkey_collisions(&prefs).is_err());
+        prefs.dictation_hotkey = key("A");
+
+        prefs.translation_hotkey = lc.clone();
+        assert!(reject_hotkey_collisions(&prefs).is_err());
+        prefs.translation_hotkey = key("B");
+
+        prefs.qa_hotkey = Some(lc.clone());
+        assert!(reject_hotkey_collisions(&prefs).is_err());
+        prefs.qa_hotkey = Some(key("C"));
+
+        prefs.switch_style_hotkey = Some(lc.clone());
+        assert!(reject_hotkey_collisions(&prefs).is_err());
+        prefs.switch_style_hotkey = Some(key("D"));
+
+        prefs.open_app_hotkey = Some(lc.clone());
+        assert!(reject_hotkey_collisions(&prefs).is_err());
+        prefs.open_app_hotkey = Some(key("E"));
+
+        // 复位后再次全不同 → 通过。
+        assert!(reject_hotkey_collisions(&prefs).is_ok());
     }
 }

--- a/openless-all/app/src-tauri/src/commands/hotkeys.rs
+++ b/openless-all/app/src-tauri/src/commands/hotkeys.rs
@@ -168,6 +168,9 @@ pub fn set_combo_hotkey(coord: CoordinatorState<'_>, binding: ComboBinding) -> R
     if let Some(open_app) = prefs.open_app_hotkey.as_ref() {
         reject_dictation_open_app_hotkey_overlap(&shortcut, open_app)?;
     }
+    if let Some(less_computer) = prefs.coding_agent_voice_hotkey.as_ref() {
+        reject_dictation_less_computer_hotkey_overlap(&shortcut, less_computer)?;
+    }
     prefs.custom_combo_hotkey = Some(binding);
     prefs.dictation_hotkey = shortcut;
     sync_dictation_hotkey_legacy_fields(&mut prefs);

--- a/openless-all/app/src-tauri/src/commands/qa.rs
+++ b/openless-all/app/src-tauri/src/commands/qa.rs
@@ -29,6 +29,9 @@ pub fn set_qa_hotkey(
         if let Some(open_app) = prefs.open_app_hotkey.as_ref() {
             reject_qa_open_app_hotkey_overlap(binding, open_app)?;
         }
+        if let Some(less_computer) = prefs.coding_agent_voice_hotkey.as_ref() {
+            reject_qa_less_computer_hotkey_overlap(binding, less_computer)?;
+        }
     }
     prefs.qa_hotkey = binding;
     coord.prefs().set(prefs).map_err(|e| e.to_string())?;


### PR DESCRIPTION
### **User description**
## 关联 issue

Closes #684

## 问题

集中式 `reject_hotkey_collisions`（`commands/hotkeys.rs:216`）已校验 `coding_agent_voice_hotkey`（Less Computer 键），但 5 个**快捷 setter** 各跑自己的部分 pairwise 校验、**全部漏掉 less_computer**：

- `set_dictation_hotkey` / `set_translation_hotkey` / `set_switch_style_hotkey` / `set_open_app_hotkey`（hotkeys.rs）
- `set_qa_hotkey`（qa.rs）

→ 用户可经单键面板把任一动作键设成与 Less Computer 键相同而不被拒，随后完整保存设置时又被 `reject_hotkey_collisions` 拒绝。两条检测路径不一致。

## 改动（单一职责）

把**早已存在但未接线**的 `reject_*_less_computer_hotkey_overlap` 接进这 5 个 setter（与现有 pairwise 校验同模式）：
- `set_dictation_hotkey` → `reject_dictation_less_computer_hotkey_overlap`
- `set_translation_hotkey` → `reject_translation_less_computer_hotkey_overlap`
- `set_switch_style_hotkey` → `reject_less_computer_switch_style_hotkey_overlap`
- `set_open_app_hotkey` → `reject_less_computer_open_app_hotkey_overlap`
- `set_qa_hotkey` → `reject_qa_less_computer_hotkey_overlap`（提升为 `pub(crate)` 供 qa.rs 调用）

未改动校验函数本体与集中式 `reject_hotkey_collisions`。

## 测试

新增碰撞矩阵单测 `each_action_hotkey_collides_with_less_computer`：每个动作键 == Less Computer 键都被拒、全不同则通过。

```
cargo test --lib commands::   # 52 passed（含新增 + 既有 persist_settings 测试）
```

> 来源：2026-06-16 全仓多 Agent 审计（commands 专项）。


___

### **PR Type**
Bug fix


___

### **Description**
- 修复 5 个快捷 setter 漏校验 Less Computer 键碰撞

- ensure per‑setter collision check matches centralized `reject_hotkey_collisions`

- 新增碰撞矩阵单测覆盖所有场景


___

### Diagram Walkthrough


```mermaid
flowchart LR
  S1["set_dictation_hotkey"] --> C1["reject_dictation_less_computer_hotkey_overlap"]
  S2["set_translation_hotkey"] --> C2["reject_translation_less_computer_hotkey_overlap"]
  S3["set_switch_style_hotkey"] --> C3["reject_less_computer_switch_style_hotkey_overlap"]
  S4["set_open_app_hotkey"] --> C4["reject_less_computer_open_app_hotkey_overlap"]
  S5["set_qa_hotkey"] --> C5["reject_qa_less_computer_hotkey_overlap"]
  S6["set_combo_hotkey"] --> C6["reject_dictation_less_computer_hotkey_overlap"]
  C1 --> T["Reject collision"]
  C2 --> T
  C3 --> T
  C4 --> T
  C5 --> T
  C6 --> T
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>hotkeys.rs</strong><dd><code>hotkeys.rs: 接入 6 个 setter 的 Less Computer 校验</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src-tauri/src/commands/hotkeys.rs

<ul><li>在 <br>set_dictation_hotkey、set_translation_hotkey、set_switch_style_hotkey、set_open_app_hotkey、set_combo_hotkey <br>中添加 less_computer 碰撞校验<br> <li> reject_qa_less_computer_hotkey_overlap 可见性提升为 pub(crate) 供 qa.rs 调用<br> <li> 新增 each_action_hotkey_collides_with_less_computer 单元测试</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/685/files#diff-40aee06b0a5c5a23d843bdc080c099bd053ffff6b072dfd0f59a044956c8dd25">+70/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>qa.rs</strong><dd><code>qa.rs: 补充 set_qa_hotkey 的 Less Computer 校验</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src-tauri/src/commands/qa.rs

- 在 set_qa_hotkey 中添加 less_computer 碰撞校验，与集中式检测一致


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/685/files#diff-79f5e2c08e82bb74573d2359babb5c94bcc38c9f6dfff63c3776829696864e81">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

