### PR TITLE
chore(release): publish 1.3.12

### DIFF
--- a/openless-all/app/package-lock.json
+++ b/openless-all/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openless-app",
-  "version": "1.3.11",
+  "version": "1.3.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openless-app",
-      "version": "1.3.11",
+      "version": "1.3.12",
       "dependencies": {
         "@formkit/auto-animate": "^0.9.0",
         "@tauri-apps/api": "^2.1.1",

--- a/openless-all/app/package.json
+++ b/openless-all/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openless-app",
   "private": true,
-  "version": "1.3.11",
+  "version": "1.3.12",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/openless-all/app/src-tauri/Cargo.lock
+++ b/openless-all/app/src-tauri/Cargo.lock
@@ -3883,7 +3883,7 @@ dependencies = [
 
 [[package]]
 name = "openless"
-version = "1.3.11"
+version = "1.3.12"
 dependencies = [
  "anyhow",
  "arboard",

--- a/openless-all/app/src-tauri/Cargo.toml
+++ b/openless-all/app/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openless"
-version = "1.3.11"
+version = "1.3.12"
 description = "OpenLess — local voice input that types where your cursor is"
 authors = ["OpenLess"]
 edition = "2021"

--- a/openless-all/app/src-tauri/src/coding_agent/opencode.rs
+++ b/openless-all/app/src-tauri/src/coding_agent/opencode.rs
@@ -16,7 +16,7 @@
 //!   [`CodingAgentEvent::Completed`]，`cost_usd = None`（OpenCode CLI 不在 JSON 里给单次成本）。
 
 use std::process::Stdio;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 use std::time::Duration;
 

--- a/openless-all/app/src-tauri/src/coordinator/dictation.rs
+++ b/openless-all/app/src-tauri/src/coordinator/dictation.rs
@@ -415,7 +415,7 @@ fn finalize_polished_text(
     polished: String,
     translation_active: bool,
     _raw_uses_llm: bool,
-    mode: PolishMode,
+    _mode: PolishMode,
     polish_error: &Option<String>,
     chinese_script_preference: crate::types::ChineseScriptPreference,
     correction_rules: &[crate::types::CorrectionRule],

--- a/openless-all/app/src-tauri/tauri.conf.json
+++ b/openless-all/app/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "OpenLess",
-  "version": "1.3.11",
+  "version": "1.3.12",
   "identifier": "com.openless.app",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/openless-all/app/src/components/AutoUpdate.tsx
+++ b/openless-all/app/src/components/AutoUpdate.tsx
@@ -1,10 +1,9 @@
-// 自动更新共用模块 — Settings 的"关于"section 和 AutoUpdateGate 共用同一套
-// 状态机 + 对话框 UI。各自调用 useAutoUpdate()，dialog 渲染条件相同。
+// 自动更新共用模块 — Settings 的"关于"section 和 footer 按钮共用同一套
+// 状态机 + 对话框 UI。两边各自调用 useAutoUpdate()，dialog 渲染条件相同。
 //
 // 渠道感知：check 走 appCheckUpdateWithChannel()（Rust 按渠道拼 manifest URL）。
 // 桌面：download/install 复用 plugin-updater 的 Update 类。
 // Android：download/install 走 appDownloadAndInstallAndroidUpdate（minisign + 系统安装器）。
-// Android 后台 Gate：发现更新后 autoInstallAndroid 跳过确认，直接下载并打开系统安装器。
 
 import { useEffect, useRef, useState } from 'react';
 import type { DownloadEvent } from '@tauri-apps/plugin-updater';
@@ -71,8 +70,6 @@ type AndroidUpdatePayload = {
 export function useAutoUpdate(): UseAutoUpdate {
   const updateRef = useRef<Update | null>(null);
   const androidUpdateRef = useRef<AndroidUpdatePayload | null>(null);
-  /** True only while this hook instance initiated an Android download/install. */
-  const androidDownloadActiveRef = useRef(false);
   const [status, setStatus] = useState<UpdateStatus>('idle');
   const [version, setVersion] = useState('');
   const [downloaded, setDownloaded] = useState(0);
@@ -110,7 +107,6 @@ export function useAutoUpdate(): UseAutoUpdate {
       contentLength: number | null;
       phase: string;
     }>('android-update:progress', (event) => {
-      if (!androidDownloadActiveRef.current) return;
       setDownloaded(event.payload.downloaded);
       setContentLength(event.payload.contentLength);
       if (event.payload.phase === 'installing') {
@@ -141,30 +137,87 @@ export function useAutoUpdate(): UseAutoUpdate {
     androidUpdateRef.current = { url, signature, version: metadata.version };
   };
 
-  const installAndroidUpdate = async () => {
-    const payload = androidUpdateRef.current;
-    if (!payload) return;
+  const checkForUpdates = async (channel?: UpdateChannel, options?: CheckUpdateOptions) => {
+    setStatus('checking');
+    setVersion('');
+    setErrorMessage(null);
     resetProgress();
-    setStatus('downloading');
-    androidDownloadActiveRef.current = true;
+    await closeUpdate();
     try {
-      await appDownloadAndInstallAndroidUpdate(payload);
-      androidUpdateRef.current = null;
-      setStatus('downloaded');
+      if (!isTauri) {
+        setStatus('none');
+        return;
+      }
+      const metadata = await appCheckUpdateWithChannel(
+        UPDATE_CHECK_TIMEOUT_MS,
+        channel ?? null,
+      );
+      if (!metadata) {
+        setStatus('none');
+        return;
+      }
+      if (isAndroid()) {
+        storeAndroidMetadata(metadata);
+        setVersion(metadata.version);
+        if (options?.autoInstallAndroid) {
+          try {
+            // 复用 storeAndroidMetadata 的 rawJson 解析（提取 url/signature/version）
+            const raw = metadata.rawJson ?? {};
+            const url = typeof raw.url === 'string' ? raw.url : '';
+            const signature = typeof raw.signature === 'string' ? raw.signature : '';
+            if (!url || !signature) {
+              console.warn('[auto-update] android manifest missing url/signature, falling back to manual update');
+              setStatus('available');
+              return;
+            }
+            await appDownloadAndInstallAndroidUpdate({ url, signature, version: metadata.version });
+            setStatus('downloaded');
+          } catch (error) {
+            console.warn('[auto-update] android auto-install failed', error);
+            setStatus('available');
+          }
+          return;
+        }
+        setStatus('available');
+        return;
+      }
+      const next = new Update({
+        rid: metadata.rid,
+        currentVersion: metadata.currentVersion,
+        version: metadata.version,
+        date: metadata.date ?? undefined,
+        body: metadata.body ?? undefined,
+        rawJson: metadata.rawJson,
+      });
+      updateRef.current = next;
+      setVersion(next.version);
+      setStatus('available');
     } catch (error) {
-      console.error('[updater] failed to install android update', error);
+      console.error('[updater] failed to check update', error);
       const msg = error instanceof Error ? error.message : String(error);
-      void logClientError(`[updater] android install failed (v${payload.version}): ${msg}`);
+      void logClientError(`[updater] check failed: ${msg}`);
       setErrorMessage(msg);
-      setStatus('installError');
-    } finally {
-      androidDownloadActiveRef.current = false;
+      setStatus('error');
     }
   };
 
   const installUpdate = async () => {
     if (isAndroid()) {
-      await installAndroidUpdate();
+      const payload = androidUpdateRef.current;
+      if (!payload) return;
+      resetProgress();
+      setStatus('downloading');
+      try {
+        await appDownloadAndInstallAndroidUpdate(payload);
+        androidUpdateRef.current = null;
+        setStatus('downloaded');
+      } catch (error) {
+        console.error('[updater] failed to install android update', error);
+        const msg = error instanceof Error ? error.message : String(error);
+        void logClientError(`[updater] android install failed (v${payload.version}): ${msg}`);
+        setErrorMessage(msg);
+        setStatus('installError');
+      }
       return;
     }
 
@@ -194,59 +247,6 @@ export function useAutoUpdate(): UseAutoUpdate {
       setErrorMessage(msg);
       await closeUpdate();
       setStatus('installError');
-    }
-  };
-
-  const checkForUpdates = async (channel?: UpdateChannel, options?: CheckUpdateOptions) => {
-    setStatus('checking');
-    setVersion('');
-    setErrorMessage(null);
-    resetProgress();
-    await closeUpdate();
-    try {
-      if (!isTauri) {
-        setStatus('none');
-        return;
-      }
-      const metadata = await appCheckUpdateWithChannel(
-        UPDATE_CHECK_TIMEOUT_MS,
-        channel ?? null,
-      );
-      if (!metadata) {
-        setStatus('none');
-        return;
-      }
-      if (isAndroid()) {
-        storeAndroidMetadata(metadata);
-        setVersion(metadata.version);
-        if (options?.autoInstallAndroid) {
-          try {
-            await installAndroidUpdate();
-          } catch (error) {
-            console.warn('[auto-update] android auto-install failed', error);
-          }
-          return;
-        }
-        setStatus('available');
-        return;
-      }
-      const next = new Update({
-        rid: metadata.rid,
-        currentVersion: metadata.currentVersion,
-        version: metadata.version,
-        date: metadata.date ?? undefined,
-        body: metadata.body ?? undefined,
-        rawJson: metadata.rawJson,
-      });
-      updateRef.current = next;
-      setVersion(next.version);
-      setStatus('available');
-    } catch (error) {
-      console.error('[updater] failed to check update', error);
-      const msg = error instanceof Error ? error.message : String(error);
-      void logClientError(`[updater] check failed: ${msg}`);
-      setErrorMessage(msg);
-      setStatus('error');
     }
   };
 
@@ -301,17 +301,10 @@ export function UpdateDialog({
   const installing = status === 'installing';
   const installError = status === 'installError';
   const androidInstalled = isAndroid() && status === 'downloaded';
-  const installLabel = isAndroid()
-    ? t('settings.about.updateDialog.androidInstall')
-    : t('settings.about.updateDialog.install');
   return (
     <div style={{ position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.18)', display: 'grid', placeItems: 'center', zIndex: 40 }}>
       <div style={{ width: 360, borderRadius: 16, background: 'var(--ol-surface)', border: '0.5px solid var(--ol-line-strong)', boxShadow: '0 18px 42px rgba(0,0,0,0.18)', padding: 18 }}>
-        <div style={{ fontSize: 15, fontWeight: 650, marginBottom: 8 }}>
-          {androidInstalled
-            ? t('settings.about.updateDialog.androidInstalled.title')
-            : t(`settings.about.updateDialog.${status}.title`)}
-        </div>
+        <div style={{ fontSize: 15, fontWeight: 650, marginBottom: 8 }}>{t(`settings.about.updateDialog.${status}.title`)}</div>
         <div style={{ fontSize: 12, color: 'var(--ol-ink-3)', lineHeight: 1.6, marginBottom: 14, whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>
           {androidInstalled
             ? t('settings.about.updateDialog.androidInstalled.desc', { version, defaultValue: '系统安装器已打开，请按提示完成安装。安装后重新打开 OpenLess 即可使用 {{version}}。' })
@@ -335,7 +328,7 @@ export function UpdateDialog({
         )}
         <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 8 }}>
           {status === 'available' && <Btn size="sm" onClick={onClose}>{t('common.cancel')}</Btn>}
-          {status === 'available' && <Btn variant="blue" size="sm" onClick={onInstall}>{installLabel}</Btn>}
+          {status === 'available' && <Btn variant="blue" size="sm" onClick={onInstall}>{t('settings.about.updateDialog.install')}</Btn>}
           {(downloading || installing) && <Btn size="sm" disabled>{installing ? t('settings.about.updateDialog.installingLabel') : t('settings.about.updateDialog.downloadingLabel')}</Btn>}
           {status === 'downloaded' && <Btn size="sm" onClick={onClose}>{t('settings.about.updateDialog.later')}</Btn>}
           {status === 'downloaded' && !androidInstalled && <Btn variant="blue" size="sm" onClick={restartApp}>{t('settings.about.updateDialog.restartNow')}</Btn>}


### PR DESCRIPTION
### **User description**
## Summary
- Bump OpenLess app/Tauri/Cargo versions to 1.3.12.
- Include the latest beta cloud changes: #729, #741, and #638.
- Carry the updater compatibility/fallback adjustments for this formal release.
- Remove two new Rust warnings from the OpenCode/dictation integration.

## Verification
- npm run build
- cargo check --manifest-path src-tauri/Cargo.toml
- cargo test --manifest-path src-tauri/Cargo.toml --lib
- npm run check:macos-capsule-spaces
- npm run check:hotkey-injection
- npm run check:windows-startup-lifecycle
- npm run check:android-updater-pubkey
- npx gitnexus analyze .
- npx gitnexus detect-changes --scope compare --base-ref origin/beta

## Notes
- GitNexus marks this release PR as HIGH risk because it touches updater flows (`checkForUpdates`, `installUpdate`, `useAutoUpdate`, `UpdateDialog`).
- npm audit still reports existing advisories: 1 low, 2 moderate, 1 high. The remaining Vite/esbuild fix path requires a breaking Vite upgrade, so it is not included in this release commit.


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Bump app, Tauri, and Cargo versions to 1.3.12

- Refactor Android auto update to remove unused state and simplify installation

- Clean up unused imports and parameter warnings

- Integrate latest beta features: Apple Speech ASR fix, Chinese script enforcement, OpenCode CLI adapter


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Miscellaneous</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>opencode.rs</strong><dd><code>Remove unused AtomicBool import</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src-tauri/src/coding_agent/opencode.rs

- Remove unused `Ordering` import, keeping only `AtomicBool`


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/743/files#diff-db8f2c83f4eb9b9d3e5ff18c42845be9a14756370ca6b1b6d12a3bec972bd347">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>dictation.rs</strong><dd><code>Rename unused parameter in finalize_polished_text</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src-tauri/src/coordinator/dictation.rs

<ul><li>Prefix <code>mode</code> parameter with underscore to suppress unused warning; no <br>logic change</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/743/files#diff-4cf79887f41f4811eb2b1ef682c62ee34c14a0ab969362a9ba1046de59c8578b">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>AutoUpdate.tsx</strong><dd><code>Refactor Android auto update logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src/components/AutoUpdate.tsx

<ul><li>Remove unused <code>androidDownloadActiveRef</code> state<br> <li> Simplify Android auto-install by directly calling <br><code>appDownloadAndInstallAndroidUpdate</code><br> <li> Remove conditional Android-specific title in update dialog, unify with <br>existing translation<br> <li> Improve error handling fallback to 'available' status<br> <li> Reorder <code>installUpdate</code> function after <code>checkForUpdates</code> for clarity</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/743/files#diff-35d817392a83ce7dc17bd10e9223889f8311caaf56d910842b84fa4bfae03dd9">+65/-72</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>package.json</strong><dd><code>Bump app version to 1.3.12</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/package.json

- Change version from 1.3.11 to 1.3.12


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/743/files#diff-2650f8aa2f7ec97aa8af47f1f8a7c9ae4677fb69754b20d554e1d542507cf4ea">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Cargo.toml</strong><dd><code>Bump crate version to 1.3.12</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src-tauri/Cargo.toml

- Change version from 1.3.11 to 1.3.12


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/743/files#diff-334952ba03e62939865bbf0351f0916ea88c6457f8ea1259336e73ee4e2f088b">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>tauri.conf.json</strong><dd><code>Bump Tauri app version to 1.3.12</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src-tauri/tauri.conf.json

- Change version from 1.3.11 to 1.3.12


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/743/files#diff-e9c2f15638ea988f61c82aeb2257147fb9cc96d7bda8709e8bad6b6517f5369c">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

