### PR TITLE
ci: execute all frontend and contract tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 # 多平台跨语言质量门禁。release-tauri.yml 是发版流水线（仅打包构建），这里负责
 # 在合并前快速验证两件事：
-#   1. 前端 typecheck + vite bundle 通过（tsc + vite build，捕获跨 locale 类型 drift）
+#   1. 全部前端/契约测试与 vite bundle 通过（捕获行为、合同及跨 locale 类型 drift）
 #   2. Rust 后端在 macOS / Windows / Linux 都能 cargo check 过（捕获 cfg 漏分支 / 平台 API 误用）
 # 跑 build-mac.sh / windows-package-msvc.ps1 / Tauri bundle 太重；只跑轻量 cargo check + vite build。
 
@@ -152,21 +152,8 @@ jobs:
             }
           }
 
-      - name: Check macOS capsule Spaces contract
-        run: npm run check:macos-capsule-spaces
-
-      - name: Check Windows UI configuration contract
-        run: npm run check:windows-ui-config
-
-      - name: Check PIN persistence security contract
-        run: npm run check:pin-persistence-security
-
-      - name: Check macOS speech usage description contract
-        if: runner.os == 'macOS'
-        run: npm run check:macos-speech-usage-description
-
-      - name: Build frontend (tsc + vite)
-        run: npm run build
+      - name: Build frontend and run frontend/contract tests
+        run: npm test
 
       - name: Check Tauri backend (cargo check)
         run: cargo check --manifest-path src-tauri/Cargo.toml

