### PR TITLE
fix(updater): discover modern Beta release tags

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -27,8 +27,10 @@ Two channels; the branch name equals the channel name:
 Release tags (created by an admin only):
 
 - **Stable release:** push tag `v<version>-tauri`.
-- **Beta release:** push tag `v<version>-beta-tauri` (published as a GitHub
-  pre-release; never auto-updates Stable users).
+- **Beta release:** push tag `v<X.Y.Z>-Beta.<N>-tauri`, for example
+  `v1.3.15-Beta.1-tauri` (published as a GitHub pre-release; never auto-updates
+  Stable users). The updater still recognizes the historical `*-beta-tauri`
+  suffix for existing releases, but new releases use the `Beta.<N>` form.
 
 ## Version-sync gate
 
@@ -41,7 +43,8 @@ with `1-app/scripts/bump-version.sh <X.Y.Z>`:
 - `openless-all/app/src-tauri/Cargo.toml`
 - `openless-all/app/src-tauri/Cargo.lock` (the `name = "openless"` block)
 
-The script takes a plain `X.Y.Z`; for a `-beta` suffix, edit the files by hand.
+The script takes a plain `X.Y.Z`; for a prerelease version such as
+`X.Y.Z-Beta.N`, edit the files by hand.
 
 ## Pre-release checklist (for the admin cutting the release)
 

--- a/openless-all/app/src-tauri/src/android/updater_logic.rs
+++ b/openless-all/app/src-tauri/src/android/updater_logic.rs
@@ -123,6 +123,24 @@ mod tests {
     }
 
     #[test]
+    fn beta_manifest_urls_skip_malformed_modern_tags_from_atom() {
+        let body = r#"<feed>
+  <entry><link href="https://github.com/appergb/openless/releases/tag/v-Beta.1-tauri"/></entry>
+  <entry><link href="https://github.com/appergb/openless/releases/tag/garbage-Beta.1-tauri"/></entry>
+  <entry><link href="https://github.com/appergb/openless/releases/tag/v1.3.15-Beta.1-tauri"/></entry>
+</feed>"#;
+        let latest = crate::commands::parse_latest_beta_from_atom(body)
+            .expect("Android updater must skip malformed Beta tags");
+
+        let urls = beta_manifest_urls("aarch64", &latest.tag_name);
+
+        assert_eq!(latest.tag_name, "v1.3.15-Beta.1-tauri");
+        assert!(urls
+            .iter()
+            .all(|url| url.contains("/releases/download/v1.3.15-Beta.1-tauri/")));
+    }
+
+    #[test]
     fn map_abi_to_arch_maps_arm64() {
         assert_eq!(map_abi_to_arch("arm64-v8a"), "aarch64");
     }

--- a/openless-all/app/src-tauri/src/android/updater_logic.rs
+++ b/openless-all/app/src-tauri/src/android/updater_logic.rs
@@ -100,6 +100,29 @@ mod tests {
     }
 
     #[test]
+    fn beta_manifest_urls_use_newest_modern_beta_tag_from_atom() {
+        let body = r#"<feed>
+  <entry>
+    <updated>2026-07-15T07:00:00Z</updated>
+    <link rel="alternate" type="text/html" href="https://github.com/appergb/openless/releases/tag/v1.3.15-Beta.1-tauri"/>
+  </entry>
+  <entry>
+    <updated>2026-06-17T15:41:46Z</updated>
+    <link rel="alternate" type="text/html" href="https://github.com/appergb/openless/releases/tag/v1.3.10-4-beta-tauri"/>
+  </entry>
+</feed>"#;
+        let latest = crate::commands::parse_latest_beta_from_atom(body)
+            .expect("Android updater must discover the modern Beta tag");
+
+        let urls = beta_manifest_urls("aarch64", &latest.tag_name);
+
+        assert_eq!(latest.tag_name, "v1.3.15-Beta.1-tauri");
+        assert!(urls
+            .iter()
+            .all(|url| url.contains("/releases/download/v1.3.15-Beta.1-tauri/")));
+    }
+
+    #[test]
     fn map_abi_to_arch_maps_arm64() {
         assert_eq!(map_abi_to_arch("arm64-v8a"), "aarch64");
     }

