### PR TITLE
fix(capsule): 胶囊跟随鼠标光标所在屏，修复多屏/多 Space 只在第一块屏显示

### DIFF
--- a/openless-all/app/scripts/macos-capsule-spaces-contract.test.mjs
+++ b/openless-all/app/scripts/macos-capsule-spaces-contract.test.mjs
@@ -47,3 +47,31 @@ for (const forbidden of ['window.show()', 'set_focus', 'NSApp.activate', 'makeKe
     throw new Error(`macOS capsule no-activate path must not call ${forbidden}`);
   }
 }
+
+// === 胶囊跟随「鼠标光标所在屏」契约（多屏 / 多 Space）===
+// 根因：定位用 AX caret、layout 去重缓存却用胶囊自己的 current_monitor，两者看
+// 不同的屏；光标移到另一块屏时缓存误判「没变化」→ 跳过重新定位 → 胶囊被锁死
+// 在第一块屏（别屏只闪一下）。修复后两条路径必须共用 capsule_target_monitor，
+// 且以鼠标光标为首选信号。这些不变量纯靠源码 grep 守护，无法在无多屏硬件的
+// 单测里覆盖，正是契约测试的用武之地。
+const libRs = (
+  await readFile(new URL('../src-tauri/src/lib.rs', import.meta.url), 'utf-8')
+).replace(/\r\n/g, '\n');
+
+assertMatch(
+  libRs,
+  /fn capsule_target_monitor[\s\S]*?macos_mouse_cursor_point\(\)\s*\.or_else\(\s*macos_focused_input_anchor_point\s*\)/,
+  'macOS capsule must resolve its target monitor from the mouse cursor first, AX caret only as fallback',
+);
+
+assertMatch(
+  libRs,
+  /跟随鼠标光标所在显示器[\s\S]*?if let Some\(mon\) = capsule_target_monitor\(window\)/,
+  'macOS capsule positioning must follow capsule_target_monitor (the mouse screen), not its own current_monitor',
+);
+
+assertMatch(
+  capsuleFocusRs,
+  /#\[cfg\(target_os = "macos"\)\][\s\S]*?crate::capsule_target_monitor\(window\)/,
+  'macOS capsule layout cache key must reuse capsule_target_monitor, or it will skip repositioning when the cursor moves to another screen',
+);

--- a/openless-all/app/src-tauri/src/coordinator/capsule_focus.rs
+++ b/openless-all/app/src-tauri/src/coordinator/capsule_focus.rs
@@ -590,10 +590,10 @@ pub(super) struct CapsuleLayoutState {
 /// 返回胶囊「应该摆放到的显示器」的标识信息。
 ///
 /// 它看的显示器必须和 `position_capsule_bottom_center` 实际定位用的一致：
-/// Windows 看「正在输入的 App 所在显示器」，其它平台看胶囊自己的显示器。
-/// 这是「是否需要重新定位」去重缓存（`maybe_position_capsule_bottom_center`）
-/// 的 key，如果这里看错了显示器，就会出现「输入焦点移到另一块屏、胶囊却没
-/// 跟过去」的 bug。
+/// Windows 看「正在输入的 App 所在显示器」，macOS 看「鼠标光标所在显示器」，
+/// 其它平台看胶囊自己的显示器。这是「是否需要重新定位」去重缓存
+/// （`maybe_position_capsule_bottom_center`）的 key，如果这里看错了显示器，
+/// 就会出现「焦点/光标移到另一块屏、胶囊却没跟过去」的 bug。
 pub(super) fn capsule_layout_snapshot<R: tauri::Runtime>(
     window: &tauri::WebviewWindow<R>,
     translation_active: bool,
@@ -614,6 +614,23 @@ pub(super) fn capsule_layout_snapshot<R: tauri::Runtime>(
             });
         }
         // 仅当 Win32 取不到前台显示器时，落回下面的 current_monitor。
