### PR TITLE
fix(android): break IPC settings barrel cycle

### DIFF
--- a/openless-all/app/android/frontend/components/AndroidPermissionsPanel.tsx
+++ b/openless-all/app/android/frontend/components/AndroidPermissionsPanel.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Icon } from '../../../src/components/Icon';
-import { getSettings, setSettings } from '../../../src/lib/ipc';
+import { getSettings, setSettings } from '../../../src/lib/ipc/settings';
 import type { UserPreferences } from '../../../src/lib/types';
 import { Btn, Pill } from '../../../src/pages/_atoms';
 import { SettingRow } from '../../../src/pages/settings/shared';

--- a/openless-all/app/package.json
+++ b/openless-all/app/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
+    "prebuild": "node scripts/android-ipc-import-boundary.test.mjs",
     "build": "tsc && vite build",
     "preview": "vite preview",
     "tauri": "tauri",

--- a/openless-all/app/scripts/android-ipc-import-boundary.test.mjs
+++ b/openless-all/app/scripts/android-ipc-import-boundary.test.mjs
@@ -1,0 +1,29 @@
+import { readFile } from 'node:fs/promises';
+
+const panelUrl = new URL(
+  '../android/frontend/components/AndroidPermissionsPanel.tsx',
+  import.meta.url,
+);
+const source = await readFile(panelUrl, 'utf8');
+const imports = [...source.matchAll(/import\s+([\s\S]*?)\s+from\s+['"]([^'"]+)['"];?/g)];
+
+function moduleFor(name) {
+  return imports
+    .filter(([, bindings]) => new RegExp(`\\b${name}\\b`).test(bindings))
+    .map(([, , moduleName]) => moduleName);
+}
+
+for (const name of ['getSettings', 'setSettings']) {
+  const modules = moduleFor(name);
+  if (modules.length !== 1 || modules[0] !== '../../../src/lib/ipc/settings') {
+    throw new Error(
+      `${name} must be imported directly from ../../../src/lib/ipc/settings; found ${JSON.stringify(modules)}`,
+    );
+  }
+}
+
+if (/from\s+['"]\.\.\/\.\.\/\.\.\/src\/lib\/ipc['"]/.test(source)) {
+  throw new Error('AndroidPermissionsPanel must not import through the IPC barrel');
+}
+
+console.log('android-ipc-import-boundary.test.mjs passed');


### PR DESCRIPTION
### **User description**
## Summary
- import Android settings IPC directly from the narrow settings module
- add a source-level regression guard against restoring the IPC barrel edge
- run the guard automatically through npm prebuild so CI and local production builds enforce it

## Verification
- RED: guard failed against the original barrel import with the expected module path
- GREEN: guard passed after the one-line direct import change
- npm run build passed without the previous circular chunk warning
- npm audit reports 0 vulnerabilities
- diff check and gitleaks passed

No visual or runtime UI behavior change.

Closes #804


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Replace barrel import with direct settings module

- Add regression guard script for import boundary

- Run guard automatically via npm prebuild


___

### Diagram Walkthrough


```mermaid
flowchart LR
  subgraph Before
    A["AndroidPermissionsPanel.tsx"] --> B["src/lib/ipc/index.ts (barrel)"] --> C["settings.ts (circular)"]
  end
  subgraph After
    A2["AndroidPermissionsPanel.tsx"] --> C2["src/lib/ipc/settings.ts (direct)"]
  end
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>AndroidPermissionsPanel.tsx</strong><dd><code>Fix import to avoid circular dependency</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/android/frontend/components/AndroidPermissionsPanel.tsx

<ul><li>Changed import of getSettings and setSettings from <br>'../../../src/lib/ipc' to '../../../src/lib/ipc/settings'</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/827/files#diff-7d253a64e6ed0e80d8be1b80717c43e4cf6f5cbed6dcf704e3e9e36df165470e">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>package.json</strong><dd><code>Add prebuild script for regression guard</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/package.json

<ul><li>Added "prebuild" script: "node <br>scripts/android-ipc-import-boundary.test.mjs"</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/827/files#diff-2650f8aa2f7ec97aa8af47f1f8a7c9ae4677fb69754b20d554e1d542507cf4ea">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>android-ipc-import-boundary.test.mjs</strong><dd><code>Add regression guard for import boundary</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/scripts/android-ipc-import-boundary.test.mjs

<ul><li>Adds script to verify settings imports are directly from ipc/settings<br> <li> Throws error if barrel import is detected</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/827/files#diff-8235e89004ab54e60c8b45ad96e87aa1b56ff28a058c4c58c57a0ff47abb7f74">+29/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

