### PR TITLE
fix(ui): unlisten Tauri events when unmounted before listen() resolves

### DIFF
--- a/openless-all/app/src/components/AudioCue.tsx
+++ b/openless-all/app/src/components/AudioCue.tsx
@@ -46,7 +46,7 @@ export function AudioCueListener() {
       listen<UserPreferences>('prefs:changed', (event) => {
         const next = event.payload;
         if (next) audioCueEnabledRef.current = next.audioCueOnRecord !== false;
-      }).then(fn => { if (!cancelled) unlisten = fn; }).catch(() => {});
+      }).then(fn => { if (cancelled) fn(); else unlisten = fn; }).catch(() => {});
     })();
     return () => { cancelled = true; unlisten?.(); };
   }, [audioCueRuntimeEnabled]);
@@ -73,7 +73,7 @@ export function AudioCueListener() {
         } else if (state !== 'recording' && prev === 'recording') {
           stopAudioCue();
         }
-      }).then(fn => { if (!cancelled) unlisten = fn; }).catch(() => {});
+      }).then(fn => { if (cancelled) fn(); else unlisten = fn; }).catch(() => {});
     })();
     return () => { cancelled = true; unlisten?.(); };
   }, [audioCueRuntimeEnabled]);

--- a/openless-all/app/src/components/WindowChrome.tsx
+++ b/openless-all/app/src/components/WindowChrome.tsx
@@ -113,7 +113,8 @@ function LinuxTitlebar() {
           if (!cancelled) setMaximized(m);
         }).catch(() => {});
       }).then((fn) => {
-        if (!cancelled) unlisten = fn;
+        if (cancelled) fn();
+        else unlisten = fn;
       }).catch(() => {});
     }).catch(() => {});
     return () => {


### PR DESCRIPTION
### **User description**
## 摘要

修复 3 处 `useEffect` 里 Tauri 事件监听的清理竞态：组件在异步 `listen()` 的 promise resolve **之前**就卸载时，会泄漏一个永不解绑的监听器。

## 问题

这几处用的是：

```ts
}).then(fn => { if (!cancelled) unlisten = fn; }).catch(() => {});
```

如果组件在 `listen()` resolve 前就卸载，`cancelled` 已经是 `true`，于是 `unlisten` 永远不会被赋值——但底层 Tauri 订阅其实已经创建。cleanup 里的 `unlisten?.()` 是空操作，监听器就此泄漏，并继续在已卸载的组件上触发回调（`setMaximized` / `setState` 等），造成无谓开销和 React 警告。

`WindowChrome` 的 `LinuxTitlebar`（`tauri://resize`）最容易复现：在那个动态 `import(...)` + `w.listen()` 还在飞行途中时快速重挂载窗口 chrome，就会泄漏一个 resize 监听器。

## 改动

对齐到**仓库自己已有的正确约定**（`Capsule.tsx` / `Vocab.tsx` / `LessComputerPanel.tsx` / `LessComputerGlow.tsx`）：

```ts
}).then(fn => { if (cancelled) fn(); else unlisten = fn; }).catch(() => {});
```

已卸载就立即解绑。涉及：

- `components/AudioCue.tsx`：`prefs:changed` 与 `capsule:state` 两个监听
- `components/WindowChrome.tsx`：`LinuxTitlebar` 的 `tauri://resize` 监听

共 +4/-3，纯前端、行为对齐既有约定、低风险。

## 验证

- `tsc --noEmit` 通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Bug fix


___

### **Description**
- Prevent Tauri event listener leaks on unmounted components

- Fix race condition: unlisten handle dropped if component unmounts before async listen() resolves

- Align AudioCue.tsx and WindowChrome.tsx with established cleanup pattern

- Low-risk, pure front-end changes


___

### Diagram Walkthrough


```mermaid
flowchart LR
    A["Component mounts"] --> B["listen() async"]
    B --> C{"Unmounted before resolve?"}
    C -- Yes --> D["Call unlisten fn immediately"]
    C -- No --> E["Store unlisten handle"]
    D --> F["Cleanup on unmount"]
    E --> F
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>AudioCue.tsx</strong><dd><code>Fix Tauri listener cleanup in AudioCue</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src/components/AudioCue.tsx

<ul><li>Fixed two Tauri event listeners (<code>prefs:changed</code> and <code>capsule:state</code>) to <br>immediately unsubscribe if component unmounted before <code>listen()</code> <br>resolves.<br> <li> Changed from <code>if (!cancelled) unlisten = fn;</code> to <code>if (cancelled) fn(); </code><br><code>else unlisten = fn;</code>.</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/730/files#diff-694018be546399ba448fe8934a7ae0fe13881518d8cb436aec7988d0b9863fc0">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>WindowChrome.tsx</strong><dd><code>Fix Tauri listener cleanup in LinuxTitlebar</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src/components/WindowChrome.tsx

<ul><li>Fixed <code>tauri://resize</code> listener in <code>LinuxTitlebar</code> to unsubscribe <br>immediately if component unmounts before <code>listen()</code> resolves.<br> <li> Changed from <code>if (!cancelled) unlisten = fn;</code> to <code>if (cancelled) fn(); </code><br><code>else unlisten = fn;</code>.</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/730/files#diff-ca98272202276bc772e02f5bdd6dfd006d06a0da7bb6d9705d03e1da14edca4c">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

