### PR TITLE
fix(local-asr): 本地 Qwen3 模型在云端 provider 下误标「当前使用」

### DIFF
--- a/openless-all/app/src/pages/LocalAsr/index.tsx
+++ b/openless-all/app/src/pages/LocalAsr/index.tsx
@@ -2831,7 +2831,15 @@ export function LocalAsr({ embedded = false }: LocalAsrProps = {}) {
                             modelDir={modelDirs[model.id] ?? ""}
                             remoteSize={remoteSizes[model.id]}
                             progress={progress[model.id]}
-                            isActive={settings?.activeModel === model.id}
+                            // 「当前使用」只在本地 Qwen3 确实是激活的 ASR provider 时才亮。
+                            // settings.activeModel 只是本地引擎内部「选中的模型」(默认
+                            // qwen3-asr-0.6b),不代表整体在用本地 ASR——否则用户在跑云端
+                            // (火山/百炼)时这里仍误标 0.6B「当前使用」。与 foundry/sherpa/
+                            // apple 三处的 activeAsrProvider 门保持一致。
+                            isActive={
+                                settings?.activeModel === model.id &&
+                                prefs?.activeAsrProvider === "local-qwen3"
+                            }
                             engineAvailable={engineAvailable}
                             disabled={
                                 busyModelId !== null && busyModelId !== model.id

--- a/openless-all/app/src/pages/LocalAsr/index.tsx
+++ b/openless-all/app/src/pages/LocalAsr/index.tsx
@@ -766,6 +766,16 @@ export function LocalAsr({ embedded = false }: LocalAsrProps = {}) {
             await setLocalAsrActiveModel(modelId)
             // 顺手把 active provider 也切到本地（避免用户改了模型却忘了切 provider）
             await setActiveAsrProvider("local-qwen3")
+            await updatePrefs((current) =>
+                current.activeAsrProvider === "local-qwen3" &&
+                current.localAsrActiveModel === modelId
+                    ? current
+                    : {
+                          ...current,
+                          activeAsrProvider: "local-qwen3",
+                          localAsrActiveModel: modelId,
+                      },
+            )
             await refresh()
         } catch (e) {
             setError(e instanceof Error ? e.message : String(e))


### PR DESCRIPTION
### **User description**
## 摘要

macOS 本地 Qwen3 模型列表里,即使当前用的是云端 ASR(火山 / 百炼),0.6B 模型仍被误标「当前使用」。

## 修复 / 新增 / 改进

- `ModelRow` 的 `isActive` 原本只判 `settings.activeModel === model.id`——那只是本地引擎内部「选中的模型」(默认 `qwen3-asr-0.6b`),不代表整体在用本地 ASR。改为同时判 `prefs?.activeAsrProvider === 'local-qwen3'`,与 foundry / sherpa / apple 三处的 `activeAsrProvider` 判定对齐。

## 兼容

- 纯前端显示条件收紧,无数据 / 行为 / 凭据影响。

## 测试计划

- [x] 平台:macOS。ASR 选云端 provider(火山 / 百炼)→「高级 → 本地模型」→ 0.6B 不再显示「当前使用」;切回 local-qwen3 → 徽标恢复。手测通过。
- [x] 前端 `tsc`(`npm run build`)→ 通过(对 `beta` 基线)。


___

### **PR Type**
Bug fix


___

### **Description**
- Fix local Qwen3 model "currently using" badge when cloud ASR provider active

- Add check for prefs.activeAsrProvider === "local-qwen3" in ModelRow isActive logic

- Also sync prefs when setting active model to ensure consistency


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["ModelRow isActive"] --> B{Old: settings.activeModel === model.id}
  A --> C{New: settings.activeModel === model.id AND prefs.activeAsrProvider === 'local-qwen3'}
  B --> D["Badge shown even with cloud ASR"]
  C --> E["Badge only when local ASR active"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.tsx</strong><dd><code>Fix active badge logic for local models</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src/pages/LocalAsr/index.tsx

<ul><li>Updated ModelRow isActive prop to also check prefs.activeAsrProvider<br> <li> Added prefs update in handleSetActiveModel to keep activeAsrProvider <br>in sync<br> <li> Fixed mislabeling bug when cloud ASR provider is active</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/794/files#diff-366aed8b57becddf2f5cda8360c75fe60589f356d4404287e9db8b743dbd1590">+19/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

