### PR TITLE
fix(ime): 繁中用户语音输入始终输出繁体 / enforce 简繁 script on output (#643)

### DIFF
--- a/openless-all/app/src-tauri/src/coordinator/dictation.rs
+++ b/openless-all/app/src-tauri/src/coordinator/dictation.rs
@@ -407,9 +407,15 @@ fn finalize_polished_text(
         return polished;
     }
     let should_force_script = if translation_active {
+        // 翻译路径目标可能是非中文（英/日/韩），OpenCC 会破坏它，故只在 polish 失败、
+        // 回退到中文原文时才做字形转换。
         polish_error.is_some()
     } else {
-        mode == PolishMode::Raw || polish_error.is_some()
+        // 普通听写：始终按用户所选字形（简/繁）做确定性 OpenCC 转换。Auto 时
+        // apply_chinese_script_preference 内部是 no-op，对默认用户零影响。
+        // 不再只在 Raw / polish 失败时转——polish 模式靠 LLM 提示输出繁体并不可靠
+        // （模型默认简体），导致繁中用户每次都拿到简体输出（issue #643）。
+        true
     };
     let polished = if should_force_script {
         apply_chinese_script_preference(&polished, chinese_script_preference)
@@ -436,8 +442,15 @@ fn streaming_insert_eligible(
     translation_active: bool,
     mode: PolishMode,
     raw_uses_llm: bool,
+    chinese_script_preference: crate::types::ChineseScriptPreference,
 ) -> bool {
-    streaming_insert_enabled && !translation_active && (mode != PolishMode::Raw || raw_uses_llm)
+    streaming_insert_enabled
+        && !translation_active
+        && (mode != PolishMode::Raw || raw_uses_llm)
+        // 非 Auto 字形（简/繁）要对成品文本做确定性 OpenCC 转换，而流式是边出边落字、
+        // 没有成品可后处理（finalize_polished_text 在 already_streamed 时直接 return）。
+        // → 非 Auto 时关掉流式，走一次性路径，确保简/繁转换真正生效（issue #643）。
+        && chinese_script_preference == crate::types::ChineseScriptPreference::Auto
 }
 
 fn default_done_message(status: InsertStatus, polish_failed: bool) -> Option<String> {
@@ -2298,6 +2311,7 @@ pub(super) async fn end_session(inner: &Arc<Inner>) -> Result<(), String> {
         translation_active,
         mode,
         raw_uses_llm,
+        chinese_script_preference,
     );
     log::info!(
         "[coord] polish dispatch: translation={translation_active} mode={mode:?} streaming_eligible={streaming_eligible}"
@@ -3001,7 +3015,65 @@ mod tests {
             false,
             PolishMode::Light,
             false,
+            ChineseScriptPreference::Auto,
         ));
+    }
+
+    #[test]
+    fn streaming_disabled_for_non_auto_script_so_opencc_runs() {
+        // issue #643：非 Auto 字形（简/繁）必须走一次性路径，让 finalize 的 OpenCC 转换生效。
+        for pref in [
+            ChineseScriptPreference::Simplified,
+            ChineseScriptPreference::Traditional,
+        ] {
+            assert!(!streaming_insert_eligible(
+                true,
+                false,
+                PolishMode::Light,
+                false,
+                pref
+            ));
+        }
+        // Auto 不受影响，仍可流式。
+        assert!(streaming_insert_eligible(
+            true,
+            false,
+            PolishMode::Light,
+            false,
+            ChineseScriptPreference::Auto,
+        ));
+    }
+
+    #[test]
+    fn polish_output_honors_chinese_script_preference() {
+        // issue #643：polish 模式（非 Raw、polish 成功）的成品也按用户字形偏好确定性转换，
+        // 不再依赖 LLM 提示——繁中用户因此每次都拿到繁体。
+        let finalize = |pref| {
+            finalize_polished_text(
+                "学习".to_string(),
+                false, // translation_active
+                false, // raw_uses_llm
+                PolishMode::Structured,
+                &None, // polish 成功
+                pref,
+                &[],
+                false, // already_streamed
+            )
+        };
+        // 繁体偏好：学习 → 學習（OpenCC S2t），至少不再含简体「学/习」。
+        let trad = finalize(ChineseScriptPreference::Traditional);
+        assert!(
+            !trad.contains('学') && !trad.contains('习'),
+            "traditional pref left simplified chars: {trad}"
+        );
+        // 简体偏好：保持简体（输入已是简体，T2s 无变化）。
+        let simp = finalize(ChineseScriptPreference::Simplified);
+        assert!(
+            simp.contains('学') && simp.contains('习'),
+            "simplified pref: {simp}"
+        );
+        // Auto：不转换，对默认用户零影响。
+        assert_eq!(finalize(ChineseScriptPreference::Auto), "学习");
     }
 
     #[test]


### PR DESCRIPTION
### **User description**
## 问题 / Problem

繁體中文使用者每次语音输入都得到**简体**输出（issue #643）。设置里选了「繁體中文」也没用 —— 这是确认过的已知 bug。

## 根因 / Root cause

`coordinator/dictation.rs::finalize_polished_text` 只在 **Raw 模式 / polish 失败** 时才跑确定性的 OpenCC 简↔繁转换（`apply_chinese_script_preference`）。**polish 成功的模式**（light/structured/formal）把字形交给 LLM —— 而中文 LLM 默认输出简体，繁中提示并不可靠。**流式插入路径**（`already_streamed`）则完全跳过转换。

`chineseScriptPreference` 默认是 `Auto`，所以这个 bug 只影响显式选了简/繁的用户。

## 改动 / Fix

- **`finalize_polished_text`**：非翻译听写**始终**调用 `apply_chinese_script_preference`。`Auto` 时内部是 no-op（默认用户零影响）；`Simplified`/`Traditional` 时确定性保证输出字形，不再赌 LLM。
- **`streaming_insert_eligible`**：加入字形偏好参数，**非 Auto 时关掉流式插入**（流式边出边落字、没有成品可后处理），走一次性路径让 OpenCC 转换生效。
- 翻译路径不动（目标可能是英/日/韩，OpenCC 会破坏）。

## 测试 / Tests

- `polish_output_honors_chinese_script_preference`：polish 成功路径下，繁体偏好真的把「学习」转成不含简体字、Auto 不转换。
- `streaming_disabled_for_non_auto_script_so_opencc_runs`：非 Auto 关流式、Auto 不受影响。
- 本地 `cargo test --lib` **470 通过**。

Closes #643


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Always enforce Chinese script preference on dictation output

- Disable streaming insert for non-Auto script preferences

- Add tests verifying script conversion and streaming eligibility


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["User dictation"] --> B["LLM polish (may output Simplified)"]
  B -- "Without fix" --> C["Simplified output (bug)"]
  B -- "With fix: OpenCC always runs" --> D["Deterministic Traditional output"]
  A --> E["Streaming insert path"]
  E -- "Non-Auto script? (fix)" --> F["Disabled, go one-shot"]
  F --> D
  E -- "Auto script (default)" --> G["Streaming allowed"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>dictation.rs</strong><dd><code>Enforce script preference and disable streaming for non-Auto</code></dd></summary>
<hr>

openless-all/app/src-tauri/src/coordinator/dictation.rs

<ul><li>Changed <code>finalize_polished_text</code> to always apply OpenCC script <br>conversion for non-translation dictation (previously only on raw mode <br>or polish failure)<br> <li> Modified <code>streaming_insert_eligible</code> to disable streaming when script <br>preference is non-Auto, ensuring one-shot path runs OpenCC conversion<br> <li> Added tests: <code>polish_output_honors_chinese_script_preference</code> and <br><code>streaming_disabled_for_non_auto_script_so_opencc_runs</code></ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/729/files#diff-4cf79887f41f4811eb2b1ef682c62ee34c14a0ab969362a9ba1046de59c8578b">+74/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

