### PR TITLE
fix: 火山引擎弱网连接重试 + Windows 概率性「未配置」修复

### DIFF
--- a/openless-all/app/src-tauri/src/asr/volcengine.rs
+++ b/openless-all/app/src-tauri/src/asr/volcengine.rs
@@ -32,6 +32,15 @@ const BYTES_PER_MS: f64 = 32.0;
 const HOTWORD_CAP: usize = 80;
 const FINAL_RESULT_TIMEOUT: Duration = Duration::from_secs(12);
 
+/// 弱网下 TLS/WebSocket 握手可能一直挂到 OS 级 TCP 超时（几十秒），期间用户卡在
+/// 「Starting」无法语音输入。协调器的全局超时只覆盖 `await_final_result`，**不**覆盖
+/// `open_session`，所以这里必须自己给握手设上限：超时即快速失败并重试，而不是冻结。
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
+/// 单次网络抖动（连接被重置 / 瞬时 DNS 失败）以前会直接让整次听写失败。重试几次让
+/// 抖动可恢复。`AuthRejected`（凭据被拒）不在重试之列——重试也不会变好，只会拖慢报错。
+const CONNECT_MAX_ATTEMPTS: usize = 3;
+const CONNECT_RETRY_BACKOFF: Duration = Duration::from_millis(250);
+
 #[derive(Clone, Debug)]
 pub struct VolcengineCredentials {
     pub app_id: String,
@@ -131,34 +140,7 @@ impl VolcengineStreamingASR {
         }
 
         let connect_id = Uuid::new_v4().to_string();
-        let mut request = ENDPOINT
-            .into_client_request()
-            .map_err(|e| VolcengineASRError::ConnectionFailed(e.to_string()))?;
-        let headers = request.headers_mut();
-        headers.insert(
-            "X-Api-App-Key",
-            HeaderValue::from_str(&self.credentials.app_id)
-                .map_err(|e| VolcengineASRError::ConnectionFailed(e.to_string()))?,
-        );
-        headers.insert(
-            "X-Api-Access-Key",
-            HeaderValue::from_str(&self.credentials.access_token)
-                .map_err(|e| VolcengineASRError::ConnectionFailed(e.to_string()))?,
-        );
-        headers.insert(
-            "X-Api-Resource-Id",
-            HeaderValue::from_str(&self.credentials.resource_id)
-                .map_err(|e| VolcengineASRError::ConnectionFailed(e.to_string()))?,
-        );
-        headers.insert(
-            "X-Api-Connect-Id",
-            HeaderValue::from_str(&connect_id)
-                .map_err(|e| VolcengineASRError::ConnectionFailed(e.to_string()))?,
-        );
-
-        let (ws, _resp) = connect_async(request)
-            .await
-            .map_err(classify_connect_error)?;
+        let ws = self.connect_with_retry(&connect_id).await?;
         let (write, read) = ws.split();
 
         let (tx, rx) = oneshot::channel();
@@ -258,6 +240,79 @@ impl VolcengineStreamingASR {
         });
 
         Ok(())
