### PR TITLE
fix(history): 润色为空时「复制」回退到原文 + 原文面板独立复制入口 (#751)

### DIFF
--- a/openless-all/app/src/pages/History.tsx
+++ b/openless-all/app/src/pages/History.tsx
@@ -48,6 +48,7 @@ export function History() {
   const [loadError, setLoadError] = useState<string | null>(null);
   const [actionError, setActionError] = useState<string | null>(null);
   const [justCopied, setJustCopied] = useState(false);
+  const [justCopiedRaw, setJustCopiedRaw] = useState(false);
   // 「重新转录」进行中：禁用按钮 + 显示「转录中…」，避免重复点击发起多次 ASR。
   const [retranscribing, setRetranscribing] = useState(false);
   // 录音文件 lazily-detected missing 状态：retention / 条数 cap 清理后磁盘上 wav
@@ -160,12 +161,31 @@ export function History() {
       if (!navigator.clipboard?.writeText) {
         throw new Error('clipboard unavailable');
       }
-      await navigator.clipboard.writeText(item.finalText);
+      // 润色失败/未产出时 finalText 为空，回退到原文，避免「复制」按钮复制空字符串
+      // 导致原文无法从 UI 取回（polish 失败时仍能拿到识别原文）。
+      await navigator.clipboard.writeText(item.finalText.trim() ? item.finalText : item.rawTranscript);
       setActionError(null);
       setJustCopied(true);
       window.setTimeout(() => setJustCopied(false), 1500);
     } catch (error) {
       console.error('[history] failed to copy entry', error);
+      setActionError(t('history.copyFailed', { err: errorMessage(error) }));
+    }
+  };
+
+  // 原文（识别结果）单独复制：润色失败或用户只想要未润色文本时使用。
+  const onCopyRaw = async () => {
+    if (!item) return;
+    try {
+      if (!navigator.clipboard?.writeText) {
+        throw new Error('clipboard unavailable');
+      }
+      await navigator.clipboard.writeText(item.rawTranscript);
+      setActionError(null);
+      setJustCopiedRaw(true);
+      window.setTimeout(() => setJustCopiedRaw(false), 1500);
+    } catch (error) {
+      console.error('[history] failed to copy raw transcript', error);
       setActionError(t('history.copyFailed', { err: errorMessage(error) }));
     }
   };
@@ -377,7 +397,14 @@ export function History() {
               )}
               <div style={{ display: 'grid', gridTemplateColumns: mobile ? '1fr' : '1fr 1fr', gap: 12 }}>
                 <div style={{ padding: 14, border: '0.5px solid var(--ol-line)', borderRadius: 10, background: 'var(--ol-surface-2)' }}>
-                  <Pill size="sm" tone="outline" style={{ marginBottom: 10 }}>{t('history.rawLabel')}</Pill>
+                  <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 8, marginBottom: 10 }}>
+                    <Pill size="sm" tone="outline">{t('history.rawLabel')}</Pill>
+                    {item.rawTranscript && (
+                      <Btn icon={justCopiedRaw ? 'check' : 'copy'} variant="ghost" size="sm" onClick={() => void onCopyRaw()}>
+                        {justCopiedRaw ? t('common.copied') : t('common.copy')}
+                      </Btn>
+                    )}
+                  </div>
                   <p style={{ margin: 0, fontSize: 13, lineHeight: 1.7, color: 'var(--ol-ink-2)', whiteSpace: 'pre-wrap' }}>
                     {item.rawTranscript || t('history.rawEmpty')}
                   </p>


### PR DESCRIPTION
### **User description**
## 摘要

Fixes #751

当润色结果为空（`finalText` 为空）时，历史页右上「复制」按钮复制的是空字符串，导致 UI 中可见的识别原文无法取回。本 PR 让原文随时可从 UI 取回。

## 改动（仅前端，无后端 / IPC 改动）

`src/pages/History.tsx`：
- `onCopy`：`finalText` 去空白后为空时，回退复制 `rawTranscript`。
- 原文面板新增独立「复制」按钮（仅在 `rawTranscript` 非空时显示），复制识别原文。
- 复用现有 `common.copy` / `common.copied`，不新增 i18n。

## 不做什么

- 不实现「历史重新润色」——该功能由 #666 / #694 推进，避免重复与合并冲突。本 PR 只解决「原文取不回」这一基础可取回性问题，与 #653 互补。

## 测试

- `tsc --noEmit` 通过。
- 在一条 `finalText` 为空的历史记录上：右上「复制」与原文面板「复制」均能取回识别原文；正常记录行为不变（「复制」仍复制润色结果）。


___

### **PR Type**
Bug fix


___

### **Description**
- Copy button falls back to raw transcript when polished text is empty

- Added independent copy button on the raw transcript panel


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Copy button clicked"] --> B{"finalText blank?"}
  B -- "Yes" --> C["Copy rawTranscript"]
  B -- "No" --> D["Copy finalText"]
  E["Raw panel copy button"] --> F["Always copy rawTranscript"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>History.tsx</strong><dd><code>Fix empty copy and add raw copy button</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src/pages/History.tsx

<ul><li>Modified onCopy to fall back to rawTranscript when finalText is empty<br> <li> Added justCopiedRaw state and onCopyRaw handler<br> <li> Added dedicated copy button in raw transcript panel header</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/752/files#diff-46c1ec3909029ec66e43bf7cab4914b700aad500151f9ed7f569936df22d5528">+29/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

