### PR TITLE
test(windows): repair and enforce UI config contract

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,6 +155,9 @@ jobs:
       - name: Check macOS capsule Spaces contract
         run: npm run check:macos-capsule-spaces
 
+      - name: Check Windows UI configuration contract
+        run: npm run check:windows-ui-config
+
       - name: Build frontend (tsc + vite)
         run: npm run build
 

--- a/openless-all/app/package.json
+++ b/openless-all/app/package.json
@@ -21,6 +21,7 @@
     "check:hotkey-injection": "node scripts/check-hotkey-injection.mjs",
     "check:hotkey-side-modifiers": "npx tsx src/lib/hotkeySideModifiers.test.ts",
     "check:windows-startup-lifecycle": "node scripts/windows-startup-lifecycle-contract.test.mjs",
+    "check:windows-ui-config": "node scripts/windows-ui-config.test.mjs",
     "check:android-updater-pubkey": "node scripts/check-android-updater-pubkey.mjs"
   },
   "dependencies": {

--- a/openless-all/app/scripts/windows-ui-config.test.mjs
+++ b/openless-all/app/scripts/windows-ui-config.test.mjs
@@ -36,8 +36,8 @@ if (!capsuleWindow) {
 if (!mainWindow) {
   throw new Error('main window config missing');
 }
-assertEqual(capsuleWindow.width, 220, 'windows capsule config keeps translation-capable width baseline');
-assertEqual(capsuleWindow.height, 110, 'windows capsule config keeps translation-capable height baseline');
+assertEqual(capsuleWindow.width, 460, 'windows capsule config keeps the shared bootstrap width');
+assertEqual(capsuleWindow.height, 180, 'windows capsule config keeps the shared bootstrap height');
 assertEqual(capsuleWindow.transparent, true, 'capsule window should keep transparent visuals');
 assertEqual(capsuleWindow.alwaysOnTop, true, 'capsule window should stay above the focused app while recording');
 assertEqual(mainWindow.decorations, true, 'windows main window should keep native decorations');
@@ -113,9 +113,11 @@ assertMatch(
   'linux should keep the custom ol-linux-titlebar shell',
 );
 
-if (!/borderRadius:\s*'var\(--ol-r-lg\)'/.test(floatingShellTsx)) {
-  throw new Error('floating shell should consume the shared radius token');
-}
+assertMatch(
+  floatingShellTsx,
+  /className="ol-console-main"[\s\S]*?borderRadius:\s*0,[\s\S]*?boxShadow:\s*'none'/,
+  'main content should keep the intentional flush shell treatment',
+);
 
 assertMatch(
   coordinatorRs,
@@ -142,9 +144,19 @@ if (!/export function getCapsuleHostMetrics\(\s*os: OS,\s*translationActive: boo
   throw new Error('capsule layout should define explicit host metrics separate from the visible pill metrics');
 }
 
-if (!/if \(os === 'win'\)\s*\{[\s\S]*?const horizontalInset = 12;[\s\S]*?const pill = getCapsulePillMetrics\(os\);[\s\S]*?width: pill\.width \+ horizontalInset \* 2,[\s\S]*?height: translationActive \? 118 : 84,[\s\S]*?horizontalInset,[\s\S]*?bottomInset: 12,[\s\S]*?badgeGap: 8,[\s\S]*?boxSizing: 'border-box',[\s\S]*?\}/.test(capsuleLayoutTs)) {
-  throw new Error('windows capsule host metrics should leave room for shadow and badge geometry');
-}
+assertMatch(
+  capsuleLayoutTs,
+  // The 1.3.14 voice-orb shell replaced the legacy 196px Windows pill and its
+  // 12px host inset. Keep the frontend and native stage contracts in sync.
+  /const VOICE_ORB_STAGE_WIDTH = 460;[\s\S]*?const VOICE_ORB_STAGE_HEIGHT = 180;/,
+  'capsule layout should keep the shared 460x180 voice-orb stage',
+);
+
+assertMatch(
+  capsuleLayoutTs,
+  /const stage = getCapsulePillMetrics\(os\);[\s\S]*?width: stage\.width,[\s\S]*?height: stage\.height,[\s\S]*?horizontalInset: 0,[\s\S]*?bottomInset: 0,[\s\S]*?badgeGap: 8,[\s\S]*?boxSizing: 'border-box'/,
+  'capsule host metrics should mirror the shared voice-orb stage without legacy Windows insets',
+);
 
 if (!/const hostMetrics = getCapsuleHostMetrics\(os,\s*translation\);/.test(capsuleTsx)) {
   throw new Error('capsule should derive host metrics from the shared layout contract');
@@ -155,24 +167,28 @@ if (!/return\s*\(\s*<div\s*style=\{\{[\s\S]*?width:\s*'100%',[\s\S]*?height:\s*'
 }
 
 if (!/paddingLeft:\s*hostMetrics\.horizontalInset,/.test(capsuleTsx) || !/paddingRight:\s*hostMetrics\.horizontalInset,/.test(capsuleTsx)) {
-  throw new Error('windows capsule host should reserve shared horizontal inset room for shadow geometry');
+  throw new Error('capsule host should consume the shared horizontal inset contract');
 }
 
 if (!/paddingBottom:\s*os === 'win' \? hostMetrics\.bottomInset : 0/.test(capsuleTsx)) {
   throw new Error('windows capsule host should respect the shared bottom inset');
 }
 
-if (!/hostMetrics\.bottomInset \+ metrics\.height \+ hostMetrics\.badgeGap/.test(capsuleTsx)) {
-  throw new Error('windows translation badge should anchor from the shared host inset instead of a fixed center-based offset');
+if (!/const badgeBottom = Math\.round\(metrics\.height \* 0\.73\);/.test(capsuleTsx)) {
+  throw new Error('translation badge should anchor proportionally within the voice-orb stage');
 }
 
-if (!/#\[cfg\(target_os = "windows"\)\][\s\S]*?const WINDOWS_CAPSULE_PILL_WIDTH: f64 = 196\.0;[\s\S]*?const WINDOWS_CAPSULE_SIDE_INSET: f64 = 12\.0;[\s\S]*?width: WINDOWS_CAPSULE_PILL_WIDTH \+ WINDOWS_CAPSULE_SIDE_INSET \* 2\.0,[\s\S]*?height: if translation_active \{ 118\.0 \} else \{ 84\.0 \},[\s\S]*?bottom_inset: 12\.0,/.test(libRs)) {
-  throw new Error('windows runtime capsule bounds should leave room for the native shadow while keeping a fixed visual pill');
-}
+assertMatch(
+  libRs,
+  /fn capsule_window_bounds\(translation_active: bool\)[\s\S]*?width: 460\.0,[\s\S]*?height: 180\.0,[\s\S]*?bottom_inset: 0\.0,/,
+  'runtime capsule bounds should match the shared 460x180 voice-orb stage',
+);
 
-if (!/#\[cfg\(target_os = "windows"\)\]\s*\{\s*52\.0\s*\}/.test(libRs)) {
-  throw new Error('windows capsule visual pill height should stay at 52px');
-}
+assertMatch(
+  libRs,
+  /fn capsule_visual_height\(_translation_active: bool\) -> f64[\s\S]*?140\.0/,
+  'runtime capsule visual anchor should preserve the intentional 140px height',
+);
 
 if (!/window\.set_size\(LogicalSize::new\(bounds\.width, bounds\.height\)\)\?/.test(libRs)) {
   throw new Error('capsule positioning should resync runtime size with the computed layout');


### PR DESCRIPTION
### **User description**
## Summary

- update the stale capsule bootstrap assertion to the current shared 460x180 voice-orb stage
- replace two additional unreachable legacy assertions with exact contracts for the intentional flush main shell and current frontend/native voice-orb geometry
- expose the test as `check:windows-ui-config` and run it in every cross-platform CI matrix job

## TDD evidence

RED on current Beta: the existing test stopped immediately at `expected 220, got 460`.

After repairing only that first assertion, the test exposed two more stale assumptions that the original issue could not reach: it still expected the pre-1.3.14 floating radius token and the old 196px Windows pill with 12px insets. Current product code intentionally uses a flush main panel plus the shared 460x180 voice-orb stage. The repaired contract now asserts those exact frontend and native values instead of deleting geometry coverage.

GREEN: the complete contract passes through the new npm script.

## Verification

- `npm run check:windows-ui-config`: passed
- `npm run check:macos-capsule-spaces`: passed
- clean `npm ci`: 0 vulnerabilities
- `npm run build`: passed, including Android IPC prebuild boundary
- `npm audit --audit-level=high`: 0 vulnerabilities
- package JSON and CI YAML parse checks: passed
- `node --check` and `git diff --check`: passed

Test and CI only; no product or UI behavior change.

Closes #803


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Update stale capsule bootstrap size assertion from 220x110 to 460x180

- Replace legacy Windows assertions with exact flush main shell and shared voice-orb geometry contracts

- Add `check:windows-ui-config` npm script and run it in cross-platform CI


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["update test assertions"] --> B["capsule window 460x180"]
  A --> C["flush main shell contract"]
  A --> D["host metrics mirror voice-orb stage"]
  B --> E["CI runs check:windows-ui-config"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ci.yml</strong><dd><code>Add Windows UI config check to CI</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/ci.yml

- Added step to run "npm run check:windows-ui-config"


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/829/files#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03f">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>package.json</strong><dd><code>Add npm script for Windows UI contract</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/package.json

- Added "check:windows-ui-config" npm script


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/829/files#diff-2650f8aa2f7ec97aa8af47f1f8a7c9ae4677fb69754b20d554e1d542507cf4ea">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>windows-ui-config.test.mjs</strong><dd><code>Repair and modernize Windows UI config tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/scripts/windows-ui-config.test.mjs

<ul><li>Updated capsule window size from 220x110 to 460x180<br> <li> Replaced old floating shell assertion with flush main panel contract<br> <li> Updated host metrics assertions to use shared voice-orb stage <br>(460x180, zero insets)<br> <li> Replaced legacy Windows runtime bounds checks with new 460x180 stage <br>and 140px visual height assertions<br> <li> Removed outdated badge anchoring assertion and replaced with <br>proportional badge positioning</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/829/files#diff-ff4f88d3d6c6af6bc0498b2cfc2b4854e29b598090032eccc3e97da597a5ceb3">+33/-17</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