--- a/openless-all/app/src-tauri/src/commands/mod.rs
+++ b/openless-all/app/src-tauri/src/commands/mod.rs
@@ -1305,6 +1305,33 @@ mod tests {
     }
 
     #[test]
+    fn parse_latest_beta_from_atom_skips_malformed_modern_tags() {
+        let body = r#"<feed>
+  <entry><link href="https://github.com/appergb/openless/releases/tag/v-Beta.1-tauri"/></entry>
+  <entry><link href="https://github.com/appergb/openless/releases/tag/garbage-Beta.1-tauri"/></entry>
+  <entry><link href="https://github.com/appergb/openless/releases/tag/1.3.15-Beta.1-tauri"/></entry>
+  <entry><link href="https://github.com/appergb/openless/releases/tag/v1.3-Beta.1-tauri"/></entry>
+  <entry><link href="https://github.com/appergb/openless/releases/tag/v1.3.15.0-Beta.1-tauri"/></entry>
+  <entry><link href="https://github.com/appergb/openless/releases/tag/v1..15-Beta.1-tauri"/></entry>
+  <entry><link href="https://github.com/appergb/openless/releases/tag/v1.3.x-Beta.1-tauri"/></entry>
+  <entry><link href="https://github.com/appergb/openless/releases/tag/v1.3.15-Beta.-tauri"/></entry>
+  <entry><link href="https://github.com/appergb/openless/releases/tag/v1.3.15-Beta.x-tauri"/></entry>
+  <entry><link href="https://github.com/appergb/openless/releases/tag/v1.3.15-Beta.1-extra-tauri"/></entry>
+  <entry><link href="https://github.com/appergb/openless/releases/tag/v1.3.15-Beta.1-tauri-extra"/></entry>
+  <entry><link href="https://github.com/appergb/openless/releases/tag/v1.3.15-Beta.2-Beta.1-tauri"/></entry>
+  <entry>
+    <updated>2026-07-15T07:00:00Z</updated>
+    <link href="https://github.com/appergb/openless/releases/tag/v1.3.15-Beta.1-tauri"/>
+  </entry>
+</feed>"#;
+
+        let got = parse_latest_beta_from_atom(body).expect("must skip malformed Beta tags");
+
+        assert_eq!(got.tag_name, "v1.3.15-Beta.1-tauri");
+        assert_eq!(got.published_at, "2026-07-15T07:00:00Z");
+    }
+
+    #[test]
     fn parse_latest_beta_from_atom_returns_none_when_only_stable_releases() {
         let body = r#"<feed>
   <entry>

--- a/openless-all/app/src-tauri/src/commands/mod.rs
+++ b/openless-all/app/src-tauri/src/commands/mod.rs
@@ -1281,6 +1281,30 @@ mod tests {
     }
 
     #[test]
+    fn parse_latest_beta_from_atom_prefers_modern_beta_tag_over_legacy_beta() {
+        let body = r#"<?xml version="1.0"?>
+<feed>
+  <entry>
+    <updated>2026-07-15T08:00:00Z</updated>
+    <link rel="alternate" type="text/html" href="https://github.com/appergb/openless/releases/tag/v1.3.15-tauri"/>
+  </entry>
+  <entry>
+    <updated>2026-07-15T07:00:00Z</updated>
+    <link rel="alternate" type="text/html" href="https://github.com/appergb/openless/releases/tag/v1.3.15-Beta.1-tauri"/>
+  </entry>
+  <entry>
+    <updated>2026-06-17T15:41:46Z</updated>
+    <link rel="alternate" type="text/html" href="https://github.com/appergb/openless/releases/tag/v1.3.10-4-beta-tauri"/>
+  </entry>
+</feed>"#;
+
+        let got = parse_latest_beta_from_atom(body).expect("must find the newest Beta entry");
+
+        assert_eq!(got.tag_name, "v1.3.15-Beta.1-tauri");
+        assert_eq!(got.published_at, "2026-07-15T07:00:00Z");
+    }
+
+    #[test]
     fn parse_latest_beta_from_atom_returns_none_when_only_stable_releases() {
         let body = r#"<feed>
   <entry>

--- a/openless-all/app/src-tauri/src/commands/settings.rs
+++ b/openless-all/app/src-tauri/src/commands/settings.rs
@@ -532,10 +532,24 @@ fn is_beta_release_tag(tag_name: &str) -> bool {
         return true;
     }
 
-    tag_name
-        .strip_suffix("-tauri")
-        .and_then(|tag| tag.rsplit_once("-Beta."))
-        .is_some_and(|(_, number)| !number.is_empty() && number.chars().all(|c| c.is_ascii_digit()))
+    let Some((version, beta_number)) = tag_name
+        .strip_prefix('v')
+        .and_then(|tag| tag.strip_suffix("-tauri"))
+        .and_then(|tag| tag.split_once("-Beta."))
+    else {
+        return false;
+    };
+
+    if beta_number.is_empty() || !beta_number.chars().all(|c| c.is_ascii_digit()) {
+        return false;
+    }
+
+    let mut version_parts = version.split('.');
+    (0..3).all(|_| {
+        version_parts
+            .next()
+            .is_some_and(|part| !part.is_empty() && part.chars().all(|c| c.is_ascii_digit()))
+    }) && version_parts.next().is_none()
 }
 
 fn extract_between(haystack: &str, open: &str, close: &str) -> Option<String> {

--- a/openless-all/app/src-tauri/src/commands/settings.rs
+++ b/openless-all/app/src-tauri/src/commands/settings.rs
@@ -465,13 +465,13 @@ pub struct LatestBetaRelease {
     pub published_at: String,
 }
 
-/// 拉 GitHub Releases atom feed 找最新 Beta release（tag 以 `-beta-tauri` 结尾）。
+/// 拉 GitHub Releases atom feed 找最新 Beta release。
 ///
 /// 历史：之前用 `api.github.com/repos/.../releases` REST 端点，**未认证 60 req/h/IP**，
 /// 多人多次切 Beta toggle 很容易撞 403 rate limit（用户报"获取 Beta 版本信息失败"
 /// 即是这个）。换成 `releases.atom` 后是公开页面 + CDN cache，没有同等 rate 限制。
-/// Atom feed 不显式标 prerelease，但项目约定 tag 后缀 `-beta-tauri` 必为 Beta，
-/// 所以只用 tag 后缀过滤就够了。
+/// Atom feed 不显式标 prerelease，所以按当前 `-Beta.N-tauri` 约定过滤，同时兼容
+/// 历史 `-beta-tauri` 后缀。
 ///
 /// 返回 `Ok(None)` = 当前没发过 Beta 版；`Err(String)` = 网络/解析故障。
 #[tauri::command]
@@ -512,7 +512,7 @@ pub(crate) fn parse_latest_beta_from_atom(body: &str) -> Option<LatestBetaReleas
             .find(|c: char| c == '"' || c == '<' || c == ' ' || c == '/')
             .unwrap_or(tag_after.len());
         let tag_name = tag_after[..tag_end].to_string();
-        if !tag_name.ends_with("-beta-tauri") {
+        if !is_beta_release_tag(&tag_name) {
             continue;
         }
         let html_url = format!("https://github.com/appergb/openless/releases/tag/{tag_name}");
@@ -525,6 +525,17 @@ pub(crate) fn parse_latest_beta_from_atom(body: &str) -> Option<LatestBetaReleas
         });
     }
     None
