### PR TITLE
fix(asr): Whisper/OpenRouter 动态超时 + 全局兜底 15→30s

### DIFF
--- a/openless-all/app/src-tauri/src/asr/whisper.rs
+++ b/openless-all/app/src-tauri/src/asr/whisper.rs
@@ -87,6 +87,12 @@ impl WhisperBatchASR {
     /// Whisper transcriptions endpoint.
     ///
     /// 失败时**保留** PCM buffer，让上层有机会重试或在历史中至少留一个失败记录；
+    /// 当前缓冲音频时长（毫秒）。Coordinator 在 transcribe() 调用前读取，
+    /// 用于计算 Whisper / OpenRouter 的动态超时。不消费缓冲。
+    pub fn buffer_duration_ms(&self) -> u64 {
+        pcm_duration_ms(&self.buffer.lock())
+    }
+
     /// 之前的实现一进函数就 `mem::take` 把 buffer 清空，凭证错或网络中断都会
     /// 让用户的录音直接消失。
     pub async fn transcribe(&self) -> Result<RawTranscript> {

--- a/openless-all/app/src-tauri/src/coordinator.rs
+++ b/openless-all/app/src-tauri/src/coordinator.rs
@@ -2897,9 +2897,9 @@ const CAPSULE_AUTO_HIDE_DELAY_MS: u64 = 2000;
 const POST_SESSION_COOLDOWN_MS: u64 = 600;
 
 /// Coordinator 全局超时保护：防止 ASR await_final_result() 永远挂起。
-/// 设置为 15 秒（比 ASR 的 12 秒 FINAL_RESULT_TIMEOUT 稍长），
-/// 只在 ASR 超时机制失效时作为最后的防线触发。
-const COORDINATOR_GLOBAL_TIMEOUT_SECS: u64 = 15;
+/// 设置为 30 秒，为云端 batch ASR（OpenRouter Whisper 等）提供足够的
+/// 网络超时预算；只在 ASR 自身超时机制失效时作为最后的防线触发。
+const COORDINATOR_GLOBAL_TIMEOUT_SECS: u64 = 30;
 
 #[cfg(target_os = "windows")]
 fn foundry_audio_transcribe_timeout_duration() -> std::time::Duration {
@@ -2913,6 +2913,17 @@ fn foundry_audio_transcribe_timeout_duration() -> std::time::Duration {
 fn local_qwen_transcribe_timeout(audio_secs: f64) -> std::time::Duration {
     let secs = ((audio_secs * 0.6).ceil() as u64)
         .saturating_add(10)
+        .max(COORDINATOR_GLOBAL_TIMEOUT_SECS);
+    std::time::Duration::from_secs(secs)
+}
+
+/// Whisper / OpenRouter 云端 batch ASR 的动态转写超时。OpenRouter 按 30s
+/// 分片，每片是一次 HTTP round-trip；网络抖动、排队、base64 body 都会
+/// 拉长耗时。公式 max(30, ceil(audio_s × 0.5) + 20)：30s 是全局兜底；
+/// 长录音按音频长度的 0.5 倍 + 20s 余量，覆盖多分片串行请求 + 网络波动。
+fn whisper_transcribe_timeout(audio_secs: f64) -> std::time::Duration {
+    let secs = ((audio_secs * 0.5).ceil() as u64)
+        .saturating_add(20)
         .max(COORDINATOR_GLOBAL_TIMEOUT_SECS);
     std::time::Duration::from_secs(secs)
 }

--- a/openless-all/app/src-tauri/src/coordinator.rs
+++ b/openless-all/app/src-tauri/src/coordinator.rs
@@ -2326,7 +2326,7 @@ mod tests {
 
     #[test]
     fn local_qwen_timeout_floors_at_global_timeout_for_short_audio() {
-        // 5s 录音：5 × 0.6 = 3, +10 = 13, max(15) = 15。短录音保留 15s 兜底。
+        // 5s 录音：5 × 0.6 = 3, +10 = 13, max(30) = 30。短录音兜底。
         assert_eq!(
             local_qwen_transcribe_timeout(5.0),
             std::time::Duration::from_secs(COORDINATOR_GLOBAL_TIMEOUT_SECS)
@@ -2344,19 +2344,47 @@ mod tests {
 
     #[test]
     fn local_qwen_timeout_ceils_partial_seconds() {
-        // 10.1s 录音：10.1 × 0.6 = 6.06, ceil = 7, +10 = 17, max(15) = 17。
+        // 10.1s 录音：10.1 × 0.6 = 6.06, ceil = 7, +10 = 17, max(30) = 30。
+        // COORDINATOR_GLOBAL_TIMEOUT_SECS 提升到 30 后，短音频统一被兜底值覆盖。
         assert_eq!(
             local_qwen_transcribe_timeout(10.1),
-            std::time::Duration::from_secs(17)
+            std::time::Duration::from_secs(COORDINATOR_GLOBAL_TIMEOUT_SECS)
         );
     }
 
     #[test]
     fn local_qwen_timeout_handles_zero_duration() {
-        // 0 时长（空 buffer 边界）：0 × 0.6 = 0, +10 = 10, max(15) = 15。
+        // 0 时长（空 buffer 边界）：0 × 0.6 = 0, +10 = 10, max(30) = 30。
         assert_eq!(
             local_qwen_transcribe_timeout(0.0),
             std::time::Duration::from_secs(COORDINATOR_GLOBAL_TIMEOUT_SECS)
+        );
+    }
+
+    #[test]
+    fn whisper_timeout_floors_at_global_timeout_for_short_audio() {
+        // 10s 录音：10 × 0.5 = 5, +20 = 25, max(30) = 30。短音频兜底。
+        assert_eq!(
+            whisper_transcribe_timeout(10.0),
+            std::time::Duration::from_secs(COORDINATOR_GLOBAL_TIMEOUT_SECS)
+        );
+    }
+
+    #[test]
+    fn whisper_timeout_scales_with_audio_duration() {
+        // 60s 录音：60 × 0.5 = 30, +20 = 50。覆盖多分片 HTTP 请求。
+        assert_eq!(
+            whisper_transcribe_timeout(60.0),
+            std::time::Duration::from_secs(50)
+        );
+    }
+
+    #[test]
+    fn whisper_timeout_ceils_partial_seconds() {
+        // 45.3s 录音：45.3 × 0.5 = 22.65, ceil = 23, +20 = 43, max(30) = 43。
+        assert_eq!(
+            whisper_transcribe_timeout(45.3),
+            std::time::Duration::from_secs(43)
         );
     }
 

--- a/openless-all/app/src-tauri/src/coordinator/dictation.rs
+++ b/openless-all/app/src-tauri/src/coordinator/dictation.rs
@@ -1691,8 +1691,15 @@ pub(super) async fn end_session(inner: &Arc<Inner>) -> Result<(), String> {
         }
         ActiveAsr::Whisper(w) => {
             debug_assert!(uses_global_timeout);
-            // Whisper 也添加类似的超时保护
-            let timeout_duration = std::time::Duration::from_secs(COORDINATOR_GLOBAL_TIMEOUT_SECS);
+            // Whisper / OpenRouter 动态超时：音频越长、分片越多，给更多
+            // HTTP round-trip 预算。公式见 `whisper_transcribe_timeout`。
+            let audio_secs = (w.buffer_duration_ms() as f64) / 1000.0;
+            let timeout_duration = whisper_transcribe_timeout(audio_secs);
+            log::info!(
+                "[coord] Whisper transcribe: audio={:.2}s timeout={}s",
+                audio_secs,
+                timeout_duration.as_secs()
+            );
             match tokio::time::timeout(timeout_duration, w.transcribe()).await {
                 Ok(Ok(r)) => r,
                 Ok(Err(e)) => {
@@ -1712,8 +1719,9 @@ pub(super) async fn end_session(inner: &Arc<Inner>) -> Result<(), String> {
                 }
                 Err(_) => {
                     log::error!(
-                        "[coord] whisper 全局超时 {} 秒",
-                        COORDINATOR_GLOBAL_TIMEOUT_SECS
+                        "[coord] Whisper 动态超时 {}s（音频 {:.2}s）",
+                        timeout_duration.as_secs(),
+                        audio_secs
                     );
                     emit_capsule(
                         inner,


### PR DESCRIPTION
### **User description**
## 问题

Closes #721

OpenRouter Whisper 长语音被 15s 全局超时硬截断。

## 方案

双重保险：

1. **全局常量 15→30s**：\`COORDINATOR_GLOBAL_TIMEOUT_SECS\` 提升为云端 ASR 留网络预算
2. **Whisper 动态超时**：\`whisper_transcribe_timeout(audio_secs)\` = \`max(30, ceil(audio×0.5)+20)\`，参考本地 Qwen 的 \`local_qwen_transcribe_timeout\`

| 音频 | 旧超时 | 新超时 |
|------|--------|--------|
| 10s | 15s | 30s |
| 30s | 15s ❌ | 35s ✅ |
| 60s | 15s ❌ | 50s ✅ |
| 90s | 15s ❌ | 65s ✅ |

## 改动

3 文件，+32 / −7 行，\`cargo check\` 通过。


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Increase global ASR timeout from 15s to 30s

- Add dynamic timeout for Whisper/OpenRouter based on audio duration

- Log audio duration and timeout for debugging

- Add unit tests covering new timeout logic


___

### Diagram Walkthrough


```mermaid
flowchart LR
  endSession["End Session (Whisper)"] -- audio_secs from buffer_duration_ms() --> calc["whisper_transcribe_timeout(audio_secs)"]
  calc -- "timeout_duration = max(30, ceil(audio*0.5)+20)" --> call["tokio::time::timeout(timeout_duration, w.transcribe())"]
  call -- "Ok(r)" --> transcript["Return transcript"]
  call -- "Err(_)" --> log["Log timeout with audio_secs"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>whisper.rs</strong><dd><code>Expose buffer duration for timeout calculation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src-tauri/src/asr/whisper.rs

<ul><li>Add <code>buffer_duration_ms()</code> method to <code>WhisperBatchASR</code> to expose audio <br>duration<br> <li> Allows coordinator to compute dynamic timeout before transcribing</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/723/files#diff-cf6696a6b96bc9f0fb12aeb6e3934ad2668e3595f06ad10652604887f9794d2b">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>coordinator.rs</strong><dd><code>Implement Whisper timeout function and update tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src-tauri/src/coordinator.rs

<ul><li>Raise <code>COORDINATOR_GLOBAL_TIMEOUT_SECS</code> from 15 to 30<br> <li> Add <code>whisper_transcribe_timeout()</code> function with formula <code>max(30, </code><br><code>ceil(audio*0.5)+20)</code><br> <li> Update <code>local_qwen_timeout</code> tests to align with new global timeout<br> <li> Add 3 new unit tests for Whisper timeout (short audio, scaling, ceil)</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/723/files#diff-73d8c004670b27293f74f0f3991b9a6fc28f0ff0b883214de2b078b1e09797ca">+46/-7</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>dictation.rs</strong><dd><code>Apply dynamic timeout to Whisper/OpenRouter session</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src-tauri/src/coordinator/dictation.rs

<ul><li>Use <code>buffer_duration_ms()</code> and <code>whisper_transcribe_timeout()</code> for dynamic <br>timeout<br> <li> Log audio duration and computed timeout duration<br> <li> Update error log message to include actual timeout seconds</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/723/files#diff-4cf79887f41f4811eb2b1ef682c62ee34c14a0ab969362a9ba1046de59c8578b">+12/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

