### PR TITLE
fix(less-computer): 护栏高危系统命令设为不可批准，修批准注入畸形规则 (#679)

### DIFF
--- a/openless-all/app/src-tauri/src/coding_agent/guard.rs
+++ b/openless-all/app/src-tauri/src/coding_agent/guard.rs
@@ -62,6 +62,34 @@ pub fn risk_equivalent_patterns(pattern: &str) -> Vec<&'static str> {
     Vec::new()
 }
 
+/// 把一个被审批的 `HIGH_RISK_PATTERNS` 子串映射到它在 [`default_deny_rules`] 里对应的
+/// **精确** deny 规则字符串。
+///
+/// - `Some(rule)`：该命令**可被用户批准放行**——批准时按此字符串从 deny 列表精确移除并加入
+///   等值 allow（保证「移除的 deny」与「加入的 allow」严格一致）。
+/// - `None`：**不可批准**——这些命令要么无法用 `Bash(<prefix>:*)` 安全表达（`| sh` / `:(){`
+///   / `> /dev/sd` 出现在命令中段或依赖 shell 语法），要么是提权 / 毁盘 / 系统级动作
+///   （sudo / dd / mkfs / chmod / chown / shutdown / reboot）；即使用户点「批准」也保持拦截
+///   （fail-closed），且不向 allow 注入任何规则。
+///
+/// 这同时修掉了旧实现的不一致：旧代码对所有 pattern 一律 `format!("Bash({p}:*)")`，对
+/// 带空格/参数的子串（`"sudo "` → `Bash(sudo :*)`）生成的串既不等于 deny `Bash(sudo:*)`
+/// （故 deny 没被移除、批准静默失效），又把畸形规则注入了 allowed_tools。
+pub fn deny_rule_for_pattern(pattern: &str) -> Option<&'static str> {
+    Some(match pattern {
+        "rm -rf" => "Bash(rm -rf:*)",
+        "rm -fr" => "Bash(rm -fr:*)",
+        "git push --force" => "Bash(git push --force:*)",
+        "git push -f" => "Bash(git push -f:*)",
+        "git reset --hard" => "Bash(git reset --hard:*)",
+        "git clean -fd" => "Bash(git clean -fd:*)",
+        "git clean -f -d" => "Bash(git clean -f -d:*)",
+        // 其余 HIGH_RISK_PATTERNS（sudo / dd if= / mkfs / chmod / chown / shutdown / reboot /
+        // 管道执行远程脚本 / fork 炸弹 / 写块设备）= 不可批准，保持拦截。
+        _ => return None,
+    })
+}
+
 /// CLI `--settings` 默认的 `permissions.deny` 规则（Claude Code 工具说明符语法）。
 ///
 /// 注意：管道执行远程脚本（`| sh`）、fork 炸弹（`:(){`）、`> /dev/sd` 等无法用命令前缀
