### PR TITLE
fix(windows): 恢复胶囊四边 clamp + 工作区定位，修被回退的 #470 (#689)

### DIFF
--- a/openless-all/app/src-tauri/src/lib.rs
+++ b/openless-all/app/src-tauri/src/lib.rs
@@ -2670,6 +2670,24 @@ mod tests {
     }
 
     #[test]
+    fn clamp_to_monitor_pushes_into_negative_origin_left_monitor() {
+        // 副屏在主屏左侧（负 X 原点），落点算到了副屏左外侧 → 夹回 area_left。
+        // 1.5x DPI 下尺寸偏大，但 area 仍宽于窗口，左上角夹到 (-2560, top)。
+        let (x, y) = clamp_to_monitor(-3000, -100, 294, 138, -2560, 0, 0, 1440);
+        assert_eq!(x, -2560);
+        assert_eq!(y, 0);
+    }
+
+    #[test]
+    fn clamp_to_monitor_respects_work_area_above_taskbar() {
+        // 工作区底部 = 1040（任务栏占了 1040..1080）。落点本在任务栏区域（y=1030），
+        // 应被夹到「工作区底 - 窗口高」之上，胶囊整窗不压任务栏。
+        let (_x, y) = clamp_to_monitor(800, 1030, 264, 126, 0, 0, 1920, 1040);
+        assert_eq!(y, 1040 - 126);
+        assert!(y + 126 <= 1040);
+    }
+
+    #[test]
     fn capsule_window_bounds_expand_for_translation_badge() {
         let bounds = capsule_window_bounds(true);
         #[cfg(target_os = "windows")]

--- a/openless-all/app/src-tauri/src/lib.rs
+++ b/openless-all/app/src-tauri/src/lib.rs
@@ -2362,6 +2362,11 @@ pub(crate) struct ForegroundMonitor {
     pub(crate) top: i32,
     pub(crate) right: i32,
     pub(crate) bottom: i32,
+    /// 工作区矩形（rcWork，= 显示器矩形减去任务栏），用于把胶囊夹在任务栏之外。
+    pub(crate) work_left: i32,
+    pub(crate) work_top: i32,
+    pub(crate) work_right: i32,
+    pub(crate) work_bottom: i32,
     /// 该显示器的有效 DPI 缩放（1.0 = 96dpi）。
     pub(crate) scale: f64,
 }
@@ -2399,6 +2404,10 @@ pub(crate) fn foreground_window_monitor() -> Option<ForegroundMonitor> {
             top: mi.rcMonitor.top,
             right: mi.rcMonitor.right,
             bottom: mi.rcMonitor.bottom,
+            work_left: mi.rcWork.left,
+            work_top: mi.rcWork.top,
+            work_right: mi.rcWork.right,
+            work_bottom: mi.rcWork.bottom,
             scale: (dpi_x as f64 / 96.0).max(0.1),
         })
     }
@@ -2431,15 +2440,24 @@ pub(crate) fn position_capsule_bottom_center<R: tauri::Runtime>(
             let offset_from_bottom =
                 (capsule_visual_height(translation_active) + 80.0 + bounds.bottom_inset) * scale;
             let y = ((mon.bottom as f64) - offset_from_bottom).round() as i32;
-            let clamped_y = y.max(mon.top);
-            // #470 诊断 v2：当前只夹了上边（.max(mon.top)），未夹下/左/右。多显示器、
-            // 负坐标或异常 DPI 下胶囊可能被算到屏幕外却无任何观测。记录显示器几何与
-            // 最终落点，用于证伪/证实「胶囊定位到屏幕外」(C 子嫌疑)。
+            // #470：用工作区（rcWork，已避开任务栏）四边夹住整窗，防止多显示器、负坐标或异常
+            // DPI 下胶囊被算到屏幕外、或压在任务栏上。取不到 rcWork 时（理论上不会，rcWork 总
+            // 随 rcMonitor 一同填）退回整屏矩形。
+            let (work_l, work_t, work_r, work_b) =
+                if mon.work_right > mon.work_left && mon.work_bottom > mon.work_top {
+                    (mon.work_left, mon.work_top, mon.work_right, mon.work_bottom)
+                } else {
+                    (mon.left, mon.top, mon.right, mon.bottom)
+                };
+            let (clamped_x, clamped_y) =
+                clamp_to_monitor(x, y, phys_w, phys_h, work_l, work_t, work_r, work_b);
             log::debug!(
-                "[capsule] win position: mon=({},{})..({},{}) scale={:.2} size=({}x{}) -> x={} y={} clamped_y={}",
-                mon.left, mon.top, mon.right, mon.bottom, scale, phys_w, phys_h, x, y, clamped_y
+                "[capsule] win position: mon=({},{})..({},{}) work=({},{})..({},{}) scale={:.2} size=({}x{}) -> x={} y={} -> clamped=({},{})",
+                mon.left, mon.top, mon.right, mon.bottom,
+                work_l, work_t, work_r, work_b,
+                scale, phys_w, phys_h, x, y, clamped_x, clamped_y
             );
-            window.set_position(PhysicalPosition::new(x, clamped_y))?;
+            window.set_position(PhysicalPosition::new(clamped_x, clamped_y))?;
             return Ok(());
         }
         // 仅当 Win32 取不到前台显示器时，落回下面的 current_monitor 逻辑。
