### PR TITLE
fix(updater): revert signing pubkey to 1DEAA803 to repair auto-update

### DIFF
--- a/openless-all/app/src-tauri/tauri.conf.json
+++ b/openless-all/app/src-tauri/tauri.conf.json
@@ -99,7 +99,7 @@
   },
   "plugins": {
     "updater": {
-      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDZGNEI1OTk0RjMzMzk0QTkKUldTcGxEUHpsRmxMYjRnMFdZNkFyaVozaHN2SUNwZ01mMDlFS0RMWnNQNisrWjF6czZQQk1RQysK",
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDFERUFBODAzNTY0QzMyM0YKUldRL01reFdBNmpxSGE1K0JadlpONXNWTzhJcGZCRGxjUVdIWExNNFJpeUNsSGZwazdlQThhemkK",
       "endpoints": [
         "https://github.com/appergb/openless/releases/latest/download/latest-{{target}}-{{arch}}.json",
         "https://fastgit.cc/https://github.com/appergb/openless/releases/latest/download/latest-{{target}}-{{arch}}-mirror.json"


### PR DESCRIPTION
### **User description**
## Problem

Desktop **and** Android auto-update are broken on all platforms: "click update → download finishes → never installs."

The download is a plain HTTP GET (always succeeds). The signature is verified inside `install()` against the app's **embedded** updater pubkey. Since `aaf4ccc` the embedded desktop pubkey is `6F4B5994…`, but:

- shipped **1.3.8 stable** users (the live base) embed/trust `1DEAA803…`;
- the CI signing key produces `1DEAA803…`-signed artifacts;
- `android/updater.rs` already hardcodes `1DEAA803…`.

So any installed app verifying against `1DEAA803` rejects a `6F4B5994`-signed package → install fails after a successful download. (Conversely, Android signs-with vs verifies-against were mismatched, so Android updates failed outright.)

## Fix

Revert the desktop updater `pubkey` in `tauri.conf.json` to `1DEAA803…`, so desktop + Android + the CI signing secret all agree on one key. One line, no logic change.

```diff
-      "pubkey": "…6F4B5994F33394A9…"
+      "pubkey": "…1DEAA803564C323F…"
```

## Verification

- Decoded keyIDs: `tauri.conf.json` and `android/updater.rs` now both = `1DEAA803564C323F`.
- Signed a probe file with the CI signing key → signature keyID = `1DEAA803564C323F` (matches).
- No remaining `6F4B5994` references in the repo.

## Compatibility

- 1.3.8 stable users (embed `1DEAA803`) → can now verify & install the next release.
- Users currently on a `6F4B5994`-embedded build (recent betas) must reinstall once to re-align — unavoidable across any key change; Tauri trusts a single embedded key.

Base: `beta`.


___

### **PR Type**
Bug fix


___

### **Description**
- Revert updater pubkey to 1DEAA803

- Fixes broken auto-update on desktop and Android


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>tauri.conf.json</strong><dd><code>Revert updater pubkey</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src-tauri/tauri.conf.json

<ul><li>Reverted updater pubkey from 6F4B5994 to 1DEAA803 to match CI signing <br>key and Android updater</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/705/files#diff-e9c2f15638ea988f61c82aeb2257147fb9cc96d7bda8709e8bad6b6517f5369c">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

