### PR TITLE
fix(asr): 百炼连接检查修复验证必败(EmptyAudio)并真实校验连通性与协议头

### DIFF
--- a/openless-all/app/src-tauri/src/asr/bailian.rs
+++ b/openless-all/app/src-tauri/src/asr/bailian.rs
@@ -62,6 +62,16 @@ impl BailianCredentials {
     }
 }
 
+/// Bailian 实时 ASR 走 DashScope WebSocket 网关，接口地址只接受 ws:// 或
+/// wss://。用户容易把百炼控制台的 `https://` 兼容模式 / 专属域名地址粘进来
+/// ——那是另一套 HTTP 协议，WebSocket 握手必然失败且底层报错
+/// （"URL scheme not supported"）对用户不可读。在验证入口先拦下，
+/// 前端据 `bailianEndpointSchemeInvalid` 错误码给出可操作的提示。
+pub fn endpoint_scheme_is_websocket(endpoint: &str) -> bool {
+    let lower = endpoint.trim().to_ascii_lowercase();
+    lower.starts_with("wss://") || lower.starts_with("ws://")
+}
+
 #[derive(Debug, thiserror::Error)]
 pub enum BailianASRError {
     #[error("credentials missing")]
@@ -879,6 +889,23 @@ mod tests {
     }
 
     // ---- existing tests kept ----
+
+    #[test]
+    fn endpoint_scheme_accepts_websocket_only() {
+        assert!(endpoint_scheme_is_websocket(DEFAULT_ENDPOINT));
+        assert!(endpoint_scheme_is_websocket("ws://localhost:9000/api-ws"));
+        assert!(endpoint_scheme_is_websocket(
+            "  WSS://dashscope.aliyuncs.com/api-ws/v1/inference/  "
+        ));
+        // 百炼控制台的 https 兼容模式 / 专属域名地址不是 WebSocket 网关
+        assert!(!endpoint_scheme_is_websocket(
+            "https://llm-xxx.cn-beijing.maas.aliyuncs.com/compatible-mode/v1"
+        ));
+        assert!(!endpoint_scheme_is_websocket(
+            "http://dashscope.aliyuncs.com/api-ws/v1/inference/"
+        ));
+        assert!(!endpoint_scheme_is_websocket(""));
+    }
 
     #[test]
     fn credentials_apply_default_endpoint_and_model() {

--- a/openless-all/app/src-tauri/src/commands/providers.rs
+++ b/openless-all/app/src-tauri/src/commands/providers.rs
@@ -28,6 +28,11 @@ pub async fn validate_provider_credentials(kind: String) -> Result<ProviderCheck
 #[tauri::command]
 pub async fn list_provider_models(kind: String) -> Result<ProviderModelsResult, String> {
     if kind == "asr" && CredentialsVault::get_active_asr() == crate::asr::bailian::PROVIDER_ID {
+        // Bailian 实时 ASR 没有模型列表 HTTP 接口，列表只能是静态的。但直接返回
+        // 硬编码列表会让「拉取模型」在 Key / endpoint 全错时也显示成功，给用户
+        // "已连通"的错觉（其他厂商这颗按钮是真实带 Key GET /models）。先跑一次
+        // 与「验证」相同的 WebSocket 连通性检查，语义对齐后再返回静态列表。
+        validate_bailian_asr_provider().await?;
         return Ok(ProviderModelsResult {
             models: vec![crate::asr::bailian::DEFAULT_MODEL.to_string()],
         });
@@ -229,6 +234,12 @@ async fn validate_bailian_asr_provider() -> Result<(), String> {
         .map_err(|e| e.to_string())?
         .filter(|s| !s.trim().is_empty())
         .unwrap_or_else(|| crate::asr::bailian::DEFAULT_ENDPOINT.to_string());
+    // 协议头先行校验：填成 https://（百炼兼容模式 / 专属域名地址）时，WebSocket
+    // 握手报的 "URL scheme not supported" 会被前端兜底成笼统的「操作失败」，
+    // 用户无从定位。这里拦下并返回专用错误码，前端映射成可操作的提示。
+    if !crate::asr::bailian::endpoint_scheme_is_websocket(&endpoint) {
+        return Err("bailianEndpointSchemeInvalid".to_string());
+    }
     let model = CredentialsVault::get(CredentialAccount::AsrModel)
         .map_err(|e| e.to_string())?
         .filter(|s| !s.trim().is_empty())
@@ -245,9 +256,12 @@ async fn validate_bailian_asr_provider() -> Result<(), String> {
         },
     ));
     asr.open_session().await.map_err(|e| e.to_string())?;
+    // 验证音频必须 ≥200ms：只发 1 个 100ms 静音块时 DashScope 必然返回
+    // task-failed: EmptyAudio，导致有效凭据也永远验证失败（2026-07 实测边界：
+    // 100ms 拒、200ms 起收）。取 500ms 留余量，与 Mimo 验证的 250ms 同量级。
     crate::asr::AudioConsumer::consume_pcm_chunk(
         &*asr,
-        &vec![0u8; crate::asr::bailian::TARGET_AUDIO_CHUNK_BYTES],
+        &vec![0u8; crate::asr::bailian::TARGET_AUDIO_CHUNK_BYTES * 5],
     );
     asr.send_last_frame().await.map_err(|e| e.to_string())?;
     asr.await_final_result()

--- a/openless-all/app/src/i18n/en.ts
+++ b/openless-all/app/src/i18n/en.ts
@@ -837,6 +837,7 @@ export const en: typeof zhCN = {
       providerHttpStatus: 'Provider returned HTTP {{status}}. Check the API key permissions or endpoint.',
       endpointMustUseHttps: 'HTTP endpoints are allowed, but API keys and audio content may leak in transit.',
       endpointInvalid: 'Endpoint format is invalid.',
+      bailianEndpointSchemeInvalid: 'Bailian realtime ASR uses the DashScope WebSocket gateway: the endpoint must start with wss:// (default: wss://dashscope.aliyuncs.com/api-ws/v1/inference/). An https:// compatible-mode URL will not work here.',
       responseTooLarge: 'Provider response is too large to validate safely.',
       asrInvalidJson: 'ASR response is not valid JSON.',
       asrMissingTextField: 'ASR response is missing the text field.',

--- a/openless-all/app/src/i18n/ja.ts
+++ b/openless-all/app/src/i18n/ja.ts
@@ -839,6 +839,7 @@ export const ja: typeof zhCN = {
       providerHttpStatus: 'サプライヤーが {{status}} を返しました。API Key 権限またはエンドポイントを確認してください。',
       endpointMustUseHttps: 'HTTP Endpoint も使用できますが、API Key と音声内容が通信中に漏えいする可能性があります。',
       endpointInvalid: 'Endpoint の形式が無効です。',
+      bailianEndpointSchemeInvalid: 'Bailian リアルタイム ASR は DashScope の WebSocket ゲートウェイを使用します。エンドポイントは wss:// で始まる必要があります（既定: wss://dashscope.aliyuncs.com/api-ws/v1/inference/）。https:// の互換モード URL はここでは使用できません。',
       responseTooLarge: 'サプライヤーの応答が大きすぎるため、安全のため検証を停止しました。',
       asrInvalidJson: 'ASR の応答が有効な JSON ではありません。',
       asrMissingTextField: 'ASR の応答に text フィールドがありません。',

--- a/openless-all/app/src/i18n/ko.ts
+++ b/openless-all/app/src/i18n/ko.ts
@@ -839,6 +839,7 @@ export const ko: typeof zhCN = {
       providerHttpStatus: '공급자가 {{status}} 를 반환했습니다. API Key 권한 또는 Endpoint 를 확인해 주세요.',
       endpointMustUseHttps: 'HTTP Endpoint 를 사용할 수 있지만, API Key 와 음성 내용이 전송 중 유출될 수 있습니다.',
       endpointInvalid: 'Endpoint 형식이 올바르지 않습니다.',
+      bailianEndpointSchemeInvalid: 'Bailian 실시간 ASR은 DashScope WebSocket 게이트웨이를 사용합니다. 엔드포인트는 wss://로 시작해야 합니다(기본값: wss://dashscope.aliyuncs.com/api-ws/v1/inference/). https:// 호환 모드 주소는 여기서 사용할 수 없습니다.',
       responseTooLarge: '공급자 응답이 너무 커서 안전을 위해 검증을 중단했습니다.',
       asrInvalidJson: 'ASR 응답이 유효한 JSON 이 아닙니다.',
       asrMissingTextField: 'ASR 응답에 text 필드가 없습니다.',

--- a/openless-all/app/src/i18n/zh-CN.ts
+++ b/openless-all/app/src/i18n/zh-CN.ts
@@ -835,6 +835,7 @@ export const zhCN = {
       providerHttpStatus: '供应商接口返回 {{status}}，请检查 API Key 权限或 Endpoint。',
       endpointMustUseHttps: '允许使用 HTTP Endpoint，但请注意：API Key 和音频内容可能在传输中泄漏。',
       endpointInvalid: 'Endpoint 格式不合法。',
+      bailianEndpointSchemeInvalid: '百炼实时 ASR 走 DashScope WebSocket 网关，接口地址必须以 wss:// 开头（默认 wss://dashscope.aliyuncs.com/api-ws/v1/inference/）；https:// 的兼容模式地址在此不可用。',
       responseTooLarge: '供应商响应过大，已停止验证以保证安全。',
       asrInvalidJson: 'ASR 响应不是有效 JSON。',
       asrMissingTextField: 'ASR 响应缺少 text 字段。',

--- a/openless-all/app/src/i18n/zh-TW.ts
+++ b/openless-all/app/src/i18n/zh-TW.ts
@@ -837,6 +837,7 @@ export const zhTW: typeof zhCN = {
       providerHttpStatus: '供應商接口返回 {{status}}，請檢查 API Key 權限或 Endpoint。',
       endpointMustUseHttps: '允許使用 HTTP Endpoint，但請注意：API Key 和音訊內容可能在傳輸中外洩。',
       endpointInvalid: 'Endpoint 格式不合法。',
+      bailianEndpointSchemeInvalid: '百煉即時 ASR 走 DashScope WebSocket 閘道，接口地址必須以 wss:// 開頭（預設 wss://dashscope.aliyuncs.com/api-ws/v1/inference/）；https:// 的相容模式地址在此不可用。',
       responseTooLarge: '供應商響應過大，已停止驗證以保證安全。',
       asrInvalidJson: 'ASR 響應不是有效 JSON。',
       asrMissingTextField: 'ASR 響應缺少 text 字段。',

--- a/openless-all/app/src/pages/settings/ProvidersSection.tsx
+++ b/openless-all/app/src/pages/settings/ProvidersSection.tsx
@@ -621,6 +621,7 @@ function providerErrorMessage(error: unknown, t: ReturnType<typeof useTranslatio
   }
   if (message === 'endpointMustUseHttps') return t('settings.providers.endpointMustUseHttps');
   if (message === 'endpointInvalid') return t('settings.providers.endpointInvalid');
+  if (message === 'bailianEndpointSchemeInvalid') return t('settings.providers.bailianEndpointSchemeInvalid');
   if (message === 'providerResponseTooLarge') return t('settings.providers.responseTooLarge');
   if (message === 'asrInvalidJson') return t('settings.providers.asrInvalidJson');
   if (message === 'asrMissingTextField') return t('settings.providers.asrMissingTextField');


### PR DESCRIPTION
### **User description**
## 摘要

Fixes #772。

「阿里云百炼实时 ASR」的连接检查此前完全不可用：「验证」对有效凭据也必然失败（EmptyAudio），「拉取模型」不发网络请求永远假成功，接口地址填错协议头时只报笼统「操作失败」。本 PR 修复验证必败的根因，并让两颗按钮的语义与其他厂商对齐。

## 修复 / 新增 / 改进

- **验证必败修复**（根因）：`validate_bailian_asr_provider` 原来只发 1 个 100ms 静音块，DashScope 对 <200ms 音频固定返回 `task-failed: EmptyAudio`（2026-07 实测边界：单帧 100ms 拒、200ms 起收）。改为发送 500ms 静音（5×`TARGET_AUDIO_CHUNK_BYTES`），与 Mimo 验证的 250ms 同量级。
- `list_provider_models` 的 bailian 分支在返回静态列表前先执行与「验证」相同的 WebSocket 连通性检查（百炼无模型列表 HTTP 接口，列表仍为静态，但失败路径不再被吞掉）。
- 验证前校验接口地址协议头必须为 `ws://` / `wss://`，否则返回 `bailianEndpointSchemeInvalid` 错误码；新增 `endpoint_scheme_is_websocket` 帮助函数与单元测试；前端 + i18n×5（en / zh-CN / zh-TW / ja / ko）映射为含默认 wss 地址的明确提示。

## 兼容

- 不包含：`xiaomi-mimo-asr` 的「拉取模型」同样是硬编码假成功（同类残留，未在本 PR 展开）；听写运行时路径不变（真实语音远超 200ms，不受 EmptyAudio 影响）。
- 对现有用户 / 本地环境 / 构建流程的影响：凭据格式、默认值、协议实现均未变。行为变化仅在设置页「连接检查」：验证从必败变为如实反映凭据状态；拉取模型从必成功变为凭据错误时如实报错。

## 测试计划

- [x] 命令：`cargo test --manifest-path src-tauri/Cargo.toml` → 555 passed / 0 failed
- [x] 命令：`npm run build`（tsc + vite）→ 通过
- [x] 协议行为：独立 WebSocket 脚本对 DashScope 线上实测——单帧 100ms 静音 → `task-failed: EmptyAudio`；200/300/500/1000ms → `task-finished`；`https://` 地址 → 握手 "URL scheme not supported"。
- [x] 手工验证（macOS 15 / Apple Silicon，`scripts/build-mac.sh` 本地构建安装）：
  - 有效 Key + 默认 wss 地址 → 验证通过（正式版 1.3.14 上同配置必失败）；拉取模型成功。
  - 接口地址填 `https://...maas.aliyuncs.com...` → 显示"接口地址必须以 wss:// 开头"明确提示。
  - 错误 Key → 验证 / 拉取模型均如实报错。
  - 正常听写不受影响。


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fixed validation always failing (EmptyAudio) by sending 500ms silence.

- Added real WebSocket connectivity check to "list provider models".

- Validated endpoint scheme (ws:///wss://) and returned specific error.

- Added i18n and frontend mapping for new error code across 5 languages.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Validate / List Models"] --> B{"Endpoint starts with ws:// or wss://?"};
  B -- No --> C["Return bailianEndpointSchemeInvalid error"];
  B -- Yes --> D["Send 500ms silence (5 chunks)"];
  D --> E["WebSocket connectivity check"];
  E -- Success --> F["Return model list (static)"];
  E -- Failure --> G["Return error from provider"];
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>bailian.rs</strong><dd><code>Added endpoint_scheme_is_websocket helper and test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/773/files#diff-143936d94ea5692befd16a4fac03dd1af84c868d0134ba7231b7b8a873fc44d4">+27/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ProvidersSection.tsx</strong><dd><code>Mapped new error code to translated message</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/773/files#diff-8fc332d1eb5b010583185b704ea439954650f6aff2d0195e00cd0cb76e526e7b">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>providers.rs</strong><dd><code>Fixed validation interval and added scheme check</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/773/files#diff-be85f4e6da802ac2f767525263e432add7c7ed2cc175d0d400e888cb2d672ece">+15/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>en.ts</strong><dd><code>Added bailianEndpointSchemeInvalid error message</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/773/files#diff-bb2f4fa05787923f8aeb23b6f11ad8705e02d9ff03a45790f9181e4615c79d83">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ja.ts</strong><dd><code>Added bailianEndpointSchemeInvalid in Japanese</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/773/files#diff-be57f0090cf34e3ff924cfa35f13d5d9e6514d3af5a1ebfdeb92bd7d36ed9cf4">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ko.ts</strong><dd><code>Added bailianEndpointSchemeInvalid in Korean</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/773/files#diff-daf35bcb6a2f8a31565b83d119cb59b69c1dededbabfccfd0d56693fdb3726ca">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>zh-CN.ts</strong><dd><code>Added bailianEndpointSchemeInvalid in Chinese (Simplified)</code></dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/773/files#diff-571576f3c7b6c4a78ae0f91accdccc5da5cbed00409955c9914c046fee6c80ea">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>zh-TW.ts</strong><dd><code>Added bailianEndpointSchemeInvalid in Chinese (Traditional)</code></dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/773/files#diff-a8d5953f9c76bc3c90ec583270be04c852bd7540297500e6ff3260760fc61ea4">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