@@ -219,5 +247,57 @@ mod tests {
         assert!(clean.contains(&"git clean -f -d"));
         // 不在任何分组里 → 返回空，调用方回落到 pattern 自身。
         assert!(risk_equivalent_patterns("sudo ").is_empty());
+    }
+
+    #[test]
+    fn approvable_pattern_maps_to_existing_deny_rule() {
+        // 关键不变量：每个「可批准」pattern 映射到的 deny 规则必须真实存在于 default_deny_rules
+        // 中，否则批准时 deny.retain 无从移除（= 旧 bug：批准静默失效）。
+        let deny = default_deny_rules();
+        for (pat, _reason) in HIGH_RISK_PATTERNS {
+            if let Some(rule) = deny_rule_for_pattern(pat) {
+                assert!(
+                    deny.iter().any(|d| d == rule),
+                    "可批准 pattern {pat:?} 映射到 {rule:?}，但它不在 default_deny_rules 中"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn dangerous_system_commands_are_not_approvable() {
+        // 提权 / 毁盘 / 系统级 / 管道执行 / fork 炸弹：即使被「批准」也必须保持拦截（fail-closed），
+        // deny_rule_for_pattern 返回 None → 不移除 deny、不注入 allow。
+        for pat in [
+            "sudo ",
+            "dd if=",
+            "mkfs",
+            "chmod -r 777 /",
+            "chown -r",
+            "shutdown",
+            "reboot",
+            "> /dev/sd",
+            "| sh",
+            "| bash",
+            ":(){",
+        ] {
+            assert!(
+                deny_rule_for_pattern(pat).is_none(),
+                "{pat:?} 不应可批准（应保持拦截）"
+            );
+        }
+    }
+
+    #[test]
+    fn approvable_git_and_rm_map_to_exact_rules() {
+        assert_eq!(
+            deny_rule_for_pattern("git push --force"),
+            Some("Bash(git push --force:*)")
+        );
+        assert_eq!(deny_rule_for_pattern("rm -rf"), Some("Bash(rm -rf:*)"));
+        assert_eq!(
+            deny_rule_for_pattern("git reset --hard"),
+            Some("Bash(git reset --hard:*)")
+        );
     }
 }

--- a/openless-all/app/src-tauri/src/coordinator/dictation.rs
+++ b/openless-all/app/src-tauri/src/coordinator/dictation.rs
@@ -761,9 +761,13 @@ async fn run_less_computer_once(
             }
         })
         .collect();
+    // 只放行「可批准」的命令：deny_rule_for_pattern 返回该 pattern 在 default_deny_rules 里的
+    // 精确 deny 规则；提权/毁盘/系统级等不可安全表达的命令返回 None → 即使被批准也保持拦截
+    // （fail-closed），且不向 allow 注入畸形规则。允许的 allow 规则与被移除的 deny 严格一致。
     let allow_rules: Vec<String> = approved_patterns
         .iter()
-        .map(|p| format!("Bash({p}:*)"))
+        .filter_map(|p| crate::coding_agent::guard::deny_rule_for_pattern(p))
+        .map(|rule| rule.to_string())
         .collect();
     if !allow_rules.is_empty() {
         deny.retain(|d| !allow_rules.iter().any(|a| a == d));


### PR DESCRIPTION
### **User description**
## 关联 issue

Closes #679

## 问题

Less Computer 护栏审批流（`coordinator/dictation.rs`）对每个命中的 `HIGH_RISK_PATTERNS` 子串一律 `format!("Bash({p}:*)")` 生成 allow 规则：
- `"sudo "`（带空格）→ `Bash(sudo :*)` ≠ deny `Bash(sudo:*)` → deny **未被移除**（批准静默失效），同时把畸形规则注入 `allowed_tools`；
- `"dd if="` / `"chmod -r 777 /"` / `"chown -r"` 同理。

## 方案（A：安全优先）

新增 `guard::deny_rule_for_pattern(pattern) -> Option<&'static str>`：
- **可批准**命令（`rm -rf` / `rm -fr` / `git push --force` / `git push -f` / `git reset --hard` / `git clean -fd` / `git clean -f -d`）→ `Some(精确 deny 规则)`，批准时按此从 deny 精确移除、并加入等值 allow（移除的 deny 与加入的 allow 严格一致）。
- **不可批准**命令（`sudo` / `dd` / `mkfs` / `chmod` / `chown` / `shutdown` / `reboot` / 管道执行 / fork 炸弹 / 写块设备）→ `None`：即使被「批准」也保持拦截（fail-closed），不注入任何 allow。

审批流改用 `filter_map(deny_rule_for_pattern)` 构造 allow 规则。

> 这是把无法用 `Bash(<prefix>:*)` 安全表达、或提权/毁盘/系统级的命令设为「不可批准」（不给 agent 这些权限），而不是让批准去解禁它们。

## 测试

```
cargo test --lib guard::   # 11 passed
  approvable_pattern_maps_to_existing_deny_rule ... ok   （每个可批准 pattern 的映射规则确实在 default_deny_rules 中）
  dangerous_system_commands_are_not_approvable ... ok    （sudo/dd/mkfs/chmod/chown/shutdown/reboot/管道/fork 一律不可批准）
  approvable_git_and_rm_map_to_exact_rules ... ok
```

> 来源：2026-06-16 全仓多 Agent 审计（护栏专项）。安全相关，按方案 A（不可批准、fail-closed）实现。


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- 新增`deny_rule_for_pattern`函数，区分可批准与不可批准命令

- 修改审批流使用`filter_map`，避免畸形allow注入

- 添加单测验证可批准映射与危险命令不可批准


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["approved patterns"] --> B["expand equivalents"]
  B --> C["deny_rule_for_pattern"]
  C -- "Some(rule)" --> D["Remove from deny, add allow"]
  C -- "None" --> E["Keep blocked, no injection"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>guard.rs</strong><dd><code>添加deny_rule_for_pattern及测试</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app-tauri/src-tauri/src/coding_agent/guard.rs

<ul><li>新增<code>deny_rule_for_pattern</code>函数，将可批准模式映射到精确deny规则，不可批准命令返回None<br> <li> 添加三个测试函数：验证可批准规则存在、危险命令不可批准、GIT和rm映射正确</ul>


</details>


  </td>
  <td><a href=""></a></td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>dictation.rs</strong><dd><code>修改审批流使用filter_map</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app-tauri/src-tauri/src/coordinator/dictation.rs

<ul><li>修改<code>allow_rules</code>生成逻辑：使用<code>filter_map</code>和<code>deny_rule_for_pattern</code>替代直接格式化<br> <li> 不可批准命令即使被批准也保持拦截，不再注入畸形allow规则</ul>


</details>


  </td>
  <td><a href=""></a></td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

