### PR TITLE
fix: audit batch 2 — correctness bugs + Android robustness

### DIFF
--- a/openless-all/app/android/kotlin/OpenLessNative.kt
+++ b/openless-all/app/android/kotlin/OpenLessNative.kt
@@ -39,4 +39,6 @@ object OpenLessNative {
     @JvmStatic external fun nativeIsOverlayVisible(): Boolean
 
     @JvmStatic external fun nativeNotifyOverlayPermissionChanged(context: android.content.Context)
+
+    @JvmStatic external fun nativeNotifyOverlayDestroyed()
 }

--- a/openless-all/app/android/kotlin/OpenLessOverlayService.kt
+++ b/openless-all/app/android/kotlin/OpenLessOverlayService.kt
@@ -93,6 +93,8 @@ class OpenLessOverlayService : Service(), OpenLessOverlayBridge.OverlayStateList
         if (instance === this) {
             instance = null
         }
+        // 系统杀死前台服务时也会走到这里：同步原生 OVERLAY_VISIBLE=false，避免状态永久残留为 true。
+        runCatching { OpenLessNative.nativeNotifyOverlayDestroyed() }
         super.onDestroy()
     }
 

--- a/openless-all/app/src-tauri/src/android/insert.rs
+++ b/openless-all/app/src-tauri/src/android/insert.rs
@@ -29,15 +29,38 @@ fn try_accessibility(inserter: &TextInserter, text: &str) -> Option<InsertStatus
         log::info!("[android-insert] accessibility service not enabled");
         return None;
     }
+    // 保存粘贴前的剪贴板内容，粘贴完成后还原，避免静默覆盖用户剪贴板。
+    let previous_clip: Option<String> =
+        crate::android::jni::android::with_android_env(|env, context| {
+            Ok(crate::android::jni::android::get_primary_clip_text(env, context))
+        })
+        .ok()
+        .flatten();
+
     if !matches!(inserter.copy_fallback(text), InsertStatus::CopiedFallback) {
         return None;
     }
