### PR TITLE
feat(llm): 新增 StepFun 供应商预设；修复 Codex OAuth 默认模型不可用

### DIFF
--- a/openless-all/app/src-tauri/src/commands/credentials.rs
+++ b/openless-all/app/src-tauri/src/commands/credentials.rs
@@ -92,6 +92,7 @@ fn llm_provider_default_endpoint(provider: &str) -> Option<&'static str> {
         "openrouterFree" => Some("https://openrouter.ai/api/v1"),
         "alibabaCoding" => Some("https://coding-intl.dashscope.aliyuncs.com/v1"),
         "codingPlanX" => Some("https://api.codingplanx.ai/v1"),
+        "stepfun" => Some("https://api.stepfun.com/v1"),
         _ => None,
     }
 }

--- a/openless-all/app/src-tauri/src/polish.rs
+++ b/openless-all/app/src-tauri/src/polish.rs
@@ -25,7 +25,10 @@ const DEFAULT_REQUEST_TIMEOUT_SECS: u64 = 30;
 const BODY_PREVIEW_LIMIT: usize = 200;
 pub const CODEX_OAUTH_PROVIDER_ID: &str = "codex_oauth";
 pub const CODEX_DEFAULT_BASE_URL: &str = "https://chatgpt.com/backend-api";
-pub const CODEX_DEFAULT_MODEL: &str = "gpt-5.3-codex-spark";
+// 注意：gpt-5.3-codex-spark 不能做默认——ChatGPT 账号走 Codex OAuth 时后端会
+// 400 拒绝（"model is not supported when using Codex with a ChatGPT account"），
+// 每次润色都失败并回退原文。gpt-5.5 是该通道实测可用的模型。
+pub const CODEX_DEFAULT_MODEL: &str = "gpt-5.5";
 const CODEX_MIN_TOKEN_TTL_SECS: u64 = 60;
 
 #[derive(Clone, Debug)]
@@ -1607,7 +1610,9 @@ fn openai_compatible_thinking_control(provider_id: &str) -> Option<ThinkingContr
         "minimax" => Some(ThinkingControl::MiniMaxThinking),
         "openrouterFree" => Some(ThinkingControl::OpenRouterReasoning),
         "alibabaCoding" => Some(ThinkingControl::EnableThinking),
-        "openai" | "codingPlanX" => Some(ThinkingControl::ReasoningEffort),
+        // StepFun step-3.x-flash 系列按官方文档接受 reasoning_effort（low/medium/high，
+        // 无法完全关闭思考）；非推理模型（如 step-1o-turbo-vision）会忽略该字段。
+        "openai" | "codingPlanX" | "stepfun" => Some(ThinkingControl::ReasoningEffort),
         // custom / 其他未声明 provider 走 base_url 兜底识别——用户用自定义
         // endpoint 接入 MiniMax 时,根据 base_url 命中即下发官方 thinking 参数。
         _ => None,
@@ -1642,6 +1647,9 @@ fn openai_compatible_thinking_control_for_base_url(base_url: &str) -> Option<Thi
     }
     if host.contains("dashscope") || host.contains("aliyuncs") {
         return Some(ThinkingControl::EnableThinking);
+    }
+    if host.contains("stepfun") {
+        return Some(ThinkingControl::ReasoningEffort);
     }
     None
 }
@@ -2648,6 +2656,47 @@ mod tests {
                 "base_url={base_url} should trigger MiniMax thinking control"
             );
         }
+    }
+
+    #[test]
+    fn openai_chat_body_adds_reasoning_effort_for_stepfun_channel() {
+        // StepFun 按渠道声明下发 reasoning_effort:开启思考发 medium,关闭发 low。
+        for (thinking_enabled, expected) in [(true, "medium"), (false, "low")] {
+            let provider = OpenAICompatibleLLMProvider::new(
+                OpenAICompatibleConfig::new(
+                    "stepfun",
+                    "StepFun",
+                    "https://api.stepfun.com/v1",
+                    "k",
+                    "step-3.7-flash",
+                )
+                .with_thinking_enabled(thinking_enabled),
+            );
+
+            let body = provider.chat_body(false, vec![json!({ "role": "user", "content": "hi" })]);
+
+            assert_eq!(body["reasoning_effort"], expected);
+        }
+    }
+
+    #[test]
+    fn openai_chat_body_falls_back_to_base_url_for_custom_stepfun_endpoint() {
+        // 用 "custom" preset + StepFun base_url 接入时,base_url 兜底识别需要
+        // 命中 "stepfun" 关键字,下发 reasoning_effort。
+        let provider = OpenAICompatibleLLMProvider::new(
+            OpenAICompatibleConfig::new(
+                "custom",
+                "Custom",
+                "https://api.stepfun.com/v1",
+                "k",
+                "step-3.7-flash",
+            )
+            .with_thinking_enabled(false),
+        );
+
+        let body = provider.chat_body(false, vec![json!({ "role": "user", "content": "hi" })]);
+
+        assert_eq!(body["reasoning_effort"], "low");
     }
 
     #[test]

