### PR TITLE
fix(deps): 升级 tauri-plugin-shell 至 2.3.5 修复 CRITICAL 漏洞 (GHSA-c9pr-q8gx-3mgp)

### DIFF
--- a/openless-all/app/package-lock.json
+++ b/openless-all/app/package-lock.json
@@ -12,7 +12,7 @@
         "@tauri-apps/api": "^2.1.1",
         "@tauri-apps/plugin-autostart": "^2.5.1",
         "@tauri-apps/plugin-dialog": "^2.7.1",
-        "@tauri-apps/plugin-shell": "^2.0.1",
+        "@tauri-apps/plugin-shell": "^2.3.5",
         "@tauri-apps/plugin-updater": "^2.10.1",
         "@types/dompurify": "^3.0.5",
         "dompurify": "^3.4.8",

--- a/openless-all/app/package.json
+++ b/openless-all/app/package.json
@@ -27,7 +27,7 @@
     "@tauri-apps/api": "^2.1.1",
     "@tauri-apps/plugin-autostart": "^2.5.1",
     "@tauri-apps/plugin-dialog": "^2.7.1",
-    "@tauri-apps/plugin-shell": "^2.0.1",
+    "@tauri-apps/plugin-shell": "^2.3.5",
     "@tauri-apps/plugin-updater": "^2.10.1",
     "@types/dompurify": "^3.0.5",
     "dompurify": "^3.4.8",

--- a/openless-all/app/src-tauri/Cargo.toml
+++ b/openless-all/app/src-tauri/Cargo.toml
@@ -21,7 +21,8 @@ cc = "1.1"
 # macos-private-api must live in [dependencies] so tauri_build can match tauri.conf.json
 # macOSPrivateApi; tray-icon stays desktop-only in the target table below.
 tauri = { version = "~2.11", features = ["macos-private-api"] }
-tauri-plugin-shell = "2"
+# 锁 >=2.3.5 修复 GHSA-c9pr-q8gx-3mgp：tauri-plugin-shell `open` 端点作用域校验绕过（CRITICAL，issue #668）。
+tauri-plugin-shell = "2.3.5"
 tauri-plugin-dialog = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"


### PR DESCRIPTION
### **User description**
## 背景 / Issue

修复 #668 —— 安全扫描（NVIDIA SkillSpector）报出 `CRITICAL SC4 — @tauri-apps/plugin-shell==2.0.1` 已知漏洞相依。

对应公告 **[GHSA-c9pr-q8gx-3mgp](https://github.com/advisories/GHSA-c9pr-q8gx-3mgp)** — *Improper Scope Validation in the `open` Endpoint of `tauri-plugin-shell`*，**CRITICAL**：
- 受影响范围：`< 2.2.1`（npm 包与 Rust crate 同一公告）
- 首个修复版本：`2.2.1`，最新：`2.3.5`
- 本项目 `src/lib/ipc/utils.ts` 正是通过该 `open` 端点打开外链，属受影响用法。

## 根因

两个 lockfile 实际**已**解析到安全版 `2.3.5`，但清单声明的**下限**仍是漏洞版本：

| 文件 | 修改前 | 修改后 |
|------|--------|--------|
| `package.json` | `"@tauri-apps/plugin-shell": "^2.0.1"` | `"^2.3.5"` |
| `Cargo.toml` | `tauri-plugin-shell = "2"`（下限 2.0.0） | `tauri-plugin-shell = "2.3.5"` |
| `package-lock.json`（spec 行） | `"^2.0.1"` | `"^2.3.5"` |

供应链扫描读取的是这个声明下限（`^2.0.1` 的 min-satisfying = `2.0.1`），因此命中 SC4。

## 改动

仅把两侧声明下限抬到最新安全版 **2.3.5**，使**清单与已锁定版本一致**、扫描不再命中。

- **解析版本不变**（两个 lockfile 早已是 `2.3.5`），无运行时行为变化。
- 不涉及应用版本号，不触发五文件版本一致门禁。
- 单一职责：仅动 plugin-shell 依赖声明，未改任何源码/其它依赖。

## 验证

- ✅ `npm ci --dry-run`：package.json ↔ package-lock.json 已同步，退出码 0。
- ✅ `cargo update -p tauri-plugin-shell --dry-run`：tauri-plugin-shell 稳定停在 `2.3.5`，`Cargo.lock` 无需改动。
- ✅ 改动面 = 3 文件 / +4 −3；`Cargo.lock`、`node_modules` 解析条目均已是 2.3.5，未变。
- 🔜 四平台完整编译交由 CI 验证。

Closes #668


___

### **PR Type**
Bug fix


___

### **Description**
- 升级 @tauri-apps/plugin-shell 至 2.3.5 修复 CRITICAL 漏洞

- 升级 tauri-plugin-shell crate 依赖至 2.3.5

- 对齐清单声明版本与 lockfile 解析版本


___

### Diagram Walkthrough


```mermaid
flowchart LR
  cmp["@tauri-apps/plugin-shell / tauri-plugin-shell"] --> old["^2.0.1 / \"2\""]
  old -- "CRITICAL GHSA-c9pr-q8gx-3mgp" --> vuln["< 2.2.1"]
  cmp --> new["^2.3.5 / \"2.3.5\""]
  new -- "安全版本" --> fixed[">= 2.2.1"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Dependency update</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>package.json</strong><dd><code>更新 npm 插件依赖版本</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/package.json

- 将 @tauri-apps/plugin-shell 依赖声明从 `^2.0.1` 更新为 `^2.3.5`


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/763/files#diff-2650f8aa2f7ec97aa8af47f1f8a7c9ae4677fb69754b20d554e1d542507cf4ea">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Security fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Cargo.toml</strong><dd><code>更新 Rust crate 依赖版本</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src-tauri/Cargo.toml

<ul><li>将 tauri-plugin-shell 依赖从宽松版本 <code>"2"</code> 更新为精确安全版本 <code>"2.3.5"</code><br> <li> 添加注释说明修复的 CVE 编号</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/763/files#diff-334952ba03e62939865bbf0351f0916ea88c6457f8ea1259336e73ee4e2f088b">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

