### PR TITLE
fix(remote): 听写完成后 emit remote:result，手机端才能看到识别结果 (#691)

### DIFF
--- a/openless-all/app/src-tauri/src/coordinator/dictation.rs
+++ b/openless-all/app/src-tauri/src/coordinator/dictation.rs
@@ -2406,6 +2406,14 @@ pub(super) async fn end_session(inner: &Arc<Inner>) -> Result<(), String> {
     ) {
         log::error!("[coord] history append failed: {e}");
     }
+    // 把本次最终文字转发给已连接的远程手机：remote_server 的 WS handler 订阅了
+    // "remote:result"，H5 在状态区下方显示（type=result）。此前全仓无任何处 emit 该事件，
+    // 手机用户永远看不到识别结果。无手机连接时该事件无人转发 = 无害空操作。
+    if !polished.trim().is_empty() {
+        if let Some(app) = inner.app.lock().clone() {
+            let _ = app.emit("remote:result", polished.clone());
+        }
+    }
     let done_message = if tsf_required_insert_failed {
         Some("TSF 未上屏，已禁止非 TSF 兜底".to_string())
     } else {


### PR DESCRIPTION
### **User description**
## 关联 issue

Closes #691

## 问题

`remote_server/mod.rs` 的 WS handler 订阅了 `"remote:result"` 并把 `{type:"result", text}` 转发给手机、H5 也准备好显示，但**全仓没有任何一处 `emit("remote:result", ...)`** → 手机端结果区永远空（状态会动，结果文本不出）。

## 改动（单一职责）

在听写 finalize（`coordinator/dictation.rs`，`history.append_with_retention` 之后）emit 最终文字 `polished` 到 `"remote:result"`，与同函数里已有的 `app.emit("vocab:updated", ...)` 完全同模式（`inner.app.lock().clone()` 取 AppHandle）。非空才发；无手机连接时无人转发 = 无害空操作。

payload 是 `String` → tauri 序列化为带引号 JSON 字符串，正是 remote_server 那侧 `serde_json::from_str::<String>` 期望的格式。

## ⚠️ 验证

本地编译通过（emit 是副作用，无单测）；**需手机真机验证**：远程输入一次，手机结果区出现最终文字。

注：审计另发现「任意 WS 关闭无条件 `cancel_remote_dictation`（双手机/重连时取消他人听写）」属另一独立 bug，单独跟进，不在本 PR。

> 来源：2026-06-16 全仓多 Agent 审计（remote_server 专项）。


___

### **PR Type**
Bug fix


___

### **Description**
- 在听写 finalize 时 emit "remote:result" 事件

- 修复手机端永远看不到识别结果的 bug

- 非空文本才发送，无手机连接时无害


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["听写 finalize"] --> B["emit remote:result"]
  B --> C["手机端接收结果"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>dictation.rs</strong><dd><code>添加 remote:result 事件发射</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src-tauri/src/coordinator/dictation.rs

<ul><li>在 <code>end_session</code> 的 <code>history.append_with_retention</code> 之后添加事件发射<br> <li> 仅当 <code>polished</code> 非空时，通过 <code>inner.app.lock().clone()</code> 获取 <code>AppHandle</code> 并 emit<br> <li> 与已有 <code>vocab:updated</code> 的发射模式一致</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/692/files#diff-4cf79887f41f4811eb2b1ef682c62ee34c14a0ab969362a9ba1046de59c8578b">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

