### PR TITLE
fix(ui): unify macOS shell top inset with sidebar/background surface

### DIFF
--- a/openless-all/app/src/components/FloatingShell.tsx
+++ b/openless-all/app/src/components/FloatingShell.tsx
@@ -194,7 +194,7 @@ function FloatingShellBody({ os, initialTab, initialSettings }: { os: OS; initia
   const useOpaqueMain = mobile || os === 'linux';
 
   return (
-    <div style={{ flex: 1, position: 'relative', display: 'flex', flexDirection: 'column', minHeight: 0, paddingTop: mobile ? 0 : os === 'mac' ? 28 : 0 }}>
+    <div style={{ flex: 1, position: 'relative', display: 'flex', flexDirection: 'column', minHeight: 0, paddingTop: mobile ? 0 : os === 'mac' ? 28 : 0, background: 'var(--ol-app-shell-bg)' }}>
 
       {mobile && (
         <MobileTopBar


### PR DESCRIPTION
### **User description**
## What

Fixes the macOS-only "extra row at the top" of the main window: the sidebar/background and the title-bar strip now read as one continuous surface (matching the Windows look), with the panel card floating on top.

## Root cause

The 28px top inset that clears the macOS overlay traffic lights sits on the content wrapper in `FloatingShell`. That wrapper had no background, so the inset exposed the lighter `WindowChrome` glass (`--ol-window-bg`) as a full-width band above the sidebar and panel — reading as an extra top row. The Windows build has no inset (`paddingTop: 0`), so it never showed this.

This is **not a regression from a single PR** — the 28px inset has existed since 1.3.8. What made the band visible was the beta theme refresh (Aura skin removed → new white-glass tokens), which changed `--ol-window-bg` vs the shell surface.

## Fix

Paint the content wrapper with the same `--ol-app-shell-bg` token the sidebar/background already use, so the inset blends into one continuous surface.

```diff
- paddingTop: mobile ? 0 : os === 'mac' ? 28 : 0 }}>
+ paddingTop: mobile ? 0 : os === 'mac' ? 28 : 0, background: 'var(--ol-app-shell-bg)' }}>
```

- **One property.** No layout, token, or other UI changes.
- The token carries its own light + dark values, so dark mode is unaffected.
- On Windows/Linux/mobile the inset is 0px, so the wrapper background is never visible there — behavior unchanged on those platforms.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] dev-server visual check on macOS — top band now blends with sidebar/background
- [x] local macOS release build + install — verified in the running app
- [ ] CI: Linux / Windows / macOS / Android build jobs

Base: `beta`.


___

### **PR Type**
Bug fix


___

### **Description**
- Add background to content wrapper to blend with sidebar/background

- Fixes visible band above sidebar/panel on macOS

- One-line change; no layout or token modifications


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Content wrapper (no bg)"] -- "exposed top inset band" --> B["Extra row visible"]
  C["Content wrapper (var(--ol-app-shell-bg))"] -- "blends with sidebar/background" --> D["Continuous surface"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>FloatingShell.tsx</strong><dd><code>Add shell background to content wrapper</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src/components/FloatingShell.tsx

<ul><li>Added <code>background: 'var(--ol-app-shell-bg)'</code> to the content wrapper div<br> <li> Ensures the 28px top inset on macOS blends with the sidebar/background <br>surface<br> <li> No other layout or style changes</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/702/files#diff-ef6d623d372a1cb87a4833f1435927fc2e2ceeedb75c18ea4064d45e1f44df38">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

