### PR TITLE
build(macos): 校验打包产物声明语音识别用途

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,6 +161,10 @@ jobs:
       - name: Check PIN persistence security contract
         run: npm run check:pin-persistence-security
 
+      - name: Check macOS speech usage description contract
+        if: runner.os == 'macOS'
+        run: npm run check:macos-speech-usage-description
+
       - name: Build frontend (tsc + vite)
         run: npm run build
 

--- a/openless-all/app/package.json
+++ b/openless-all/app/package.json
@@ -18,6 +18,7 @@
     "merge:android-overlay-manifest": "node scripts/merge-android-overlay-manifest.mjs",
     "copy:android-scaffolding": "node scripts/copy-android-scaffolding.mjs",
     "check:macos-capsule-spaces": "node scripts/macos-capsule-spaces-contract.test.mjs",
+    "check:macos-speech-usage-description": "node scripts/macos-speech-usage-description-contract.test.mjs",
     "check:hotkey-injection": "node scripts/check-hotkey-injection.mjs",
     "check:hotkey-side-modifiers": "tsx src/lib/hotkeySideModifiers.test.ts",
     "check:windows-startup-lifecycle": "node scripts/windows-startup-lifecycle-contract.test.mjs",

--- a/openless-all/app/scripts/build-mac.sh
+++ b/openless-all/app/scripts/build-mac.sh
@@ -33,7 +33,7 @@ npm run tauri -- "${TAURI_BUILD_ARGS[@]}"
 
 echo "▶ 校验 Info.plist / 签名"
 /usr/libexec/PlistBuddy -c "Print :NSMicrophoneUsageDescription" "$INFO" >/dev/null
-/usr/libexec/PlistBuddy -c "Print :NSSpeechRecognitionUsageDescription" "$INFO" >/dev/null
+bash scripts/check-macos-speech-usage-description.sh "$INFO"
 codesign -d --entitlements :- "$APP" 2>/dev/null | grep -q "com.apple.security.device.audio-input"
 codesign --verify --deep --strict --verbose=2 "$APP" 2>&1 | tail -2
 

--- a/openless-all/app/scripts/build-mac.sh
+++ b/openless-all/app/scripts/build-mac.sh
@@ -33,6 +33,7 @@ npm run tauri -- "${TAURI_BUILD_ARGS[@]}"
 
 echo "▶ 校验 Info.plist / 签名"
 /usr/libexec/PlistBuddy -c "Print :NSMicrophoneUsageDescription" "$INFO" >/dev/null
+/usr/libexec/PlistBuddy -c "Print :NSSpeechRecognitionUsageDescription" "$INFO" >/dev/null
 codesign -d --entitlements :- "$APP" 2>/dev/null | grep -q "com.apple.security.device.audio-input"
 codesign --verify --deep --strict --verbose=2 "$APP" 2>&1 | tail -2
 

--- a/openless-all/app/scripts/check-macos-speech-usage-description.sh
+++ b/openless-all/app/scripts/check-macos-speech-usage-description.sh
@@ -14,7 +14,7 @@ DESCRIPTION=$(/usr/bin/plutil \
   -o - \
   -- "$PLIST_PATH")
 
-if [[ ! "$DESCRIPTION" =~ [^[:space:]] ]]; then
+if ! node -e 'process.exit(process.argv[1].trim().length === 0 ? 1 : 0)' -- "$DESCRIPTION"; then
   echo "NSSpeechRecognitionUsageDescription must be a non-empty string in $PLIST_PATH" >&2
   exit 1
 fi

--- a/openless-all/app/scripts/check-macos-speech-usage-description.sh
+++ b/openless-all/app/scripts/check-macos-speech-usage-description.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+PLIST_PATH="${1:-}"
+if [ -z "$PLIST_PATH" ]; then
+  echo "usage: $0 <Info.plist>" >&2
+  exit 2
+fi
+
+DESCRIPTION=$(/usr/bin/plutil \
+  -extract NSSpeechRecognitionUsageDescription raw \
+  -expect string \
+  -o - \
+  -- "$PLIST_PATH")
+
+if [[ ! "$DESCRIPTION" =~ [^[:space:]] ]]; then
+  echo "NSSpeechRecognitionUsageDescription must be a non-empty string in $PLIST_PATH" >&2
+  exit 1
+fi

--- a/openless-all/app/scripts/macos-speech-usage-description-contract.test.mjs
+++ b/openless-all/app/scripts/macos-speech-usage-description-contract.test.mjs
@@ -21,8 +21,11 @@ function writeFixture(name, value) {
   return path;
 }
 
