### PR TITLE
fix(llm): make custom provider temperature configurable

### DIFF
--- a/openless-all/app/src-tauri/src/commands/credentials.rs
+++ b/openless-all/app/src-tauri/src/commands/credentials.rs
@@ -1,6 +1,7 @@
 use super::*;
 
 const LLM_EXTRA_HEADERS_ACCOUNT: &str = "ark.extra_headers";
+const LLM_TEMPERATURE_ACCOUNT: &str = "ark.temperature";
 
 #[tauri::command]
 pub fn get_credentials() -> CredentialsStatus {
@@ -160,6 +161,11 @@ pub fn set_credential(window: Window, account: String, value: String) -> Result<
         let _ = window.emit("credentials:changed", ());
         return Ok(());
     }
+    if account == LLM_TEMPERATURE_ACCOUNT {
+        CredentialsVault::set_active_llm_temperature(&value).map_err(|e| e.to_string())?;
+        let _ = window.emit("credentials:changed", ());
+        return Ok(());
+    }
     let acc = parse_account(&account)?;
     if value.is_empty() {
         CredentialsVault::remove(acc).map_err(|e| e.to_string())?;
@@ -245,6 +251,9 @@ pub fn read_credential(window: Window, account: String) -> Result<Option<String>
     ensure_main_window(&window)?;
     if account == LLM_EXTRA_HEADERS_ACCOUNT {
         return CredentialsVault::get_active_llm_extra_headers_json().map_err(|e| e.to_string());
+    }
+    if account == LLM_TEMPERATURE_ACCOUNT {
+        return Ok(CredentialsVault::get_active_llm_temperature_string());
     }
     let acc = parse_account(&account)?;
     CredentialsVault::get(acc).map_err(|e| e.to_string())

--- a/openless-all/app/src-tauri/src/commands/mod.rs
+++ b/openless-all/app/src-tauri/src/commands/mod.rs
@@ -47,9 +47,9 @@ pub(crate) use crate::persistence::{
     PreferencesStore,
 };
 pub(crate) use crate::polish::{
-    http_client_builder, CodexOAuthConfig, CodexOAuthCredentials, CodexOAuthLLMProvider, LLMError,
-    OpenAICompatibleConfig, OpenAICompatibleLLMProvider, CODEX_DEFAULT_MODEL,
-    CODEX_OAUTH_PROVIDER_ID,
+    http_client_builder, openai_compatible_temperature_for_provider, CodexOAuthConfig,
+    CodexOAuthCredentials, CodexOAuthLLMProvider, LLMError, OpenAICompatibleConfig,
+    OpenAICompatibleLLMProvider, CODEX_DEFAULT_MODEL, CODEX_OAUTH_PROVIDER_ID,
 };
 #[cfg(not(mobile))]
 pub(crate) use crate::recorder::{AudioConsumer, Recorder};
@@ -1325,6 +1325,7 @@ mod tests {
             base_url: format!("http://{}", addr),
             api_key: String::new(),
             extra_headers: Default::default(),
+            temperature: None,
         })
         .await
         .unwrap();
@@ -1373,6 +1374,7 @@ mod tests {
             extra_headers: [("x-openless-test-token".to_string(), "secret".to_string())]
                 .into_iter()
                 .collect(),
+            temperature: None,
         })
         .await
         .unwrap();