--- a/openless-all/app/package.json
+++ b/openless-all/app/package.json
@@ -4,6 +4,8 @@
   "version": "1.3.14",
   "type": "module",
   "scripts": {
+    "pretest": "npm run build",
+    "test": "node scripts/frontend-test-runner.mjs",
     "dev": "vite",
     "prebuild": "node scripts/android-ipc-import-boundary.test.mjs",
     "build": "tsc && vite build",

--- a/openless-all/app/scripts/check-hotkey-injection.mjs
+++ b/openless-all/app/scripts/check-hotkey-injection.mjs
@@ -1,5 +1,13 @@
 import { spawnSync } from 'node:child_process';
 
+if (process.platform === 'win32') {
+  // The full Tauri lib-test binary is compile-only on clean Windows runners because an
+  // optional native runtime DLL is unavailable there. CI executes this behavioral gate on
+  // macOS/Linux and still compiles the same Rust test on Windows via `cargo test --no-run`.
+  console.log('Hotkey injection runtime gate skipped on Windows (covered by lib-test compilation).');
+  process.exit(0);
+}
+
 const result = spawnSync(
   'cargo',
   ['test', '--manifest-path', 'src-tauri/Cargo.toml', 'hotkey_injection_gate_logs_pressed_and_cancels', '--', '--nocapture'],

--- a/openless-all/app/scripts/frontend-test-runner.mjs
+++ b/openless-all/app/scripts/frontend-test-runner.mjs
@@ -1,0 +1,87 @@
+import { readdirSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import { dirname, join, relative, resolve, sep } from 'node:path';
+import process from 'node:process';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const DEFAULT_APP_ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
+
+function collectFiles(directory, predicate, files = []) {
+  for (const entry of readdirSync(directory, { withFileTypes: true }).sort((a, b) =>
+    a.name.localeCompare(b.name),
+  )) {
+    const entryPath = join(directory, entry.name);
+    if (entry.isDirectory()) {
+      collectFiles(entryPath, predicate, files);
+    } else if (entry.isFile() && predicate(entry.name)) {
+      files.push(entryPath);
+    }
+  }
+  return files;
+}
+
+export function discoverTestFiles(appRoot = DEFAULT_APP_ROOT) {
+  return [
+    ...collectFiles(join(appRoot, 'src'), (name) => name.endsWith('.test.ts')),
+    ...collectFiles(
+      join(appRoot, 'scripts'),
+      (name) => name.endsWith('.test.mjs') || (name.startsWith('check-') && name.endsWith('.mjs')),
+    ),
+  ]
+    .map((file) => relative(appRoot, file).split(sep).join('/'))
+    .sort();
+}
+
+export function runTestFiles(
+  testFiles,
+  {
+    appRoot = DEFAULT_APP_ROOT,
+    log = console.log,
+    spawn = spawnSync,
+    tsxCli,
+  } = {},
+) {
+  let resolvedTsxCli = tsxCli;
+
+  for (const testFile of testFiles) {
+    const absoluteTestFile = resolve(appRoot, testFile);
+    let args;
+    if (testFile.endsWith('.test.ts')) {
+      resolvedTsxCli ??= fileURLToPath(import.meta.resolve('tsx/cli'));
+      args = [resolvedTsxCli, absoluteTestFile];
+    } else if (testFile.endsWith('.mjs')) {
+      args = [absoluteTestFile];
+    } else {
+      log(`[frontend-tests] unsupported test file: ${testFile}`);
+      return 1;
+    }
+
+    log(`[frontend-tests] ${testFile}`);
+    const result = spawn(process.execPath, args, {
+      cwd: appRoot,
+      env: process.env,
+      stdio: 'inherit',
+    });
+    if (result.error) {
+      log(`[frontend-tests] failed to start ${testFile}: ${result.error.message}`);
+      return 1;
+    }
+    if (result.status !== 0) {
+      return result.status ?? 1;
+    }
+  }
+
+  return 0;
+}
+
+const invokedPath = process.argv[1] ? pathToFileURL(resolve(process.argv[1])).href : '';
+if (invokedPath === import.meta.url) {
+  const testFiles = discoverTestFiles();
+  if (testFiles.length === 0) {
+    console.error('[frontend-tests] no tests discovered');
+    process.exitCode = 1;
+  } else {
+    console.log(`[frontend-tests] discovered ${testFiles.length} tests`);
+    process.exitCode = runTestFiles(testFiles);
+  }
+}

--- a/openless-all/app/scripts/frontend-test-runner.test.mjs
+++ b/openless-all/app/scripts/frontend-test-runner.test.mjs
@@ -1,0 +1,51 @@
+import assert from 'node:assert/strict';
+import { resolve } from 'node:path';
+import process from 'node:process';
+
+import { discoverTestFiles, runTestFiles } from './frontend-test-runner.mjs';
+
+const discovered = discoverTestFiles();
+for (const expected of [
+  'scripts/check-android-updater-pubkey.mjs',
+  'scripts/check-hotkey-injection.mjs',
+  'scripts/macos-capsule-spaces-contract.test.mjs',
+  'scripts/macos-speech-usage-description-contract.test.mjs',
+  'scripts/windows-ui-config.test.mjs',
+  'src/lib/hotkeyRecorder.test.ts',
+  'src/lib/windowHotkeyFallback.test.ts',
+]) {
+  assert(discovered.includes(expected), `aggregate discovery omitted ${expected}`);
+}
+assert.equal(new Set(discovered).size, discovered.length, 'aggregate discovery must not duplicate tests');
+
+const invocations = [];
+const statuses = [0, 7, 0];
+const exitCode = runTestFiles(
+  [
+    'src/lib/passes.test.ts',
+    'scripts/fails.test.mjs',
+    'scripts/must-not-run.test.mjs',
+  ],
+  {
+    appRoot: '/app',
+    log: () => {},
+    spawn(command, args, options) {
+      invocations.push({ command, args, options });
+      return { status: statuses[invocations.length - 1] };
+    },
+    tsxCli: '/tools/tsx-cli.mjs',
+  },
+);
+
+assert.equal(exitCode, 7, 'the aggregate runner must propagate a failing child status');
+assert.equal(invocations.length, 2, 'the aggregate runner must stop after the first failure');
+assert.deepEqual(invocations[0].args, [
+  '/tools/tsx-cli.mjs',
+  resolve('/app', 'src/lib/passes.test.ts'),
+]);
+assert.deepEqual(invocations[1].args, [resolve('/app', 'scripts/fails.test.mjs')]);
+assert.equal(invocations[0].command, process.execPath);
+assert.equal(invocations[1].command, process.execPath);
+assert.equal(invocations[0].options.stdio, 'inherit');
+
+console.log('frontend-test-runner.test.mjs passed');

--- a/openless-all/app/scripts/macos-speech-usage-description-contract.test.mjs
+++ b/openless-all/app/scripts/macos-speech-usage-description-contract.test.mjs
@@ -4,6 +4,11 @@ import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { spawnSync } from 'node:child_process';
 
+if (process.platform !== 'darwin') {
+  console.log('macOS speech usage description contract skipped on non-macOS');
+  process.exit(0);
+}
+
 const scriptsDir = fileURLToPath(new URL('.', import.meta.url));
 const checker = join(scriptsDir, 'check-macos-speech-usage-description.sh');
 const fixtureDir = mkdtempSync(join(tmpdir(), 'openless-speech-usage-'));


### PR DESCRIPTION
### **User description**
Closes #806

## Summary
- add one deterministic `npm test` entry point that discovers every tracked `src/**/*.test.ts`, `scripts/**/*.test.mjs`, and `scripts/check-*.mjs` check
- invoke the pinned local `tsx` CLI through Node without `npx`, shell chaining, or runtime downloads
- build the frontend in `pretest` so the Tauri hotkey gate has a clean `frontendDist`
- run the aggregate command on macOS, Windows, and Linux CI after `npm ci`
- preserve the repository Windows lib-test limitation: the hotkey behavior runs on macOS/Linux and the same Rust test remains compile-checked on Windows

## RED
- `npm test` failed because no aggregate runner existed
- after adding discovery, the runner failed on `check-*.mjs`, proving those checks would otherwise be omitted
- from an empty `dist`, the hotkey child failed at Tauri `frontendDist`, leading to the deterministic `pretest` build

## GREEN / verification
- clean-dist `CARGO_TARGET_DIR=/Volumes/mac/openless-target/issue-806 npm test` (19 discovered checks; all passed)
- aggregate self-test injects child status 7 and asserts exact propagation plus fail-fast
- `npm audit --audit-level=high` (0 vulnerabilities)
- Node syntax checks for all changed `.mjs` files
- workflow YAML parse
- `git diff --check`
- exact-commit gitleaks scan

No product or UI behavior changes.


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Replace multiple CI steps with a single `npm test` command

- Add aggregate test runner that discovers all test files

- Add platform-specific skips for hotkey and speech tests


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["npm test"] --> B["pretest: npm run build"]
  B --> C["test: node frontend-test-runner.mjs"]
  C --> D["discover test files"]
  D --> E["run .test.ts via tsx"]
  D --> F["run .test.mjs directly"]
  D --> G["run check-*.mjs directly"]
  E --> H["results"]
  F --> H
  G --> H
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Ci</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ci.yml</strong><dd><code>Consolidate CI test steps into one</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/ci.yml

<ul><li>Replaced separate contract test steps with a single <code>npm test</code> command.<br> <li> Removed individual check steps for macOS, Windows, PIN, and speech <br>contracts.</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/832/files#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03f">+3/-16</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>package.json</strong><dd><code>Add test scripts to package.json</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/package.json

<ul><li>Added <code>pretest</code> script to build frontend before testing.<br> <li> Added <code>test</code> script to invoke the aggregate test runner.</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/832/files#diff-2650f8aa2f7ec97aa8af47f1f8a7c9ae4677fb69754b20d554e1d542507cf4ea">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>frontend-test-runner.mjs</strong><dd><code>Aggregate test runner implementation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/scripts/frontend-test-runner.mjs

<ul><li>New file that discovers and runs all test files (<code>.test.ts</code>, <code>.test.mjs</code>, <br><code>check-*.mjs</code>).<br> <li> Exports <code>discoverTestFiles</code> and <code>runTestFiles</code> for reuse.<br> <li> Supports CLI invocation for direct use.</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/832/files#diff-c3cd002c7fd589d440b5c44075fe8c612acbb50a2c109f4c5e67a9c74406ab6e">+87/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>frontend-test-runner.test.mjs</strong><dd><code>Self-test for aggregate runner</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/scripts/frontend-test-runner.test.mjs

<ul><li>Self-test for the aggregate runner verifying discovery and failure <br>propagation.<br> <li> Spies on spawn calls to validate correct command and arguments.</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/832/files#diff-99c1cf28598eed30e3f5eada739e9e0a81078354c8500793b39fa33e049d762c">+51/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>check-hotkey-injection.mjs</strong><dd><code>Skip hotkey runtime gate on Windows</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/scripts/check-hotkey-injection.mjs

<ul><li>Added early exit on Windows with explanatory comment.<br> <li> Maintains compile-only check on Windows via <code>cargo test --no-run</code>.</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/832/files#diff-55c3be5b349ec49a46bf1bcea3d9eb7169c09335c674a086f2524e774ad808c9">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>macos-speech-usage-description-contract.test.mjs</strong><dd><code>Skip speech contract on non-macOS</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/scripts/macos-speech-usage-description-contract.test.mjs

- Added platform check to skip on non-macOS systems.


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/832/files#diff-61a36946915037f107aa9f04f67902ce82c6c5fba58a85364f5fd7cd34ffdcec">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

