### PR TITLE
fix(linux): prevent startup panic from unrealized capsule GDK window | fix(linux): 修复胶囊窗口因 GDK 未实例化导致的启动崩溃

### DIFF
--- a/openless-all/app/src-tauri/Cargo.lock
+++ b/openless-all/app/src-tauri/Cargo.lock
@@ -3909,6 +3909,7 @@ dependencies = [
  "futures-util",
  "getrandom 0.3.4",
  "global-hotkey",
+ "gtk",
  "hmac",
  "hyper",
  "hyper-util",

--- a/openless-all/app/src-tauri/Cargo.toml
+++ b/openless-all/app/src-tauri/Cargo.toml
@@ -90,6 +90,7 @@ features = ["windows-native"]
 
 [target.'cfg(target_os = "linux")'.dependencies]
 dbus = "0.9"
+gtk = "0.18"
 [target.'cfg(all(unix, not(target_os = "macos"), not(target_os = "android")))'.dependencies.keyring]
 version = "3.6.3"
 default-features = false

--- a/openless-all/app/src-tauri/src/lib.rs
+++ b/openless-all/app/src-tauri/src/lib.rs
@@ -95,6 +95,9 @@ use std::sync::mpsc;
 use std::sync::Arc;
 use std::time::Duration;
 
+#[cfg(target_os = "linux")]
+use gtk::prelude::WidgetExt;
+
 const LOG_ROTATE_LIMIT_BYTES: u64 = 10 * 1024 * 1024;
 #[cfg(target_os = "macos")]
 const OPENLESS_BUNDLE_ID: &str = "com.openless.app";
@@ -520,20 +523,27 @@ fn run_desktop() {
                 }
                 // 纯光效舞台没有任何可点元素（✕/✓ 按钮已移除），而窗口放大到 460×180
                 // 盖住屏幕底部中央 —— 必须鼠标穿透，否则会挡住底下应用的点击。
-                //
-                // Linux (X11) 兼容：tao 在调用 set_ignore_cursor_events 时要求 GDK
-                // 窗口已实例化（window.window() 返回 Some），但 Capsule 在
-                // tauri.conf.json 中定义 visible=false → GDK 窗口从未 real ize →
-                // tao event_loop.rs:457 unwrap() 崩溃。
-                // 解决办法：先移到屏幕外，show() 强制 GDK 实例化，然后再设穿透。
-                // 参考 voicebox PR#837: https://github.com/jamiepine/voicebox/pull/837
+                // Linux 下 tao 的鼠标穿透实现会直接解包底层 GDK 窗口；visible=false 时
+                // 窗口尚未 realize。这里只创建窗口系统资源而不 map，避免 X11 崩溃，
+                // 也不会像 show() 那样在不支持窗口定位的 Wayland 上造成启动闪窗。
                 #[cfg(target_os = "linux")]
-                {
-                    let _ = capsule.set_position(tauri::LogicalPosition::new(-10000.0, -10000.0));
-                    let _ = capsule.show();
-                }
-                if let Err(e) = capsule.set_ignore_cursor_events(true) {
-                    log::warn!("[capsule] set_ignore_cursor_events failed: {e}");
+                let cursor_passthrough_ready = match capsule.gtk_window() {
+                    Ok(gtk_window) => {
+                        gtk_window.realize();
+                        true
+                    }
+                    Err(e) => {
+                        log::warn!("[capsule] gtk_window failed; skipping cursor passthrough: {e}");
+                        false
+                    }
+                };
+                #[cfg(not(target_os = "linux"))]
+                let cursor_passthrough_ready = true;
+
+                if cursor_passthrough_ready {
+                    if let Err(e) = capsule.set_ignore_cursor_events(true) {
+                        log::warn!("[capsule] set_ignore_cursor_events failed: {e}");
+                    }
                 }
                 if let Err(e) = position_capsule_bottom_center(&capsule, false) {
                     log::warn!("[capsule] position failed: {e}");

--- a/openless-all/app/src-tauri/src/lib.rs
+++ b/openless-all/app/src-tauri/src/lib.rs
@@ -520,6 +520,18 @@ fn run_desktop() {
                 }
                 // 纯光效舞台没有任何可点元素（✕/✓ 按钮已移除），而窗口放大到 460×180
                 // 盖住屏幕底部中央 —— 必须鼠标穿透，否则会挡住底下应用的点击。
+                //
+                // Linux (X11) 兼容：tao 在调用 set_ignore_cursor_events 时要求 GDK
+                // 窗口已实例化（window.window() 返回 Some），但 Capsule 在
+                // tauri.conf.json 中定义 visible=false → GDK 窗口从未 real ize →
+                // tao event_loop.rs:457 unwrap() 崩溃。
+                // 解决办法：先移到屏幕外，show() 强制 GDK 实例化，然后再设穿透。
+                // 参考 voicebox PR#837: https://github.com/jamiepine/voicebox/pull/837
+                #[cfg(target_os = "linux")]
+                {
+                    let _ = capsule.set_position(tauri::LogicalPosition::new(-10000.0, -10000.0));
+                    let _ = capsule.show();
+                }
                 if let Err(e) = capsule.set_ignore_cursor_events(true) {
                     log::warn!("[capsule] set_ignore_cursor_events failed: {e}");
                 }


### PR DESCRIPTION
### **User description**
## Problem

OpenLess crashes on Linux X11 immediately at startup with:



## Root Cause

The capsule window is defined in `tauri.conf.json` with `visible: false` + `transparent: true`. On Linux/GTK3, a hidden window never has its underlying GDK window realized. When `capsule.set_ignore_cursor_events(true)` is called during startup, tao internally calls `window.window().unwrap()` which returns `None` for the unrealized window — panic.

This is the same issue reported in:
- voicebox [#680](https://github.com/jamiepine/voicebox/issues/680) / [PR#837](https://github.com/jamiepine/voicebox/pull/837)
- tao [#635](https://github.com/tauri-apps/tao/issues/635)

## Fix

Before calling `set_ignore_cursor_events`, move the window off-screen and call `show()` to force GDK window realization. The window is then repositioned correctly by the existing `position_capsule_bottom_center()` and hidden as normal.

The change is Linux-only (`#[cfg(target_os = "linux")]`) and confined to the capsule setup block; no other call sites are touched.

## Testing

Verified on Deepin Linux 23 (X11, DDE/kwin_x11):
- Before: crashes 100% on startup
- After: app initializes normally, hotkey listeners register, tray icon appears, capsule shows/hides on speak

## References

- voicebox PR#837 (same fix approach): https://github.com/jamiepine/voicebox/pull/837


___

### **PR Type**
Bug fix


___

### **Description**
- Prevent Linux X11 crash when capsule window has `visible: false` + `transparent: true`

- Force GDK window realization via `gtk_window.realize()` before setting cursor passthrough

- Avoids `window.window().unwrap()` panic in tao’s Linux event loop


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A[Capsule window created with visible=false] --> B[gtk_window? Ok]
  B --> C[gtk_window.realize()]
  C --> D[set_ignore_cursor_events true]
  D --> E[Position capsule normally]
  B --> F[Err: skip cursor passthrough]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>lib.rs</strong><dd><code>Force GDK window realization on Linux before input passthrough</code></dd></summary>
<hr>

openless-all/app/src-tauri/src/lib.rs

<ul><li>Added <code>use gtk::prelude::WidgetExt;</code> under <code>#[cfg(target_os = "linux")]</code><br> <li> Before <code>set_ignore_cursor_events</code>, retrieve GTK window and call <br><code>realize()</code> to force GDK window creation<br> <li> Only execute cursor passthrough if GTK window is obtained successfully</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/792/files#diff-6b8eb1bbf8e378bab914f1a12962f7add5cc4ba9e013c37c9921a1032fa5e110">+24/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Cargo.toml</strong><dd><code>Add gtk crate dependency for Linux build</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src-tauri/Cargo.toml

- Added `gtk = "0.18"` dependency for Linux target


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/792/files#diff-334952ba03e62939865bbf0351f0916ea88c6457f8ea1259336e73ee4e2f088b">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