-    if crate::android::accessibility::paste_via_accessibility() {
+    let result = if crate::android::accessibility::paste_via_accessibility() {
         Some(InsertStatus::Inserted)
     } else {
         log::warn!("[android-insert] accessibility paste failed; text remains on clipboard");
         Some(InsertStatus::CopiedFallback)
+    };
+
+    // 还原用户原有剪贴板内容（仅当粘贴成功时还原；失败时用户需要自己处理）。
+    if matches!(result, Some(InsertStatus::Inserted)) {
+        if let Some(prev) = previous_clip {
+            if let Err(e) =
+                crate::android::jni::android::with_android_env(|env, context| {
+                    crate::android::jni::android::set_primary_clip_text(env, context, &prev)
+                })
+            {
+                log::warn!("[android-insert] failed to restore clipboard: {e}");
+            }
+        }
     }
+
+    result
 }
 
 fn clipboard_fallback(inserter: &TextInserter, text: &str) -> InsertStatus {

--- a/openless-all/app/src-tauri/src/android/jni.rs
+++ b/openless-all/app/src-tauri/src/android/jni.rs
@@ -17,7 +17,13 @@ pub mod android {
         let mut env = vm
             .attach_current_thread()
             .map_err(|error| format!("attach Android thread: {error}"))?;
-        let context = unsafe { JObject::from_raw(android_context.context() as jni::sys::jobject) };
+        let raw_context = android_context.context() as jni::sys::jobject;
+        if raw_context.is_null() {
+            return Err("Android context not yet initialized".to_string());
+        }
+        // SAFETY: raw_context is non-null and points to a valid Android Context object
+        // provided by tao/Tauri; the reference lifetime is valid for the duration of `f`.
+        let context = unsafe { JObject::from_raw(raw_context) };
         f(&mut env, &context)
     }
 
@@ -311,6 +317,77 @@ pub mod android {
         env.get_static_field("android/os/Build$VERSION", "SDK_INT", "I")
             .and_then(|value| value.i())
             .map_err(|error| format!("read SDK_INT: {error}"))
+    }
+
+    /// 读取剪贴板当前的第一条纯文本内容，用于在粘贴后还原。
+    /// 失败或剪贴板为空时返回 None（不返回错误，避免阻塞主流程）。
+    pub fn get_primary_clip_text(
+        env: &mut JNIEnv,
+        context: &JObject,
+    ) -> Option<String> {
+        let clipboard_name = jobject_str(env, "clipboard").ok()?;
+        let clipboard = env
+            .call_method(
+                context,
+                "getSystemService",
+                "(Ljava/lang/String;)Ljava/lang/Object;",
+                &[JValue::Object(&clipboard_name)],
+            )
+            .and_then(|value| value.l())
+            .ok()?;
+        let clip = env
+            .call_method(
+                &clipboard,
+                "getPrimaryClip",
+                "()Landroid/content/ClipData;",
+                &[],
+            )
+            .and_then(|value| value.l())
+            .ok()?;
+        if clip.is_null() {
+            return None;
+        }
+        let item = env
+            .call_method(
+                &clip,
+                "getItemAt",
+                "(I)Landroid/content/ClipData$Item;",
+                &[JValue::Int(0)],
+            )
+            .and_then(|value| value.l())
+            .ok()?;
+        if item.is_null() {
+            return None;
+        }
+        let text_val = env
+            .call_method(
+                &item,
+                "getText",
+                "()Ljava/lang/CharSequence;",
+                &[],
+            )
+            .and_then(|value| value.l())
+            .ok()?;
+        if text_val.is_null() {
+            return None;
+        }
+        let text_str = env
+            .call_method(&text_val, "toString", "()Ljava/lang/String;", &[])
+            .and_then(|value| value.l())
+            .ok()?;
+        let jstr = JString::from(text_str);
+        env.get_string(&jstr)
+            .map(|s| s.to_string_lossy().into_owned())
+            .ok()
+    }
+
+    /// 将指定文本写回剪贴板，用于 accessibility 粘贴后还原用户原有内容。
+    pub fn set_primary_clip_text(
+        env: &mut JNIEnv,
+        context: &JObject,
+        text: &str,
+    ) -> Result<(), String> {
+        copy_to_clipboard(env, context, text).map(|_| ())
     }
 
     pub fn copy_to_clipboard(

--- a/openless-all/app/src-tauri/src/android/native_bridge.rs
+++ b/openless-all/app/src-tauri/src/android/native_bridge.rs
@@ -128,6 +128,14 @@ pub fn is_overlay_visible() -> bool {
     OVERLAY_VISIBLE.load(std::sync::atomic::Ordering::SeqCst)
 }
 
+/// Kotlin overlay service 的 onDestroy() 调用此函数，以便在 OS 杀死服务时
+/// 同步清除 OVERLAY_VISIBLE 标志，避免 refresh_overlay_if_visible() 向死亡
+/// 服务发送无效命令。
+pub fn notify_overlay_destroyed() {
+    OVERLAY_VISIBLE.store(false, std::sync::atomic::Ordering::SeqCst);
+    log::info!("[android-native] overlay service destroyed — OVERLAY_VISIBLE reset");
+}
+
 pub fn overlay_trigger_mode_name() -> &'static str {
     let Some(coordinator) = COORDINATOR.get() else {
         return "background";
@@ -392,5 +400,15 @@ mod jni_exports {
                 show_overlay_with_context(env, context)
             });
         }
+    }
+
+    /// 供 Kotlin overlay service 的 onDestroy() 调用，将 OVERLAY_VISIBLE 清除。
+    /// 解决 OS 杀死服务时 Rust 端状态永久失同步的问题。
+    #[no_mangle]
+    pub unsafe extern "system" fn Java_com_openless_app_OpenLessNative_nativeNotifyOverlayDestroyed(
+        _env: *mut JNIEnv,
+        _class: JClass,
+    ) {
+        notify_overlay_destroyed();
     }
 }

