### PR TITLE
fix(audio-cue): 重建/唤醒退化的 AudioContext，修「用久了提示音消失」

### DIFF
--- a/openless-all/app/src/lib/audioCue.test.ts
+++ b/openless-all/app/src/lib/audioCue.test.ts
@@ -3,6 +3,7 @@
 // 播放/停止依赖 Web Audio 运行时，不在此单测覆盖；这里只钉住可被回归的音符规划。
 
 import {
+  audioContextActionForState,
   cueTotalDurationMs,
   recordStartCueTones,
   shouldPlayDeferredCue,
@@ -105,6 +106,39 @@ function assertEqual<T>(actual: T, expected: T, name: string) {
     }),
     true,
     'cue at exactly the threshold still plays',
+  );
+}
+
+{
+  // 「用久了没声音」的回归钉子：closed 的 ctx 必须重建，否则提示音/试听永久静默。
+  assertEqual(
+    audioContextActionForState('closed'),
+    'recreate',
+    'closed context must be recreated',
+  );
+  // running 可直接排期。
+  assertEqual(
+    audioContextActionForState('running'),
+    'ready',
+    'running context is ready to schedule',
+  );
+  // suspended 先 resume 再排期（WKWebView/WebView2 常态）。
+  assertEqual(
+    audioContextActionForState('suspended'),
+    'resume',
+    'suspended context needs resume',
+  );
+  // WebKit 非标准 interrupted（音频会话被抢占）同样需要 resume，不能当 running 直接排期。
+  assertEqual(
+    audioContextActionForState('interrupted'),
+    'resume',
+    'interrupted context needs resume',
+  );
+  // 任何未知非运行态都保守地走 resume（宁可尝试唤醒也不静默漏音）。
+  assertEqual(
+    audioContextActionForState('some-future-state'),
+    'resume',
+    'unknown non-running state falls back to resume',
   );
 }
 

