### PR TITLE
fix(local-asr): 模型下载「已存在即跳过」改为校验大小，拒收截断/损坏文件 (#686)

### DIFF
--- a/openless-all/app/src-tauri/src/asr/local/download.rs
+++ b/openless-all/app/src-tauri/src/asr/local/download.rs
@@ -319,7 +319,11 @@ async fn run_download(
         .iter()
         .map(|f| {
             let d = dir.join(&f.path);
-            if d.exists() {
+            // 只把「确实完整」的已存在文件计入已完成字节，与下面 run_download 的「完整才跳过、
+            // 否则删除重下」一致。若对大小不符的坏文件也按 f.size 计入，重下时 in_flight 又从 0
+            // 涨到 f.size，会双重计数、进度条短暂 >100%。
+            let actual = std::fs::metadata(&d).ok().map(|m| m.len());
+            if existing_file_is_complete(actual, f.size) {
                 f.size
             } else {
                 0

--- a/openless-all/app/src-tauri/src/asr/local/download.rs
+++ b/openless-all/app/src-tauri/src/asr/local/download.rs
@@ -242,6 +242,17 @@ pub(crate) fn build_client() -> Result<reqwest::Client> {
     builder.build().context("build reqwest client failed")
 }
 
+/// 判断目录里已存在的目标文件是否可信为「完整下载」。
+/// `actual_size` 为 `None`（取不到元数据）一律视为不完整。`expected_size == 0` 表示 HF 未
+/// 给出该文件大小（未知）→ 退回旧行为：只要文件存在就信任，避免对未知大小的文件反复重下。
+/// 否则严格要求字节数一致——上次被中断/外部损坏而残留的截断文件不再被当作完整跳过。
+fn existing_file_is_complete(actual_size: Option<u64>, expected_size: u64) -> bool {
+    match actual_size {
+        Some(actual) => expected_size == 0 || actual == expected_size,
+        None => false,
+    }
+}
+
 async fn run_download(
     app: &AppHandle,
     model_id: ModelId,
@@ -322,8 +333,20 @@ async fn run_download(
     for (idx, file) in info.files.iter().enumerate() {
         let dest = dir.join(&file.path);
         if dest.exists() {
-            // 已经下完的（目录里直接存在 dest 文件）跳过；前面 already_done_bytes 已计入
-            continue;
+            let actual = std::fs::metadata(&dest).ok().map(|m| m.len());
+            if existing_file_is_complete(actual, file.size) {
+                // 已完整下载（大小一致，或 HF 未给大小时退回信任存在）→ 跳过；
+                // already_done_bytes 已计入。
+                continue;
+            }
+            // 大小不符：上次被中断 / 外部损坏的截断文件，删除后重新下载，避免被当成完整。
+            log::warn!(
+                "[download] 已存在文件 {} 大小 {:?} != 期望 {}，删除重下",
+                file.path,
+                actual,
+                file.size
+            );
+            let _ = std::fs::remove_file(&dest);
         }
         let url = format!(
             "{}/{}/resolve/main/{}",
@@ -997,4 +1020,26 @@ fn emit_cancelled(
             error: None,
         },
     );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::existing_file_is_complete;
+
+    #[test]
+    fn existing_file_complete_only_when_size_matches_or_unknown() {
+        // 大小一致 → 完整。
+        assert!(existing_file_is_complete(Some(1024), 1024));
+        // 截断（偏小）→ 不完整，触发删除重下。
+        assert!(!existing_file_is_complete(Some(512), 1024));
+        // 比期望大（损坏 / 串写）→ 不完整。
+        assert!(!existing_file_is_complete(Some(2048), 1024));
+        // 取不到元数据 → 不完整。
+        assert!(!existing_file_is_complete(None, 1024));
+        // HF 未给大小（expected == 0）→ 退回「只要存在就信任」。
+        assert!(existing_file_is_complete(Some(0), 0));
+        assert!(existing_file_is_complete(Some(123), 0));
+        // expected == 0 但元数据取不到 → 仍不完整。
+        assert!(!existing_file_is_complete(None, 0));
+    }
 }


### PR DESCRIPTION
### **User description**
## 关联 issue

Closes #686

## 问题

`asr/local/download.rs::run_download` 在目标文件已存在时仅凭 `dest.exists()` 跳过，**不校验大小**：上次被中断 / 外部损坏而残留的截断文件被当成「已下完」跳过，最终在模型加载时以含糊错误失败，用户难自查。（多块路径 `download_one` 末尾已有 `actual != total_size` 校验，缺口在这个「已存在即跳过」分支。）

## 改动（单一职责）

- 新增纯函数 `existing_file_is_complete(actual_size, expected_size)`：大小一致 → 完整；不符 → 不完整；`expected_size == 0`（HF 未给大小）→ 退回旧行为「存在即信任」；元数据取不到 → 不完整。
- `run_download` 在 `dest.exists()` 时据此判定：完整才跳过；否则 `log::warn` + 删除残留文件，回到正常下载路径重下。

## 测试

```
cargo test --lib existing_file_complete
  existing_file_complete_only_when_size_matches_or_unknown ... ok
```
真值表覆盖：一致 / 截断 / 超大 / 无元数据 / 未知大小。

> 来源：2026-06-16 全仓多 Agent 审计（asr-local 专项）。


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Added file size verification for existing downloads

- Delete and redownload truncated/corrupted files instead of skipping

- Fixed progress bar double-counting during redownloads

- Unit tests for the integrity check function


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A[File exists?] -->|Yes| B{Check file size}
  B -->|Size matches or unknown| C[Skip, count as done]
  B -->|Size mismatch| D[Delete file, then download]
  A -->|No| D
  D --> E[Download normally]
  E --> F[Download complete]
  C --> F
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>download.rs</strong><dd><code>Add integrity check for existing files</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app-tauri/src-tauri/src/asr/local/download.rs

<ul><li>New pure function <code>existing_file_is_complete</code> to verify file integrity <br>via size comparison<br> <li> Modified <code>run_download</code> to check file size before skipping; delete and <br>redownload if corrupt<br> <li> Updated <code>already_done_bytes</code> to only count truly complete files, fixing <br>progress double-counting<br> <li> Added unit tests for the integrity check with edge cases (truncated, <br>oversized, missing metadata, unknown size)</ul>


</details>


  </td>
  <td><a href=""></a></td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

