### PR TITLE
chore(release): prepare 1.3.15-Beta.1

### DIFF
--- a/openless-all/app/package-lock.json
+++ b/openless-all/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openless-app",
-  "version": "1.3.14",
+  "version": "1.3.15-Beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openless-app",
-      "version": "1.3.14",
+      "version": "1.3.15-Beta.1",
       "dependencies": {
         "@base-ui/react": "^1.6.0",
         "@formkit/auto-animate": "^0.9.0",

--- a/openless-all/app/package.json
+++ b/openless-all/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openless-app",
   "private": true,
-  "version": "1.3.14",
+  "version": "1.3.15-Beta.1",
   "type": "module",
   "scripts": {
     "pretest": "npm run build",

--- a/openless-all/app/src-tauri/Cargo.lock
+++ b/openless-all/app/src-tauri/Cargo.lock
@@ -3909,7 +3909,7 @@ dependencies = [
 
 [[package]]
 name = "openless"
-version = "1.3.14"
+version = "1.3.15-Beta.1"
 dependencies = [
  "anyhow",
  "arboard",

--- a/openless-all/app/src-tauri/Cargo.toml
+++ b/openless-all/app/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openless"
-version = "1.3.14"
+version = "1.3.15-Beta.1"
 description = "OpenLess — local voice input that types where your cursor is"
 authors = ["OpenLess"]
 edition = "2021"

--- a/openless-all/app/src-tauri/tauri.conf.json
+++ b/openless-all/app/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "OpenLess",
-  "version": "1.3.14",
+  "version": "1.3.15-Beta.1",
   "identifier": "com.openless.app",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
### **User description**
## Summary
- bump the synchronized app, Tauri, and Cargo package version to `1.3.15-Beta.1`
- keep the release diff limited to five metadata files (six version values)
- prepare the collision-free tag `v1.3.15-Beta.1-tauri`

This PR contains no application logic or UI changes.

## Verification
- `npm test` (22 frontend/contract tests; hotkey gate passed)
- `cargo test --locked --lib --quiet` (728 passed)
- `cargo test --manifest-path backend-tests/Cargo.toml --quiet` (119 passed)
- `cargo check --locked`
- `npm audit --audit-level=low` (0 vulnerabilities)
- `cargo audit` (0 denied advisories; 18 repository-allowed warnings)
- `gitleaks git --log-opts=v1.3.14-tauri..HEAD` (no leaks)
- local macOS release bundle succeeded; Info.plist, ad-hoc signature, and quarantine checks passed

## Release
After independent review and all exact-head checks pass, merge into `beta`, create `v1.3.15-Beta.1-tauri`, and verify the desktop and Android release workflows/assets.


___

### **PR Type**
Other


___

### **Description**
- Bump version to 1.3.15-Beta.1 across frontend, backend, and Tauri config


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["package.json"] --> B["version 1.3.15-Beta.1"]
  C["Cargo.toml"] --> B
  D["tauri.conf.json"] --> B
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>package.json</strong><dd><code>Bump frontend version to 1.3.15-Beta.1</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/package.json

- Updated version from 1.3.14 to 1.3.15-Beta.1


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/834/files#diff-2650f8aa2f7ec97aa8af47f1f8a7c9ae4677fb69754b20d554e1d542507cf4ea">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Cargo.toml</strong><dd><code>Bump backend version to 1.3.15-Beta.1</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src-tauri/Cargo.toml

- Updated version from 1.3.14 to 1.3.15-Beta.1


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/834/files#diff-334952ba03e62939865bbf0351f0916ea88c6457f8ea1259336e73ee4e2f088b">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>tauri.conf.json</strong><dd><code>Bump Tauri config version to 1.3.15-Beta.1</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src-tauri/tauri.conf.json

- Updated version from 1.3.14 to 1.3.15-Beta.1


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/834/files#diff-e9c2f15638ea988f61c82aeb2257147fb9cc96d7bda8709e8bad6b6517f5369c">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