--- a/openless-all/app/src/lib/audioCue.ts
+++ b/openless-all/app/src/lib/audioCue.ts
@@ -81,6 +81,26 @@ export function shouldPlayDeferredCue(params: {
   return true;
 }
 
+/** 提示音播放前对持有的 AudioContext 该做的处置。 */
+export type AudioContextAction = 'ready' | 'resume' | 'recreate';
+
+/**
+ * 依据 AudioContext 的运行期状态决定如何处置它。纯函数，便于单测，是「用久了没声音」
+ * 这个 bug 的修复核心：
+ *  - 'closed'  → 'recreate'：已关闭的 ctx 无法复活（resume() 必拒、createOscillator() 必抛），
+ *                必须丢弃重建。长时间使用中频繁录音抢占音频会话，WKWebView/WebView2 的
+ *                共享 ctx 可能被系统关闭却从不重建——于是「开始提示音」和设置页「试听」
+ *                双双永久静默（两个窗口各自持有一份 ctx，都会这样退化）。
+ *  - 'running' → 'ready'：可直接排期合成。
+ *  - 其余（'suspended' / WebKit 非标准 'interrupted' / 任何未知非运行态）→ 'resume'：
+ *                先异步 resume 唤醒再排期。
+ */
+export function audioContextActionForState(state: string): AudioContextAction {
+  if (state === 'closed') return 'recreate';
+  if (state === 'running') return 'ready';
+  return 'resume';
+}
+
 function resolveAudioContextCtor(): AudioContextCtor | null {
   if (typeof window === 'undefined') return null;
   // window.AudioContext 来自全局声明；webkit 前缀单独用结构化类型拿，避免 any。
@@ -91,6 +111,12 @@ function resolveAudioContextCtor(): AudioContextCtor | null {
 function getContext(): AudioContext | null {
   const Ctor = resolveAudioContextCtor();
   if (!Ctor) return null;
+  // 已 closed 的 ctx 无法复活，丢弃后重建——否则后续所有提示音永久静默（本 bug 根因）。
+  // 旧 ctx 上挂着的 activeVoices 也一并清空，避免去叠音时操作已失效节点。
+  if (sharedCtx && audioContextActionForState(sharedCtx.state) === 'recreate') {
+    sharedCtx = null;
+    activeVoices = [];
+  }
   if (!sharedCtx) {
     try {
       sharedCtx = new Ctor();
@@ -174,9 +200,10 @@ function scheduleCueVoices(ctx: AudioContext): void {
  * resume 宽松，预热通常能让常见路径走同步分支。胶囊窗口挂载时调用一次即可。
  */
 export function primeAudioCue(): void {
+  // getContext 会把 closed 的 ctx 重建掉；这里只需把 suspended/interrupted 唤醒。
   const ctx = getContext();
   if (!ctx) return;
-  if (ctx.state === 'suspended') {
+  if (audioContextActionForState(ctx.state) === 'resume') {
     ctx.resume().catch(() => undefined);
   }
 }
@@ -186,9 +213,10 @@ export function playRecordStartCue(): void {
   const ctx = getContext();
   if (!ctx) return;
 
-  // WKWebView / WebView2 的 AudioContext 常处于 suspended：必须先 resume 再排期，
-  // 不能在 resume 未完成时就用冻结的 currentTime 排节点。resume() 失败也不抛（无声降级）。
-  if (ctx.state === 'suspended') {
+  // WKWebView / WebView2 的 AudioContext 常处于 suspended（或被音频会话抢占后的非标准
+  // interrupted）：必须先 resume 再排期，不能在 resume 未完成时就用冻结的 currentTime 排
+  // 节点。resume() 失败也不抛（无声降级）。closed 的情况已在 getContext 重建掉了。
+  if (audioContextActionForState(ctx.state) === 'resume') {
     const myPlay = ++playSeq;
     const stopAtRequest = stopSeq;
     const requestedAt = nowMs();


### PR DESCRIPTION
### **User description**
## 问题

用户反馈：OpenLess **使用时间长了之后会没有音频**——按下录音热键时的「开始提示音」消失，去 设置 → 录音与输入 点「试听」也没声音了。需要重启才恢复。

## 根因

提示音不打包音频文件，而是用 Web Audio API 即时合成（`src/lib/audioCue.ts`）。模块持有一个 AudioContext 单例 `sharedCtx`，**创建后从不检查、也从不恢复它的运行期状态**：

- **`interrupted`（最可能的 macOS 根因）**：本 app 高频录音，每次录音会抢占系统音频会话，WKWebView 的 AudioContext 因此可能转入 WebKit 非标准的 `interrupted` 态。旧代码 `playRecordStartCue` 只判断 `ctx.state === 'suspended'`，`interrupted` 被当作可直接排期 → 节点排到一个非 `running` 的 ctx 上，**无声、且根本不尝试 resume** → 永久静默。
- **`closed`**：ctx 也可能被系统关闭。`closed` 的 ctx 无法复活（`resume()` 必拒、`createOscillator()` 必抛、异常被 `catch` 静默吞掉），而 `getContext()` 从不重建它 → 永久静默。
- 胶囊窗口与设置窗口是两个独立 webview，**各持一份 `sharedCtx`**，都会这样退化 → 「开始提示音」和「试听」同时失效，与现象吻合。

## 修复（surgical，公共 API 签名不变）

- 新增可单测的纯函数 `audioContextActionForState(state)`：`closed → recreate` / `running → ready` / 其余（`suspended`、`interrupted`、任何未知非运行态）→ `resume`。单一真相。
- `getContext()`：当持有的 ctx 为 `closed` 时**丢弃并重建**（并清空挂在旧 ctx 上的 `activeVoices`，避免去叠音时操作失效节点）。
- `playRecordStartCue()` / `primeAudioCue()` 改用该分类器，把 `interrupted` 一并按 `resume` 唤醒。

任何环境（无 Web Audio / 被自动播放策略挂起 / 创建失败）仍保持原有的**静默降级**，绝不抛错影响录音主流程。

## 影响面

仅 `src/components/AudioCue.tsx`（胶囊监听）与 `src/pages/settings/RecordingInputSection.tsx`（试听按钮）复用这几个公共函数，签名与行为向后兼容。

## 测试

- `npx tsc --noEmit` 通过（exit 0）。
- `src/lib/audioCue.test.ts` 新增 5 条状态分类断言（closed/running/suspended/interrupted/未知态），`npx tsx` 跑全部通过。
- 「用久了」的退化态依赖 Web Audio 运行时，单测覆盖不到，已用纯函数把可回归的判定逻辑钉住。


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Add `audioContextActionForState` to handle closed, running, and interrupted states.

- Recreate closed AudioContext in `getContext`; resume otherwise.

- Update `primeAudioCue` and `playRecordStartCue` to use new classification.

- Add unit tests for all state transitions.


___

### Diagram Walkthrough


```mermaid
flowchart LR
    A["AudioContext state"] --> B{"audioContextActionForState"}
    B -- "closed" --> C["recreate"]
    B -- "running" --> D["ready"]
    B -- "suspended/interrupted/other" --> E["resume"]
    C --> F["Discard old ctx, create new"]
    E --> G["ctx.resume()"]
    D --> H["Schedule audio"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>audioCue.test.ts</strong><dd><code>Add unit tests for AudioContext state classification</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src/lib/audioCue.test.ts

<ul><li>Added 5 test assertions for <code>audioContextActionForState</code> covering <br>'closed', 'running', 'suspended', 'interrupted', and unknown states.</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/737/files#diff-63830f2d1230ef86a91da91fccb9ed2c6dd6b5681e2ece446f728cc115aa2096">+34/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>audioCue.ts</strong><dd><code>Implement AudioContext state recovery logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src/lib/audioCue.ts

<ul><li>Added <code>AudioContextAction</code> type and <code>audioContextActionForState</code> function.<br> <li> Modified <code>getContext</code> to recreate closed AudioContext.<br> <li> Updated <code>primeAudioCue</code> and <code>playRecordStartCue</code> to use the new function, <br>including handling of 'interrupted' state.</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/737/files#diff-712672f9e47feca9cb681daed18f86b30ef95133acb2bb67e6aea32f0e7bd6ca">+32/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