--- a/openless-all/app/src/i18n/en.ts
+++ b/openless-all/app/src/i18n/en.ts
@@ -782,6 +782,7 @@ export const en: typeof zhCN = {
         alibabaCoding: 'Alibaba Cloud Coding Plan',
         codingPlanX: 'CodingPlanX',
         minimax: 'MiniMax (M3)',
+        stepfun: 'StepFun',
         custom: 'Custom',
         asrVolcengine: 'Volcengine bigasr',
         asrBailian: 'Alibaba Bailian realtime ASR',

--- a/openless-all/app/src/i18n/ja.ts
+++ b/openless-all/app/src/i18n/ja.ts
@@ -784,6 +784,7 @@ export const ja: typeof zhCN = {
         alibabaCoding: 'Alibaba Cloud Coding Plan',
         codingPlanX: 'CodingPlanX',
         minimax: 'MiniMax（M3）',
+        stepfun: 'StepFun（階躍星辰）',
         custom: 'カスタム',
         asrVolcengine: 'Volcengine bigasr',
         asrBailian: 'Alibaba Bailian リアルタイム ASR',

--- a/openless-all/app/src/i18n/ko.ts
+++ b/openless-all/app/src/i18n/ko.ts
@@ -784,6 +784,7 @@ export const ko: typeof zhCN = {
         alibabaCoding: 'Alibaba Cloud Coding Plan',
         codingPlanX: 'CodingPlanX',
         minimax: 'MiniMax (M3)',
+        stepfun: 'StepFun',
         custom: '사용자 정의',
         asrVolcengine: 'Volcengine bigasr',
         asrBailian: 'Alibaba Bailian 실시간 ASR',

--- a/openless-all/app/src/i18n/zh-CN.ts
+++ b/openless-all/app/src/i18n/zh-CN.ts
@@ -780,6 +780,7 @@ export const zhCN = {
         alibabaCoding: '阿里云 Coding Plan',
         codingPlanX: 'CodingPlanX',
         minimax: 'MiniMax（M3）',
+        stepfun: 'StepFun（阶跃星辰）',
         custom: '自定义',
         asrVolcengine: '火山引擎 bigasr',
         asrBailian: '阿里云百炼实时 ASR',

--- a/openless-all/app/src/i18n/zh-TW.ts
+++ b/openless-all/app/src/i18n/zh-TW.ts
@@ -782,6 +782,7 @@ export const zhTW: typeof zhCN = {
         alibabaCoding: '阿里雲 Coding Plan',
         codingPlanX: 'CodingPlanX',
         minimax: 'MiniMax（M3）',
+        stepfun: 'StepFun（階躍星辰）',
         custom: '自定義',
         asrVolcengine: '火山引擎 bigasr',
         asrBailian: '阿里雲百煉即時 ASR',

--- a/openless-all/app/src/pages/settings/ProvidersSection.tsx
+++ b/openless-all/app/src/pages/settings/ProvidersSection.tsx
@@ -88,7 +88,9 @@ const LLM_PRESETS = [
     id: 'codex_oauth',
     nameKey: 'codexOAuth',
     baseUrl: '',
-    modelPlaceholder: 'gpt-5.3-codex-spark',
+    // gpt-5.3-codex-spark 对 ChatGPT 账号的 Codex 通道会被 400 拒绝，
+    // 默认与占位一律用实测可用的 gpt-5.5（见 polish.rs::CODEX_DEFAULT_MODEL）。
+    modelPlaceholder: 'gpt-5.5',
   },
   {
     id: 'mimo',
@@ -131,6 +133,19 @@ const LLM_PRESETS = [
     nameKey: 'minimax',
     baseUrl: 'https://api.minimaxi.com/v1',
     modelPlaceholder: 'MiniMax-M3',
+  },
+  {
+    // StepFun（阶跃星辰）OpenAI 兼容 /v1/chat/completions。
+    // 默认模型选 step-1o-turbo-vision：step-3.x-flash 系列是推理模型且思考无法关闭
+    // （reasoning_effort 只能调档，正式内容要等隐藏思考结束，润色场景 TTFT 2s+），
+    // 而 step-1o-turbo-vision 无思考、TTFT ~0.3s，润色忠实度实测更适合听写链路。
+    // provider_id 在后端 polish.rs::openai_compatible_thinking_control 命中
+    // "stepfun" → ReasoningEffort 分支；走"自定义"preset 接入时由 base_url
+    // 含 "stepfun" 兜底识别，见 polish.rs。
+    id: 'stepfun',
+    nameKey: 'stepfun',
+    baseUrl: 'https://api.stepfun.com/v1',
+    modelPlaceholder: 'step-1o-turbo-vision',
   },
   {
     id: 'custom',


### PR DESCRIPTION
### **User description**
## 背景

两个实际使用中撞上的问题：

1. **Codex OAuth 默认模型开箱即坏**：默认/占位模型 `gpt-5.3-codex-spark` 对 ChatGPT 账号的 Codex 通道会被后端 400 拒绝（`The 'gpt-5.3-codex-spark' model is not supported when using Codex with a ChatGPT account`）。每次润色都失败并静默回退原文，用户只会觉得"模型没处理"。
2. **StepFun 接入体验差**：用"自定义"preset 接 StepFun 时，"思考"开关完全不生效（thinking 控制表不认识 `api.stepfun.com`），而热门的 step-3.x-flash 系列是思考无法关闭的推理模型，润色一次 5–13 秒。

## 改动

### 新增 StepFun（阶跃星辰）LLM 供应商预设
- 预填 `https://api.stepfun.com/v1`，默认模型 `step-1o-turbo-vision`
- 五语言（zh-CN / zh-TW / en / ja / ko）显示名
- `llm_provider_default_endpoint` 补映射

**默认模型选型依据（真实润色 prompt 实测）：**

| 模型 | 流式首字 | 总耗时 | 结论 |
|---|---|---|---|
| step-3.7-flash | 2.2–4.3s | 至 5.6s | 思考关不掉（reasoning_effort / thinking:disabled 等 5 种写法均无法禁用，每次先输出 150–900 字隐藏思考） |
| step-3.5-flash-2603 | 1.6–3.9s | 至 5.6s | 同上 |
| stepaudio-2.5-chat | 0.4–0.5s | 0.4–1.0s | 最快但指令遵循不稳定，出现过不润色反而"回答"转写内容的情况 |
| **step-1o-turbo-vision** | **0.2–0.5s** | 短句 <1s | 无思考、润色忠实稳定，胜出 |

### thinking 控制支持 StepFun
- `openai_compatible_thinking_control` 新增 `stepfun → ReasoningEffort`（官方参数：开=medium / 关=low）
- base_url 兜底识别新增 `stepfun` 关键字，覆盖用"自定义"preset 接入的存量用户
- 新增两个单元测试（preset 命中 + base_url 兜底命中）

### Codex OAuth 默认模型改为 gpt-5.5
- `CODEX_DEFAULT_MODEL` 与前端占位从 `gpt-5.3-codex-spark` 改为实测可用的 `gpt-5.5`，常量处注释记录 400 拒绝原因

## 验证

- `cargo test --lib polish`：72 通过（含 2 个新测试）
- `tsc --noEmit`、`vite build` 无错
- StepFun 各模型延迟/质量为真实 API 实测（见上表）

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Add StepFun (阶跃星辰) LLM provider preset with default model

- Fix Codex OAuth default model causing silent failure

- Enable "thinking" control for StepFun via reasoning_effort

- Add i18n translations for StepFun across 5 languages


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>credentials.rs</strong><dd><code>Add StepFun default endpoint mapping</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/836/files#diff-8d658e9fd5232f39056b70074eebd9a30437059e28f5118e37a6ba3c3c0ad80f">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>polish.rs</strong><dd><code>Fix Codex default model; add StepFun thinking control & tests</code></dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/836/files#diff-1be30d25d0bf8fc3e6c11bf4fa179521045a52ef4843271545acedfd0535e38b">+51/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ProvidersSection.tsx</strong><dd><code>Add StepFun preset; fix Codex placeholder model</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/836/files#diff-8fc332d1eb5b010583185b704ea439954650f6aff2d0195e00cd0cb76e526e7b">+16/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>en.ts</strong><dd><code>Add StepFun English translation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/836/files#diff-bb2f4fa05787923f8aeb23b6f11ad8705e02d9ff03a45790f9181e4615c79d83">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ja.ts</strong><dd><code>Add StepFun Japanese translation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/836/files#diff-be57f0090cf34e3ff924cfa35f13d5d9e6514d3af5a1ebfdeb92bd7d36ed9cf4">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ko.ts</strong><dd><code>Add StepFun Korean translation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/836/files#diff-daf35bcb6a2f8a31565b83d119cb59b69c1dededbabfccfd0d56693fdb3726ca">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>zh-CN.ts</strong><dd><code>Add StepFun Simplified Chinese translation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/836/files#diff-571576f3c7b6c4a78ae0f91accdccc5da5cbed00409955c9914c046fee6c80ea">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>zh-TW.ts</strong><dd><code>Add StepFun Traditional Chinese translation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/836/files#diff-a8d5953f9c76bc3c90ec583270be04c852bd7540297500e6ff3260760fc61ea4">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

