### PR TITLE
fix(ui): 修复风格市场弹窗按钮对比度并透明化概览指标容器

### DIFF
--- a/openless-all/app/src/components/MarketplaceModal.tsx
+++ b/openless-all/app/src/components/MarketplaceModal.tsx
@@ -3,7 +3,7 @@
 // 入口在 Style 页面「风格包」标题右侧，由 Style.tsx 控制 open/close。
 // 顶部 pill 显示当前「登录身份」（dev 模式 = marketplaceDevLogin），未填时引导跳 Settings。
 
-import { useEffect } from 'react';
+import { useEffect, type CSSProperties } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Icon } from './Icon';
 import { Marketplace } from '../pages/Marketplace';
@@ -12,6 +12,29 @@ import { useHotkeySettings } from '../state/HotkeySettingsContext';
 interface MarketplaceModalProps {
   onClose: () => void;
 }
+
+const modalChipDarkStyle: CSSProperties = {
+  background: 'var(--ol-pill-selected-bg)',
+  color: 'var(--ol-pill-selected-ink)',
+  border: '0.5px solid var(--ol-pill-selected-border)',
+  boxShadow: 'var(--ol-shadow-sm)',
+};
+
+const modalCloseBtnStyle: CSSProperties = {
+  ...modalChipDarkStyle,
+  position: 'absolute',
+  top: 16,
+  right: 16,
+  zIndex: 3,
+  width: 32,
+  height: 32,
+  borderRadius: 8,
+  display: 'inline-flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  cursor: 'default',
+  transition: 'opacity 0.16s var(--ol-motion-quick)',
+};
 
 export function MarketplaceModal({ onClose }: MarketplaceModalProps) {
   const { t } = useTranslation();
@@ -71,14 +94,16 @@ export function MarketplaceModal({ onClose }: MarketplaceModalProps) {
             style={{
               display: 'inline-flex', alignItems: 'center', gap: 6,
               padding: '4px 10px', borderRadius: 999,
-              border: loggedIn ? '0.5px solid var(--ol-line)' : '0.5px solid rgba(239,68,68,0.32)',
-              background: loggedIn ? 'rgba(255,255,255,0.85)' : 'rgba(239,68,68,0.08)',
-              color: loggedIn ? 'var(--ol-ink-2)' : 'var(--ol-red, #ef4444)',
               fontSize: 11.5, fontWeight: 500,
               cursor: 'default',
-              boxShadow: '0 1px 2px rgba(15,17,22,0.05)',
-              backdropFilter: 'blur(8px) saturate(140%)',
-              WebkitBackdropFilter: 'blur(8px) saturate(140%)',
+              ...(loggedIn
+                ? modalChipDarkStyle
+                : {
+                    border: '0.5px solid rgba(239,68,68,0.32)',
+                    background: 'rgba(239,68,68,0.08)',
+                    color: 'var(--ol-red, #ef4444)',
+                    boxShadow: '0 1px 2px rgba(15,17,22,0.05)',
+                  }),
             }}
           >
             <Icon name="user" size={11} />
@@ -88,27 +113,12 @@ export function MarketplaceModal({ onClose }: MarketplaceModalProps) {
 
         <button
           onClick={onClose}
-          style={{
-            position: 'absolute', top: 16, right: 16, zIndex: 3,
-            width: 32, height: 32,
-            border: '0.5px solid var(--ol-line)',
-            borderRadius: 8,
-            background: 'rgba(255,255,255,0.85)',
-            color: 'var(--ol-ink-2)',
-            display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
-            cursor: 'default',
-            boxShadow: '0 1px 2px rgba(15,17,22,0.05)',
-            backdropFilter: 'blur(8px) saturate(140%)',
-            WebkitBackdropFilter: 'blur(8px) saturate(140%)',
-            transition: 'background 0.16s var(--ol-motion-quick), color 0.16s var(--ol-motion-quick)',
-          }}
+          style={modalCloseBtnStyle}
           onMouseEnter={(e) => {
-            (e.currentTarget as HTMLButtonElement).style.background = 'var(--ol-surface)';
-            (e.currentTarget as HTMLButtonElement).style.color = 'var(--ol-ink)';
+            (e.currentTarget as HTMLButtonElement).style.opacity = '0.85';
           }}
           onMouseLeave={(e) => {
-            (e.currentTarget as HTMLButtonElement).style.background = 'rgba(255,255,255,0.85)';
-            (e.currentTarget as HTMLButtonElement).style.color = 'var(--ol-ink-2)';
+            (e.currentTarget as HTMLButtonElement).style.opacity = '1';
           }}
           aria-label={t('common.close')}
           title={t('common.close')}

--- a/openless-all/app/src/styles/global.css
+++ b/openless-all/app/src/styles/global.css
@@ -214,8 +214,8 @@ html[data-ol-platform="android"] .ol-frost::before {
 }
 
 .ol-overview-hero {
-  background: var(--ol-card-bg);
-  border: 0.5px solid var(--ol-card-border);
+  background: transparent;
+  border: none;
 }
 
 .ol-capsule-pill {


### PR DESCRIPTION
### **User description**
## 摘要

修复风格市场弹窗顶部控件在浅色背景上对比度不足的问题，并简化概览页指标区外层容器样式。标题：ix(ui): 修复风格市场弹窗按钮对比度并透明化概览指标容器

## 修复 / 新增 / 改进

- **风格市场弹窗（MarketplaceModal）**：关闭按钮与已登录 GitHub 身份 pill 改用 --ol-pill-selected-* 深色 chip 样式，hover 仅调整 opacity，避免白底毛玻璃与弹窗卡片背景融为一体导致 × 不可见
- **概览页（Overview）**：.ol-overview-hero 外层容器改为透明、无边框，指标卡片仍由内部 Card 组件独立渲染

## 兼容

- 不包含：API、构建脚本、后端逻辑变更
- 对现有用户 / 本地环境 / 构建流程的影响：纯前端 CSS/组件样式调整，无破坏性变更

## 测试计划

- [x] 命令：cd openless-all/app && npm run dev
- [x] 结果：风格页 → 打开风格市场弹窗，确认关闭按钮与 @用户 pill 为深色底 + 白色图标/文字；概览页指标区无外层卡片边框，四个 Metric 卡片样式正常
- [x] 证据路径：浏览器本地预览 http://localhost:1420/


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- 修复 MarketplaceModal 关闭按钮与登录 pill 在白色背景上的对比度

- 透明化概览页指标区域外层容器样式


___

### Diagram Walkthrough


```mermaid
flowchart LR
  modal["MarketplaceModal"] -- "关闭按钮+登录 pill" --> darkChip["深色 chip 样式"]
  overview["概览页"] -- "外层容器" --> transparentBg["透明背景+无边框"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>MarketplaceModal.tsx</strong><dd><code>为弹窗控件添加深色 chip 样式</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src/components/MarketplaceModal.tsx

<ul><li>引入 <code>CSSProperties</code> 类型<br> <li> 定义 <code>modalChipDarkStyle</code> 和 <code>modalCloseBtnStyle</code> 深色样式<br> <li> 登录 pill 和关闭按钮改用深色背景、白色文字，hover 只调透明度</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/709/files#diff-b17d26eaf24292411daab4a9ac48b20345d45728793850fca01732a3660c201c">+35/-25</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>global.css</strong><dd><code>透明化概览页外层容器</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src/styles/global.css

- 将 `.ol-overview-hero` 的背景设为透明
- 移除边框，实现透明化


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/709/files#diff-ba6dfef13673e14e7e2ae1888f48b081d20a99e6b5a93c451cff7096e80ea47f">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