+}
+
+fn is_beta_release_tag(tag_name: &str) -> bool {
+    if tag_name.ends_with("-beta-tauri") {
+        return true;
+    }
+
+    tag_name
+        .strip_suffix("-tauri")
+        .and_then(|tag| tag.rsplit_once("-Beta."))
+        .is_some_and(|(_, number)| !number.is_empty() && number.chars().all(|c| c.is_ascii_digit()))
 }
 
 fn extract_between(haystack: &str, open: &str, close: &str) -> Option<String> {


### PR DESCRIPTION
### **User description**
## Summary

- recognize the current `vX.Y.Z-Beta.N-tauri` release-tag convention when reading the GitHub Releases Atom feed
- preserve discovery of historical `*-beta-tauri` releases
- cover desktop selection and Android manifest URL composition with regressions that prefer `v1.3.15-Beta.1-tauri` over the obsolete `v1.3.10-4-beta-tauri`
- align `RELEASING.md` with the modern Beta tag convention

## Root cause

The shared Atom parser only accepted tags ending in lowercase `-beta-tauri`. Current releases use `-Beta.N-tauri`, so desktop and Android skipped every recent Beta entry and selected the last legacy release still present in the feed.

## Validation

- RED: both new focused tests failed with actual `v1.3.10-4-beta-tauri` vs expected `v1.3.15-Beta.1-tauri`
- GREEN: both focused tests pass after the shared parser fix
- `cargo test --manifest-path openless-all/app/src-tauri/Cargo.toml --lib` — 726 passed
- `cargo test --manifest-path openless-all/app/src-tauri/backend-tests/Cargo.toml` — 119 passed
- `npm test` — aggregate runner passed all 22 discovered frontend/contract tests
- `cargo check --manifest-path openless-all/app/src-tauri/Cargo.toml`
- `cargo audit --file openless-all/app/src-tauri/Cargo.lock` — no vulnerabilities; 18 allowed upstream maintenance/unsoundness warnings
- `npm audit` — 0 vulnerabilities
- `npm run build`
- changed Rust files formatted with `rustfmt`; `git diff --check` passed
- gitleaks scanned the exact commit with no leaks
- current `beta` merge-tree passed cleanly against `664633f32d8d877510db25ec9d37e8b49e54d918`

## Scope

No UI changes, version bump, tag, release, or release-workflow trigger.


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Recognize modern `vX.Y.Z-Beta.N-tauri` tag format in Atom feed parser

- Preserve backward compatibility with legacy `*-beta-tauri` suffix

- Reject malformed modern tags (invalid version or beta number)

- Update unit tests for desktop and Android, and document new convention


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A[Atom Feed] --> B(parse_latest_beta_from_atom)
  B --> C{is_beta_release_tag}
  C -->|Legacy -beta-tauri| D[Accept]
  C -->|Modern -Beta.N-tauri| E[Validate version & beta number]
  E --> F[Accept]
  E --> G[Skip]
  D --> H[Return latest release]
  F --> H
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>settings.rs</strong><dd><code>Add is_beta_release_tag validation function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src-tauri/src/commands/settings.rs

<ul><li>Added <code>is_beta_release_tag</code> function to validate both legacy and modern <br>beta tag formats<br> <li> Updated <code>parse_latest_beta_from_atom</code> to use the new function<br> <li> Added validation to reject malformed modern tags (e.g., missing <br>version parts, non-digit beta number)<br> <li> Updated doc comments to reflect new tag convention</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/833/files#diff-c261a627e4d3feecf669d8b70aca73334411840c7f3cce4ef7746efa45e2fba1">+29/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mod.rs</strong><dd><code>Add unit tests for modern beta tag detection</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src-tauri/src/commands/mod.rs

<ul><li>Added test <br><code>parse_latest_beta_from_atom_prefers_modern_beta_tag_over_legacy_beta</code><br> <li> Added test <code>parse_latest_beta_from_atom_skips_malformed_modern_tags</code></ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/833/files#diff-927cec8f506f8369417751238e7d018c43bad50133e1488750ee0f9feb5f6449">+51/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>updater_logic.rs</strong><dd><code>Add Android beta URL tests with modern tags</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src-tauri/src/android/updater_logic.rs

<ul><li>Added test <code>beta_manifest_urls_use_newest_modern_beta_tag_from_atom</code><br> <li> Added test <code>beta_manifest_urls_skip_malformed_modern_tags_from_atom</code></ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/833/files#diff-e3b88842f22f5d1f57184d4d82cb6fe07629e39a4c513271d8da64ae79336bb4">+41/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>RELEASING.md</strong><dd><code>Update RELEASING.md with modern beta tag convention</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

RELEASING.md

<ul><li>Updated beta release tag format to <code>vX.Y.Z-Beta.<N>-tauri</code><br> <li> Noted backward compatibility with historical <code>*-beta-tauri</code> suffix<br> <li> Updated version bump script instructions for prerelease versions</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/833/files#diff-87d6a57a759f2386bf9caf5309b9aa0b9ff0ca70f5e38696e114a1ccdb0e785d">+6/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

