### PR TITLE
fix(security): redact Less Computer approval tokens

### DIFF
--- a/openless-all/app/src-tauri/src/coordinator/dictation.rs
+++ b/openless-all/app/src-tauri/src/coordinator/dictation.rs
@@ -67,9 +67,9 @@ pub(super) fn resolve_less_computer_approval(token: &str, approved: bool) {
         .and_then(|mut m| m.remove(token));
     if let Some(tx) = sender {
         let _ = tx.send(approved);
-        log::info!("[less-computer] 审批 token={token} approved={approved}");
+        log::info!("[less-computer] 审批已解析 approved={approved}");
     } else {
-        log::info!("[less-computer] 审批 token={token} 已失效（超时/重复）");
+        log::info!("[less-computer] 审批请求已失效（超时/重复）");
     }
 }
 
@@ -178,6 +178,34 @@ mod less_computer_event_log_tests {
         assert_eq!(log.events.len(), LESS_COMPUTER_EVENT_LOG_CAP);
         // 丢最旧：队首是第 6 条（seq 从 1 起）。
         assert_eq!(log.events.front().unwrap()["seq"], 6);
+    }
+}
+
+#[cfg(test)]
+mod less_computer_approval_log_tests {
+    #[test]
+    fn approval_capability_is_never_interpolated_into_logs() {
+        let sources = [
+            include_str!("dictation.rs"),
+            include_str!("hotkey_loops.rs"),
+            include_str!("../coordinator.rs"),
+            include_str!("../commands/qa.rs"),
+            include_str!("../lib.rs"),
+        ];
+
+        for source in sources {
+            for statement in source.split("log::").skip(1) {
+                let statement = statement
+                    .split_once(");")
+                    .map_or(statement, |(head, _)| head);
+                if statement.contains("[less-computer]") {
+                    assert!(
+                        !statement.contains("token"),
+                        "Less Computer approval logs must not contain the capability token: {statement}"
+                    );
+                }
+            }
+        }
     }
 }
 


### PR DESCRIPTION
### **User description**
Closes #810

## Summary
- remove the one-time Less Computer approval capability from resolved and stale-request logs
- preserve the non-sensitive `approved` outcome for successful resolutions
- add a source contract covering every `[less-computer]` Rust log call site so future capability-token interpolation fails tests

## Verification
- `cargo test --locked --lib less_computer_approval_log_tests -- --nocapture`: 1 passed
- `npm run check:hotkey-injection`: passed
- `npm run build`: passed (existing Android IPC circular-chunk warning only)
- macOS capsule, side-modifier, Windows lifecycle, Android updater contracts: passed
- `npm audit --audit-level=high`: 0 vulnerabilities
- `cargo audit --file Cargo.lock`: 0 vulnerabilities; 18 existing allowed warnings
- `git diff --check`: passed

## Review gate
No frontend/UI files are changed. Keep Draft until a separate agent reviews the exact head and all platform CI checks pass.


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Remove one-time approval capability token from resolved and stale-request logs

- Preserve non-sensitive `approved` outcome for successful resolutions

- Add source-contract test to prevent future token interpolation into logs


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>dictation.rs</strong><dd><code>Redact approval token and add source-contract test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src-tauri/src/coordinator/dictation.rs

<ul><li>Removed token field from both accepted and stale approval log messages<br> <li> Added a compile-time test that scans all Less Computer log statements <br>for the word "token"</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/820/files#diff-4cf79887f41f4811eb2b1ef682c62ee34c14a0ab969362a9ba1046de59c8578b">+30/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

