### PR TITLE
fix(cask): update Homebrew package to v1.3.14

### DIFF
--- a/Casks/openless.rb
+++ b/Casks/openless.rb
@@ -1,9 +1,9 @@
 cask "openless" do
   arch arm: "aarch64", intel: "x64"
 
-  version "1.3.12"
-  sha256 arm:   "d6cd007e7a08ae840e93a174c6a3b125608ca4da8d56305b8eac6d3137f02b74",
-         intel: "82e67ee081206fefcc3cb93698308fc425737deca1fdac679862c1c3d6d602e6"
+  version "1.3.14"
+  sha256 arm:   "4bfa85f48714626ec010b92d22a5ab98c834f60b5c7e5f6281e12a11ad90ad9f",
+         intel: "929ad6c047fc8942724b7e1edb5dc0d88affbd2ec4184b2dd3d482c0e06d999f"
 
   url "https://github.com/appergb/openless/releases/download/v#{version}-tauri/OpenLess_#{version}_#{arch}.dmg"
   name "OpenLess"

--- a/Casks/openless.rb
+++ b/Casks/openless.rb
@@ -7,7 +7,7 @@ cask "openless" do
 
   url "https://github.com/appergb/openless/releases/download/v#{version}-tauri/OpenLess_#{version}_#{arch}.dmg"
   name "OpenLess"
-  desc "Menu-bar voice input layer for macOS"
+  desc "Menu-bar voice input layer"
   homepage "https://github.com/appergb/openless"
 
   livecheck do
@@ -16,6 +16,7 @@ cask "openless" do
   end
 
   auto_updates true
+  depends_on macos: :monterey
 
   app "OpenLess.app"
 


### PR DESCRIPTION
### **User description**
## Summary

- update the Homebrew Cask from the unavailable `v1.3.12-tauri` release to the current stable `v1.3.14-tauri` release
- set the arm64 and Intel SHA-256 values to the digests verified from the published DMG assets
- declare macOS Monterey as the minimum supported system, matching `LSMinimumSystemVersion=12.0` in both DMGs
- keep the Cask description compliant with Homebrew style rules

## Verification

- `ruby -c Casks/openless.rb`
- `brew audit --cask --strict review802/openless/openless` in a temporary local tap
- `brew readall --aliases --os all --arch all review802/openless`
- `brew style --cask review802/openless/openless`
- `brew fetch --cask --all-platforms --force --retry review802/openless/openless`
- `brew livecheck --cask review802/openless/openless` (`1.3.14 ==> 1.3.14`)
- downloaded and verified both DMGs with `hdiutil verify`; both app bundles report `LSMinimumSystemVersion=12.0`
- independently verified both SHA-256 digests
- `git diff HEAD^ HEAD --check`

Fixes #766


___

### **PR Type**
Bug fix


___

### **Description**
- Update Homebrew Cask to v1.3.14 to fix download failure.

- Update SHA-256 checksums for arm64 and Intel.

- Add macOS Monterey as minimum system requirement.


___

### Diagram Walkthrough


```mermaid
flowchart LR
    Old["v1.3.12 Cask"] -->|Update version & SHA| New["v1.3.14 Cask"]
    Old -->|Add macOS requirement| Monterey["depends_on macos: :monterey"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>openless.rb</strong><dd><code>Update version to v1.3.14 and add macOS Monterey dependency</code></dd></summary>
<hr>

Casks/openless.rb

<ul><li>Bump version from 1.3.12 to 1.3.14.<br> <li> Update SHA-256 values for arm64 and Intel.<br> <li> Simplify description text.<br> <li> Add <code>depends_on macos: :monterey</code>.</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/802/files#diff-e7c9f13357bfa65862250bdbdb0d2af908f271746881dd0f40af443a5099daa4">+5/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