+    }
+    // macOS：以「鼠标光标所在显示器」为基准，必须和
+    // position_capsule_bottom_center 实际定位用的同一块屏；否则光标移到另一块
+    // 屏时这里仍读到胶囊旧屏 → 误判「没变化」→ 跳过重新定位 → 胶囊锁死在第一块屏。
+    #[cfg(target_os = "macos")]
+    {
+        if let Some(mon) = crate::capsule_target_monitor(window) {
+            return Some(CapsuleLayoutState {
+                translation_active,
+                monitor_x: mon.physical_x,
+                monitor_y: mon.physical_y,
+                monitor_width: mon.physical_width,
+                monitor_height: mon.physical_height,
+                scale_bits: mon.scale.to_bits(),
+            });
+        }
+        // 取不到光标 / AX 位置时落回下面的 current_monitor。
     }
     let monitor = window.current_monitor().ok().flatten()?;
     Some(CapsuleLayoutState {

--- a/openless-all/app/src-tauri/src/lib.rs
+++ b/openless-all/app/src-tauri/src/lib.rs
@@ -1574,17 +1574,34 @@ impl CapsuleTargetMonitor {
     }
 }
 
-/// macOS：把「当前 focused input / caret」映射到显示器。
+/// macOS：决定胶囊应该摆到哪块显示器。
 ///
-/// 不能用 capsule window 的 current_monitor：窗口隐藏时它仍停留在上一次出现的屏，
-/// 多屏输入会因此被缓存误判为“不需要移动”。这里先用 AX 取 caret/输入框位置，
-/// 再在 Tauri 的 monitor 坐标系里选包含该点的屏；如果点短暂落在所有屏外，
-/// 退到最近的屏，避免虚拟桌面负坐标/屏幕排列边缘导致完全不显示。
+/// 跟随**鼠标光标所在的屏**——这是用户的操作/视线焦点，也是唯一始终可用、
+/// 无需任何权限的信号，多显示器 + 多 Space 下都能稳定命中。光标取不到时
+/// （理论上不会）才退回 AX focused-input/caret 位置。
+///
+/// 关键：不能用 capsule window 自己的 current_monitor——窗口隐藏时它仍停留在
+/// 上一次出现的屏，多屏会被缓存误判为“不需要移动”，把胶囊锁死在第一块屏。
+/// 选屏时先找包含该点的屏；点短暂落在所有屏外则退到最近的屏，避免虚拟桌面
+/// 负坐标 / 屏幕排列边缘导致完全不显示。定位与 layout 去重缓存共用本函数，
+/// 二者看的必须是同一块屏。
 #[cfg(target_os = "macos")]
-pub(crate) fn focused_input_target_monitor<R: tauri::Runtime>(
+pub(crate) fn capsule_target_monitor<R: tauri::Runtime>(
     window: &tauri::WebviewWindow<R>,
 ) -> Option<CapsuleTargetMonitor> {
-    let (x, y) = macos_focused_input_anchor_point()?;
+    let (x, y) = macos_mouse_cursor_point().or_else(macos_focused_input_anchor_point)?;
+    monitor_for_anchor_point(window, x, y)
+}
+
+/// 在 Tauri 的 monitor 坐标系里，选出包含逻辑坐标点 `(x, y)` 的显示器；
+/// 点落在所有屏之外时退到最近的屏。坐标系同 AX / CGEvent 的全局显示空间
+/// （左上原点，points）。
+#[cfg(target_os = "macos")]
+fn monitor_for_anchor_point<R: tauri::Runtime>(
+    window: &tauri::WebviewWindow<R>,
+    x: f64,
+    y: f64,
+) -> Option<CapsuleTargetMonitor> {
     let monitors = window.available_monitors().ok()?;
     let mut nearest: Option<(f64, CapsuleTargetMonitor)> = None;
 
@@ -1608,6 +1625,11 @@ pub(crate) fn focused_input_target_monitor<R: tauri::Runtime>(
     }
 
     nearest.map(|(_, target)| target)
+}
+
+#[cfg(target_os = "macos")]
+fn macos_mouse_cursor_point() -> Option<(f64, f64)> {
+    macos_capsule_ax::mouse_cursor_point()
 }
 
 #[cfg(target_os = "macos")]
@@ -1692,6 +1714,30 @@ mod macos_capsule_ax {
             let width = rect.size.width.max(1.0);
             let height = rect.size.height.max(1.0);
             Some((rect.origin.x + width / 2.0, rect.origin.y + height / 2.0))
+        }
+    }
+
+    type CGEventRef = *const c_void;
+    type CGEventSourceRef = *const c_void;
+
+    #[link(name = "CoreGraphics", kind = "framework")]
+    extern "C" {
+        fn CGEventCreate(source: CGEventSourceRef) -> CGEventRef;
+        fn CGEventGetLocation(event: CGEventRef) -> CGPoint;
+    }
+
+    /// 当前鼠标光标在「全局显示坐标系」(左上原点，points) 的位置。该坐标系与 AX
+    /// caret 完全一致，可直接拿去和 `logical_frame` 比较选屏。`CGEventGetLocation`
+    /// 始终可用、不需要任何权限，所以作为胶囊跟随屏幕的首选信号。
+    pub(super) fn mouse_cursor_point() -> Option<(f64, f64)> {
+        unsafe {
+            let event = CGEventCreate(std::ptr::null());
+            if event.is_null() {
+                return None;
+            }
+            let point = CGEventGetLocation(event);
+            CFRelease(event as CFTypeRef);
+            Some((point.x, point.y))
         }
     }
 
@@ -2486,11 +2532,11 @@ pub(crate) fn position_capsule_bottom_center<R: tauri::Runtime>(
         // 仅当 Win32 取不到前台显示器时，落回下面的 current_monitor 逻辑。
     }
 
-    // macOS：跟随当前 focused input / caret 所在显示器，而不是胶囊窗口
-    // 上一次停留的显示器。这样外接屏上输入时，隐藏态胶囊也能先移动再出现。
+    // macOS：跟随鼠标光标所在显示器，而不是胶囊窗口上一次停留的显示器。
+    // 这样在任意外接屏 / 任意 Space 上触发时，隐藏态胶囊也能先移动再出现。
     #[cfg(target_os = "macos")]
     {
-        if let Some(mon) = focused_input_target_monitor(window) {
+        if let Some(mon) = capsule_target_monitor(window) {
             window.set_size(LogicalSize::new(bounds.width, bounds.height))?;
             let frame = mon.logical_frame();
             let (x, y) = bottom_visual_position(


### PR DESCRIPTION
### **User description**
## 问题
多屏 + 多桌面（Spaces）下，听写胶囊只出现在**第一块屏**，其他屏只闪一下就消失。期望：胶囊出现在**鼠标当前所在的屏/桌面**，其他屏不显示。

## 根因（macOS）
胶囊「该摆哪块屏」用了两套互相矛盾的判断：
1. **定位** `position_capsule_bottom_center` 用 `focused_input_target_monitor`（AX 输入框 caret 位置）。多数 App 取不到可用的 AX 矩形 → 返回 `None` → 跌落 `window.current_monitor()`（胶囊自己上次停留的屏 = 第一块屏）。
2. **去重缓存** `capsule_layout_snapshot` 在 macOS 也用 `window.current_monitor()`，**和定位看的不是同一块屏**。两者不一致 → 胶囊一旦落到第一块屏，之后每次状态变化都判 `snapshot == last` → **跳过重新定位**，被锁死在第一块屏；切换时在别屏短暂出现 = 那个「闪一下」。

两条路都**没有跟踪鼠标光标**——而这正是用户要的、也是唯一「永远可用、零权限」的信号。`capsule_focus.rs` 自己的注释（590–596 行）早就警告过这两者必须一致。

## 修法
- 新增 `macos_capsule_ax::mouse_cursor_point()`：CoreGraphics `CGEventCreate`+`CGEventGetLocation` 取光标位置，与 AX caret **同属 Quartz 全局显示坐标系（左上原点、points）**，可直接复用现有 `logical_frame`/`frame_contains_point` 选屏；零权限、始终可用。
- `focused_input_target_monitor` → `capsule_target_monitor`，选屏改**光标优先**（`mouse_cursor_point().or_else(focused_input_anchor_point)`），选屏循环抽成纯函数 `monitor_for_anchor_point`。
- **定位**与**去重快照**统一走 `capsule_target_monitor`，彻底消除不一致 → 不再锁死第一块屏、不再闪现，胶囊跟随鼠标所在的屏/桌面。
- 保留 `CAN_JOIN_ALL_SPACES`：Spaces 契约测试强制，且本就正确——窗口帧落在光标那块屏 → 只那块屏显示，同时跨 Space 跟随（满足「鼠标所在桌面才显示」）。
- 扩展 `macos-capsule-spaces` 契约测试，新增 3 条源码 grep 守护本次不变量（光标优先、定位走 `capsule_target_monitor`、快照复用同一函数），防止回归成「测试绿、线上坏」。

坐标系坑：`NSEvent.mouseLocation` 是左下原点 Cocoa 系（需翻转，未采用）；`CGEventGetLocation` 是左上原点、免翻转，与 AX 对齐。

Windows 路径**未改动**——它本就走 `foreground_window_monitor`（跟随正在输入的 App 所在屏），且定位与快照一致。

## 测试
- [x] `cargo check --manifest-path src-tauri/Cargo.toml`（仅既有 warning）
- [x] lib 纯函数单测（monitor / frame / clamp 共 18 项）全绿
- [x] `npm run check:macos-capsule-spaces`（含新增 3 条契约）通过
- [ ] 真机多屏 + 多桌面（桌面 1~4）逐屏触发听写，确认胶囊出现在鼠标所在屏、其他屏不闪现（已出 1.3.10 ad-hoc dmg 自测）

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Capsule now follows mouse cursor across multi-screen/Spaces

- Unified monitor detection: both positioning and layout cache use same function

- Added contract tests to guard invariants


___

### Diagram Walkthrough


```mermaid
flowchart LR
  MouseCursor["Mouse Cursor (CGEvent)"] --> capsuleTargetMonitor["capsule_target_monitor()"]
  AXcaret["AX Caret (fallback)"] --> capsuleTargetMonitor
  capsuleTargetMonitor --> positioning["position_capsule_bottom_center"]
  capsuleTargetMonitor --> layoutCache["capsule_layout_snapshot"]
  layoutCache --> reposition["Skip reposition if no change"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>capsule_focus.rs</strong><dd><code>Add macOS monitor detection to layout cache</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src-tauri/src/coordinator/capsule_focus.rs

<ul><li>Added macOS branch in <code>capsule_layout_snapshot</code> to use <br><code>capsule_target_monitor</code><br> <li> Ensures layout cache and positioning use the same monitor</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/714/files#diff-33748f0457086ffe0757eff826cdd9f835f70a86f7a6a9a1071038ff8b64892e">+21/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>lib.rs</strong><dd><code>Introduce mouse cursor based monitor selection</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src-tauri/src/lib.rs

<ul><li>Renamed <code>focused_input_target_monitor</code> to <code>capsule_target_monitor</code><br> <li> Added <code>macos_mouse_cursor_point()</code> using CoreGraphics (zero-permission)<br> <li> Positioning falls back to AX caret if mouse cursor unavailable<br> <li> Updated comments and logic</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/714/files#diff-6b8eb1bbf8e378bab914f1a12962f7add5cc4ba9e013c37c9921a1032fa5e110">+56/-10</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>macos-capsule-spaces-contract.test.mjs</strong><dd><code>Add contract tests for capsule monitor selection</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/scripts/macos-capsule-spaces-contract.test.mjs

<ul><li>Added contract tests to verify mouse cursor priority and shared <br>function<br> <li> Uses grep on source code</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/714/files#diff-f246fa613cf2c504b2b8dc1b7826d521871b382825e13724daed2831f2118f91">+28/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

