### PR TITLE
feat(asr): 火山引擎说话人分离，过滤非主要说话人

### DIFF
--- a/openless-all/app/src-tauri/src/asr/volcengine.rs
+++ b/openless-all/app/src-tauri/src/asr/volcengine.rs
@@ -393,6 +393,7 @@ impl VolcengineStreamingASR {
             "enable_itn": true,
             "enable_punc": true,
             "show_utterances": true,
+            "enable_speaker_info": true,
         });
         if let Some(context) = hotword_context(&self.hotwords) {
             request["context"] = Value::String(context);
@@ -474,13 +475,59 @@ impl VolcengineStreamingASR {
             .to_string();
 
         if let Some(utterances) = result.get("utterances").and_then(|v| v.as_array()) {
-            // 优先用 utterances 拼接的文本（包含全部分段，不论 definite 与否）
-            let pieces: Vec<&str> = utterances
+            // --- 声纹过滤：只保留主要说话人（说话时长最长的） ---
+            // 1. 统计每个 speaker 的说话时长
+            let mut speaker_durations: std::collections::HashMap<String, u64> =
+                std::collections::HashMap::new();
+            for u in utterances.iter() {
+                if let (Some(speaker), Some(start), Some(end)) = (
+                    u.get("speaker").and_then(|s| s.as_str()),
+                    u.get("start_time").and_then(|t| t.as_u64()),
+                    u.get("end_time").and_then(|t| t.as_u64()),
+                ) {
+                    let dur = end.saturating_sub(start);
+                    *speaker_durations.entry(speaker.to_string()).or_insert(0) += dur;
+                }
+            }
+
+            // 2. 找到说话时长最长的 speaker（即"主要说话人"）
+            let primary_speaker: Option<String> = speaker_durations
                 .iter()
-                .filter_map(|u| u.get("text").and_then(|t| t.as_str()))
-                .collect();
+                .max_by_key(|(_, &dur)| dur)
+                .map(|(s, _)| s.clone());
+
+            // 3. 只拼接主要说话人的文本；如果没有任何 speaker 标签，回退到全量拼接
+            let pieces: Vec<&str> = if let Some(ref primary) = primary_speaker {
+                utterances
+                    .iter()
+                    .filter(|u| {
+                        u.get("speaker")
+                            .and_then(|s| s.as_str())
+                            .map(|s| s == primary.as_str())
+                            .unwrap_or(true) // 无 speaker 字段的 utterance 保留
+                    })
+                    .filter_map(|u| u.get("text").and_then(|t| t.as_str()))
+                    .collect()
+            } else {
+                utterances
+                    .iter()
+                    .filter_map(|u| u.get("text").and_then(|t| t.as_str()))
+                    .collect()
+            };
+
             if !pieces.is_empty() {
                 full_text = pieces.join("");
+                if let Some(ref primary) = primary_speaker {
+                    let filtered_count = utterances.len().saturating_sub(pieces.len());
+                    if filtered_count > 0 {
+                        log::info!(
+                            "[asr] speaker filter: primary={}, kept={}, filtered={}",
+                            primary,
+                            pieces.len(),
+                            filtered_count
+                        );
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
### **User description**
## 摘要

开启火山引擎流式 ASR 的 `enable_speaker_info` 选项，让返回的每个 utterance 带说话人标签。然后按说话人分组，取说话时长最长的作为「主要说话人」，只拼接其文本，丢弃其他人（比如听写时旁边同事插话）的片段。

这是「只识别我自己的声音」需求的 Quick Win，不是真正的声纹注册验证——后者需要本地 embedding 模型，后续另做。

## 改动（仅 `volcengine.rs`，无前端 / IPC / 配置改动）

- `build_first_frame_payload`：请求参数加 `enable_speaker_info: true`
- 结果组装：统计每个 `speaker` 的 `end_time - start_time` 总和 → 取最大者为主要说话人 → 只拼接该 speaker 的 utterance 文本
- 无 speaker 标签时行为不变（全量拼接），向后兼容
- 加日志 `[asr] speaker filter: primary=..., kept=..., filtered=...`，过滤生效时可见

## 不做什么

- 不做声纹注册 / 本地 embedding 验证（第二步，后续另做）
- 不动其他 ASR provider（bailian / whisper / local 等暂不跟进）
- 不改 `RawTranscript` 结构（过滤后的 text 直接体现在 text 字段，无需新增字段）
- 不加前端 UI / 开关（如需开关后续再加）

## 测试

- 编译通过（`cargo check` + `tauri build`，既有 101 warnings，无新增错误）
- macOS 1.3.13-Beta.1 实测：自己说话时旁边有人插话，非主要说话人片段被过滤
- 单人说话场景：行为与改动前一致（只有一个 speaker，无过滤）

## 局限

- 「主要说话人」= 说话时长最长者。若你说话比旁边人短，会被误判为次要而被过滤（真正的声纹验证可解决，见「不做什么」）
- 火山返回的 speaker 是匿名标签（`speaker_0` / `speaker_1`），不等于「已注册用户」


___

### **PR Type**
Enhancement


___

### **Description**
- Enable speaker diarization for Volcengine streaming ASR

- Filter utterances to keep only the primary speaker (longest speaking time)

- Fall back to all utterances if no speaker labels present

- Add logging for speaker filter statistics


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A[Enable speaker_info] --> B[Collect speaker durations]
  B --> C[Select primary speaker]
  C --> D[Filter utterances]
  D --> E[Concatenate text]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>volcengine.rs</strong><dd><code>Add speaker diarization filtering logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src-tauri/src/asr/volcengine.rs

<ul><li>Added <code>enable_speaker_info: true</code> to first frame payload<br> <li> Implemented speaker duration tracking and primary speaker selection<br> <li> Filtered utterances to keep only primary speaker's text<br> <li> Added logging for filtered utterances count</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/760/files#diff-2fc7df3684f696c8aed87ee4e9bb6564e2048cece6769c9d2a787e08a257b140">+51/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