@@ -2619,6 +2637,35 @@ mod tests {
         assert_eq!(
             (bounds.width, bounds.height, bounds.bottom_inset),
             (220.0, 110.0, 0.0)
+        );
+    }
+
+    // #470：胶囊四边 clamp（工作区，避开任务栏 + 不溢出屏外）。clamp_to_monitor 是纯函数，
+    // 三平台都跑。area = (0,0)..(1920,1040)，窗口 264x126。
+    #[test]
+    fn clamp_to_monitor_leaves_on_screen_position_untouched() {
+        // 完全在工作区内 → 不改动。
+        assert_eq!(
+            clamp_to_monitor(800, 900, 264, 126, 0, 0, 1920, 1040),
+            (800, 900)
+        );
+    }
+
+    #[test]
+    fn clamp_to_monitor_pulls_back_off_screen_right_and_bottom() {
+        // 右/下溢出 → 收回到「整窗仍可见」的最大位置（area_right-w, area_bottom-h）。
+        assert_eq!(
+            clamp_to_monitor(2000, 1200, 264, 126, 0, 0, 1920, 1040),
+            (1920 - 264, 1040 - 126)
+        );
+    }
+
+    #[test]
+    fn clamp_to_monitor_pulls_back_when_right_edge_overflows_inside_area() {
+        // 左上角在区域内、但右缘 x+w 超出 area_right → 仍需收回 x。
+        assert_eq!(
+            clamp_to_monitor(1800, 500, 264, 126, 0, 0, 1920, 1040),
+            (1920 - 264, 500)
         );
     }
 


### PR DESCRIPTION
### **User description**
## 关联 issue

Closes #689（#470 的四边 clamp 回退）

## 问题

多显示器 / 负坐标 / 异常 DPI 下，Windows 胶囊可能被定位到**屏幕外**或**压在任务栏上**。#470 曾用 `fab9651`（+`4824080` 防溢出）加入「四边 clamp + 工作区(rcWork)定位」，被 Android 移植 commit `1ea467a` 回退：
- `ForegroundMonitor` 丢失 `work_*` 字段；
- `position_capsule_bottom_center` 退回**只夹上边** `y.max(mon.top)`（x/下/右不夹、不避任务栏）；
- `clamp_to_monitor` 沦为死码（本体仍在 `lib.rs:1823`，仅 test import 引用），单测被删。

## 改动（恢复 fab9651，单一职责）

- `ForegroundMonitor` 加回 `work_left/top/right/bottom`，`foreground_window_monitor` 从 `mi.rcWork` 填充；
- `position_capsule_bottom_center` 改回用 `clamp_to_monitor` 四边夹**工作区**（取不到 rcWork 退回整屏矩形）；
- 恢复 `clamp_to_monitor` 的 3 个纯函数单测。

`clamp_to_monitor` 本体（含 `saturating_sub` 防溢出）一直在，只是没被调用。

## 测试

```
cargo test --lib clamp_to_monitor   # 3 passed（纯函数，三平台跑）
  ..._leaves_on_screen_position_untouched
  ..._pulls_back_off_screen_right_and_bottom
  ..._pulls_back_when_right_edge_overflows_inside_area
```

## ⚠️ 验证范围

本地 macOS 只能编译非 Windows 分支；`ForegroundMonitor.work_*` + `rcWork` 是 Windows-only 代码，**由 CI 的 Windows 构建编译验证**，并需 **Windows 真机确认**多屏下胶囊不再出屏/压任务栏。

> 来源：2026-06-16 全仓多 Agent 审计（#470 专项），git 溯源回退提交为 1ea467a。


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Restored work_* fields in ForegroundMonitor from rcWork for taskbar avoidance

- Used clamp_to_monitor with work area to prevent capsule positioning off-screen

- Restored 5 unit tests covering negative origin multi-monitor and taskbar avoidance


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["ForegroundMonitor: add work_* fields from rcWork"] --> B["position_capsule_bottom_center"]
  B --> C["clamp_to_monitor: 4-sided clamp to work area"]
  C --> D["Window position inside visible area, avoiding taskbar"]
  E["5 unit tests"] -.->|"validate" C
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>lib.rs</strong><dd><code>Restore capsule clamp to work area with unit tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src-tauri/src/lib.rs

<ul><li>Added work_left, work_top, work_right, work_bottom fields to <br>ForegroundMonitor<br> <li> Populated work_* from mi.rcWork in foreground_window_monitor()<br> <li> Modified position_capsule_bottom_center to use clamp_to_monitor with <br>work area<br> <li> Restored 5 unit tests for clamp_to_monitor (on-screen, off-screen, <br>negative origin, taskbar)</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/690/files#diff-6b8eb1bbf8e378bab914f1a12962f7add5cc4ba9e013c37c9921a1032fa5e110">+72/-7</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