--- a/openless-all/app/src-tauri/src/commands/providers.rs
+++ b/openless-all/app/src-tauri/src/commands/providers.rs
@@ -57,6 +57,7 @@ pub(crate) struct ProviderConfig {
     pub(crate) base_url: String,
     pub(crate) api_key: String,
     pub(crate) extra_headers: HashMap<String, String>,
+    pub(crate) temperature: Option<f32>,
 }
 
 fn read_openai_provider_config(kind: &str) -> Result<ProviderConfig, String> {
@@ -79,10 +80,17 @@ fn read_openai_provider_config(kind: &str) -> Result<ProviderConfig, String> {
     let base_url = CredentialsVault::get(endpoint_account)
         .map_err(|e| e.to_string())?
         .unwrap_or_default();
-    let extra_headers = if kind == "llm" {
-        CredentialsVault::get_active_llm_extra_headers()
+    let (extra_headers, temperature) = if kind == "llm" {
+        let active_llm = CredentialsVault::get_active_llm();
+        (
+            CredentialsVault::get_active_llm_extra_headers(),
+            openai_compatible_temperature_for_provider(
+                &active_llm,
+                CredentialsVault::get_active_llm_temperature(),
+            ),
+        )
     } else {
-        HashMap::new()
+        (HashMap::new(), None)
     };
     if api_key_required && api_key.trim().is_empty() {
         return Err("API Key 为空".to_string());
@@ -101,6 +109,7 @@ fn read_openai_provider_config(kind: &str) -> Result<ProviderConfig, String> {
         base_url,
         api_key,
         extra_headers,
+        temperature,
     })
 }
 
@@ -154,6 +163,7 @@ async fn validate_llm_provider() -> Result<(), String> {
             model,
         )
         .with_thinking_enabled(llm_thinking_enabled)
+        .with_temperature(config.temperature)
         .with_extra_headers(config.extra_headers),
     );
     provider

--- a/openless-all/app/src-tauri/src/coordinator.rs
+++ b/openless-all/app/src-tauri/src/coordinator.rs
@@ -45,8 +45,9 @@ use crate::persistence::{
 
 use crate::llm_gemini::{GeminiConfig, GeminiProvider};
 use crate::polish::{
-    ActiveLLMProvider, CodexOAuthConfig, CodexOAuthLLMProvider, OpenAICompatibleConfig,
-    OpenAICompatibleLLMProvider, CODEX_DEFAULT_MODEL, CODEX_OAUTH_PROVIDER_ID,
+    openai_compatible_temperature_for_provider, ActiveLLMProvider, CodexOAuthConfig,
+    CodexOAuthLLMProvider, OpenAICompatibleConfig, OpenAICompatibleLLMProvider,
+    CODEX_DEFAULT_MODEL, CODEX_OAUTH_PROVIDER_ID,
 };
 use crate::qa_hotkey::{QaHotkeyError, QaHotkeyEvent, QaHotkeyMonitor};
 use crate::recorder::{Recorder, RecorderError};
@@ -2034,8 +2035,13 @@ fn build_active_llm_provider(llm_thinking_enabled: bool) -> anyhow::Result<Activ
         .trim_end_matches("/chat/completions")
         .trim_end_matches('/')
         .to_string();
+    let temperature = openai_compatible_temperature_for_provider(
+        &active,
+        CredentialsVault::get_active_llm_temperature(),
+    );
     let config = OpenAICompatibleConfig::new(active, "OpenLess LLM", base_url, api_key, model)
         .with_thinking_enabled(llm_thinking_enabled)
+        .with_temperature(temperature)
         .with_extra_headers(CredentialsVault::get_active_llm_extra_headers());
     Ok(ActiveLLMProvider::OpenAI(OpenAICompatibleLLMProvider::new(
         config,

--- a/openless-all/app/src-tauri/src/persistence/credentials.rs
+++ b/openless-all/app/src-tauri/src/persistence/credentials.rs
@@ -217,6 +217,22 @@ fn active_llm_extra_headers(root: &CredsRoot) -> HashMap<String, String> {
         .unwrap_or_default()
 }
 
+fn active_llm_temperature(root: &CredsRoot) -> Option<f32> {
+    root.providers
+        .llm
+        .get(&root.active.llm)
+        .and_then(|entry| entry.temperature)
+        .map(|value| value as f32)
+}
+
+fn active_llm_temperature_string(root: &CredsRoot) -> Option<String> {
+    root.providers
+        .llm
+        .get(&root.active.llm)
+        .and_then(|entry| entry.temperature)
+        .map(|value| value.to_string())
+}
+
 fn active_llm_extra_headers_json(root: &CredsRoot) -> Result<Option<String>> {
     let headers = active_llm_extra_headers(root);
     if headers.is_empty() {
@@ -257,6 +273,21 @@ fn parse_extra_headers_json(value: &str) -> Result<HashMap<String, String>> {
         headers.insert(key.to_string(), value.to_string());
     }
     Ok(headers)
+}
+
+fn parse_llm_temperature(value: &str) -> Result<Option<f64>> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return Ok(None);
+    }
+    let temperature: f64 = trimmed.parse().context("temperature must be a number")?;
+    if !temperature.is_finite() {
+        anyhow::bail!("temperature must be finite");
+    }
+    if !(0.0..=2.0).contains(&temperature) {
+        anyhow::bail!("temperature must be between 0 and 2");
+    }
+    Ok(Some(temperature))
 }
 
 fn is_valid_header_name(name: &str) -> bool {
@@ -940,11 +971,38 @@ impl CredentialsVault {
         active_llm_extra_headers_json(&load_credentials())
     }
 
+    pub fn get_active_llm_temperature() -> Option<f32> {
+        let _guard = credentials_lock().lock();
+        active_llm_temperature(&load_credentials())
+    }
+
+    pub fn get_active_llm_temperature_string() -> Option<String> {
+        let _guard = credentials_lock().lock();
+        active_llm_temperature_string(&load_credentials())
+    }
+
+    pub fn set_active_llm_temperature(value: &str) -> Result<()> {
+        let _guard = credentials_lock().lock();
+        let temperature = parse_llm_temperature(value)?;
+        let mut root = load_credentials_for_update()?;
+        let entry = root
+            .providers
+            .llm
+            .entry(root.active.llm.clone())
+            .or_default();
+        entry.temperature = temperature;
+        save_credentials(&root)
+    }
+
     pub fn set_active_llm_extra_headers_json(value: &str) -> Result<()> {
         let _guard = credentials_lock().lock();
         let headers = parse_extra_headers_json(value)?;
         let mut root = load_credentials_for_update()?;
-        let entry = root.providers.llm.entry(root.active.llm.clone()).or_default();
+        let entry = root
+            .providers
+            .llm
+            .entry(root.active.llm.clone())
+            .or_default();
         entry.extraHeaders = if headers.is_empty() {
             None
         } else {
@@ -972,7 +1030,10 @@ impl CredentialsVault {
 
 #[cfg(test)]
 mod tests {
-    use super::{chunk_json_payload, parse_extra_headers_json, KEYRING_CHUNK_MAX_UTF16_UNITS};
+    use super::{
+        chunk_json_payload, parse_extra_headers_json, parse_llm_temperature,
+        KEYRING_CHUNK_MAX_UTF16_UNITS,
+    };
 
     #[test]
     fn credential_payload_chunks_stay_under_windows_blob_limit() {
@@ -1004,6 +1065,23 @@ mod tests {
             assert!(
                 err.contains("reserved extra header name"),
                 "unexpected error for {name}: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn parse_llm_temperature_accepts_empty_and_valid_range() {
+        assert_eq!(parse_llm_temperature("").unwrap(), None);
+        assert_eq!(parse_llm_temperature(" 0.3 ").unwrap(), Some(0.3));
+        assert_eq!(parse_llm_temperature("2").unwrap(), Some(2.0));
+    }
+
+    #[test]
+    fn parse_llm_temperature_rejects_invalid_values() {
+        for value in ["abc", "-0.1", "2.1", "NaN", "inf"] {
+            assert!(
+                parse_llm_temperature(value).is_err(),
+                "{value} should be rejected"
             );
         }
     }

--- a/openless-all/app/src-tauri/src/polish.rs
+++ b/openless-all/app/src-tauri/src/polish.rs
@@ -36,7 +36,7 @@ pub struct OpenAICompatibleConfig {
     pub api_key: String,
     pub model: String,
     pub extra_headers: HashMap<String, String>,
-    pub temperature: f32,
+    pub temperature: Option<f32>,
     pub request_timeout_secs: u64,
     /// true = 让支持的 OpenAI-compatible provider 启用推理 / 思考；
     /// false = 按渠道级官方参数关闭或压低思考。不做模型白名单判断，
@@ -59,7 +59,7 @@ impl OpenAICompatibleConfig {
             api_key: api_key.into(),
             model: model.into(),
             extra_headers: HashMap::new(),
-            temperature: DEFAULT_TEMPERATURE,
+            temperature: Some(DEFAULT_TEMPERATURE),
             request_timeout_secs: DEFAULT_REQUEST_TIMEOUT_SECS,
             thinking_enabled: false,
         }
@@ -73,6 +73,22 @@ impl OpenAICompatibleConfig {
     pub fn with_extra_headers(mut self, extra_headers: HashMap<String, String>) -> Self {
         self.extra_headers = extra_headers;
         self
+    }
+
+    pub fn with_temperature(mut self, temperature: Option<f32>) -> Self {
+        self.temperature = temperature;
+        self
+    }
+}
+
+pub fn openai_compatible_temperature_for_provider(
+    provider_id: &str,
+    custom_temperature: Option<f32>,
+) -> Option<f32> {
+    if provider_id == "custom" {
+        custom_temperature
+    } else {
+        Some(DEFAULT_TEMPERATURE)
     }
 }
 
@@ -500,9 +516,11 @@ impl OpenAICompatibleLLMProvider {
         let mut body = json!({
             "model": self.config.model,
             "stream": stream,
-            "temperature": self.config.temperature,
             "messages": messages,
         });
+        if let Some(temperature) = self.config.temperature {
+            body["temperature"] = json!(temperature);
+        }
         apply_openai_compatible_thinking_control(&mut body, &self.config);
         body
     }
@@ -1668,7 +1686,6 @@ fn openai_chat_reasoning_effort(model: &str, thinking_enabled: bool) -> Option<&
     }
 }
 
-
 fn extract_assistant_content(body: &str) -> Result<String, LLMError> {
     let json: Value = serde_json::from_str(body)
         .map_err(|e| LLMError::ParseError(format!("not valid JSON: {}", e)))?;
@@ -1686,7 +1703,6 @@ fn extract_assistant_content(body: &str) -> Result<String, LLMError> {
         .ok_or_else(|| LLMError::ParseError("message.content is not a string".into()))?;
     Ok(clean_polish_output(content))
 }
-
 
 pub mod prompts {
     use crate::types::PolishMode;
@@ -2433,6 +2449,75 @@ mod tests {
         let body = provider.chat_body(false, vec![json!({ "role": "user", "content": "hi" })]);
 
         assert_eq!(body["reasoning_effort"], "medium");
+    }
+
+    #[test]
+    fn chat_body_omits_temperature_when_config_is_none() {
+        let provider = OpenAICompatibleLLMProvider::new(
+            OpenAICompatibleConfig::new(
+                "custom",
+                "Custom",
+                "https://example.test/v1",
+                "k",
+                "gpt-5.6-terra",
+            )
+            .with_temperature(None),
+        );
+
+        let body = provider.chat_body(false, vec![json!({ "role": "user", "content": "hi" })]);
+
+        assert!(body.get("temperature").is_none());
+    }
+
+    #[test]
+    fn chat_body_sends_configured_temperature() {
+        for temperature in [0.0, 0.3, 1.0] {
+            let provider = OpenAICompatibleLLMProvider::new(
+                OpenAICompatibleConfig::new(
+                    "custom",
+                    "Custom",
+                    "https://example.test/v1",
+                    "k",
+                    "gpt-5.6-terra",
+                )
+                .with_temperature(Some(temperature)),
+            );
+
+            let body = provider.chat_body(true, vec![json!({ "role": "user", "content": "hi" })]);
+
+            assert_eq!(body["temperature"], json!(temperature));
+        }
+    }
+
+    #[test]
+    fn chat_body_uses_default_temperature_when_unspecified() {
+        let provider = OpenAICompatibleLLMProvider::new(OpenAICompatibleConfig::new(
+            "custom",
+            "Custom",
+            "https://example.test/v1",
+            "k",
+            "qwen3-max",
+        ));
+
+        let body = provider.chat_body(true, vec![json!({ "role": "user", "content": "hi" })]);
+
+        assert_eq!(body["temperature"], json!(DEFAULT_TEMPERATURE));
+    }
+
+    #[test]
+    fn provider_temperature_policy_makes_custom_opt_in() {
+        assert_eq!(
+            openai_compatible_temperature_for_provider("custom", None),
+            None
+        );
+        assert_eq!(
+            openai_compatible_temperature_for_provider("custom", Some(0.7)),
+            Some(0.7)
+        );
+        assert_eq!(
+            openai_compatible_temperature_for_provider("openai", None),
+            Some(DEFAULT_TEMPERATURE)
+        );
     }
 
     #[test]

--- a/openless-all/app/src/i18n/en.ts
+++ b/openless-all/app/src/i18n/en.ts
@@ -783,6 +783,8 @@ export const en: typeof zhCN = {
       apiKeyLabel: 'API Key',
       baseUrlLabel: 'Base URL',
       modelLabel: 'Model',
+      temperatureLabel: 'Temperature',
+      temperaturePlaceholder: 'Leave empty to omit; e.g. 0.3',
       extraHeadersLabel: 'Extra headers',
       extraHeadersPlaceholder: '{"custom-head":"..."}',
       thinkingModeLabel: 'Thinking',

--- a/openless-all/app/src/i18n/en.ts
+++ b/openless-all/app/src/i18n/en.ts
@@ -784,7 +784,7 @@ export const en: typeof zhCN = {
       baseUrlLabel: 'Base URL',
       modelLabel: 'Model',
       temperatureLabel: 'Temperature',
-      temperaturePlaceholder: 'Leave empty to omit; e.g. 0.3',
+      temperaturePlaceholder: 'Leave empty to omit; range 0–2 inclusive, e.g. 0.3',
       extraHeadersLabel: 'Extra headers',
       extraHeadersPlaceholder: '{"custom-head":"..."}',
       thinkingModeLabel: 'Thinking',

--- a/openless-all/app/src/i18n/ja.ts
+++ b/openless-all/app/src/i18n/ja.ts
@@ -786,7 +786,7 @@ export const ja: typeof zhCN = {
       baseUrlLabel: 'エンドポイント',
       modelLabel: 'モデル',
       temperatureLabel: 'Temperature',
-      temperaturePlaceholder: '空欄なら送信しません。例: 0.3',
+      temperaturePlaceholder: '空欄なら送信しません。範囲は 0〜2（両端を含む）。例: 0.3',
       extraHeadersLabel: '追加 Headers',
       extraHeadersPlaceholder: '{"custom-head":"..."}',
       thinkingModeLabel: '思考',

--- a/openless-all/app/src/i18n/ja.ts
+++ b/openless-all/app/src/i18n/ja.ts
@@ -785,6 +785,8 @@ export const ja: typeof zhCN = {
       apiKeyLabel: 'API キー',
       baseUrlLabel: 'エンドポイント',
       modelLabel: 'モデル',
+      temperatureLabel: 'Temperature',
+      temperaturePlaceholder: '空欄なら送信しません。例: 0.3',
       extraHeadersLabel: '追加 Headers',
       extraHeadersPlaceholder: '{"custom-head":"..."}',
       thinkingModeLabel: '思考',

--- a/openless-all/app/src/i18n/ko.ts
+++ b/openless-all/app/src/i18n/ko.ts
@@ -785,6 +785,8 @@ export const ko: typeof zhCN = {
       apiKeyLabel: 'API 키',
       baseUrlLabel: '엔드포인트',
       modelLabel: '모델',
+      temperatureLabel: 'Temperature',
+      temperaturePlaceholder: '비워 두면 보내지 않음. 예: 0.3',
       extraHeadersLabel: '추가 Headers',
       extraHeadersPlaceholder: '{"custom-head":"..."}',
       thinkingModeLabel: '사고',

--- a/openless-all/app/src/i18n/ko.ts
+++ b/openless-all/app/src/i18n/ko.ts
@@ -786,7 +786,7 @@ export const ko: typeof zhCN = {
       baseUrlLabel: '엔드포인트',
       modelLabel: '모델',
       temperatureLabel: 'Temperature',
-      temperaturePlaceholder: '비워 두면 보내지 않음. 예: 0.3',
+      temperaturePlaceholder: '비워 두면 보내지 않음. 범위 0~2(양 끝 포함), 예: 0.3',
       extraHeadersLabel: '추가 Headers',
       extraHeadersPlaceholder: '{"custom-head":"..."}',
       thinkingModeLabel: '사고',

--- a/openless-all/app/src/i18n/zh-CN.ts
+++ b/openless-all/app/src/i18n/zh-CN.ts
@@ -781,6 +781,8 @@ export const zhCN = {
       apiKeyLabel: 'API 密钥',
       baseUrlLabel: '接口地址',
       modelLabel: '模型',
+      temperatureLabel: 'Temperature',
+      temperaturePlaceholder: '留空则不发送；例如 0.3',
       extraHeadersLabel: '额外 Headers',
       extraHeadersPlaceholder: '{"custom-head":"..."}',
       thinkingModeLabel: '思考',

--- a/openless-all/app/src/i18n/zh-CN.ts
+++ b/openless-all/app/src/i18n/zh-CN.ts
@@ -782,7 +782,7 @@ export const zhCN = {
       baseUrlLabel: '接口地址',
       modelLabel: '模型',
       temperatureLabel: 'Temperature',
-      temperaturePlaceholder: '留空则不发送；例如 0.3',
+      temperaturePlaceholder: '留空则不发送；范围 0～2（含边界），例如 0.3',
       extraHeadersLabel: '额外 Headers',
       extraHeadersPlaceholder: '{"custom-head":"..."}',
       thinkingModeLabel: '思考',

--- a/openless-all/app/src/i18n/zh-TW.ts
+++ b/openless-all/app/src/i18n/zh-TW.ts
@@ -784,7 +784,7 @@ export const zhTW: typeof zhCN = {
       baseUrlLabel: '接口地址',
       modelLabel: '模型',
       temperatureLabel: 'Temperature',
-      temperaturePlaceholder: '留空則不發送；例如 0.3',
+      temperaturePlaceholder: '留空則不發送；範圍 0～2（含邊界），例如 0.3',
       extraHeadersLabel: '額外 Headers',
       extraHeadersPlaceholder: '{"custom-head":"..."}',
       thinkingModeLabel: '思考',

--- a/openless-all/app/src/i18n/zh-TW.ts
+++ b/openless-all/app/src/i18n/zh-TW.ts
@@ -783,6 +783,8 @@ export const zhTW: typeof zhCN = {
       apiKeyLabel: 'API 密鑰',
       baseUrlLabel: '接口地址',
       modelLabel: '模型',
+      temperatureLabel: 'Temperature',
+      temperaturePlaceholder: '留空則不發送；例如 0.3',
       extraHeadersLabel: '額外 Headers',
       extraHeadersPlaceholder: '{"custom-head":"..."}',
       thinkingModeLabel: '思考',

--- a/openless-all/app/src/pages/settings/ProvidersSection.tsx
+++ b/openless-all/app/src/pages/settings/ProvidersSection.tsx
@@ -377,14 +377,23 @@ export function ProvidersSection({ kind = 'all' }: ProvidersSectionProps = {}) {
             <CredentialField key={`${committedLlmProvider}:endpoint`} label={t('settings.providers.baseUrlLabel')} account="ark.endpoint"
               placeholder={preset.baseUrl || 'https://your-endpoint/v1'} />
             {committedLlmProvider === 'custom' && (
-              <CredentialField
-                key={`${committedLlmProvider}:extra_headers`}
-                label={t('settings.providers.extraHeadersLabel')}
-                account="ark.extra_headers"
-                placeholder={t('settings.providers.extraHeadersPlaceholder')}
-                mono
-                mask
-              />
+              <>
+                <CredentialField
+                  key={`${committedLlmProvider}:temperature`}
+                  label={t('settings.providers.temperatureLabel')}
+                  account="ark.temperature"
+                  placeholder={t('settings.providers.temperaturePlaceholder')}
+                  mono
+                />
+                <CredentialField
+                  key={`${committedLlmProvider}:extra_headers`}
+                  label={t('settings.providers.extraHeadersLabel')}
+                  account="ark.extra_headers"
+                  placeholder={t('settings.providers.extraHeadersPlaceholder')}
+                  mono
+                  mask
+                />
+              </>
             )}
           </>
         )}


### PR DESCRIPTION
### **User description**
## Summary

This PR makes `temperature` configurable for custom OpenAI-compatible LLM providers.

Previously, the OpenAI-compatible chat completion path always sent `temperature: 0.3`. Some custom gateways or Azure/OpenAI-compatible proxies reject that field for certain models, which causes validation and polish requests to fail with HTTP 400. Instead of hard-coding model-name rules, this change makes the behavior provider-config driven.

For custom providers:

- leaving `Temperature` empty omits the `temperature` field entirely
- setting a numeric value sends that value
- valid values are constrained to `0..=2`

Built-in OpenAI-compatible providers keep the existing default behavior and still send `0.3`.

## Changes

- Change `OpenAICompatibleConfig.temperature` to `Option<f32>`
- Send `temperature` only when configured
- Add `ark.temperature` credential storage for the active LLM provider
- Add a `Temperature` field in Settings for custom LLM providers
- Use the same temperature config in provider validation and real polish requests
- Remove the previous model-version-based temperature handling
- Add tests for omitted/configured temperature and input validation

## Why

The original failure surfaced with a custom provider backed by an Azure OpenAI-compatible gateway:

```text
HTTP 400 ... Unsupported value: 'temperature' does not support 0.300...
```

This appears to be gateway/model-specific behavior rather than something the app should infer from model names. Making custom provider `temperature` explicit lets users work with gateways that require the field to be omitted, while preserving current behavior for built-in providers.

## Validation

- `cargo test --manifest-path openless-all/app/src-tauri/Cargo.toml --lib`
- `npm run build -- --mode development`
- `git diff --cached --check`


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Make temperature configurable for custom LLM providers

- Omit temperature from API request when unset (fixes HTTP 400)

- Keep default 0.3 for built-in OpenAI-compatible providers

- Add UI field and credential storage for custom temperature


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A[CredentialVault::get_active_llm_temperature] --> B{provider_id == "custom"?}
  B -- yes --> C[openai_compatible_temperature_for_provider returns custom value or None]
  B -- no --> D[returns Some(DEFAULT_TEMPERATURE)]
  C --> E[OpenAICompatibleConfig.temperature]
  D --> E
  E --> F[chat_body: omit or include temperature field]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>7 files</summary><table>
<tr>
  <td><strong>credentials.rs</strong><dd><code>Add ark.temperature credential account</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/818/files#diff-8d658e9fd5232f39056b70074eebd9a30437059e28f5118e37a6ba3c3c0ad80f">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>mod.rs</strong><dd><code>Export temperature helper; add temperature to ProviderConfig</code></dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/818/files#diff-927cec8f506f8369417751238e7d018c43bad50133e1488750ee0f9feb5f6449">+5/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>providers.rs</strong><dd><code>Integrate temperature into provider config</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/818/files#diff-be85f4e6da802ac2f767525263e432add7c7ed2cc175d0d400e888cb2d672ece">+13/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>coordinator.rs</strong><dd><code>Pass temperature when building active LLM provider</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/818/files#diff-73d8c004670b27293f74f0f3991b9a6fc28f0ff0b883214de2b078b1e09797ca">+8/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>credentials.rs</strong><dd><code>Add temperature storage, parsing, and validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/818/files#diff-6ed5731fbd0b7f6d98a59e85ec178d77591b097310b5b8d52cd6d7361ee86a01">+80/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>polish.rs</strong><dd><code>Change temperature to Option; add with_temperature and policy func</code></dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/818/files#diff-1be30d25d0bf8fc3e6c11bf4fa179521045a52ef4843271545acedfd0535e38b">+90/-5</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ProvidersSection.tsx</strong><dd><code>Add temperature input field for custom providers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/818/files#diff-8fc332d1eb5b010583185b704ea439954650f6aff2d0195e00cd0cb76e526e7b">+17/-8</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>en.ts</strong><dd><code>Add English temperature labels</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/818/files#diff-bb2f4fa05787923f8aeb23b6f11ad8705e02d9ff03a45790f9181e4615c79d83">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ja.ts</strong><dd><code>Add Japanese temperature labels</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/818/files#diff-be57f0090cf34e3ff924cfa35f13d5d9e6514d3af5a1ebfdeb92bd7d36ed9cf4">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ko.ts</strong><dd><code>Add Korean temperature labels</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/818/files#diff-daf35bcb6a2f8a31565b83d119cb59b69c1dededbabfccfd0d56693fdb3726ca">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>zh-CN.ts</strong><dd><code>Add Chinese (Simplified) temperature labels</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/818/files#diff-571576f3c7b6c4a78ae0f91accdccc5da5cbed00409955c9914c046fee6c80ea">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>zh-TW.ts</strong><dd><code>Add Chinese (Traditional) temperature labels</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/818/files#diff-a8d5953f9c76bc3c90ec583270be04c852bd7540297500e6ff3260760fc61ea4">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

