### PR TITLE
fix(onboarding): require macOS Accessibility grant before first-run completes

### DIFF
--- a/openless-all/app/src/components/Onboarding.tsx
+++ b/openless-all/app/src/components/Onboarding.tsx
@@ -293,7 +293,12 @@ function DesktopOnboarding({
     ]);
     setAccessibility(a);
     setMicrophone(m);
-    const aOk = !requiresAccessibility || a === 'granted' || a === 'notApplicable';
+    // Gate on the real permission status — macOS returns granted/denied, other
+    // platforms return notApplicable. This must NOT depend on the hotkey
+    // capability flag: it is null while it loads, so trusting it let mic-only
+    // onboarding finish before we knew macOS needs Accessibility, dropping users
+    // into the app with a dead hotkey. Mirrors the gate in App.tsx.
+    const aOk = a === 'granted' || a === 'notApplicable';
     const mOk = m === 'granted' || m === 'notApplicable';
     if (aOk && mOk) {
       onComplete();
@@ -362,7 +367,7 @@ function DesktopOnboarding({
       >
         <BrandHeader title={t('onboarding.welcome')} desc={t('onboarding.intro')} />
 
-        {requiresAccessibility && (
+        {(requiresAccessibility || accessibility === 'denied') && (
           <PermissionStep
             index={1}
             title={capability?.requiresAccessibilityPermission ? t('onboarding.accessibilityTitle') : t('onboarding.hotkeyTitle')}
@@ -380,13 +385,13 @@ function DesktopOnboarding({
                     : t('onboarding.actionGrant')
             }
             onAction={onGrantAccessibility}
-            disabled={busy || !capability?.requiresAccessibilityPermission || accessibility === 'granted' || accessibility === 'notApplicable'}
+            disabled={busy || accessibility === 'granted' || accessibility === 'notApplicable'}
             hint={capability?.requiresAccessibilityPermission ? t('onboarding.accessibilityHint') : undefined}
           />
         )}
 
         <PermissionStep
-          index={requiresAccessibility ? 2 : 1}
+          index={(requiresAccessibility || accessibility === 'denied') ? 2 : 1}
           title={t('onboarding.micTitle')}
           desc={t('onboarding.micDesc')}
           status={microphone}


### PR DESCRIPTION
### **User description**
## Problem

On macOS, first-run onboarding could complete after **Microphone only** and drop the user into the main UI **without Accessibility granted** — so the global hotkey silently does nothing and the app looks broken.

## Cause

`DesktopOnboarding` gated completion on the hotkey **capability flag** `requiresAccessibilityPermission`:

```ts
const aOk = !requiresAccessibility || a === 'granted' || a === 'notApplicable';
```

That flag comes from an async IPC and is **`null` while it loads** → `requiresAccessibility` is briefly `false` → `aOk` is `true`. If Microphone gets granted inside that window, `refresh()` calls `onComplete()` before Accessibility was ever requested. The accessibility step (`{requiresAccessibility && …}`) hadn't rendered yet either. Meanwhile `App.tsx`'s startup gate *always* requires Accessibility, so the two disagreed.

Confirmed in source: macOS `HotkeyCapability` has `requires_accessibility_permission: true` (`types.rs`), but the TS fallback/mock default to `false`.

## Fix (`Onboarding.tsx`, desktop path only)

1. **Gate on the real permission status**, mirroring `App.tsx` — timing-independent, capability-flag-independent:
   ```ts
   const aOk = a === 'granted' || a === 'notApplicable';
   ```
   `check_accessibility()` returns `granted`/`denied` on macOS and `notApplicable` on Windows/Linux/Android, so this requires Accessibility exactly where it's needed.
2. **Show the Accessibility step whenever it's `denied`** (a macOS-only state) in addition to the capability flag, so the step reliably appears even before/if the capability hasn't loaded.
3. **Drop the capability dependency from the grant button's `disabled`**, so it's actionable in that same window.

## Behavior

- **macOS:** onboarding now stays until **both** Accessibility and Microphone are granted. No more "in the app but hotkey dead."
- **Windows / Linux / Android:** Accessibility is `notApplicable` → `aOk` true, step hidden → **unchanged**.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [ ] macOS fresh-run (TCC reset): onboarding blocks until Accessibility granted; grant flow opens System Settings; completes only after both
- [ ] Windows/Linux: onboarding unchanged (mic-only), CI build green

Base: `beta`.


___

### **PR Type**
Bug fix


___

### **Description**
- Fix macOS onboarding completing without Accessibility granted

- Gate completion on real permission status, not capability flag

- Show Accessibility step when denied even before capability loads

- Drop capability dependency from grant button disabled state


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Onboarding refresh()"] --> B["Check permissions"]
  B --> C{"Accessibility = granted or notApplicable?"}
  C -- "True" --> D{"Microphone = granted or notApplicable?"}
  D -- "True" --> E["onComplete()"]
  D -- "False" --> F["Wait for Mic grant"]
  C -- "False" --> G["Show Accessibility step"]
  G --> H["User grants Accessibility"]
  H --> B
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Onboarding.tsx</strong><dd><code>Fix Accessibility permission gating and step visibility</code>&nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src/components/Onboarding.tsx

<ul><li>Modified <code>refresh()</code> to gate completion on real accessibility permission <br>status instead of <code>requiresAccessibility</code> flag<br> <li> Changed rendering condition for Accessibility step to include <br><code>accessibility === 'denied'</code><br> <li> Removed <code>capability?.requiresAccessibilityPermission</code> from grant button <br><code>disabled</code> condition<br> <li> Updated step index calculation to account for accessibility step when <br>denied</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/703/files#diff-b268b8893cf3791067a27e6509d5721b260046fd4c7093f958697c09f3eeb5f7">+9/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

