### PR TITLE
fix(windows-ime): eliminate thread deadlock causing AppHangB1 in host processes

### DIFF
--- a/openless-all/app/windows-ime/src/ipc_client.cpp
+++ b/openless-all/app/windows-ime/src/ipc_client.cpp
@@ -336,10 +336,15 @@ std::wstring EscapeJsonString(const std::wstring& value) {
 
 }  // namespace
 
-OpenLessPipeServer::OpenLessPipeServer() = default;
+OpenLessPipeServer::OpenLessPipeServer()
+    : shutdown_event_(CreateEventW(nullptr, TRUE, FALSE, nullptr)) {}
 
 OpenLessPipeServer::~OpenLessPipeServer() {
   Stop();
+  if (shutdown_event_ != nullptr) {
+    CloseHandle(shutdown_event_);
+    shutdown_event_ = nullptr;
+  }
 }
 
 void OpenLessPipeServer::Start(OpenLessTextService* service) {
@@ -348,6 +353,11 @@ void OpenLessPipeServer::Start(OpenLessTextService* service) {
   }
 
   stop_requested_.store(false);
+
+  if (shutdown_event_ != nullptr) {
+    ResetEvent(shutdown_event_);
+  }
+
   pipe_name_ = PipeNameForCurrentThread();
   service_ = service;
   service_->AddRef();
@@ -356,10 +366,19 @@ void OpenLessPipeServer::Start(OpenLessTextService* service) {
 
 void OpenLessPipeServer::Stop() {
   stop_requested_.store(true);
+
+  if (shutdown_event_ != nullptr) {
+    SetEvent(shutdown_event_);
+  }
+
   if (thread_.joinable()) {
     CancelSynchronousIo(thread_.native_handle());
     WakePipe();
     thread_.join();
+  }
+
+  if (shutdown_event_ != nullptr) {
+    ResetEvent(shutdown_event_);
   }
 
   if (service_ != nullptr) {
@@ -458,7 +477,8 @@ void OpenLessPipeServer::HandleSubmitLine(HANDLE pipe, const std::string& line) 
   }
 
   const HRESULT hr =
-      service_->SubmitTextFromPipe(message.session_id, message.text);
+      service_->SubmitTextFromPipe(message.session_id, message.text,
+                                   shutdown_event_);
   if (SUCCEEDED(hr)) {
     WriteResult(pipe, message.session_id, L"committed", nullptr);
   } else {

--- a/openless-all/app/windows-ime/src/ipc_client.h
+++ b/openless-all/app/windows-ime/src/ipc_client.h
@@ -32,6 +32,7 @@ class OpenLessPipeServer {
   std::thread thread_;
   std::mutex pipe_mutex_;
   HANDLE pipe_handle_ = INVALID_HANDLE_VALUE;
+  HANDLE shutdown_event_ = nullptr;
   std::wstring pipe_name_;
   OpenLessTextService* service_ = nullptr;
 };

--- a/openless-all/app/windows-ime/src/text_service.cpp
+++ b/openless-all/app/windows-ime/src/text_service.cpp
@@ -20,6 +20,7 @@ struct SubmitTextRequest {
   std::shared_ptr<OpenLessAsyncEditState> async_completion;
   bool wait_for_async_completion = false;
   HRESULT result = E_UNEXPECTED;
+  HANDLE completion_event = nullptr;
 };
 
 HRESULT WaitForAsyncEditCompletion(
@@ -133,7 +134,8 @@ STDMETHODIMP OpenLessTextService::Deactivate() {
 
 HRESULT OpenLessTextService::SubmitTextFromPipe(
     const std::wstring& session_id,
-    const std::wstring& text) {
+    const std::wstring& text,
+    HANDLE shutdown_event) {
   if (GetCurrentThreadId() == owner_thread_id_) {
     return CommitTextOnOwnerThread(session_id, text, nullptr, nullptr);
   }
@@ -145,21 +147,49 @@ HRESULT OpenLessTextService::SubmitTextFromPipe(
   SubmitTextRequest request;
   request.session_id = &session_id;
   request.text = &text;
-  DWORD_PTR message_result = 0;
-  const LRESULT sent = SendMessageTimeoutW(
-      message_window_, kSubmitTextMessage, 0,
-      reinterpret_cast<LPARAM>(&request), SMTO_ABORTIFHUNG,
-      kSubmitTextTimeoutMs, &message_result);
-  if (sent == 0) {
+  request.completion_event =
+      CreateEventW(nullptr, TRUE, FALSE, nullptr);
+  if (request.completion_event == nullptr) {
+    return HRESULT_FROM_WIN32(GetLastError());
+  }
+
+  if (!PostMessageW(message_window_, kSubmitTextMessage, 0,
+                    reinterpret_cast<LPARAM>(&request))) {
     const DWORD error = GetLastError();
-    return HRESULT_FROM_WIN32(error != ERROR_SUCCESS ? error : ERROR_TIMEOUT);
+    CloseHandle(request.completion_event);
+    return HRESULT_FROM_WIN32(error);
   }
 
-  if (request.wait_for_async_completion) {
-    return WaitForAsyncEditCompletion(request.async_completion);
+  HANDLE wait_handles[2] = {};
+  DWORD wait_count = 0;
+
+  wait_handles[wait_count] = request.completion_event;
+  ++wait_count;
+
+  if (shutdown_event != nullptr) {
+    wait_handles[wait_count] = shutdown_event;
+    ++wait_count;
   }
 
-  return request.result;
+  const DWORD wait_result = WaitForMultipleObjects(
+      wait_count, wait_handles, FALSE, kSubmitTextTimeoutMs);
+
+  HRESULT result;
+  if (wait_result == WAIT_OBJECT_0) {
+    result = request.result;
+    if (request.wait_for_async_completion) {
+      result = WaitForAsyncEditCompletion(request.async_completion);
+    }
+  } else if (wait_count > 1 && wait_result == WAIT_OBJECT_0 + 1) {
+    result = HRESULT_FROM_WIN32(ERROR_CANCELLED);
+  } else if (wait_result == WAIT_TIMEOUT) {
+    result = HRESULT_FROM_WIN32(ERROR_TIMEOUT);
+  } else {
+    result = HRESULT_FROM_WIN32(GetLastError());
+  }
+
+  CloseHandle(request.completion_event);
+  return result;
 }
 
 HRESULT OpenLessTextService::StartIpcServer() {
@@ -325,6 +355,9 @@ LRESULT CALLBACK OpenLessTextService::MessageWindowProc(HWND window,
     request->result = service->CommitTextOnOwnerThread(
         *request->session_id, *request->text, &request->async_completion,
         &request->wait_for_async_completion);
+    if (request->completion_event != nullptr) {
+      SetEvent(request->completion_event);
+    }
     return 1;
   }
 

--- a/openless-all/app/windows-ime/src/text_service.cpp
+++ b/openless-all/app/windows-ime/src/text_service.cpp
@@ -1,5 +1,6 @@
 #include "text_service.h"
 
+#include <atomic>
 #include <memory>
 #include <new>
 
@@ -15,12 +16,25 @@ constexpr UINT kSubmitTextMessage = WM_APP + 1;
 constexpr UINT kSubmitTextTimeoutMs = 2000;
 
 struct SubmitTextRequest {
-  const std::wstring* session_id = nullptr;
-  const std::wstring* text = nullptr;
+  // Owned copies — not pointers into another thread's stack.
+  std::wstring session_id;
+  std::wstring text;
   std::shared_ptr<OpenLessAsyncEditState> async_completion;
   bool wait_for_async_completion = false;
   HRESULT result = E_UNEXPECTED;
   HANDLE completion_event = nullptr;
+  // Two owners at creation: pipe thread (waiting on completion_event) and
+  // the queued window message.  Each owner calls Release() when done; the
+  // last one to Release() closes the event and deletes the request.
+  std::atomic<int> ref_count{2};
+  void Release() {
+    if (ref_count.fetch_sub(1, std::memory_order_acq_rel) == 1) {
+      if (completion_event != nullptr) {
+        CloseHandle(completion_event);
+      }
+      delete this;
+    }
+  }
 };
 
 HRESULT WaitForAsyncEditCompletion(
@@ -144,26 +158,32 @@ HRESULT OpenLessTextService::SubmitTextFromPipe(
     return E_UNEXPECTED;
   }
 
-  SubmitTextRequest request;
-  request.session_id = &session_id;
-  request.text = &text;
-  request.completion_event =
+  auto* request = new (std::nothrow) SubmitTextRequest;
+  if (request == nullptr) {
+    return E_OUTOFMEMORY;
+  }
+
+  request->session_id = session_id;
+  request->text = text;
+  request->completion_event =
       CreateEventW(nullptr, TRUE, FALSE, nullptr);
-  if (request.completion_event == nullptr) {
+  if (request->completion_event == nullptr) {
+    delete request;
     return HRESULT_FROM_WIN32(GetLastError());
   }
 
   if (!PostMessageW(message_window_, kSubmitTextMessage, 0,
-                    reinterpret_cast<LPARAM>(&request))) {
+                    reinterpret_cast<LPARAM>(request))) {
     const DWORD error = GetLastError();
-    CloseHandle(request.completion_event);
+    CloseHandle(request->completion_event);
+    delete request;
     return HRESULT_FROM_WIN32(error);
   }
 
   HANDLE wait_handles[2] = {};
   DWORD wait_count = 0;
 
-  wait_handles[wait_count] = request.completion_event;
+  wait_handles[wait_count] = request->completion_event;
   ++wait_count;
 
   if (shutdown_event != nullptr) {
@@ -176,9 +196,9 @@ HRESULT OpenLessTextService::SubmitTextFromPipe(
 
   HRESULT result;
   if (wait_result == WAIT_OBJECT_0) {
-    result = request.result;
-    if (request.wait_for_async_completion) {
-      result = WaitForAsyncEditCompletion(request.async_completion);
+    result = request->result;
+    if (request->wait_for_async_completion) {
+      result = WaitForAsyncEditCompletion(request->async_completion);
     }
   } else if (wait_count > 1 && wait_result == WAIT_OBJECT_0 + 1) {
     result = HRESULT_FROM_WIN32(ERROR_CANCELLED);
@@ -188,7 +208,9 @@ HRESULT OpenLessTextService::SubmitTextFromPipe(
     result = HRESULT_FROM_WIN32(GetLastError());
   }
 
-  CloseHandle(request.completion_event);
+  // Release the pipe-thread reference.  The message-thread reference, if
+  // still outstanding (timeout / shutdown paths), will clean up later.
+  request->Release();
   return result;
 }
 
@@ -230,6 +252,18 @@ HRESULT OpenLessTextService::EnsureMessageWindow() {
 
 void OpenLessTextService::DestroyMessageWindow() {
   if (message_window_ != nullptr) {
+    // Drain any kSubmitTextMessage still in the queue so the associated
+    // SubmitTextRequest references are released before the window is gone.
+    // These are left over when SubmitTextFromPipe exited via timeout or
+    // shutdown before the owner thread could dispatch the message.
+    MSG msg;
+    while (PeekMessageW(&msg, message_window_, kSubmitTextMessage,
+                        kSubmitTextMessage, PM_REMOVE)) {
+      auto* request = reinterpret_cast<SubmitTextRequest*>(msg.lParam);
+      if (request != nullptr) {
+        request->Release();
+      }
+    }
     DestroyWindow(message_window_);
     message_window_ = nullptr;
   }
@@ -347,17 +381,21 @@ LRESULT CALLBACK OpenLessTextService::MessageWindowProc(HWND window,
       GetWindowLongPtrW(window, GWLP_USERDATA));
   if (message == kSubmitTextMessage && service != nullptr) {
     auto* request = reinterpret_cast<SubmitTextRequest*>(lparam);
-    if (request == nullptr || request->session_id == nullptr ||
-        request->text == nullptr) {
+    if (request == nullptr || request->session_id.empty() ||
+        request->text.empty()) {
+      if (request != nullptr) {
+        request->Release();
+      }
       return 0;
     }
 
     request->result = service->CommitTextOnOwnerThread(
-        *request->session_id, *request->text, &request->async_completion,
+        request->session_id, request->text, &request->async_completion,
         &request->wait_for_async_completion);
     if (request->completion_event != nullptr) {
       SetEvent(request->completion_event);
     }
+    request->Release();
     return 1;
   }
 

--- a/openless-all/app/windows-ime/src/text_service.h
+++ b/openless-all/app/windows-ime/src/text_service.h
@@ -27,7 +27,8 @@ class OpenLessTextService final : public ITfTextInputProcessorEx {
                           DWORD flags) override;
 
   HRESULT SubmitTextFromPipe(const std::wstring& session_id,
-                             const std::wstring& text);
+                             const std::wstring& text,
+                             HANDLE shutdown_event = nullptr);
 
  private:
   HRESULT StartIpcServer();


### PR DESCRIPTION
### **User description**
## Summary

Fixes #665 — the intermittent `AppHangB1` in `explorer.exe`, `chrome.exe`, `clash-verge.exe` and other host processes caused by `OpenLessIme.dll`.

## Root Cause

`OpenLessPipeServer::Stop()` calls `thread_.join()`, which blocks the calling thread (often the TSF owner/UI thread). Meanwhile, the pipe server thread can be in `SubmitTextFromPipe()` → `SendMessageTimeoutW()`, which blocks waiting for the owner thread's message pump. Classic circular wait deadlock lasting up to 2 seconds (the `SendMessageTimeoutW` timeout), causing the host process to appear hung. Windows detects this as `AppHangB1` and may restart the process.

## Fix

Replace `SendMessageTimeoutW` with `PostMessageW` + `WaitForMultipleObjects` in the cross-thread path of `SubmitTextFromPipe`. A `shutdown_event` (manual-reset event owned by `OpenLessPipeServer`) is added to the wait array. When `Stop()` is called, it signals the shutdown event *before* calling `thread_.join()`, unblocking the pipe thread immediately.

### Changes (4 files, +69/-14)

| File | Change |
|------|--------|
| `ipc_client.h` | Add `HANDLE shutdown_event_` member |
| `ipc_client.cpp` | Create/destroy event; signal in `Stop()` before join; pass to `SubmitTextFromPipe` |
| `text_service.h` | Add `HANDLE shutdown_event = nullptr` parameter |
| `text_service.cpp` | `PostMessageW` + `WaitForMultipleObjects` replaces `SendMessageTimeoutW`; `MessageWindowProc` signals completion event |

### Architecture

```
Before (deadlock):
  pipe thread: HandleSubmitLine → SubmitTextFromPipe → SendMessageTimeoutW [blocked]
  owner thread: Deactivate → Stop → thread_.join() [blocked waiting for pipe thread]
  → DEADLOCK until SendMessageTimeoutW times out (2s)

After (fixed):
  pipe thread: HandleSubmitLine → SubmitTextFromPipe → PostMessage → WaitForMultipleObjects [blocked]
  owner thread: Deactivate → Stop → SetEvent(shutdown) → thread_.join() [unblocked]
  → pipe thread wakes from WaitForMultipleObjects, loop exits, join succeeds immediately
```

## Test Plan

- [ ] Build `OpenLessIme.dll` with Visual Studio (open `OpenLessIme.sln`, build Release x64 + x86)
- [ ] Replace installed DLLs at the OpenLess installation directory under `windows-ime\x64\` and `x86\`
- [ ] Enable OpenLess Voice Input TSF (`HKLM\SOFTWARE\Microsoft\CTF\TIP\{6B9F3F4F-5EE7-42D6-9C61-9F80B03A5D7D}\Enable = 1`)
- [ ] Use OpenLess voice input normally for 24+ hours
- [ ] Verify zero new `AppHangB1` events in Event Viewer
- [ ] Verify `OpenLessIme.dll` is loaded in Explorer but no hangs occur

## Environment Confirmed Affected

- Windows 10 19045 + Windows 11 26100
- OpenLess v1.3.8 through v1.3.10
- Host processes: `explorer.exe`, `chrome.exe`, `clash-verge.exe`


___

### **PR Type**
Bug fix


___

### **Description**
- Replace SendMessageTimeoutW with PostMessageW + WaitForMultipleObjects to prevent deadlock

- Introduce shutdown_event to unblock pipe thread during Stop() before join

- Heap-allocate SubmitTextRequest with atomic ref-count to avoid use-after-free

- Drain pending kSubmitTextMessage in DestroyMessageWindow for clean shutdown


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Pipe Thread"]
  B["Message Window"]
  C["Completion Event"]
  D["Shutdown Event"]
  E["Stop()"]
  A -- "PostMessageW" --> B
  A -- "WaitForMultipleObjects" --> C
  A -- "WaitForMultipleObjects" --> D
  B -- "SetEvent" --> C
  E -- "SetEvent" --> D
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ipc_client.cpp</strong><dd><code>Manage shutdown event lifecycle and signal in Stop()</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/windows-ime/src/ipc_client.cpp

<ul><li>Create/destroy <code>shutdown_event_</code> in constructor/destructor<br> <li> Signal event in <code>Stop()</code> before <code>thread_.join()</code> to unblock pipe thread<br> <li> Pass <code>shutdown_event_</code> to <code>SubmitTextFromPipe</code> for the wait array</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/745/files#diff-f463292d4d0d98918e9181082f26497fe7ac9f0d8f04b6e26187a6bdaf2f2fc5">+22/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>text_service.cpp</strong><dd><code>Eliminate deadlock with event-driven communication</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/windows-ime/src/text_service.cpp

<ul><li>Replace <code>SendMessageTimeoutW</code> with <code>PostMessageW</code> + <code>WaitForMultipleObjects</code><br> <li> Heap-allocate <code>SubmitTextRequest</code> with atomic ref-count to prevent <br>use-after-free<br> <li> Drain pending <code>kSubmitTextMessage</code> in <code>DestroyMessageWindow</code> for cleanup</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/745/files#diff-5ba5fb59f6766fa5706c90c034af3975372658f4af9fbc9cdc26761e465d31a6">+90/-19</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ipc_client.h</strong><dd><code>Add shutdown event handle member</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/windows-ime/src/ipc_client.h

- Add `HANDLE shutdown_event_` member variable


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/745/files#diff-6598db0c81d3cc68f02820cd12cfc04450e3b4ff17e75deaa5c5b45e56cf71e3">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>text_service.h</strong><dd><code>Update method signature to accept shutdown event</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/windows-ime/src/text_service.h

- Add `HANDLE shutdown_event` parameter to `SubmitTextFromPipe`


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/745/files#diff-0ccec04005e2984a4f215d154f7abd20e2b30a6570b6ee93417a3e1f174ad0fc">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

