### PR TITLE
fix(windows-ime): stop explorer.exe AppHang from IME pipe server shutdown

### DIFF
--- a/openless-all/app/windows-ime/src/ipc_client.cpp
+++ b/openless-all/app/windows-ime/src/ipc_client.cpp
@@ -348,6 +348,24 @@ void OpenLessPipeServer::Start(OpenLessTextService* service) {
   }
 
   stop_requested_.store(false);
+
+  // Manual-reset events: stop_event_ wakes every overlapped wait the moment
+  // Stop() runs; io_event_ is the completion event reused by each overlapped
+  // operation on the worker thread.
+  stop_event_ = CreateEventW(nullptr, TRUE, FALSE, nullptr);
+  io_event_ = CreateEventW(nullptr, TRUE, FALSE, nullptr);
+  if (stop_event_ == nullptr || io_event_ == nullptr) {
+    if (stop_event_ != nullptr) {
+      CloseHandle(stop_event_);
+      stop_event_ = nullptr;
+    }
+    if (io_event_ != nullptr) {
+      CloseHandle(io_event_);
+      io_event_ = nullptr;
+    }
+    return;
+  }
+
   pipe_name_ = PipeNameForCurrentThread();
   service_ = service;
   service_->AddRef();
@@ -356,10 +374,25 @@ void OpenLessPipeServer::Start(OpenLessTextService* service) {
 
 void OpenLessPipeServer::Stop() {
   stop_requested_.store(true);
+  if (stop_event_ != nullptr) {
+    SetEvent(stop_event_);
+  }
+
+  // The worker parks in WaitForMultipleObjects on {io_event_, stop_event_}, so
+  // signaling stop_event_ wakes it deterministically. join() then returns at
+  // once instead of blocking the host UI thread on an uncancelable
+  // ConnectNamedPipe wait — the root cause of the explorer.exe AppHang.
   if (thread_.joinable()) {
-    CancelSynchronousIo(thread_.native_handle());
-    WakePipe();
     thread_.join();
+  }
+
+  if (io_event_ != nullptr) {
+    CloseHandle(io_event_);
+    io_event_ = nullptr;
+  }
+  if (stop_event_ != nullptr) {
+    CloseHandle(stop_event_);
+    stop_event_ = nullptr;
   }
 
   if (service_ != nullptr) {
@@ -372,24 +405,14 @@ void OpenLessPipeServer::Run() {
   const std::wstring pipe_name = pipe_name_;
   while (!stop_requested_.load()) {
     HANDLE pipe = CreateNamedPipeW(
-        pipe_name.c_str(), PIPE_ACCESS_DUPLEX,
+        pipe_name.c_str(), PIPE_ACCESS_DUPLEX | FILE_FLAG_OVERLAPPED,
         PIPE_TYPE_MESSAGE | PIPE_READMODE_BYTE | PIPE_WAIT, 1,
         kPipeBufferSize, kPipeBufferSize, 0, nullptr);
     if (pipe == INVALID_HANDLE_VALUE) {
       return;
     }
 
-    {
-      std::lock_guard<std::mutex> lock(pipe_mutex_);
-      pipe_handle_ = pipe;
-    }
-
-    const BOOL connected =
-        ConnectNamedPipe(pipe, nullptr)
-            ? TRUE
-            : (GetLastError() == ERROR_PIPE_CONNECTED ? TRUE : FALSE);
-
-    if (connected && !stop_requested_.load()) {
+    if (WaitForClient(pipe) && !stop_requested_.load()) {
       std::string line;
       if (ReadJsonLine(pipe, &line)) {
         HandleSubmitLine(pipe, line);
@@ -399,14 +422,76 @@ void OpenLessPipeServer::Run() {
     FlushFileBuffers(pipe);
     DisconnectNamedPipe(pipe);
     CloseHandle(pipe);
+  }
+}
 
-    {
-      std::lock_guard<std::mutex> lock(pipe_mutex_);
-      if (pipe_handle_ == pipe) {
-        pipe_handle_ = INVALID_HANDLE_VALUE;
-      }
+bool OpenLessPipeServer::WaitForClient(HANDLE pipe) {
+  OVERLAPPED overlapped = {};
+  overlapped.hEvent = io_event_;
+  ResetEvent(io_event_);
+
+  if (ConnectNamedPipe(pipe, &overlapped)) {
+    // Overlapped ConnectNamedPipe is not expected to return TRUE, but if it
+    // does the client is already connected.
+    return true;
+  }
+
+  const DWORD error = GetLastError();
+  if (error == ERROR_PIPE_CONNECTED) {
+    return true;  // A client connected before ConnectNamedPipe was called.
+  }
+  if (error != ERROR_IO_PENDING) {
+    return false;  // Genuine failure establishing the connection.
+  }
+
+  const HANDLE wait_handles[2] = {io_event_, stop_event_};
+  const DWORD wait = WaitForMultipleObjects(2, wait_handles, FALSE, INFINITE);
+  if (wait == WAIT_OBJECT_0) {
+    DWORD transferred = 0;
+    return GetOverlappedResult(pipe, &overlapped, &transferred, FALSE) != 0;
+  }
+
+  // Stop requested (or the wait failed): cancel the pending connect and block
+  // until the kernel is finished with the stack OVERLAPPED before returning.
+  CancelIoEx(pipe, &overlapped);
+  DWORD transferred = 0;
+  GetOverlappedResult(pipe, &overlapped, &transferred, TRUE);
+  return false;
+}
+
+bool OpenLessPipeServer::RunOverlapped(HANDLE pipe,
+                                       bool is_write,
+                                       void* buffer,
+                                       DWORD length,
+                                       DWORD* bytes) {
+  *bytes = 0;
+
+  OVERLAPPED overlapped = {};
+  overlapped.hEvent = io_event_;
+  ResetEvent(io_event_);
+
+  const BOOL started =
+      is_write ? WriteFile(pipe, buffer, length, nullptr, &overlapped)
+               : ReadFile(pipe, buffer, length, nullptr, &overlapped);
+  if (!started) {
+    const DWORD error = GetLastError();
+    if (error != ERROR_IO_PENDING) {
+      return false;  // e.g. ERROR_BROKEN_PIPE once the client disconnects.
+    }
+
+    const HANDLE wait_handles[2] = {io_event_, stop_event_};
+    const DWORD wait = WaitForMultipleObjects(2, wait_handles, FALSE, INFINITE);
+    if (wait != WAIT_OBJECT_0) {
+      // Stop requested (or the wait failed): cancel and drain before the stack
+      // OVERLAPPED and caller buffer go out of scope.
+      CancelIoEx(pipe, &overlapped);
+      DWORD drained = 0;
+      GetOverlappedResult(pipe, &overlapped, &drained, TRUE);
+      return false;
     }
   }
+
+  return GetOverlappedResult(pipe, &overlapped, bytes, FALSE) != 0;
 }
 
 bool OpenLessPipeServer::ReadJsonLine(HANDLE pipe, std::string* line) {
@@ -415,12 +500,8 @@ bool OpenLessPipeServer::ReadJsonLine(HANDLE pipe, std::string* line) {
 
   while (!stop_requested_.load() && line->size() < kMaxJsonLineBytes) {
     DWORD bytes_read = 0;
-    if (!ReadFile(pipe, buffer, sizeof(buffer), &bytes_read, nullptr)) {
-      const DWORD error = GetLastError();
-      if (error == ERROR_MORE_DATA && bytes_read > 0) {
-        line->append(buffer, buffer + bytes_read);
-        continue;
-      }
+    if (!RunOverlapped(pipe, /*is_write=*/false, buffer, sizeof(buffer),
+                       &bytes_read)) {
       return !line->empty();
     }
 
@@ -492,20 +573,8 @@ bool OpenLessPipeServer::WriteResult(HANDLE pipe,
   }
 
   DWORD bytes_written = 0;
-  return WriteFile(pipe, utf8_response.data(),
-                   static_cast<DWORD>(utf8_response.size()), &bytes_written,
-                   nullptr) &&
+  return RunOverlapped(pipe, /*is_write=*/true, utf8_response.data(),
+                       static_cast<DWORD>(utf8_response.size()),
+                       &bytes_written) &&
          bytes_written == utf8_response.size();
-}
-
-void OpenLessPipeServer::WakePipe() {
-  if (pipe_name_.empty()) {
-    return;
-  }
-  HANDLE pipe =
-      CreateFileW(pipe_name_.c_str(), GENERIC_READ | GENERIC_WRITE, 0, nullptr,
-                  OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr);
-  if (pipe != INVALID_HANDLE_VALUE) {
-    CloseHandle(pipe);
-  }
 }

--- a/openless-all/app/windows-ime/src/ipc_client.h
+++ b/openless-all/app/windows-ime/src/ipc_client.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <atomic>
-#include <mutex>
 #include <string>
 #include <thread>
 #include <windows.h>
@@ -20,18 +19,27 @@ class OpenLessPipeServer {
 
  private:
   void Run();
+  bool WaitForClient(HANDLE pipe);
   bool ReadJsonLine(HANDLE pipe, std::string* line);
   void HandleSubmitLine(HANDLE pipe, const std::string& line);
   bool WriteResult(HANDLE pipe,
                    const std::wstring& session_id,
                    const wchar_t* status,
                    const wchar_t* error_code);
-  void WakePipe();
+  // Issues one overlapped read or write and waits until it completes or the
+  // stop event is signaled. Returns true only on successful completion, with
+  // the transferred byte count stored in *bytes. Overlapped I/O keeps every
+  // pipe wait cancelable so Stop() never blocks the host process UI thread.
+  bool RunOverlapped(HANDLE pipe,
+                     bool is_write,
+                     void* buffer,
+                     DWORD length,
+                     DWORD* bytes);
 
   std::atomic<bool> stop_requested_{false};
   std::thread thread_;
-  std::mutex pipe_mutex_;
-  HANDLE pipe_handle_ = INVALID_HANDLE_VALUE;
+  HANDLE stop_event_ = nullptr;
+  HANDLE io_event_ = nullptr;
   std::wstring pipe_name_;
   OpenLessTextService* service_ = nullptr;
 };


### PR DESCRIPTION
### **User description**
## 问题 / Problem

Windows 11 上开启 OpenLess 后，资源管理器 / 任务栏偶发（部分机器必现）无响应，`explorer.exe` 记录 `AppHangB1`，随后自动重启。见 #707、#665。

`OpenLessIme.dll` 是**系统级启用的 TSF 键盘输入法（TIP）**，Windows CTF 会把它注入**每一个有文本输入的进程**（含 `explorer.exe`、任务栏），并运行在各宿主进程的 **UI 线程**上。#665 的 WER 日志证实挂起时 `OpenLessIme.dll` 就加载在 `explorer.exe` 里，且禁用该 TSF 配置后 12+ 小时不复现、重新启用又复现。

## 根因 / Root cause

`windows-ime/src/ipc_client.cpp` 的管道服务器关闭路径会挂死宿主 UI 线程：

- 后台 worker 线程在 `ConnectNamedPipe(pipe, nullptr)` 上**同步、无限阻塞**等待客户端。
- TSF 在切输入法 / 焦点 / 线程销毁时于**宿主 UI 线程**调用 `Deactivate() → Stop() → thread.join()`，必须等 worker 退出。
- 唤醒那个阻塞只靠两个**有竞态**的机制：`CancelSynchronousIo`（worker 尚未进入阻塞调用时是 no-op）和自连接 `WakePipe()`（与 `Run()` 创建/关闭管道的窗口期竞态，命中 `ERROR_FILE_NOT_FOUND`/`ERROR_PIPE_BUSY` 即静默失效）。
- 两个唤醒都输掉竞态时，worker 重新进入 `ConnectNamedPipe` 永久阻塞，`join()` 就把宿主 UI 线程**永久冻结** → `explorer.exe AppHangB1`。竞态性质解释了「偶发 vs 必现」的差异。

## 修复 / Fix

把每一次管道等待都改成**可确定性取消**：

- 管道用 `FILE_FLAG_OVERLAPPED` 打开；新增两个手动复位事件 `stop_event_` / `io_event_`（在 `Start()` 里、spawn 线程前创建，`Stop()` join 之后关闭）。
- 连接 / 读 / 写统一走新的 `WaitForClient` / `RunOverlapped`，都用 `WaitForMultipleObjects({io_event_, stop_event_})` 等待；停止或超时路径 `CancelIoEx` + `GetOverlappedResult(bWait=TRUE)` 排空栈上 `OVERLAPPED` 与缓冲区后再返回。
- `Stop()` 现在只需 `SetEvent(stop_event_)` 再 `join()`——**立即返回，永不阻塞宿主 UI 线程，也不泄漏 worker 线程**。
- 删除竞态的 `WakePipe` / `CancelSynchronousIo` / `pipe_handle_` / `pipe_mutex_`。

**管道名、JSON 线协议、Rust 客户端（`windows_ime_ipc.rs`）完全不变**——只改宿主进程内那段等待逻辑。

## 验证 / Verification

- ✅ 独立 C++ 评审（逐行）：OVERLAPPED 生命周期、`io_event_` 复用、`ConnectNamedPipe` 语义（`ERROR_PIPE_CONNECTED`/`ERROR_IO_PENDING`/同步完成）、泄漏 / 双重 Stop / Start-after-Stop / Stop-without-Start、死锁、排空路径——**无 CRITICAL/HIGH/MEDIUM 正确性问题**。
- ⚠️ **CI 不编译该 DLL**：`ci.yml` 四平台门禁只做 Rust/前端，`OpenLessIme.dll` 仅在 `release-tauri.yml`（MSBuild / C++17 / `/MT`）发版时编译。因此本 PR 的 CI 绿 **不代表** C++ 已编译验证。
- ⬜ **待人工验证（Windows 实机）**：
  1. Windows 上 `scripts/windows-ime-build.ps1 -Configuration Release -Platform x64` 编译通过；
  2. 装 IME、日常使用，切输入法 / 焦点期间不再出现 `explorer.exe` `AppHangB1`；
  3. 语音听写插入（TSF 提交）功能回归正常。

## 备注 / Notes

- 独立评审另指出一处**有界、非本次范围**的既有细节：若 `Deactivate` 那一刻恰有一次听写正通过 `SubmitTextFromPipe` 的 `SendMessageTimeoutW`（2s 上限）提交，`Stop()` 的 `join()` 至多被拖慢约 2 秒——远低于 AppHang 的 ~5s 阈值，且本 PR 之前就存在，未改动。
- `openless-all/app-opencode/windows-ime/` 有一份未打包的同源副本，存在同样的 bug，但不参与发版构建，本 PR 未改动。
- 🔴 未触碰更新器签名公钥，无版本号变更。

Fixes #665
Fixes #707

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Bug fix


___

### **Description**
- Converted pipe server to overlapped I/O with events.

- Made Stop() immediately cancel waits via stop_event.

- Removed racy WakePipe and CancelSynchronousIo.

- Prevented UI thread freeze on shutdown.


___

### Diagram Walkthrough


```mermaid
flowchart LR
    Old["Sync ConnectNamedPipe"] -->|"blocked indefinitely"| Hang["explorer.exe AppHang"]
    New["Overlapped ConnectNamedPipe + stop_event"] -->|"deterministic cancel"| Exit["thread.join() returns promptly"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ipc_client.cpp</strong><dd><code>Convert pipe server to overlapped I/O with stop event</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/windows-ime/src/ipc_client.cpp

<ul><li>Added event handles (stop_event_, io_event_) for deterministic <br>cancellation.<br> <li> Replaced synchronous ConnectNamedPipe with overlapped WaitForClient.<br> <li> Replaced ReadFile/WriteFile with RunOverlapped for cancelable I/O.<br> <li> Removed racy WakePipe and CancelSynchronousIo calls.<br> <li> Updated Start/Stop to manage event lifecycle.</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/764/files#diff-f463292d4d0d98918e9181082f26497fe7ac9f0d8f04b6e26187a6bdaf2f2fc5">+109/-40</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ipc_client.h</strong><dd><code>Update header for overlapped I/O changes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/windows-ime/src/ipc_client.h

<ul><li>Removed pipe_mutex_, pipe_handle_ fields.<br> <li> Added stop_event_, io_event_ HANDLE fields.<br> <li> Declared WaitForClient and RunOverlapped methods.<br> <li> Removed WakePipe declaration.</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/764/files#diff-6598db0c81d3cc68f02820cd12cfc04450e3b4ff17e75deaa5c5b45e56cf71e3">+12/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