+    }
+
+    /// Build the WebSocket handshake request (endpoint + auth headers). Rebuilt
+    /// per connect attempt because `connect_async` consumes the request and
+    /// `http::Request` is not `Clone`.
+    fn build_connect_request(
+        &self,
+        connect_id: &str,
+    ) -> Result<tokio_tungstenite::tungstenite::handshake::client::Request, VolcengineASRError>
+    {
+        let mut request = ENDPOINT
+            .into_client_request()
+            .map_err(|e| VolcengineASRError::ConnectionFailed(e.to_string()))?;
+        let headers = request.headers_mut();
+        headers.insert(
+            "X-Api-App-Key",
+            HeaderValue::from_str(&self.credentials.app_id)
+                .map_err(|e| VolcengineASRError::ConnectionFailed(e.to_string()))?,
+        );
+        headers.insert(
+            "X-Api-Access-Key",
+            HeaderValue::from_str(&self.credentials.access_token)
+                .map_err(|e| VolcengineASRError::ConnectionFailed(e.to_string()))?,
+        );
+        headers.insert(
+            "X-Api-Resource-Id",
+            HeaderValue::from_str(&self.credentials.resource_id)
+                .map_err(|e| VolcengineASRError::ConnectionFailed(e.to_string()))?,
+        );
+        headers.insert(
+            "X-Api-Connect-Id",
+            HeaderValue::from_str(connect_id)
+                .map_err(|e| VolcengineASRError::ConnectionFailed(e.to_string()))?,
+        );
+        Ok(request)
+    }
+
+    /// Connect with a per-attempt timeout and bounded retries so a poor network
+    /// (hung handshake or a transient blip) doesn't kill the whole dictation.
+    /// `AuthRejected` short-circuits — bad credentials never heal on retry.
+    async fn connect_with_retry(&self, connect_id: &str) -> Result<WsStream, VolcengineASRError> {
+        let mut attempt = 0usize;
+        loop {
+            attempt += 1;
+            let request = self.build_connect_request(connect_id)?;
+            match tokio::time::timeout(CONNECT_TIMEOUT, connect_async(request)).await {
+                Ok(Ok((ws, _resp))) => return Ok(ws),
+                Ok(Err(e)) => {
+                    let classified = classify_connect_error(e);
+                    if matches!(classified, VolcengineASRError::AuthRejected(_))
+                        || attempt >= CONNECT_MAX_ATTEMPTS
+                    {
+                        return Err(classified);
+                    }
+                    log::warn!(
+                        "[asr] 连接尝试 {attempt}/{CONNECT_MAX_ATTEMPTS} 失败: {classified}；重试中"
+                    );
+                }
+                Err(_) => {
+                    if attempt >= CONNECT_MAX_ATTEMPTS {
+                        return Err(VolcengineASRError::ConnectionFailed(format!(
+                            "连接超时（{} ms）",
+                            CONNECT_TIMEOUT.as_millis()
+                        )));
+                    }
+                    log::warn!(
+                        "[asr] 连接尝试 {attempt}/{CONNECT_MAX_ATTEMPTS} 超时（{} ms）；重试中",
+                        CONNECT_TIMEOUT.as_millis()
+                    );
+                }
+            }
+            tokio::time::sleep(CONNECT_RETRY_BACKOFF * attempt as u32).await;
+        }
     }
 
     pub async fn send_last_frame(&self) -> Result<(), VolcengineASRError> {

--- a/openless-all/app/src-tauri/src/persistence/credentials.rs
+++ b/openless-all/app/src-tauri/src/persistence/credentials.rs
@@ -362,13 +362,62 @@ fn read_chunk_manifest(json: &str) -> Option<CredsChunkManifest> {
     }
 }
 
