### PR TITLE
fix(updater): 安装失败可见化 + 手动下载兜底 + 错误写日志 (#706)

### DIFF
--- a/openless-all/app/src-tauri/src/lib.rs
+++ b/openless-all/app/src-tauri/src/lib.rs
@@ -288,6 +288,7 @@ macro_rules! app_invoke_handler_desktop {
             commands::sherpa_onnx_asr_reveal_model_dir,
             commands::export_error_log,
             restart_app,
+            log_client_error,
             set_windows_caption_theme,
         ]
     };
@@ -378,6 +379,7 @@ macro_rules! app_invoke_handler_mobile {
             $crate::commands::app_check_update_with_channel,
             $crate::commands::app_download_and_install_android_update,
             $crate::restart_app,
+            $crate::log_client_error,
         ]
     };
 }
@@ -1138,6 +1140,26 @@ fn restart_app(app: AppHandle) {
     #[cfg(target_os = "macos")]
     reset_tcc_for_beta_restart();
     app.restart();
+}
+
+/// 把前端的关键错误（如自动更新 install 失败）转发到 Rust 文件日志（openless.log）。
+/// webview 的 console.error 不会进 openless.log，单独留一个 IPC，便于用户「导出日志」
+/// 后我们拿到自动更新失败的真实原因。
+#[tauri::command]
+fn log_client_error(message: String) {
+    // message 由前端 webview 可控，可能很长或含换行（伪造日志行）。先把换行折成空格、
+    // 再按 UTF-8 字符边界截断，避免单条日志过大或污染日志格式。
+    const MAX_LEN: usize = 2048;
+    let mut sanitized = message.replace(['\n', '\r'], " ");
+    if sanitized.len() > MAX_LEN {
+        let mut end = MAX_LEN;
+        while !sanitized.is_char_boundary(end) {
+            end -= 1;
+        }
+        sanitized.truncate(end);
+        sanitized.push_str("…(truncated)");
+    }
+    log::error!("[client] {sanitized}");
 }
 
 #[cfg(target_os = "macos")]

--- a/openless-all/app/src/components/AutoUpdate.tsx
+++ b/openless-all/app/src/components/AutoUpdate.tsx
@@ -15,6 +15,8 @@ import {
   appDownloadAndInstallAndroidUpdate,
   isAndroid,
   isTauri,
+  logClientError,
+  openExternal,
   restartApp,
   type AppUpdateMetadata,
   type UpdateChannel,
@@ -22,6 +24,9 @@ import {
 import { Btn } from '../pages/_atoms';
 
 const UPDATE_CHECK_TIMEOUT_MS = 15_000;
+
+// 自动更新失败时的手动下载兜底：直达 GitHub Releases（与「关于」页 RELEASE_NOTES_URL 一致）。
+const RELEASE_DOWNLOAD_URL = 'https://github.com/appergb/openless/releases';
 
 export type UpdateStatus =
   | 'idle'
@@ -31,7 +36,11 @@ export type UpdateStatus =
   | 'downloading'
   | 'installing'
   | 'downloaded'
-  | 'error';
+  | 'error'
+  // installError：下载/安装这一步失败（区别于 'error' 的「检查失败」）。
+  // 检查失败沿用 'error'，在 CheckUpdateButton 里只做按钮内轻提示、不弹框，
+  // 后台自动检查失败也不弹框；只有 installError 才让弹框留在原地显示错误 + 手动下载兜底。
+  | 'installError';
 
 export interface UseAutoUpdate {
   status: UpdateStatus;
@@ -162,6 +171,7 @@ export function useAutoUpdate(): UseAutoUpdate {
     } catch (error) {
       console.error('[updater] failed to check update', error);
       const msg = error instanceof Error ? error.message : String(error);
+      void logClientError(`[updater] check failed: ${msg}`);
       setErrorMessage(msg);
       setStatus('error');
     }
@@ -180,8 +190,9 @@ export function useAutoUpdate(): UseAutoUpdate {
       } catch (error) {
         console.error('[updater] failed to install android update', error);
         const msg = error instanceof Error ? error.message : String(error);
+        void logClientError(`[updater] android install failed (v${payload.version}): ${msg}`);
         setErrorMessage(msg);
-        setStatus('error');
+        setStatus('installError');
       }
       return;
     }
@@ -208,9 +219,10 @@ export function useAutoUpdate(): UseAutoUpdate {
     } catch (error) {
       console.error('[updater] failed to install update', error);
       const msg = error instanceof Error ? error.message : String(error);
+      void logClientError(`[updater] install failed (v${update.version}): ${msg}`);
       setErrorMessage(msg);
       await closeUpdate();
-      setStatus('error');
+      setStatus('installError');
     }
   };
 
@@ -237,8 +249,8 @@ export function useAutoUpdate(): UseAutoUpdate {
   };
 }
 
