### PR TITLE
fix(asr): 修复 Apple Speech 听写误走火山路径

### DIFF
--- a/openless-all/app/src-tauri/src/coordinator/asr_wiring.rs
+++ b/openless-all/app/src-tauri/src/coordinator/asr_wiring.rs
@@ -71,6 +71,17 @@ pub(super) fn ensure_asr_credentials() -> Result<(), String> {
         }
     }
 
+    if crate::asr::local::is_apple_speech(&active_asr) {
+        #[cfg(not(target_os = "macos"))]
+        {
+            return Err("Apple Speech 当前仅支持 macOS".to_string());
+        }
+        #[cfg(target_os = "macos")]
+        {
+            return Ok(());
+        }
+    }
+
     if crate::asr::local::foundry::is_foundry_local_whisper(&active_asr) {
         #[cfg(not(target_os = "windows"))]
         {

--- a/openless-all/app/src-tauri/src/coordinator/dictation.rs
+++ b/openless-all/app/src-tauri/src/coordinator/dictation.rs
@@ -14,6 +14,24 @@ use super::*;
 const HOTKEY_DEBOUNCE: std::time::Duration = std::time::Duration::from_millis(250);
 const STREAMING_INSERT_FLUSH_INTERVAL: std::time::Duration = std::time::Duration::from_millis(12);
 
+#[cfg(target_os = "macos")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum MacosKeylessDictationProvider {
+    LocalQwen3,
+    AppleSpeech,
+}
+
+#[cfg(target_os = "macos")]
+fn macos_keyless_dictation_provider(active_asr: &str) -> Option<MacosKeylessDictationProvider> {
+    if crate::asr::local::is_local_qwen3(active_asr) {
+        Some(MacosKeylessDictationProvider::LocalQwen3)
+    } else if crate::asr::local::is_apple_speech(active_asr) {
+        Some(MacosKeylessDictationProvider::AppleSpeech)
+    } else {
+        None
+    }
+}
+
 /// Less Computer 浮窗的 Tauri 事件名（前端 LessComputerPanel 订阅）。
 const LESS_COMPUTER_EVENT: &str = "less-computer:event";
 
@@ -1215,33 +1233,58 @@ pub(super) async fn begin_session_as(
     }
 
     #[cfg(target_os = "macos")]
-    if crate::asr::local::is_local_qwen3(&active_asr) {
-        let local = match build_local_qwen3(inner).await {
-            Ok(l) => l,
-            Err(e) => {
-                log::error!("[coord] 本地 Qwen3-ASR 初始化失败: {e:#}");
-                emit_capsule(
+    if let Some(provider) = macos_keyless_dictation_provider(&active_asr) {
+        match provider {
+            MacosKeylessDictationProvider::LocalQwen3 => {
+                let local = match build_local_qwen3(inner).await {
+                    Ok(l) => l,
+                    Err(e) => {
+                        log::error!("[coord] 本地 Qwen3-ASR 初始化失败: {e:#}");
+                        emit_capsule(
+                            inner,
+                            CapsuleState::Error,
+                            0.0,
+                            0,
+                            Some(format!("本地模型初始化失败: {e}")),
+                            None,
+                        );
+                        restore_prepared_windows_ime_session(inner, current_session_id);
+                        inner.state.lock().phase = SessionPhase::Idle;
+                        schedule_capsule_idle(inner, CAPSULE_AUTO_HIDE_DELAY_MS);
+                        return Err(format!("local ASR init failed: {e}"));
+                    }
+                };
+                store_asr_for_session(
                     inner,
-                    CapsuleState::Error,
-                    0.0,
-                    0,
-                    Some(format!("本地模型初始化失败: {e}")),
-                    None,
+                    current_session_id,
+                    ActiveAsr::Local(Arc::clone(&local)),
                 );
-                restore_prepared_windows_ime_session(inner, current_session_id);
-                inner.state.lock().phase = SessionPhase::Idle;
-                schedule_capsule_idle(inner, CAPSULE_AUTO_HIDE_DELAY_MS);
-                return Err(format!("local ASR init failed: {e}"));
+                let consumer: Arc<dyn crate::recorder::AudioConsumer> = local;
+                start_recorder_and_enter_listening(
+                    inner,
+                    current_session_id,
+                    &active_asr,
+                    consumer,
+                )
+                .await?;
             }
-        };
-        store_asr_for_session(
-            inner,
-            current_session_id,
-            ActiveAsr::Local(Arc::clone(&local)),
-        );
-        let consumer: Arc<dyn crate::recorder::AudioConsumer> = local;
-        start_recorder_and_enter_listening(inner, current_session_id, &active_asr, consumer)
-            .await?;
+            MacosKeylessDictationProvider::AppleSpeech => {
+                let local = build_apple_speech();
+                store_asr_for_session(
+                    inner,
+                    current_session_id,
+                    ActiveAsr::AppleSpeech(Arc::clone(&local)),
+                );
+                let consumer: Arc<dyn crate::recorder::AudioConsumer> = local;
+                start_recorder_and_enter_listening(
+                    inner,
+                    current_session_id,
+                    &active_asr,
+                    consumer,
+                )
+                .await?;
+            }
+        }
         return Ok(());
     }
 
@@ -2700,6 +2743,8 @@ mod tests {
         finalize_polished_text, flush_streaming_insert_buffer_with, pcm_duration_ms,
         pcm_from_wav_bytes, streaming_insert_eligible,
     };
+    #[cfg(target_os = "macos")]
+    use super::{macos_keyless_dictation_provider, MacosKeylessDictationProvider};
     use crate::types::{
         ChineseScriptPreference, CorrectionRule, DictationSession, InsertStatus, PolishMode,
     };
@@ -2794,6 +2839,20 @@ mod tests {
         let sid = Uuid::new_v4();
         let session = build_transcribe_failed_session(sid, 1, PolishMode::Structured, false);
         assert_eq!(session.has_audio_recording, Some(false));
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn macos_keyless_dictation_provider_routes_apple_speech_locally() {
+        assert_eq!(
+            macos_keyless_dictation_provider(crate::asr::local::APPLE_SPEECH_PROVIDER_ID),
+            Some(MacosKeylessDictationProvider::AppleSpeech)
+        );
+        assert_eq!(
+            macos_keyless_dictation_provider(crate::asr::local::PROVIDER_ID),
+            Some(MacosKeylessDictationProvider::LocalQwen3)
+        );
+        assert_eq!(macos_keyless_dictation_provider("volcengine"), None);
     }
 
     #[test]


### PR DESCRIPTION
### **User description**
## 摘要

Fixes #731。

修复 macOS Apple Speech ASR 在普通听写启动时仍落入火山引擎凭据 / WebSocket 路径的问题。

## 修复 / 新增 / 改进

- 将 `apple-speech` 纳入无外部凭据的本地 ASR provider 门禁，macOS 直接放行，非 macOS 返回明确平台错误。
- 普通听写启动路径新增 Apple Speech 本地分支，录音 consumer 直接接入 `ActiveAsr::AppleSpeech`，不再进入 Volcengine fallback。
- 增加 macOS provider 路由单测，锁定 `apple-speech` 与 `local-qwen3` 的本地路径选择。

## 兼容

- 不包含：Apple Speech 识别实现、权限弹窗、音频处理逻辑变更。
- 对现有用户 / 本地环境 / 构建流程的影响：仅影响选择 `apple-speech` 的 macOS 用户；其他 ASR provider 路径保持不变。

## 测试计划

- [x] 命令：`git diff --check`
- [x] 命令：`cargo test --lib macos_keyless_dictation_provider_routes_apple_speech_locally`
- [x] 命令：`cargo test --lib qa_asr_provider_kind_tracks_active_provider`
- [x] 命令：`cargo test --lib local_asr_providers_skip_external_validation`
- [x] 结果：上述检查通过。`cargo test` 有仓库既有 unused/deprecated warning，未发现本次改动相关失败。
- [x] 证据路径：本 PR 分支本地终端输出。


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Add Apple Speech to local ASR credential gate

- Route Apple Speech dictation locally on macOS

- Unify local dictation providers with enum


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["active_asr"] --> B{"is apple-speech?"}
  B -- yes --> C["credential gate: macOS -> Ok"]
  C --> D["begin_session_as: apple-speech local branch"]
  B -- no --> E["existing paths (volcengine, bailian, etc.)"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>asr_wiring.rs</strong><dd><code>Add Apple Speech to credential gate</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src-tauri/src/coordinator/asr_wiring.rs

<ul><li>Added Apple Speech to the local ASR credential gate<br> <li> On macOS, returns Ok; on non-macOS, returns a platform error<br> <li> Prevents Apple Speech from falling through to Volcengine credential <br>checks</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/741/files#diff-9fe355023b6fbdce8c332d15ed2ef01564d123418ef1aa11274671d23f3d56ea">+11/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>dictation.rs</strong><dd><code>Route Apple Speech dictation locally</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src-tauri/src/coordinator/dictation.rs

<ul><li>Introduced <code>MacosKeylessDictationProvider</code> enum<br> <li> Implemented <code>macos_keyless_dictation_provider</code> function<br> <li> Added Apple Speech local branch in <code>begin_session_as</code><br> <li> Added unit test for provider routing</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/741/files#diff-4cf79887f41f4811eb2b1ef682c62ee34c14a0ab969362a9ba1046de59c8578b">+83/-24</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