+/// Windows Credential Manager (`CredReadW`) can transiently fail right after
+/// login / under contention when we read the manifest entry plus every chunk
+/// entry in quick succession. A single failed read makes the whole credential
+/// set look empty → `load_keyring_credentials` returns `Err` → `load_credentials`
+/// falls back to an empty default → Overview shows「火山引擎未配置」even though the
+/// secrets are present (the next dictation re-reads and succeeds, which is why the
+/// bug is *probabilistic* and the app "实际可以正常使用"). The more chunks a
+/// credential set spans, the more reads per load, the higher the odds at least
+/// one trips. Retry transient errors a few times with short backoff.
+///
+/// macOS / Linux keep the original single-shot behavior on purpose: their read
+/// errors are ACL denials that won't heal on retry, and the un-cached error path
+/// already retries on the next call — adding sleeps there would only slow the
+/// macOS first-launch Keychain authorization flow.
+#[cfg(target_os = "windows")]
+const KEYRING_READ_RETRY_ATTEMPTS: usize = 4;
+#[cfg(target_os = "windows")]
+const KEYRING_READ_RETRY_BACKOFF_MS: u64 = 60;
+
 #[cfg(not(target_os = "android"))]
 fn get_keyring_password(account: &str) -> Result<Option<String>> {
-    match keyring_entry_for(account)?.get_password() {
-        Ok(value) => Ok(Some(value)),
-        Err(keyring::Error::NoEntry) => Ok(None),
-        Err(e) => {
-            Err(anyhow!(e)).with_context(|| format!("read system credential vault {account}"))
+    #[cfg(target_os = "windows")]
+    {
+        let mut attempt = 0usize;
+        loop {
+            match keyring_entry_for(account)?.get_password() {
+                Ok(value) => return Ok(Some(value)),
+                // NoEntry is a definitive "not stored" answer, never a transient
+                // failure — return immediately so genuinely-unconfigured providers
+                // don't pay the retry latency.
+                Err(keyring::Error::NoEntry) => return Ok(None),
+                Err(e) => {
+                    attempt += 1;
+                    if attempt >= KEYRING_READ_RETRY_ATTEMPTS {
+                        return Err(anyhow!(e))
+                            .with_context(|| format!("read system credential vault {account}"));
+                    }
+                    log::warn!(
+                        "[vault] transient credential read for {account} failed \
+                         (attempt {attempt}/{KEYRING_READ_RETRY_ATTEMPTS}): {e}; retrying"
+                    );
+                    std::thread::sleep(std::time::Duration::from_millis(
+                        KEYRING_READ_RETRY_BACKOFF_MS * attempt as u64,
+                    ));
+                }
+            }
+        }
+    }
+    #[cfg(not(target_os = "windows"))]
+    {
+        match keyring_entry_for(account)?.get_password() {
+            Ok(value) => Ok(Some(value)),
+            Err(keyring::Error::NoEntry) => Ok(None),
+            Err(e) => {
+                Err(anyhow!(e)).with_context(|| format!("read system credential vault {account}"))
+            }
         }
     }
 }


### PR DESCRIPTION
### **User description**
## 背景

两个用户反馈的火山引擎接入问题，根因均已定位并修复。纯后端、外科手术式改动，**对 PC 端只增不减、无 UI 改动**。

## 问题 1：Windows 端概率性显示「火山引擎未配置」，但实际可正常使用

**根因**：Windows Credential Manager(`CredReadW`) 在登录后/并发下读取凭据条目时会**瞬时失败**。凭据 v1 payload 按 1000 UTF-16 单位分片存成 `manifest + 多个 chunk` 条目；`load_keyring_credentials` 顺序读每一条，任一条读失败就 `?` 抛错 → `load_credentials` 回退到空默认值 → 概览页 `asrConfigured=false` 显示「未配置」。而错误路径**不缓存**，下一次听写重读成功，所以是**概率性**、且**实际能用**。chunk 越多，单次 load 读取次数越多，命中瞬时失败概率越高。

**修法**（`persistence/credentials.rs`）：仅在 Windows 上，对非 `NoEntry` 的读错误做有限次短退避重试（4 次 / 60·n ms）。`NoEntry` 是确定的「未存储」立即返回，不付重试延迟。macOS/Linux 保持原单次行为（cfg 隔离）——其读错误是 ACL 拒绝，重试无益，且会拖慢 macOS 首次 Keychain 授权流程。

## 问题 2：网络环境较差时无法正常进行语音输入

**根因**：`open_session` 里的 `connect_async` **既无超时也无重试**。弱网下 TLS/WS 握手可挂到 OS 级 TCP 超时（几十秒），用户卡在「Starting」；协调器全局超时只覆盖 `await_final_result`，**不覆盖 open_session**。单次网络抖动也直接让整次听写失败。

**修法**（`asr/volcengine.rs`）：每次握手包 `5s` 超时，最多 `3` 次尝试、`250·n ms` 退避；`AuthRejected`（凭据被拒）短路不重试。请求构造抽成 `build_connect_request`（`connect_async` 消费 request 且 `http::Request` 非 `Clone`，需每次重建）。最坏耗时从「无界(~75s)」降到有界(~15s)，并新增抖动可恢复。桌面与安卓共享此路径，改动对两端等效。

## 平台影响

- Windows 凭据修复：`#[cfg(target_os="windows")]` 隔离，macOS/Linux/Android **零变更**。
- 连接超时重试：桌面 + 安卓共享，对 PC 端纯增益（更快失败 + 可恢复），无 UI 改动。

## 验证

- `cargo check` 通过（仅既有无关 warning）
- `cargo test --lib` **458 passed / 0 failed**
- 自有新增代码已过 rustfmt

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Bug fix


___

### **Description**
- Fix probabilistic "Volcengine not configured" on Windows by credential read retry

- Fix session hang on poor network with connection timeout and retry


___

### Diagram Walkthrough


```mermaid
flowchart LR
    subgraph Windows Credential Read
        A[Read credential] --> B{Success?}
        B -- Yes --> C[Return value]
        B -- No --> D{NoEntry?}
        D -- Yes --> E[Return None]
        D -- No --> F[Retry up to 4 times, 60ms backoff]
        F --> A
    end
    subgraph Volcengine Connection
        G[Connect with 5s timeout] --> H{Success?}
        H -- Yes --> I[Return WebSocket]
        H -- No --> J{AuthRejected? or max retries?}
        J -- Yes --> K[Return error]
        J -- No --> L[Sleep backoff, retry]
        L --> G
    end
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>volcengine.rs</strong><dd><code>Add timeout and retry for Volcengine WebSocket connection</code></dd></summary>
<hr>

openless-all/app/src-tauri/src/asr/volcengine.rs

<ul><li>Added CONNECT_TIMEOUT (5s) and CONNECT_MAX_ATTEMPTS (3) with backoff<br> <li> Refactored connection into build_connect_request and <br>connect_with_retry<br> <li> connect_with_retry handles timeout and transient errors, excludes <br>AuthRejected</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/722/files#diff-2fc7df3684f696c8aed87ee4e9bb6564e2048cece6769c9d2a787e08a257b140">+83/-28</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>credentials.rs</strong><dd><code>Retry transient Windows credential read failures</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src-tauri/src/persistence/credentials.rs

<ul><li>Added retry loop for Windows-specific credential read failures (4 <br>attempts, 60ms backoff)<br> <li> NoEntry errors are not retried; returned immediately<br> <li> macOS/Linux remain unchanged</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/722/files#diff-6ed5731fbd0b7f6d98a59e85ec178d77591b097310b5b8d52cd6d7361ee86a01">+54/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