--- a/openless-all/app/src-tauri/src/coordinator.rs
+++ b/openless-all/app/src-tauri/src/coordinator.rs
@@ -91,8 +91,8 @@ pub(super) fn qa_event_target() -> &'static str {
 #[cfg(test)]
 use dictation::dictation_error_code;
 use dictation::{
-    begin_session, cancel_session, end_session, handle_pressed_edge, handle_released_edge,
-    request_stop_during_starting,
+    begin_session, begin_session_as, cancel_session, end_session, handle_pressed_edge,
+    handle_released_edge, request_stop_during_starting,
 };
 #[cfg(any(debug_assertions, test))]
 use dictation::{handle_pressed, handle_released};
@@ -362,13 +362,25 @@ impl Coordinator {
         #[cfg(not(target_os = "windows"))]
         {
             let history = HistoryStore::new().unwrap_or_else(|e| {
-                log::error!("[coord] HistoryStore init failed: {e}; falling back to empty");
-                HistoryStore::new().expect("history store init")
+                log::error!("[coord] HistoryStore init failed: {e}; 降级为空历史记录");
+                HistoryStore::new_fallback()
             });
-            let prefs = PreferencesStore::new().expect("preferences store init");
-            let style_packs = StylePackStore::new(&prefs).expect("style pack store init");
-            let vocab = DictionaryStore::new().expect("dictionary store init");
-            let correction_rules = CorrectionRuleStore::new().expect("correction rule store init");
+            let prefs = PreferencesStore::new().unwrap_or_else(|e| {
+                log::error!("[coord] PreferencesStore init failed: {e}; 降级为默认偏好设置");
+                PreferencesStore::new_fallback()
+            });
+            let style_packs = StylePackStore::new(&prefs).unwrap_or_else(|e| {
+                log::error!("[coord] StylePackStore init failed: {e}; 降级为空样式包列表");
+                StylePackStore::new_fallback()
+            });
+            let vocab = DictionaryStore::new().unwrap_or_else(|e| {
+                log::error!("[coord] DictionaryStore init failed: {e}; 降级为空词库");
+                DictionaryStore::new_fallback()
+            });
+            let correction_rules = CorrectionRuleStore::new().unwrap_or_else(|e| {
+                log::error!("[coord] CorrectionRuleStore init failed: {e}; 降级为空纠错规则");
+                CorrectionRuleStore::new_fallback()
+            });
 
             Self {
                 inner: Arc::new(Inner {
@@ -440,13 +452,25 @@ impl Coordinator {
         sherpa_onnx_runtime: Arc<SherpaOnnxRuntime>,
     ) -> Self {
         let history = HistoryStore::new().unwrap_or_else(|e| {
-            log::error!("[coord] HistoryStore init failed: {e}; falling back to empty");
-            HistoryStore::new().expect("history store init")
+            log::error!("[coord] HistoryStore init failed: {e}; 降级为空历史记录");
+            HistoryStore::new_fallback()
         });
-        let prefs = PreferencesStore::new().expect("preferences store init");
-        let style_packs = StylePackStore::new(&prefs).expect("style pack store init");
-        let vocab = DictionaryStore::new().expect("dictionary store init");
-        let correction_rules = CorrectionRuleStore::new().expect("correction rule store init");
+        let prefs = PreferencesStore::new().unwrap_or_else(|e| {
+            log::error!("[coord] PreferencesStore init failed: {e}; 降级为默认偏好设置");
+            PreferencesStore::new_fallback()
+        });
+        let style_packs = StylePackStore::new(&prefs).unwrap_or_else(|e| {
+            log::error!("[coord] StylePackStore init failed: {e}; 降级为空样式包列表");
+            StylePackStore::new_fallback()
+        });
+        let vocab = DictionaryStore::new().unwrap_or_else(|e| {
+            log::error!("[coord] DictionaryStore init failed: {e}; 降级为空词库");
+            DictionaryStore::new_fallback()
+        });
+        let correction_rules = CorrectionRuleStore::new().unwrap_or_else(|e| {
+            log::error!("[coord] CorrectionRuleStore init failed: {e}; 降级为空纠错规则");
+            CorrectionRuleStore::new_fallback()
+        });
 
         Self {
             inner: Arc::new(Inner {

--- a/openless-all/app/src-tauri/src/coordinator/dictation.rs
+++ b/openless-all/app/src-tauri/src/coordinator/dictation.rs
@@ -999,6 +999,15 @@ pub(super) fn request_stop_during_starting(inner: &Arc<Inner>, reason: &str) {
 }
 
 pub(super) async fn begin_session(inner: &Arc<Inner>) -> Result<(), String> {
+    begin_session_as(inner, false).await
+}
+
+/// begin_session 的带参版本，voice_agent=true 时在 Starting 阶段就标记好，
+/// 防止 finish_starting_session 处理 pending_stop 时丢失标志。
+pub(super) async fn begin_session_as(
+    inner: &Arc<Inner>,
+    voice_agent: bool,
+) -> Result<(), String> {
     let current_session_id = {
         let mut state = inner.state.lock();
         let Some(session_id) =
@@ -1006,6 +1015,9 @@ pub(super) async fn begin_session(inner: &Arc<Inner>) -> Result<(), String> {
         else {
             return Ok(());
         };
+        if voice_agent {
+            state.voice_agent = true;
+        }
         if let Some(label) = state.front_app.as_deref() {
             log::info!("[coord] front_app captured: {label}");
         }
@@ -1635,6 +1647,8 @@ pub(super) async fn end_session(inner: &Arc<Inner>) -> Result<(), String> {
                 Ok(Ok(r)) => r,
                 Ok(Err(e)) => {
                     log::error!("[coord] await final failed: {e}");
+                    // 关闭 WebSocket 连接，避免流式 ASR 资源泄漏
+                    asr.cancel();
                     emit_capsule(
                         inner,
                         CapsuleState::Error,
@@ -1762,6 +1776,8 @@ pub(super) async fn end_session(inner: &Arc<Inner>) -> Result<(), String> {
                 Ok(Ok(r)) => r,
                 Ok(Err(e)) => {
                     log::error!("[coord] Bailian await final failed: {e}");
+                    // 关闭 WebSocket 连接，避免流式 ASR 资源泄漏
+                    asr.cancel();
                     emit_capsule(
                         inner,
                         CapsuleState::Error,

--- a/openless-all/app/src-tauri/src/coordinator/hotkey_loops.rs
+++ b/openless-all/app/src-tauri/src/coordinator/hotkey_loops.rs
@@ -403,16 +403,18 @@ pub(super) async fn handle_less_computer_pressed(inner: &Arc<Inner>) {
         return;
     }
 
-    if begin_session(inner).await.is_err() {
+    // voice_agent=true 在 Starting 阶段就写入 state，防止 finish_starting_session
+    // 处理 pending_stop 时（快速松手 race）丢失标志，导致意外走普通听写路径。
+    if begin_session_as(inner, true).await.is_err() {
         return;
     }
     let started = {
-        let mut state = inner.state.lock();
+        let state = inner.state.lock();
+        // voice_agent 已在 begin_session_as 内设置；这里只检查阶段是否推进成功。
         if matches!(
             state.phase,
-            SessionPhase::Starting | SessionPhase::Listening
+            SessionPhase::Starting | SessionPhase::Listening | SessionPhase::Processing
         ) {
-            state.voice_agent = true;
             log::info!(
                 "[less-computer] voice session started (session={:?})",
                 state.session_id

--- a/openless-all/app/src-tauri/src/persistence.rs
+++ b/openless-all/app/src-tauri/src/persistence.rs
@@ -1165,6 +1165,16 @@ impl HistoryStore {
         })
     }
 
+    /// 在 data_dir 不可用时构造一个降级实例（指向临时目录）。
+    /// 该实例在运行期间读写会安静地失败或返回空，不会 panic，
+    /// 也不会影响正常启动路径。
+    pub(crate) fn new_fallback() -> Self {
+        Self {
+            path: std::env::temp_dir().join("openless_history_fallback.json"),
+            lock: Mutex::new(()),
+        }
+    }
+
     pub fn list(&self) -> Result<Vec<DictationSession>> {
         let _guard = self.lock.lock();
         self.read_locked()
@@ -1213,12 +1223,14 @@ impl HistoryStore {
         let sessions = self.read_locked()?;
         let cutoff = chrono::Utc::now() - chrono::Duration::minutes(i64::from(minutes));
         // sessions 是 newest-first，超出窗口的会话之后的都更老，take_while 即可。
+        // unwrap_or(true)：时间戳解析失败时保留该条目，与 append_with_retention 的保守策略一致；
+        // 避免单条坏记录截断整个上下文窗口。
         let filtered: Vec<DictationSession> = sessions
             .into_iter()
             .take_while(|s| {
                 chrono::DateTime::parse_from_rfc3339(&s.created_at)
                     .map(|t| t.with_timezone(&chrono::Utc) >= cutoff)
-                    .unwrap_or(false)
+                    .unwrap_or(true)
             })
             .collect();
         Ok(filtered)
@@ -1289,6 +1301,14 @@ impl PreferencesStore {
             path,
             state: Mutex::new(prefs),
         })
+    }
+
+    /// 降级实例：data_dir 不可用时使用默认配置，写操作会安静地失败。
+    pub(crate) fn new_fallback() -> Self {
+        Self {
+            path: std::env::temp_dir().join("openless_prefs_fallback.json"),
+            state: Mutex::new(UserPreferences::default()),
+        }
     }
 
     pub fn get(&self) -> UserPreferences {
@@ -1392,6 +1412,16 @@ impl StylePackStore {
             asset_root,
             state: Mutex::new(packs),
         })
+    }
+
+    /// 降级实例：data_dir 不可用时使用临时路径和空列表，写操作会安静地失败。
+    pub(crate) fn new_fallback() -> Self {
+        let tmp = std::env::temp_dir();
+        Self {
+            path: tmp.join("openless_style_packs_fallback.json"),
+            asset_root: tmp.join("openless_style_pack_assets_fallback"),
+            state: Mutex::new(Vec::new()),
+        }
     }
 
     pub fn list(&self) -> Result<Vec<StylePack>> {
@@ -2156,6 +2186,14 @@ impl DictionaryStore {
         })
     }
 
+    /// 降级实例：data_dir 不可用时使用临时路径，读写会安静地失败或返回空。
+    pub(crate) fn new_fallback() -> Self {
+        Self {
+            path: std::env::temp_dir().join("openless_vocab_fallback.json"),
+            lock: Mutex::new(()),
+        }
+    }
+
     pub fn list(&self) -> Result<Vec<DictionaryEntry>> {
         let _guard = self.lock.lock();
         self.read_locked()
@@ -2298,6 +2336,14 @@ impl CorrectionRuleStore {
             path: dir.join(CORRECTION_RULES_FILE),
             lock: Mutex::new(()),
         })
+    }
+
+    /// 降级实例：data_dir 不可用时使用临时路径，读写会安静地失败或返回空。
+    pub(crate) fn new_fallback() -> Self {
+        Self {
+            path: std::env::temp_dir().join("openless_correction_rules_fallback.json"),
+            lock: Mutex::new(()),
+        }
     }
 
     pub fn list(&self) -> Result<Vec<CorrectionRule>> {


### PR DESCRIPTION
### **User description**
## Summary

**Batch 2** of the 1-app audit: 7 medium-severity correctness/robustness findings (3 bugs, 3 Android robustness, 1 startup-panic). Behavior-preserving defect fixes; no broad refactors.

### Bugs
- `recent_within_minutes`: a single unparseable timestamp no longer silently truncates the context window.
- `handle_less_computer_pressed`: set `voice_agent=true` inside the lock before the async ASR handshake (was set after `pending_stop` could fire).
- Volcengine/Bailian ASR error path: call `asr.cancel()` on `Ok(Err)` to avoid leaking the WebSocket.

### Robustness
- Store init no longer panics on I/O failure at startup — falls back to a temp-dir-backed store; normal startup unchanged.

### Android (Rust CI-verified; Kotlin needs a real Android build)
- `OVERLAY_VISIBLE` desync: reset to false when the overlay service is destroyed (incl. OS kill) — Rust export + `OpenLessOverlayService.onDestroy()` wiring.
- JNI: null-check the raw context pointer before `JObject::from_raw`.
- Accessibility paste: save/restore the user clipboard around the paste fallback.

### Verification (macOS host)
- `cargo test --lib`: **446 passed, 0 failed**; `cargo check`/`clippy` clean; `npx tsc --noEmit` clean; `npm run build` clean.
- Android Rust compiles via the Android cargo-check CI job. The Kotlin `onDestroy` wiring is not compile-checked by CI (cargo only) — minimal pattern-matching change; confirm in a real Android build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fix 3 correctness bugs (timestamp parse, ASR leak, voice_agent race)

- Add store init fallback to avoid panics

- Improve Android robustness (overlay sync, null check, clipboard restore)


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><details><summary>6 files</summary><table>
<tr>
  <td><strong>insert.rs</strong><dd><code>Save and restore clipboard during accessibility paste</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/696/files#diff-3f956f0d7a7261e7e3fb23e4cc2276afba1498dd78bbcc93c900c723cd6d9ab4">+24/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>native_bridge.rs</strong><dd><code>Add overlay destroy notification to sync state</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/696/files#diff-877993f69d990acf3385f921b15d4341a56193418b3d42c22dcf334423e20e24">+18/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>dictation.rs</strong><dd><code>Fix ASR resource leaks and add voice_agent flag during session start</code></dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/696/files#diff-4cf79887f41f4811eb2b1ef682c62ee34c14a0ab969362a9ba1046de59c8578b">+16/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>hotkey_loops.rs</strong><dd><code>Fix voice_agent race by setting it before ASR handshake</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/696/files#diff-6ac2653587479859e5a792fd19c46c7ba3c553387935bd4e090c68d61b7144ac">+6/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>persistence.rs</strong><dd><code>Add store fallbacks and fix timestamp parsing fallback</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/696/files#diff-fe150b5c0806f2cac2827075208fe552ab2b17590ad3dddfbdbdc240084e1adb">+47/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>OpenLessOverlayService.kt</strong><dd><code>Call overlay destroy notification on service destruction</code>&nbsp; </dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/696/files#diff-4ffb977a8726824928547aab8683c052a217a98257c04776ee2f22b354e510d4">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>jni.rs</strong><dd><code>Add clipboard functions and null-check for Android context</code></dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/696/files#diff-93adf06036f4ca07a2dfb21e3304bc6aaf2957dc3bac7304d4428280e6fb4cb0">+78/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>OpenLessNative.kt</strong><dd><code>Declare native overlay destroy function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/696/files#diff-37d33e5a95c29edfb683ae96cb2882be3975e0c339dd90d90a518eb9a41aa3bc">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Error handling</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>coordinator.rs</strong><dd><code>Fallback store initialization to avoid panics</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/696/files#diff-73d8c004670b27293f74f0f3991b9a6fc28f0ff0b883214de2b078b1e09797ca">+38/-14</a>&nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