-export function isDialogStatus(status: UpdateStatus): status is 'available' | 'downloading' | 'installing' | 'downloaded' {
-  return status === 'available' || status === 'downloading' || status === 'installing' || status === 'downloaded';
+export function isDialogStatus(status: UpdateStatus): status is 'available' | 'downloading' | 'installing' | 'downloaded' | 'installError' {
+  return status === 'available' || status === 'downloading' || status === 'installing' || status === 'downloaded' || status === 'installError';
 }
 
 export function UpdateDialog({
@@ -247,29 +259,34 @@ export function UpdateDialog({
   progress,
   downloaded,
   contentLength,
+  errorMessage,
   onInstall,
   onClose,
 }: {
-  status: 'available' | 'downloading' | 'installing' | 'downloaded';
+  status: 'available' | 'downloading' | 'installing' | 'downloaded' | 'installError';
   version: string;
   progress: number | null;
   downloaded: number;
   contentLength: number | null;
+  errorMessage?: string | null;
   onInstall: () => void;
   onClose: () => void;
 }) {
   const { t } = useTranslation();
   const downloading = status === 'downloading';
   const installing = status === 'installing';
+  const installError = status === 'installError';
   const androidInstalled = isAndroid() && status === 'downloaded';
   return (
     <div style={{ position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.18)', display: 'grid', placeItems: 'center', zIndex: 40 }}>
       <div style={{ width: 360, borderRadius: 16, background: 'var(--ol-surface)', border: '0.5px solid var(--ol-line-strong)', boxShadow: '0 18px 42px rgba(0,0,0,0.18)', padding: 18 }}>
         <div style={{ fontSize: 15, fontWeight: 650, marginBottom: 8 }}>{t(`settings.about.updateDialog.${status}.title`)}</div>
-        <div style={{ fontSize: 12, color: 'var(--ol-ink-3)', lineHeight: 1.6, marginBottom: 14 }}>
+        <div style={{ fontSize: 12, color: 'var(--ol-ink-3)', lineHeight: 1.6, marginBottom: 14, whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>
           {androidInstalled
             ? t('settings.about.updateDialog.androidInstalled.desc', { version, defaultValue: '系统安装器已打开，请按提示完成安装。安装后重新打开 OpenLess 即可使用 {{version}}。' })
-            : t(`settings.about.updateDialog.${status}.desc`, { version })}
+            : installError
+              ? t('settings.about.updateDialog.installError.desc', { error: errorMessage || t('settings.about.updateError') })
+              : t(`settings.about.updateDialog.${status}.desc`, { version })}
         </div>
         {(downloading || installing || status === 'downloaded') && (
           <div style={{ marginBottom: 14 }}>
@@ -291,6 +308,8 @@ export function UpdateDialog({
           {(downloading || installing) && <Btn size="sm" disabled>{installing ? t('settings.about.updateDialog.installingLabel') : t('settings.about.updateDialog.downloadingLabel')}</Btn>}
           {status === 'downloaded' && <Btn size="sm" onClick={onClose}>{t('settings.about.updateDialog.later')}</Btn>}
           {status === 'downloaded' && !androidInstalled && <Btn variant="blue" size="sm" onClick={restartApp}>{t('settings.about.updateDialog.restartNow')}</Btn>}
+          {installError && <Btn size="sm" onClick={onClose}>{t('common.cancel')}</Btn>}
+          {installError && <Btn variant="blue" size="sm" onClick={() => void openExternal(RELEASE_DOWNLOAD_URL)}>{t('settings.about.updateDialog.manualDownload')}</Btn>}
         </div>
       </div>
     </div>

--- a/openless-all/app/src/components/AutoUpdateGate.tsx
+++ b/openless-all/app/src/components/AutoUpdateGate.tsx
@@ -60,6 +60,7 @@ export function AutoUpdateGate() {
       progress={u.progress}
       downloaded={u.downloaded}
       contentLength={u.contentLength}
+      errorMessage={u.errorMessage}
       onInstall={u.installUpdate}
       onClose={u.dismissDialog}
     />

--- a/openless-all/app/src/i18n/en.ts
+++ b/openless-all/app/src/i18n/en.ts
@@ -1041,6 +1041,11 @@ export const en: typeof zhCN = {
         restartNow: 'Restart now',
         progress: '{{progress}}% · {{downloaded}} / {{total}}',
         progressUnknown: '{{downloaded}} downloaded',
+        installError: {
+          title: 'Update failed',
+          desc: "The automatic update couldn't finish: {{error}}. You can download and install the latest version manually.",
+        },
+        manualDownload: 'Download manually',
       },
     },
   },

--- a/openless-all/app/src/i18n/ja.ts
+++ b/openless-all/app/src/i18n/ja.ts
@@ -1009,6 +1009,11 @@ export const ja: typeof zhCN = {
         restartNow: '今すぐ再起動',
         progress: '{{progress}}% · {{downloaded}} / {{total}}',
         progressUnknown: 'ダウンロード済み {{downloaded}}',
+        installError: {
+          title: '更新に失敗しました',
+          desc: '自動更新を完了できませんでした：{{error}}。ダウンロードページから手動で最新版を入手できます。',
+        },
+        manualDownload: '手動でダウンロード',
       },
     },
   },

--- a/openless-all/app/src/i18n/ko.ts
+++ b/openless-all/app/src/i18n/ko.ts
@@ -1009,6 +1009,11 @@ export const ko: typeof zhCN = {
         restartNow: '지금 재시작',
         progress: '{{progress}}% · {{downloaded}} / {{total}}',
         progressUnknown: '다운로드됨 {{downloaded}}',
+        installError: {
+          title: '업데이트 실패',
+          desc: '자동 업데이트를 완료하지 못했습니다: {{error}}. 다운로드 페이지에서 최신 버전을 직접 받아 설치할 수 있습니다.',
+        },
+        manualDownload: '수동 다운로드',
       },
     },
   },

--- a/openless-all/app/src/i18n/zh-CN.ts
+++ b/openless-all/app/src/i18n/zh-CN.ts
@@ -1039,6 +1039,11 @@ export const zhCN = {
         restartNow: '现在重启',
         progress: '{{progress}}% · {{downloaded}} / {{total}}',
         progressUnknown: '已下载 {{downloaded}}',
+        installError: {
+          title: '更新失败',
+          desc: '自动更新没能完成：{{error}}。你可以前往下载页手动下载安装最新版本。',
+        },
+        manualDownload: '手动下载',
       },
     },
   },

--- a/openless-all/app/src/i18n/zh-TW.ts
+++ b/openless-all/app/src/i18n/zh-TW.ts
@@ -1007,6 +1007,11 @@ export const zhTW: typeof zhCN = {
         restartNow: '現在重啓',
         progress: '{{progress}}% · {{downloaded}} / {{total}}',
         progressUnknown: '已下載 {{downloaded}}',
+        installError: {
+          title: '更新失敗',
+          desc: '自動更新未能完成：{{error}}。你可以前往下載頁手動下載安裝最新版本。',
+        },
+        manualDownload: '手動下載',
       },
     },
   },

--- a/openless-all/app/src/lib/ipc/index.ts
+++ b/openless-all/app/src/lib/ipc/index.ts
@@ -195,4 +195,4 @@ export {
 } from "./marketplace-cache"
 
 // utils
-export { openExternal, exportErrorLog } from "./utils"
+export { openExternal, exportErrorLog, logClientError } from "./utils"

--- a/openless-all/app/src/lib/ipc/utils.ts
+++ b/openless-all/app/src/lib/ipc/utils.ts
@@ -47,3 +47,16 @@ export async function exportErrorLog(
     )
     return target
 }
+
+/**
+ * 把前端关键错误（如自动更新 install 失败）转发到 Rust 文件日志（openless.log）。
+ * webview 的 console.error 不会落进 openless.log，单独走 IPC，便于用户「导出日志」
+ * 后我们拿到失败的真实原因。永不抛错——日志失败不应再影响调用方的错误处理。
+ */
+export async function logClientError(message: string): Promise<void> {
+    try {
+        await invokeOrMock<void>("log_client_error", { message }, () => undefined)
+    } catch (error) {
+        console.warn("[log-client-error] failed to forward error to app log", error)
+    }
+}

--- a/openless-all/app/src/pages/settings/CheckUpdateButton.tsx
+++ b/openless-all/app/src/pages/settings/CheckUpdateButton.tsx
@@ -62,6 +62,7 @@ export function CheckUpdateButton({ channel }: { channel: UpdateChannel }) {
           progress={updater.progress}
           downloaded={updater.downloaded}
           contentLength={updater.contentLength}
+          errorMessage={updater.errorMessage}
           onInstall={() => void updater.installUpdate()}
           onClose={() => void updater.dismissDialog()}
         />


### PR DESCRIPTION
### **User description**
## 背景

修复 #706：macOS/桌面自动更新「提示更新 → 下载中 → 下载完弹框消失 → 之后无反应、重启仍旧版」。

## 根因

`AutoUpdate.tsx` 的 `installUpdate()` 里，`update.download()/install()` 一旦抛错，`catch` 把 `status` 置成 `'error'`。但 `UpdateDialog` 只在 `available/downloading/installing/downloaded` 渲染——`error` 态下**弹框直接消失，错误只 `console.error`（还不进 `openless.log`）**，用户完全无感知。底层 `install()` 失败最可能是 ad-hoc 签名 + `com.apple.quarantine` → App Translocation → 原地替换 `.app` 失败。

## 改动

- **新增独立状态 `installError`**：仅「下载/安装失败」用它。`'error'` 仍表示「检查失败」，行为**完全不变**——`CheckUpdateButton` 仍是按钮内 2.5s 轻提示、后台 60min 自动检查失败也不弹框（**零回归**，避免网络波动时无故弹错误框）。
- 失败弹框**留在原地显示真实错误** + 「手动下载」按钮直达 GitHub Releases 兜底。
- 新增 Rust IPC `log_client_error`，把前端更新错误写进 `openless.log`（webview console 不入文件日志），便于用户「关于 → 导出日志」后定位真因。
- 5 个 i18n 文件补 `updateDialog.installError` / `manualDownload`（zh-CN/zh-TW/ja/en/ko）。

## 影响面

`AutoUpdate.tsx`（状态机 + 弹框）、两处渲染点（`AutoUpdateGate.tsx` 后台、`CheckUpdateButton.tsx` 设置页）、`lib/ipc`（新增 `logClientError`）、`lib.rs`（新增命令 + desktop/mobile 两处注册）、5 个 i18n。共 11 文件 +78/-9。

## 验证

- [x] `npx tsc --noEmit` 通过
- [x] `cargo check --manifest-path src-tauri/Cargo.toml` 通过（仅既有 warning）
- [ ] 真机：本地无 JS test runner，且需真·更新失败才会走到该路径；真机效果待下一个失败用户暴露新弹框/日志确认

## 重要边界（非本 PR 范围）

这是**兜底**（失败可见 + 可诊断 + 手动路径），**不**让 ad-hoc/quarantine 机器的自动更新「真正成功」。根治需 Apple Developer ID 签名 + 公证（暂缓，无开发者账号）。后续 Phase 2 计划：自建更新服务器（3-backend axum）控版本/灰度/强更/kill-switch + 前端 OTA 热补丁。

Closes #706


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Show install failure error dialog instead of disappearing

- Add manual download button to GitHub Releases

- Log client errors to openless.log via new Rust IPC

- Add i18n strings for install error and manual download


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A[Download & Install] -->|success| B[Downloaded]
  A -->|failure| C[Install Error]
  C --> D[Show error + Manual Download]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>8 files</summary><table>
<tr>
  <td><strong>lib.rs</strong><dd><code>Add log_client_error Rust IPC command</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/708/files#diff-6b8eb1bbf8e378bab914f1a12962f7add5cc4ba9e013c37c9921a1032fa5e110">+22/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>en.ts</strong><dd><code>Add installError and manualDownload i18n keys</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/708/files#diff-bb2f4fa05787923f8aeb23b6f11ad8705e02d9ff03a45790f9181e4615c79d83">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ja.ts</strong><dd><code>Add Japanese translation for install error</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/708/files#diff-be57f0090cf34e3ff924cfa35f13d5d9e6514d3af5a1ebfdeb92bd7d36ed9cf4">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ko.ts</strong><dd><code>Add Korean translation for install error</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/708/files#diff-daf35bcb6a2f8a31565b83d119cb59b69c1dededbabfccfd0d56693fdb3726ca">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>zh-CN.ts</strong><dd><code>Add Chinese translation for install error</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/708/files#diff-571576f3c7b6c4a78ae0f91accdccc5da5cbed00409955c9914c046fee6c80ea">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>zh-TW.ts</strong><dd><code>Add Traditional Chinese translation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/708/files#diff-a8d5953f9c76bc3c90ec583270be04c852bd7540297500e6ff3260760fc61ea4">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>index.ts</strong><dd><code>Export logClientError function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/708/files#diff-dc89fbf143ba47551193aad82ba02687ecb8fe83619daefc5c1f9e67dbfb4032">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>utils.ts</strong><dd><code>Implement logClientError with invoke</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/708/files#diff-2ae031f7c2a7045cb044e13213a6d81805e5eeef6470c5d891654edf8677f7c6">+13/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>AutoUpdate.tsx</strong><dd><code>Add installError status and manual download</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/708/files#diff-35d817392a83ce7dc17bd10e9223889f8311caaf56d910842b84fa4bfae03dd9">+27/-8</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>AutoUpdateGate.tsx</strong><dd><code>Pass errorMessage to UpdateDialog</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/708/files#diff-5d27e64e24729b1cc26b9d6964a918d29f1b46c9a1e1bd1d5bd25fac0b1cbde7">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>CheckUpdateButton.tsx</strong><dd><code>Pass errorMessage to UpdateDialog</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/708/files#diff-f58a72e68e822e0ad4f276151038ac2446491351ab15e224b7ddbd816ad67cc3">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