-function runChecker(path) {
-  return spawnSync('bash', [checker, path], { encoding: 'utf8' });
+function runChecker(path, env = {}) {
+  return spawnSync('bash', [checker, path], {
+    encoding: 'utf8',
+    env: { ...process.env, ...env },
+  });
 }
 
 function expectSuccessSilent(name, path) {
@@ -35,8 +38,8 @@ function expectSuccessSilent(name, path) {
   }
 }
 
-function expectFailure(name, path) {
-  const result = runChecker(path);
+function expectFailure(name, path, env = {}) {
+  const result = runChecker(path, env);
   if (result.status === 0) {
     throw new Error(`${name}: expected non-zero exit`);
   }
@@ -62,6 +65,20 @@ try {
       '<key>NSSpeechRecognitionUsageDescription</key><string>  \n\t  </string>',
     ),
   );
+  for (const [name, slug, whitespace] of [
+    ['NBSP', 'nbsp', '\u00a0'],
+    ['EM SPACE', 'em-space', '\u2003'],
+    ['IDEOGRAPHIC SPACE', 'ideographic-space', '\u3000'],
+  ]) {
+    expectFailure(
+      `${name}-only string under C locale`,
+      writeFixture(
+        `${slug}-only.plist`,
+        `<key>NSSpeechRecognitionUsageDescription</key><string>${whitespace}</string>`,
+      ),
+      { LC_ALL: 'C', LANG: 'C' },
+    );
+  }
   expectFailure(
     'wrong type',
     writeFixture('wrong-type.plist', '<key>NSSpeechRecognitionUsageDescription</key><true/>'),

--- a/openless-all/app/scripts/macos-speech-usage-description-contract.test.mjs
+++ b/openless-all/app/scripts/macos-speech-usage-description-contract.test.mjs
@@ -1,0 +1,72 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { spawnSync } from 'node:child_process';
+
+const scriptsDir = fileURLToPath(new URL('.', import.meta.url));
+const checker = join(scriptsDir, 'check-macos-speech-usage-description.sh');
+const fixtureDir = mkdtempSync(join(tmpdir(), 'openless-speech-usage-'));
+
+function plist(value) {
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0"><dict>${value}</dict></plist>
+`;
+}
+
+function writeFixture(name, value) {
+  const path = join(fixtureDir, name);
+  writeFileSync(path, plist(value));
+  return path;
+}
+
+function runChecker(path) {
+  return spawnSync('bash', [checker, path], { encoding: 'utf8' });
+}
+
+function expectSuccessSilent(name, path) {
+  const result = runChecker(path);
+  if (result.status !== 0) {
+    throw new Error(`${name}: expected exit 0, got ${result.status}\n${result.stderr}`);
+  }
+  if (result.stdout !== '' || result.stderr !== '') {
+    throw new Error(`${name}: success must be silent, got ${JSON.stringify(result.stdout + result.stderr)}`);
+  }
+}
+
+function expectFailure(name, path) {
+  const result = runChecker(path);
+  if (result.status === 0) {
+    throw new Error(`${name}: expected non-zero exit`);
+  }
+}
+
+try {
+  expectSuccessSilent(
+    'valid string',
+    writeFixture(
+      'valid.plist',
+      '<key>NSSpeechRecognitionUsageDescription</key><string>OpenLess transcribes speech locally.</string>',
+    ),
+  );
+  expectFailure('missing key', writeFixture('missing-key.plist', ''));
+  expectFailure(
+    'empty string',
+    writeFixture('empty-string.plist', '<key>NSSpeechRecognitionUsageDescription</key><string></string>'),
+  );
+  expectFailure(
+    'whitespace-only string',
+    writeFixture(
+      'whitespace-string.plist',
+      '<key>NSSpeechRecognitionUsageDescription</key><string>  \n\t  </string>',
+    ),
+  );
+  expectFailure(
+    'wrong type',
+    writeFixture('wrong-type.plist', '<key>NSSpeechRecognitionUsageDescription</key><true/>'),
+  );
+  expectFailure('missing file', join(fixtureDir, 'does-not-exist.plist'));
+} finally {
+  rmSync(fixtureDir, { recursive: true, force: true });
+}


### PR DESCRIPTION
### **User description**
## 摘要

Fixes #823。

macOS 最终 `.app/Contents/Info.plist` 中的 `NSSpeechRecognitionUsageDescription` 现在必须是 string，且按 ECMAScript Unicode whitespace 规则 trim 后非空；否则 `build-mac.sh` 非零退出，阻止后续 codesign 验证、本地安装以及该 macOS artifact 的上传/发布。

## 修复内容

- 新增 `scripts/check-macos-speech-usage-description.sh`：使用系统 `/usr/bin/plutil -extract ... -expect string` 保留 plist 类型校验，并用 locale-independent 的 ECMAScript `trim()` 拒绝空字符串或仅含 Unicode 空白的字符串。
- `scripts/build-mac.sh` 在 Tauri 完成 bundle 后，对最终 `OpenLess.app/Contents/Info.plist` 调用真实 checker；合法路径不产生额外输出。
- 新增 macOS hermetic contract test，临时生成 plist fixtures，覆盖：
  - 合法非空 string：退出 0 且 stdout/stderr 均为空；
  - 缺 key；
  - 空 string；
  - ASCII 纯空白 string；
  - 在 `LC_ALL=C` 下仅含 NBSP（U+00A0）、EM SPACE（U+2003）或 IDEOGRAPHIC SPACE（U+3000）的 string；
  - bool 错误类型；
  - plist 文件不存在。
- 新增 npm contract 入口，并接入 GitHub `macOS checks`；测试不依赖完整 Tauri 打包。

## Release 路径复核

`release-tauri.yml` 当前并非另一条独立 macOS 打包路径：两种 macOS runner 的 `Build (macOS)` step 都以 `INSTALL=0` 调用 `bash scripts/build-mac.sh`。因此本次 checker 同时保护本地打包和 macOS release workflow。

## 行为与范围

- 无 Rust、React/TypeScript UI、配置、依赖或运行时行为变更。
- 正常 bundle 的校验保持静默。
- 校验发生在 `tauri build` 之后：失败时 target 目录中可能已经存在未验证的 `.app`/DMG，但脚本会在后续 codesign 验证和本地安装前非零退出；对应 macOS matrix 不会上传/发布该 artifact。`fail-fast: false` 下其他平台 matrix 可继续，整体 workflow 不保证完全停止。这里不再声称“失败时完全不生成 bundle”。

## 验证

TDD RED：在旧 checker 上先加入 C locale Unicode fixtures；NBSP-only fixture 明确出现 `expected non-zero exit`，证明原来的 Bash whitespace 判断可被绕过。

GREEN / 回归检查：

- `LC_ALL=C LANG=C npm run check:macos-speech-usage-description` — 通过，覆盖 U+00A0/U+2003/U+3000；
- `npm run check:macos-capsule-spaces` — 通过；
- `bash -n scripts/build-mac.sh scripts/check-macos-speech-usage-description.sh` — 通过；
- `node --check scripts/macos-speech-usage-description-contract.test.mjs` — 通过；
- checker 对 `src-tauri/Info.plist` — 退出 0 且静默；
- `git diff --check` — 通过；
- `release-tauri.yml` macOS step 调用 `build-mac.sh` — 已核对。

完整 `INSTALL=0 bash scripts/build-mac.sh` 已验证通过，真实执行 checker、生成 `.app`/DMG，并通过 codesign 与 quarantine 检查；contract test 仍保持 hermetic，不依赖打包产物。最新 `beta` 精确基线上另通过全部合约、生产构建及 687 个 Rust lib tests。


___

### **PR Type**
Bug fix, Enhancement, Tests


___

### **Description**
- Add checker for NSSpeechRecognitionUsageDescription in build-mac.sh

- Contract tests for valid/invalid plist variants

- Add CI step for macOS speech usage description check


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Tauri build"] --> B["build-mac.sh"]
  B --> C["check-macos-speech-usage-description.sh"]
  C -->|"NSSpeechRecognitionUsageDescription exists & non-empty"| D["Continue: codesign, install"]
  C -->|"missing/empty"| E["Exit non-zero, abort build"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>build-mac.sh</strong><dd><code>Integrate speech usage description checker</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/scripts/build-mac.sh

<ul><li>Added call to <code>check-macos-speech-usage-description.sh</code> after Tauri <br>build<br> <li> Uses existing <code>$INFO</code> variable path</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/825/files#diff-4904f258fd103e9382312e3dad116ceab2d6372853c63fa376e906e4b15715db">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>check-macos-speech-usage-description.sh</strong><dd><code>Add speech usage description validation script</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/scripts/check-macos-speech-usage-description.sh

<ul><li>New script to validate NSSpeechRecognitionUsageDescription key<br> <li> Uses /usr/bin/plutil to extract and expect string type<br> <li> Rejects empty/whitespace-only strings via node inline check</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/825/files#diff-bbf5b7b51d9306070115ecccc91f8ccdc6d0f90af8e3c1b5365e366c7a95bfb6">+20/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>macos-speech-usage-description-contract.test.mjs</strong><dd><code>Contract tests for speech description checker</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/scripts/macos-speech-usage-description-contract.test.mjs

<ul><li>Hermetic test using temporary plist fixtures<br> <li> Covers valid, missing key, empty, whitespace, wrong type, missing file<br> <li> Verifies silent success and non-zero exit on failures</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/825/files#diff-61a36946915037f107aa9f04f67902ce82c6c5fba58a85364f5fd7cd34ffdcec">+89/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>package.json</strong><dd><code>Add npm script for contract test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/package.json

- Added npm script "check:macos-speech-usage-description"


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/825/files#diff-2650f8aa2f7ec97aa8af47f1f8a7c9ae4677fb69754b20d554e1d542507cf4ea">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ci.yml</strong><dd><code>Add macOS speech check to CI</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/ci.yml

<ul><li>Added CI step to run speech usage description contract test on macOS</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/825/files#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03f">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___


