### PR TITLE
fix(asr): add MiMo provider to credential gate validation

### DIFF
--- a/openless-all/app/src-tauri/src/coordinator/asr_wiring.rs
+++ b/openless-all/app/src-tauri/src/coordinator/asr_wiring.rs
@@ -93,7 +93,10 @@ pub(super) fn ensure_asr_credentials() -> Result<(), String> {
         }
     }
 
-    if is_whisper_compatible_provider(&active_asr) || is_bailian_provider(&active_asr) {
+    if is_whisper_compatible_provider(&active_asr)
+        || is_bailian_provider(&active_asr)
+        || is_mimo_provider(&active_asr)
+    {
         let api_key = CredentialsVault::get(CredentialAccount::AsrApiKey)
             .ok()
             .flatten()


### PR DESCRIPTION
### **User description**
## 问题描述

使用 `xiaomi-mimo-asr` 作为 ASR provider 时，语音输入被拦截，报错：

```
[WARN] [coord] ASR credential gate failed: 请先在设置中填写火山引擎 ASR App Key 和 Access Key
```

## 根本原因

`ensure_asr_credentials()` 函数（位于 `coordinator/asr_wiring.rs`）没有处理 MiMo provider。

当前验证逻辑：
1. ✅ 本地 Qwen3-ASR → 跳过验证
2. ✅ Foundry Whisper → 跳过验证
3. ✅ sherpa-onnx → 跳过验证
4. ✅ Whisper 兼容 / 百炼 → 检查 API Key
5. ❌ **其他所有 provider → 强制检查火山引擎凭证**

MiMo provider 不匹配任何条件，fall through 到第 5 步，被火山引擎凭证检查拦截。

## 修复方式

在第 4 步的条件中添加 `is_mimo_provider(&active_asr)`，让 MiMo 走与其他 API Key 类型 provider 相同的验证路径：

```rust
// Before
if is_whisper_compatible_provider(&active_asr) || is_bailian_provider(&active_asr) {

// After
if is_whisper_compatible_provider(&active_asr)
    || is_bailian_provider(&active_asr)
    || is_mimo_provider(&active_asr)
{
```

## 测试

- [x] 使用 `xiaomi-mimo-asr` provider 成功完成语音输入
- [x] 历史记录正常保存
- [x] 无 "ASR credential gate failed" 错误
- [x] 流式润色正常工作


___

### **PR Type**
Bug fix


___

### **Description**
- Fix MiMo provider credential gate validation

- Add `is_mimo_provider()` to condition


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Credential gate"] --> B{"Provider?"}
  B -- "Whisper/Bailian/MiMo" --> C["Check API Key"]
  B -- "Other" --> D["Volcengine error"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>asr_wiring.rs</strong><dd><code>Add MiMo provider to credential gate condition</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app-tauri/src-tauri/src/coordinator/asr_wiring.rs

- Added `is_mimo_provider()` to credential gate condition


</details>


  </td>
  <td><a href=""></a></td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

