### PR TITLE
fix(android): protect credentials with Android Keystore

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,11 +106,14 @@ jobs:
         run: node scripts/copy-android-scaffolding.mjs
 
       - name: Run JVM credential tests and compile instrumentation tests
+        # These tests are Kotlin-only. The Rust target is checked above; direct Gradle
+        # rustBuild requires the live Tauri CLI RPC server used by `tauri android build`.
         run: >-
           src-tauri/gen/android/gradlew
           --project-dir src-tauri/gen/android
           :app:testX86_64DebugUnitTest
           :app:assembleX86_64DebugAndroidTest
+          -x :app:rustBuildX86_64Debug
           --no-daemon
 
       - name: Enable KVM for Android instrumentation tests
@@ -126,11 +129,13 @@ jobs:
           api-level: 35
           target: google_apis
           arch: x86_64
+          # The instrumentation suite exercises AndroidKeyStore without launching Tauri.
           script: >-
             cd openless-all/app &&
             src-tauri/gen/android/gradlew
             --project-dir src-tauri/gen/android
             :app:connectedX86_64DebugAndroidTest
+            -x :app:rustBuildX86_64Debug
             --no-daemon
 
   cross-platform:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,6 +97,9 @@ jobs:
       - name: Generate Tauri Gradle dependency scripts
         env:
           TAURI_ANDROID_PROJECT_PATH: ${{ github.workspace }}/openless-all/app/src-tauri/gen/android
+          TAURI_ANDROID_PACKAGE_UNESCAPED: com.openless.app
+          WRY_ANDROID_LIBRARY: openless_lib
+          WRY_ANDROID_PACKAGE: com.openless.app
         run: cargo check --manifest-path src-tauri/Cargo.toml --target x86_64-linux-android
 
       - name: Copy Android production and test scaffolding

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,10 @@ jobs:
           echo "CXX_aarch64_linux_android=$prebuilt/bin/aarch64-linux-android24-clang++" >> "$GITHUB_ENV"
           echo "AR_aarch64_linux_android=$prebuilt/bin/llvm-ar" >> "$GITHUB_ENV"
           echo "CARGO_TARGET_AARCH64_LINUX_ANDROID_LINKER=$prebuilt/bin/aarch64-linux-android24-clang" >> "$GITHUB_ENV"
+          echo "CC_x86_64_linux_android=$prebuilt/bin/x86_64-linux-android24-clang" >> "$GITHUB_ENV"
+          echo "CXX_x86_64_linux_android=$prebuilt/bin/x86_64-linux-android24-clang++" >> "$GITHUB_ENV"
+          echo "AR_x86_64_linux_android=$prebuilt/bin/llvm-ar" >> "$GITHUB_ENV"
+          echo "CARGO_TARGET_X86_64_LINUX_ANDROID_LINKER=$prebuilt/bin/x86_64-linux-android24-clang" >> "$GITHUB_ENV"
 
       - uses: actions/setup-node@v4
         with:
@@ -65,7 +69,7 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@stable
         with:
-          targets: aarch64-linux-android
+          targets: aarch64-linux-android,x86_64-linux-android
 
       - uses: gradle/actions/setup-gradle@v4
 
@@ -97,8 +101,8 @@ jobs:
         run: >-
           src-tauri/gen/android/gradlew
           --project-dir src-tauri/gen/android
-          :app:testDebugUnitTest
-          :app:assembleDebugAndroidTest
+          :app:testX86_64DebugUnitTest
+          :app:assembleX86_64DebugAndroidTest
           --no-daemon
 
       - name: Enable KVM for Android instrumentation tests
@@ -118,7 +122,7 @@ jobs:
             cd openless-all/app &&
             src-tauri/gen/android/gradlew
             --project-dir src-tauri/gen/android
-            :app:connectedDebugAndroidTest
+            :app:connectedX86_64DebugAndroidTest
             --no-daemon
 
   cross-platform:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,9 +58,16 @@ jobs:
           cache: npm
           cache-dependency-path: openless-all/app/package-lock.json
 
+      - uses: actions/setup-java@v4
+        with:
+          distribution: zulu
+          java-version: "17"
+
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: aarch64-linux-android
+
+      - uses: gradle/actions/setup-gradle@v4
 
       - name: Install Linux check dependencies
         run: |
@@ -79,6 +86,20 @@ jobs:
 
       - name: Check Tauri backend (Android target)
         run: cargo check --manifest-path src-tauri/Cargo.toml --target aarch64-linux-android
+
+      - name: Initialize generated Android project
+        run: npm run tauri -- android init --ci
+
+      - name: Copy Android production and test scaffolding
+        run: node scripts/copy-android-scaffolding.mjs
+
+      - name: Run JVM credential tests and compile instrumentation tests
+        run: >-
+          src-tauri/gen/android/gradlew
+          --project-dir src-tauri/gen/android
+          :app:testDebugUnitTest
+          :app:assembleDebugAndroidTest
+          --no-daemon
 
   cross-platform:
     name: ${{ matrix.label }} checks

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,11 @@ jobs:
       - name: Initialize generated Android project
         run: npm run tauri -- android init --ci
 
+      - name: Generate Tauri Gradle dependency scripts
+        env:
+          TAURI_ANDROID_PROJECT_PATH: ${{ github.workspace }}/openless-all/app/src-tauri/gen/android
+        run: cargo check --manifest-path src-tauri/Cargo.toml --target x86_64-linux-android
+
       - name: Copy Android production and test scaffolding
         run: node scripts/copy-android-scaffolding.mjs
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,8 +99,11 @@ jobs:
           TAURI_ANDROID_PROJECT_PATH: ${{ github.workspace }}/openless-all/app/src-tauri/gen/android
           TAURI_ANDROID_PACKAGE_UNESCAPED: com.openless.app
           WRY_ANDROID_LIBRARY: openless_lib
+          WRY_ANDROID_KOTLIN_FILES_OUT_DIR: ${{ github.workspace }}/openless-all/app/src-tauri/gen/android/app/src/main/java/com/openless/app/generated
           WRY_ANDROID_PACKAGE: com.openless.app
-        run: cargo check --manifest-path src-tauri/Cargo.toml --target x86_64-linux-android
+        run: |
+          mkdir -p "$WRY_ANDROID_KOTLIN_FILES_OUT_DIR"
+          cargo check --manifest-path src-tauri/Cargo.toml --target x86_64-linux-android
 
       - name: Copy Android production and test scaffolding
         run: node scripts/copy-android-scaffolding.mjs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          sdkmanager "ndk;26.1.10909125"
+          sdkmanager "ndk;26.1.10909125" "platforms;android-36" "build-tools;36.0.0"
           ndk_dir="$ANDROID_HOME/ndk/26.1.10909125"
           echo "ANDROID_NDK_HOME=$ndk_dir" >> "$GITHUB_ENV"
           echo "NDK_HOME=$ndk_dir" >> "$GITHUB_ENV"
@@ -100,6 +100,26 @@ jobs:
           :app:testDebugUnitTest
           :app:assembleDebugAndroidTest
           --no-daemon
+
+      - name: Enable KVM for Android instrumentation tests
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' \
+            | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
+      - name: Run Android Keystore instrumentation tests
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: 35
+          target: google_apis
+          arch: x86_64
+          script: >-
+            cd openless-all/app &&
+            src-tauri/gen/android/gradlew
+            --project-dir src-tauri/gen/android
+            :app:connectedDebugAndroidTest
+            --no-daemon
 
   cross-platform:
     name: ${{ matrix.label }} checks

--- a/openless-all/app/android/kotlin/OpenLessCredentialCipher.kt
+++ b/openless-all/app/android/kotlin/OpenLessCredentialCipher.kt
@@ -1,0 +1,45 @@
+package com.openless.app
+
+import java.security.GeneralSecurityException
+import javax.crypto.Cipher
+import javax.crypto.SecretKey
+import javax.crypto.spec.GCMParameterSpec
+
+/** Pure JCA AES-GCM packet codec; AndroidKeyStore ownership lives in the facade. */
+internal object OpenLessCredentialCipher {
+    internal const val NONCE_BYTES = 12
+    internal const val TAG_BITS = 128
+    private const val TAG_BYTES = TAG_BITS / 8
+    private const val TRANSFORMATION = "AES/GCM/NoPadding"
+
+    @Throws(GeneralSecurityException::class)
+    fun seal(key: SecretKey, plaintext: ByteArray, aad: ByteArray): ByteArray {
+        val cipher = Cipher.getInstance(TRANSFORMATION)
+        cipher.init(Cipher.ENCRYPT_MODE, key)
+        val nonce = cipher.iv
+        require(nonce.size == NONCE_BYTES) { "unexpected AES-GCM nonce length" }
+        cipher.updateAAD(aad)
+        val ciphertext = cipher.doFinal(plaintext)
+        return byteArrayOf(nonce.size.toByte()) + nonce + ciphertext
+    }
+
+    @Throws(GeneralSecurityException::class)
+    fun open(key: SecretKey, packet: ByteArray, aad: ByteArray): ByteArray {
+        if (packet.isEmpty()) {
+            throw IllegalArgumentException("malformed credential packet")
+        }
+        val nonceLength = packet[0].toInt() and 0xff
+        if (
+            nonceLength != NONCE_BYTES ||
+            packet.size < 1 + nonceLength + TAG_BYTES
+        ) {
+            throw IllegalArgumentException("malformed credential packet")
+        }
+        val nonce = packet.copyOfRange(1, 1 + nonceLength)
+        val ciphertext = packet.copyOfRange(1 + nonceLength, packet.size)
+        val cipher = Cipher.getInstance(TRANSFORMATION)
+        cipher.init(Cipher.DECRYPT_MODE, key, GCMParameterSpec(TAG_BITS, nonce))
+        cipher.updateAAD(aad)
+        return cipher.doFinal(ciphertext)
+    }
+}

--- a/openless-all/app/android/kotlin/OpenLessCredentialVault.kt
+++ b/openless-all/app/android/kotlin/OpenLessCredentialVault.kt
@@ -24,6 +24,13 @@ private fun credentialResponse(status: Byte, payload: ByteArray = byteArrayOf())
     return byteArrayOf(status) + payload
 }
 
+internal fun credentialStatusForKeyLoadFailure(error: GeneralSecurityException): Byte {
+    return when (error) {
+        is KeyPermanentlyInvalidatedException -> CREDENTIAL_STATUS_KEY_MISSING
+        else -> CREDENTIAL_STATUS_TEMPORARILY_UNAVAILABLE
+    }
+}
+
 /** AndroidKeyStore owner with fixed, secret-free status responses for JNI. */
 internal class AndroidKeystoreCredentialVault(private val alias: String) {
     @Synchronized
@@ -33,10 +40,13 @@ internal class AndroidKeystoreCredentialVault(private val alias: String) {
                 CREDENTIAL_STATUS_OK,
                 OpenLessCredentialCipher.seal(getOrCreateKey(), plaintext, aad),
             )
-        } catch (_: KeyPermanentlyInvalidatedException) {
-            credentialResponse(CREDENTIAL_STATUS_KEY_MISSING)
-        } catch (_: UnrecoverableKeyException) {
-            credentialResponse(CREDENTIAL_STATUS_KEY_MISSING)
+        } catch (error: KeyPermanentlyInvalidatedException) {
+            credentialResponse(credentialStatusForKeyLoadFailure(error))
+        } catch (error: UnrecoverableKeyException) {
+            // Keystore2 wraps backend-busy and other provider failures in this
+            // broad JCA exception too. Only an absent alias or the explicit
+            // permanent-invalidated exception is safe to treat as data loss.
+            credentialResponse(credentialStatusForKeyLoadFailure(error))
         } catch (_: IllegalArgumentException) {
             credentialResponse(CREDENTIAL_STATUS_MALFORMED)
         } catch (_: GeneralSecurityException) {
@@ -51,10 +61,10 @@ internal class AndroidKeystoreCredentialVault(private val alias: String) {
         return try {
             val key = existingKey() ?: return credentialResponse(CREDENTIAL_STATUS_KEY_MISSING)
             credentialResponse(CREDENTIAL_STATUS_OK, OpenLessCredentialCipher.open(key, packet, aad))
-        } catch (_: KeyPermanentlyInvalidatedException) {
-            credentialResponse(CREDENTIAL_STATUS_KEY_MISSING)
-        } catch (_: UnrecoverableKeyException) {
-            credentialResponse(CREDENTIAL_STATUS_KEY_MISSING)
+        } catch (error: KeyPermanentlyInvalidatedException) {
+            credentialResponse(credentialStatusForKeyLoadFailure(error))
+        } catch (error: UnrecoverableKeyException) {
+            credentialResponse(credentialStatusForKeyLoadFailure(error))
         } catch (_: AEADBadTagException) {
             credentialResponse(CREDENTIAL_STATUS_AUTHENTICATION_FAILED)
         } catch (_: BadPaddingException) {
@@ -76,6 +86,36 @@ internal class AndroidKeystoreCredentialVault(private val alias: String) {
                 keyStore.deleteEntry(alias)
             }
             credentialResponse(CREDENTIAL_STATUS_OK)
+        } catch (_: GeneralSecurityException) {
+            credentialResponse(CREDENTIAL_STATUS_TEMPORARILY_UNAVAILABLE)
+        } catch (_: IOException) {
+            credentialResponse(CREDENTIAL_STATUS_TEMPORARILY_UNAVAILABLE)
+        }
+    }
+
+    @Synchronized
+    fun keyExists(): ByteArray {
+        return try {
+            credentialResponse(
+                CREDENTIAL_STATUS_OK,
+                byteArrayOf(if (loadKeyStore().containsAlias(alias)) 1 else 0),
+            )
+        } catch (_: GeneralSecurityException) {
+            credentialResponse(CREDENTIAL_STATUS_TEMPORARILY_UNAVAILABLE)
+        } catch (_: IOException) {
+            credentialResponse(CREDENTIAL_STATUS_TEMPORARILY_UNAVAILABLE)
+        }
+    }
+
+    @Synchronized
+    fun ensureKey(): ByteArray {
+        return try {
+            getOrCreateKey()
+            credentialResponse(CREDENTIAL_STATUS_OK)
+        } catch (error: KeyPermanentlyInvalidatedException) {
+            credentialResponse(credentialStatusForKeyLoadFailure(error))
+        } catch (error: UnrecoverableKeyException) {
+            credentialResponse(credentialStatusForKeyLoadFailure(error))
         } catch (_: GeneralSecurityException) {
             credentialResponse(CREDENTIAL_STATUS_TEMPORARILY_UNAVAILABLE)
         } catch (_: IOException) {
@@ -123,7 +163,9 @@ internal class AndroidKeystoreCredentialVault(private val alias: String) {
 @Keep
 object OpenLessCredentialVault {
     private const val KEY_ALIAS = "com.openless.app.credentials.v2"
+    private const val MIGRATION_MARKER_ALIAS = "com.openless.app.credentials.v2.migrated"
     private val backend = AndroidKeystoreCredentialVault(KEY_ALIAS)
+    private val migrationMarker = AndroidKeystoreCredentialVault(MIGRATION_MARKER_ALIAS)
 
     @JvmStatic
     fun seal(plaintext: ByteArray, aad: ByteArray): ByteArray = backend.seal(plaintext, aad)
@@ -133,4 +175,10 @@ object OpenLessCredentialVault {
 
     @JvmStatic
     fun deleteKey(): ByteArray = backend.deleteKey()
+
+    @JvmStatic
+    fun migrationComplete(): ByteArray = migrationMarker.keyExists()
+
+    @JvmStatic
+    fun markMigrationComplete(): ByteArray = migrationMarker.ensureKey()
 }

--- a/openless-all/app/android/kotlin/OpenLessCredentialVault.kt
+++ b/openless-all/app/android/kotlin/OpenLessCredentialVault.kt
@@ -1,0 +1,136 @@
+package com.openless.app
+
+import android.security.keystore.KeyGenParameterSpec
+import android.security.keystore.KeyPermanentlyInvalidatedException
+import android.security.keystore.KeyProperties
+import androidx.annotation.Keep
+import java.io.IOException
+import java.security.GeneralSecurityException
+import java.security.KeyStore
+import java.security.KeyStoreException
+import java.security.UnrecoverableKeyException
+import javax.crypto.AEADBadTagException
+import javax.crypto.BadPaddingException
+import javax.crypto.KeyGenerator
+import javax.crypto.SecretKey
+
+internal const val CREDENTIAL_STATUS_OK: Byte = 0
+internal const val CREDENTIAL_STATUS_KEY_MISSING: Byte = 1
+internal const val CREDENTIAL_STATUS_AUTHENTICATION_FAILED: Byte = 2
+internal const val CREDENTIAL_STATUS_TEMPORARILY_UNAVAILABLE: Byte = 3
+internal const val CREDENTIAL_STATUS_MALFORMED: Byte = 4
+
+private fun credentialResponse(status: Byte, payload: ByteArray = byteArrayOf()): ByteArray {
+    return byteArrayOf(status) + payload
+}
+
+/** AndroidKeyStore owner with fixed, secret-free status responses for JNI. */
+internal class AndroidKeystoreCredentialVault(private val alias: String) {
+    @Synchronized
+    fun seal(plaintext: ByteArray, aad: ByteArray): ByteArray {
+        return try {
+            credentialResponse(
+                CREDENTIAL_STATUS_OK,
+                OpenLessCredentialCipher.seal(getOrCreateKey(), plaintext, aad),
+            )
+        } catch (_: KeyPermanentlyInvalidatedException) {
+            credentialResponse(CREDENTIAL_STATUS_KEY_MISSING)
+        } catch (_: UnrecoverableKeyException) {
+            credentialResponse(CREDENTIAL_STATUS_KEY_MISSING)
+        } catch (_: IllegalArgumentException) {
+            credentialResponse(CREDENTIAL_STATUS_MALFORMED)
+        } catch (_: GeneralSecurityException) {
+            credentialResponse(CREDENTIAL_STATUS_TEMPORARILY_UNAVAILABLE)
+        } catch (_: IOException) {
+            credentialResponse(CREDENTIAL_STATUS_TEMPORARILY_UNAVAILABLE)
+        }
+    }
+
+    @Synchronized
+    fun open(packet: ByteArray, aad: ByteArray): ByteArray {
+        return try {
+            val key = existingKey() ?: return credentialResponse(CREDENTIAL_STATUS_KEY_MISSING)
+            credentialResponse(CREDENTIAL_STATUS_OK, OpenLessCredentialCipher.open(key, packet, aad))
+        } catch (_: KeyPermanentlyInvalidatedException) {
+            credentialResponse(CREDENTIAL_STATUS_KEY_MISSING)
+        } catch (_: UnrecoverableKeyException) {
+            credentialResponse(CREDENTIAL_STATUS_KEY_MISSING)
+        } catch (_: AEADBadTagException) {
+            credentialResponse(CREDENTIAL_STATUS_AUTHENTICATION_FAILED)
+        } catch (_: BadPaddingException) {
+            credentialResponse(CREDENTIAL_STATUS_AUTHENTICATION_FAILED)
+        } catch (_: IllegalArgumentException) {
+            credentialResponse(CREDENTIAL_STATUS_MALFORMED)
+        } catch (_: GeneralSecurityException) {
+            credentialResponse(CREDENTIAL_STATUS_TEMPORARILY_UNAVAILABLE)
+        } catch (_: IOException) {
+            credentialResponse(CREDENTIAL_STATUS_TEMPORARILY_UNAVAILABLE)
+        }
+    }
+
+    @Synchronized
+    fun deleteKey(): ByteArray {
+        return try {
+            val keyStore = loadKeyStore()
+            if (keyStore.containsAlias(alias)) {
+                keyStore.deleteEntry(alias)
+            }
+            credentialResponse(CREDENTIAL_STATUS_OK)
+        } catch (_: GeneralSecurityException) {
+            credentialResponse(CREDENTIAL_STATUS_TEMPORARILY_UNAVAILABLE)
+        } catch (_: IOException) {
+            credentialResponse(CREDENTIAL_STATUS_TEMPORARILY_UNAVAILABLE)
+        }
+    }
+
+    @Throws(GeneralSecurityException::class, IOException::class)
+    private fun existingKey(): SecretKey? {
+        val keyStore = loadKeyStore()
+        if (!keyStore.containsAlias(alias)) {
+            return null
+        }
+        return keyStore.getKey(alias, null) as? SecretKey
+    }
+
+    @Throws(GeneralSecurityException::class, IOException::class)
+    private fun getOrCreateKey(): SecretKey {
+        existingKey()?.let { return it }
+        val generator = KeyGenerator.getInstance(KeyProperties.KEY_ALGORITHM_AES, KEYSTORE_PROVIDER)
+        generator.init(
+            KeyGenParameterSpec.Builder(
+                alias,
+                KeyProperties.PURPOSE_ENCRYPT or KeyProperties.PURPOSE_DECRYPT,
+            )
+                .setBlockModes(KeyProperties.BLOCK_MODE_GCM)
+                .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_NONE)
+                .setKeySize(256)
+                .setRandomizedEncryptionRequired(true)
+                .build(),
+        )
+        return generator.generateKey()
+    }
+
+    @Throws(KeyStoreException::class, IOException::class, GeneralSecurityException::class)
+    private fun loadKeyStore(): KeyStore {
+        return KeyStore.getInstance(KEYSTORE_PROVIDER).apply { load(null) }
+    }
+
+    private companion object {
+        const val KEYSTORE_PROVIDER = "AndroidKeyStore"
+    }
+}
+
+@Keep
+object OpenLessCredentialVault {
+    private const val KEY_ALIAS = "com.openless.app.credentials.v2"
+    private val backend = AndroidKeystoreCredentialVault(KEY_ALIAS)
+
+    @JvmStatic
+    fun seal(plaintext: ByteArray, aad: ByteArray): ByteArray = backend.seal(plaintext, aad)
+
+    @JvmStatic
+    fun open(packet: ByteArray, aad: ByteArray): ByteArray = backend.open(packet, aad)
+
+    @JvmStatic
+    fun deleteKey(): ByteArray = backend.deleteKey()
+}

--- a/openless-all/app/android/kotlin/androidTest/OpenLessCredentialVaultInstrumentedTest.kt
+++ b/openless-all/app/android/kotlin/androidTest/OpenLessCredentialVaultInstrumentedTest.kt
@@ -1,0 +1,66 @@
+package com.openless.app
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import java.security.KeyStore
+import java.util.UUID
+import org.junit.After
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class OpenLessCredentialVaultInstrumentedTest {
+    private lateinit var alias: String
+    private lateinit var vault: AndroidKeystoreCredentialVault
+
+    @Before
+    fun setUp() {
+        alias = "com.openless.app.credentials.test.${UUID.randomUUID()}"
+        vault = AndroidKeystoreCredentialVault(alias)
+    }
+
+    @After
+    fun tearDown() {
+        vault.deleteKey()
+    }
+
+    private fun payload(response: ByteArray): ByteArray {
+        assertEquals(CREDENTIAL_STATUS_OK, response.first())
+        return response.copyOfRange(1, response.size)
+    }
+
+    @Test
+    fun roundTripUsesNonExportableKey() {
+        val plaintext = "instrumented credential".toByteArray()
+        val aad = "format-version-account".toByteArray()
+        val packet = payload(vault.seal(plaintext, aad))
+
+        assertArrayEquals(plaintext, payload(vault.open(packet, aad)))
+        val key = KeyStore.getInstance("AndroidKeyStore").apply { load(null) }.getKey(alias, null)
+        assertNull(key.encoded)
+    }
+
+    @Test
+    fun deletedKeyIsReportedAsMissing() {
+        val aad = "format-version-account".toByteArray()
+        val packet = payload(vault.seal("secret".toByteArray(), aad))
+        assertEquals(CREDENTIAL_STATUS_OK, vault.deleteKey().first())
+
+        assertEquals(CREDENTIAL_STATUS_KEY_MISSING, vault.open(packet, aad).first())
+    }
+
+    @Test
+    fun tamperedCiphertextIsRejected() {
+        val aad = "format-version-account".toByteArray()
+        val packet = payload(vault.seal("secret".toByteArray(), aad))
+        packet[packet.lastIndex] = (packet.last().toInt() xor 1).toByte()
+
+        assertEquals(
+            CREDENTIAL_STATUS_AUTHENTICATION_FAILED,
+            vault.open(packet, aad).first(),
+        )
+    }
+}

--- a/openless-all/app/android/kotlin/androidTest/OpenLessCredentialVaultInstrumentedTest.kt
+++ b/openless-all/app/android/kotlin/androidTest/OpenLessCredentialVaultInstrumentedTest.kt
@@ -44,6 +44,29 @@ class OpenLessCredentialVaultInstrumentedTest {
     }
 
     @Test
+    fun keyMarkerStateTracksKeyCreationAndDeletion() {
+        assertArrayEquals(byteArrayOf(0), payload(vault.keyExists()))
+        assertEquals(CREDENTIAL_STATUS_OK, vault.ensureKey().first())
+        assertArrayEquals(byteArrayOf(1), payload(vault.keyExists()))
+        assertEquals(CREDENTIAL_STATUS_OK, vault.deleteKey().first())
+        assertArrayEquals(byteArrayOf(0), payload(vault.keyExists()))
+    }
+
+    @Test
+    fun publicFacadeRoundTripExercisesJvmStaticEntryPoints() {
+        OpenLessCredentialVault.deleteKey()
+        try {
+            val plaintext = "facade credential".toByteArray()
+            val aad = "facade aad".toByteArray()
+            val packet = payload(OpenLessCredentialVault.seal(plaintext, aad))
+
+            assertArrayEquals(plaintext, payload(OpenLessCredentialVault.open(packet, aad)))
+        } finally {
+            OpenLessCredentialVault.deleteKey()
+        }
+    }
+
+    @Test
     fun deletedKeyIsReportedAsMissing() {
         val aad = "format-version-account".toByteArray()
         val packet = payload(vault.seal("secret".toByteArray(), aad))

--- a/openless-all/app/android/kotlin/test/OpenLessCredentialCipherTest.kt
+++ b/openless-all/app/android/kotlin/test/OpenLessCredentialCipherTest.kt
@@ -1,11 +1,15 @@
 package com.openless.app
 
+import java.lang.reflect.Modifier
 import java.security.GeneralSecurityException
+import java.security.UnrecoverableKeyException
 import javax.crypto.KeyGenerator
 import javax.crypto.SecretKey
 import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class OpenLessCredentialCipherTest {
@@ -78,5 +82,30 @@ class OpenLessCredentialCipherTest {
         assertThrows(GeneralSecurityException::class.java) {
             OpenLessCredentialCipher.open(key, packet, "account-b".toByteArray())
         }
+    }
+
+    @Test
+    fun facadeMethodsExposeExactStaticJniSignatures() {
+        val facade = OpenLessCredentialVault::class.java
+        val signatures: List<Pair<String, Array<Class<*>>>> = listOf(
+            "seal" to arrayOf<Class<*>>(ByteArray::class.java, ByteArray::class.java),
+            "open" to arrayOf<Class<*>>(ByteArray::class.java, ByteArray::class.java),
+            "deleteKey" to emptyArray(),
+            "migrationComplete" to emptyArray(),
+            "markMigrationComplete" to emptyArray(),
+        )
+        for ((name, parameters) in signatures) {
+            val method = facade.getDeclaredMethod(name, *parameters)
+            assertTrue("$name must be static for JNI", Modifier.isStatic(method.modifiers))
+            assertEquals(ByteArray::class.java, method.returnType)
+        }
+    }
+
+    @Test
+    fun unrecoverableKeyExceptionRemainsRetryable() {
+        assertEquals(
+            CREDENTIAL_STATUS_TEMPORARILY_UNAVAILABLE,
+            credentialStatusForKeyLoadFailure(UnrecoverableKeyException("backend busy")),
+        )
     }
 }

--- a/openless-all/app/android/kotlin/test/OpenLessCredentialCipherTest.kt
+++ b/openless-all/app/android/kotlin/test/OpenLessCredentialCipherTest.kt
@@ -1,0 +1,82 @@
+package com.openless.app
+
+import java.security.GeneralSecurityException
+import javax.crypto.KeyGenerator
+import javax.crypto.SecretKey
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertThrows
+import org.junit.Test
+
+class OpenLessCredentialCipherTest {
+    private fun key(): SecretKey {
+        return KeyGenerator.getInstance("AES").apply { init(256) }.generateKey()
+    }
+
+    @Test
+    fun roundTrip() {
+        val key = key()
+        val plaintext = "credential-secret".toByteArray()
+        val aad = "format-version-account".toByteArray()
+
+        val packet = OpenLessCredentialCipher.seal(key, plaintext, aad)
+
+        assertArrayEquals(plaintext, OpenLessCredentialCipher.open(key, packet, aad))
+        assertFalse(packet.toString(Charsets.UTF_8).contains("credential-secret"))
+    }
+
+    @Test
+    fun freshNonce() {
+        val key = key()
+        val plaintext = "same plaintext".toByteArray()
+        val aad = "same aad".toByteArray()
+
+        val first = OpenLessCredentialCipher.seal(key, plaintext, aad)
+        val second = OpenLessCredentialCipher.seal(key, plaintext, aad)
+
+        assertFalse(first.contentEquals(second))
+        assertFalse(
+            first.copyOfRange(1, 1 + OpenLessCredentialCipher.NONCE_BYTES).contentEquals(
+                second.copyOfRange(1, 1 + OpenLessCredentialCipher.NONCE_BYTES),
+            ),
+        )
+    }
+
+    @Test
+    fun tamperedCiphertext() {
+        val key = key()
+        val aad = "authenticated metadata".toByteArray()
+        val packet = OpenLessCredentialCipher.seal(key, "secret".toByteArray(), aad)
+        packet[packet.lastIndex] = (packet.last().toInt() xor 1).toByte()
+
+        assertThrows(GeneralSecurityException::class.java) {
+            OpenLessCredentialCipher.open(key, packet, aad)
+        }
+    }
+
+    @Test
+    fun tamperedNonce() {
+        val key = key()
+        val aad = "authenticated metadata".toByteArray()
+        val packet = OpenLessCredentialCipher.seal(key, "secret".toByteArray(), aad)
+        packet[1] = (packet[1].toInt() xor 1).toByte()
+
+        assertThrows(GeneralSecurityException::class.java) {
+            OpenLessCredentialCipher.open(key, packet, aad)
+        }
+    }
+
+    @Test
+    fun tamperedAad() {
+        val key = key()
+        val packet = OpenLessCredentialCipher.seal(
+            key,
+            "secret".toByteArray(),
+            "account-a".toByteArray(),
+        )
+
+        assertThrows(GeneralSecurityException::class.java) {
+            OpenLessCredentialCipher.open(key, packet, "account-b".toByteArray())
+        }
+    }
+}

--- a/openless-all/app/scripts/android-credential-keystore-contract.test.mjs
+++ b/openless-all/app/scripts/android-credential-keystore-contract.test.mjs
@@ -154,7 +154,7 @@ requirePattern(
   'startup persistence must use Tao\'s non-panicking Android context registry',
 );
 const androidCredentialPath = credentials.match(
-  /fn\s+android_credentials_path\s*\([^)]*\)\s*->\s*Result<PathBuf>[\s\S]*?\n}\n/,
+  /fn\s+android_credentials_path\s*\([^)]*\)\s*->\s*Result<PathBuf>[\s\S]*?\r?\n}\r?\n/,
 );
 if (!androidCredentialPath) {
   throw new Error('missing Android credential path resolver');

--- a/openless-all/app/scripts/android-credential-keystore-contract.test.mjs
+++ b/openless-all/app/scripts/android-credential-keystore-contract.test.mjs
@@ -159,13 +159,33 @@ requirePattern(
   'generated Android project must declare the AndroidX instrumentation runner',
 );
 
-requirePattern(ci, /testDebugUnitTest/, 'PR CI must execute JVM credential tests');
-requirePattern(ci, /assembleDebugAndroidTest/, 'PR CI must compile instrumentation tests');
 requirePattern(
   ci,
-  /connectedDebugAndroidTest/,
-  'PR CI must execute Android Keystore instrumentation tests on a device',
+  /targets:\s*aarch64-linux-android,x86_64-linux-android/,
+  'PR CI must install the Rust target used by the x86_64 emulator',
 );
+requirePattern(
+  ci,
+  /testX86_64DebugUnitTest/,
+  'PR CI must execute JVM credential tests for the x86_64 flavor',
+);
+requirePattern(
+  ci,
+  /assembleX86_64DebugAndroidTest/,
+  'PR CI must compile x86_64 instrumentation tests',
+);
+requirePattern(
+  ci,
+  /connectedX86_64DebugAndroidTest/,
+  'PR CI must execute x86_64 Android Keystore instrumentation tests on a device',
+);
+if (
+  /:app:(?:testDebugUnitTest|assembleDebugAndroidTest|connectedDebugAndroidTest)\b/.test(
+    ci,
+  )
+) {
+  throw new Error('PR CI must not use Android tasks without the required ABI flavor');
+}
 requirePattern(
   rustStore,
   /successful_v2_rejects_legacy_base64_downgrade/,

--- a/openless-all/app/scripts/android-credential-keystore-contract.test.mjs
+++ b/openless-all/app/scripts/android-credential-keystore-contract.test.mjs
@@ -18,6 +18,7 @@ const paths = {
     '../src-tauri/src/persistence/android_credentials.rs',
     import.meta.url,
   ),
+  persistence: new URL('../src-tauri/src/persistence/mod.rs', import.meta.url),
   credentials: new URL('../src-tauri/src/persistence/credentials.rs', import.meta.url),
   jni: new URL('../src-tauri/src/android/jni.rs', import.meta.url),
   copyScript: new URL('./copy-android-scaffolding.mjs', import.meta.url),
@@ -43,13 +44,14 @@ function requirePattern(source, pattern, message) {
   }
 }
 
-const [cipher, vault, unitTest, instrumentedTest, rustStore, credentials, jni, copyScript, ci] =
+const [cipher, vault, unitTest, instrumentedTest, rustStore, persistence, credentials, jni, copyScript, ci] =
   await Promise.all([
     requiredSource('pure AES-GCM codec', paths.cipher),
     requiredSource('Android Keystore bridge', paths.vault),
     requiredSource('JVM cipher tests', paths.unitTest),
     requiredSource('Android Keystore instrumentation tests', paths.instrumentedTest),
     requiredSource('Rust Android credential store', paths.rustStore),
+    requiredSource('persistence root', paths.persistence),
     requiredSource('credentials integration', paths.credentials),
     requiredSource('JNI bridge', paths.jni),
     requiredSource('Android scaffolding copier', paths.copyScript),
@@ -142,6 +144,29 @@ for (const pattern of [
 ]) {
   requirePattern(jni, pattern, `JNI bridge is missing ${pattern}`);
 }
+requirePattern(
+  jni,
+  /fn\s+app_files_dir\s*\([\s\S]*?getFilesDir[\s\S]*?getAbsolutePath/,
+  'JNI bridge must resolve the app-private Context files directory',
+);
+requirePattern(
+  persistence,
+  /#\[cfg\(target_os = "android"\)\][\s\S]*?app_files_dir\(\)[\s\S]*?join\("OpenLess"\)/,
+  'Android persistence must use the app-private files directory',
+);
+if (/TAURI_ANDROID_APP_DATA_DIR|std::env::temp_dir\(\)\.join\("OpenLess"\)/.test(persistence)) {
+  throw new Error('Android persistence must not fall back to environment or temporary storage');
+}
+requirePattern(
+  rustStore,
+  /let verified = open_envelope\(&persisted, crypto\)\?;[\s\S]*?if verified != plaintext \{[\s\S]*?\}[\s\S]*?mark_migration_complete\(\)[\s\S]*?fault\(WriteStage::AfterVerification\)/,
+  'legacy downgrade barrier must be durable before the v2 envelope is installed',
+);
+requirePattern(
+  rustStore,
+  /verified_v2_commit_barrier_rejects_legacy_after_pre_rename_failure/,
+  'Rust store must test the pre-rename legacy downgrade barrier',
+);
 
 for (const file of [
   'OpenLessCredentialCipher.kt',

--- a/openless-all/app/scripts/android-credential-keystore-contract.test.mjs
+++ b/openless-all/app/scripts/android-credential-keystore-contract.test.mjs
@@ -123,6 +123,7 @@ for (const pattern of [
   /migration_complete/,
   /mark_migration_complete/,
   /recover_verified_sanitized_legacy/,
+  /recover_verified_v2_temporary/,
   /mode\(0o600\)/,
   /sync_all\(\)/,
 ]) {
@@ -181,8 +182,8 @@ requirePattern(
 );
 requirePattern(
   rustStore,
-  /verified_v2_commit_barrier_rejects_legacy_after_pre_rename_failure/,
-  'Rust store must test the pre-rename legacy downgrade barrier',
+  /verified_v2_commit_barrier_recovers_verified_temp_after_pre_rename_failure/,
+  'Rust store must recover the verified pre-rename v2 candidate without accepting legacy',
 );
 
 for (const file of [

--- a/openless-all/app/scripts/android-credential-keystore-contract.test.mjs
+++ b/openless-all/app/scripts/android-credential-keystore-contract.test.mjs
@@ -122,6 +122,7 @@ for (const pattern of [
   /TemporarilyUnavailable/,
   /migration_complete/,
   /mark_migration_complete/,
+  /recover_verified_sanitized_legacy/,
   /mode\(0o600\)/,
   /sync_all\(\)/,
 ]) {

--- a/openless-all/app/scripts/android-credential-keystore-contract.test.mjs
+++ b/openless-all/app/scripts/android-credential-keystore-contract.test.mjs
@@ -18,7 +18,6 @@ const paths = {
     '../src-tauri/src/persistence/android_credentials.rs',
     import.meta.url,
   ),
-  persistence: new URL('../src-tauri/src/persistence/mod.rs', import.meta.url),
   credentials: new URL('../src-tauri/src/persistence/credentials.rs', import.meta.url),
   jni: new URL('../src-tauri/src/android/jni.rs', import.meta.url),
   copyScript: new URL('./copy-android-scaffolding.mjs', import.meta.url),
@@ -44,14 +43,13 @@ function requirePattern(source, pattern, message) {
   }
 }
 
-const [cipher, vault, unitTest, instrumentedTest, rustStore, persistence, credentials, jni, copyScript, ci] =
+const [cipher, vault, unitTest, instrumentedTest, rustStore, credentials, jni, copyScript, ci] =
   await Promise.all([
     requiredSource('pure AES-GCM codec', paths.cipher),
     requiredSource('Android Keystore bridge', paths.vault),
     requiredSource('JVM cipher tests', paths.unitTest),
     requiredSource('Android Keystore instrumentation tests', paths.instrumentedTest),
     requiredSource('Rust Android credential store', paths.rustStore),
-    requiredSource('persistence root', paths.persistence),
     requiredSource('credentials integration', paths.credentials),
     requiredSource('JNI bridge', paths.jni),
     requiredSource('Android scaffolding copier', paths.copyScript),
@@ -150,12 +148,31 @@ requirePattern(
   'JNI bridge must resolve the app-private Context files directory',
 );
 requirePattern(
-  persistence,
-  /#\[cfg\(target_os = "android"\)\][\s\S]*?app_files_dir\(\)[\s\S]*?join\("OpenLess"\)/,
-  'Android persistence must use the app-private files directory',
+  jni,
+  /fn\s+with_tao_android_env[\s\S]*?main_android_context/,
+  'startup persistence must use Tao\'s non-panicking Android context registry',
 );
-if (/TAURI_ANDROID_APP_DATA_DIR|std::env::temp_dir\(\)\.join\("OpenLess"\)/.test(persistence)) {
-  throw new Error('Android persistence must not fall back to environment or temporary storage');
+const androidCredentialPath = credentials.match(
+  /fn\s+android_credentials_path\s*\([^)]*\)\s*->\s*Result<PathBuf>[\s\S]*?\n}\n/,
+);
+if (!androidCredentialPath) {
+  throw new Error('missing Android credential path resolver');
+}
+requirePattern(
+  androidCredentialPath[0],
+  /app_files_dir\(\)[\s\S]*?join\("OpenLess"\)[\s\S]*?join\(ANDROID_CREDENTIALS_FILE\)/,
+  'Android credentials must use the app-private files directory',
+);
+if (/TAURI_ANDROID_APP_DATA_DIR|temp_dir/.test(androidCredentialPath[0])) {
+  throw new Error('Android credential storage must not fall back to environment or temporary storage');
+}
+for (const pattern of [
+  /android_legacy_credentials_paths/,
+  /load_android_credentials_from_source_with_crypto/,
+  /remove_migrated_android_legacy_credentials/,
+  /android_legacy_root_migrates_to_private_destination_and_is_erased/,
+]) {
+  requirePattern(credentials, pattern, `Android credential root migration is missing ${pattern}`);
 }
 requirePattern(
   rustStore,

--- a/openless-all/app/scripts/android-credential-keystore-contract.test.mjs
+++ b/openless-all/app/scripts/android-credential-keystore-contract.test.mjs
@@ -70,8 +70,23 @@ for (const pattern of [
   /fun\s+seal\s*\(/,
   /fun\s+open\s*\(/,
   /fun\s+deleteKey\s*\(/,
+  /fun\s+migrationComplete\s*\(/,
+  /fun\s+markMigrationComplete\s*\(/,
 ]) {
   requirePattern(vault, pattern, `Keystore bridge is missing ${pattern}`);
+}
+if (
+  /catch\s*\([^:]+:\s*UnrecoverableKeyException\)\s*\{\s*credentialResponse\(CREDENTIAL_STATUS_KEY_MISSING\)/.test(
+    vault,
+  )
+) {
+  throw new Error('UnrecoverableKeyException must never trigger destructive key-missing cleanup');
+}
+for (const pattern of [
+  /is\s+KeyPermanentlyInvalidatedException\s*->\s*CREDENTIAL_STATUS_KEY_MISSING/,
+  /else\s*->\s*CREDENTIAL_STATUS_TEMPORARILY_UNAVAILABLE/,
+]) {
+  requirePattern(vault, pattern, `Keystore failure classifier is missing ${pattern}`);
 }
 if (/\b(?:Log\.|println\s*\()/.test(vault)) {
   throw new Error('Keystore bridge must not log secret-bearing inputs or crypto exceptions');
@@ -83,6 +98,7 @@ for (const pattern of [
   /tamperedNonce/,
   /tamperedCiphertext/,
   /tamperedAad/,
+  /unrecoverableKeyExceptionRemainsRetryable/,
 ]) {
   requirePattern(unitTest, pattern, `JVM crypto tests are missing ${pattern}`);
 }
@@ -104,6 +120,8 @@ for (const pattern of [
   /KeyMissingOrInvalidated/,
   /AuthenticationFailed/,
   /TemporarilyUnavailable/,
+  /migration_complete/,
+  /mark_migration_complete/,
   /mode\(0o600\)/,
   /sync_all\(\)/,
 ]) {
@@ -113,7 +131,14 @@ if (/Stub:\s*base64 envelope/.test(credentials)) {
   throw new Error('legacy Base64 stub is still the Android credential writer');
 }
 
-for (const pattern of [/keystore_seal/, /keystore_open/, /keystore_delete_key/, /JByteArray/]) {
+for (const pattern of [
+  /keystore_seal/,
+  /keystore_open/,
+  /keystore_delete_key/,
+  /keystore_migration_complete/,
+  /keystore_mark_migration_complete/,
+  /JByteArray/,
+]) {
   requirePattern(jni, pattern, `JNI bridge is missing ${pattern}`);
 }
 
@@ -135,5 +160,20 @@ requirePattern(
 
 requirePattern(ci, /testDebugUnitTest/, 'PR CI must execute JVM credential tests');
 requirePattern(ci, /assembleDebugAndroidTest/, 'PR CI must compile instrumentation tests');
+requirePattern(
+  ci,
+  /connectedDebugAndroidTest/,
+  'PR CI must execute Android Keystore instrumentation tests on a device',
+);
+requirePattern(
+  rustStore,
+  /successful_v2_rejects_legacy_base64_downgrade/,
+  'Rust store must test that legacy migration closes after v2 succeeds',
+);
+requirePattern(
+  credentials,
+  /android_bearer_is_scrubbed_before_failed_keystore_migration_returns/,
+  'credentials integration must preserve the fail-closed Marketplace bearer scrub',
+);
 
 console.log('android-credential-keystore-contract.test.mjs passed');

--- a/openless-all/app/scripts/android-credential-keystore-contract.test.mjs
+++ b/openless-all/app/scripts/android-credential-keystore-contract.test.mjs
@@ -185,6 +185,11 @@ requirePattern(
   /verified_v2_commit_barrier_recovers_verified_temp_after_pre_rename_failure/,
   'Rust store must recover the verified pre-rename v2 candidate without accepting legacy',
 );
+requirePattern(
+  rustStore,
+  /invalidated_key_clears_pending_v2_recovery_candidate/,
+  'Rust store must clear an unrecoverable pending v2 candidate so credentials can be reconfigured',
+);
 
 for (const file of [
   'OpenLessCredentialCipher.kt',

--- a/openless-all/app/scripts/android-credential-keystore-contract.test.mjs
+++ b/openless-all/app/scripts/android-credential-keystore-contract.test.mjs
@@ -1,0 +1,139 @@
+import { access, readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = fileURLToPath(new URL('../../..', import.meta.url));
+
+const paths = {
+  cipher: new URL('../android/kotlin/OpenLessCredentialCipher.kt', import.meta.url),
+  vault: new URL('../android/kotlin/OpenLessCredentialVault.kt', import.meta.url),
+  unitTest: new URL(
+    '../android/kotlin/test/OpenLessCredentialCipherTest.kt',
+    import.meta.url,
+  ),
+  instrumentedTest: new URL(
+    '../android/kotlin/androidTest/OpenLessCredentialVaultInstrumentedTest.kt',
+    import.meta.url,
+  ),
+  rustStore: new URL(
+    '../src-tauri/src/persistence/android_credentials.rs',
+    import.meta.url,
+  ),
+  credentials: new URL('../src-tauri/src/persistence/credentials.rs', import.meta.url),
+  jni: new URL('../src-tauri/src/android/jni.rs', import.meta.url),
+  copyScript: new URL('./copy-android-scaffolding.mjs', import.meta.url),
+  ci: new URL('../../../.github/workflows/ci.yml', import.meta.url),
+};
+
+function display(url) {
+  return fileURLToPath(url).replace(`${repoRoot}/`, '');
+}
+
+async function requiredSource(name, url) {
+  try {
+    await access(url);
+  } catch {
+    throw new Error(`missing ${name}: ${display(url)}`);
+  }
+  return readFile(url, 'utf8');
+}
+
+function requirePattern(source, pattern, message) {
+  if (!pattern.test(source)) {
+    throw new Error(message);
+  }
+}
+
+const [cipher, vault, unitTest, instrumentedTest, rustStore, credentials, jni, copyScript, ci] =
+  await Promise.all([
+    requiredSource('pure AES-GCM codec', paths.cipher),
+    requiredSource('Android Keystore bridge', paths.vault),
+    requiredSource('JVM cipher tests', paths.unitTest),
+    requiredSource('Android Keystore instrumentation tests', paths.instrumentedTest),
+    requiredSource('Rust Android credential store', paths.rustStore),
+    requiredSource('credentials integration', paths.credentials),
+    requiredSource('JNI bridge', paths.jni),
+    requiredSource('Android scaffolding copier', paths.copyScript),
+    requiredSource('PR CI workflow', paths.ci),
+  ]);
+
+requirePattern(cipher, /AES\/GCM\/NoPadding/, 'cipher must use AES/GCM/NoPadding');
+requirePattern(cipher, /NONCE_BYTES\s*=\s*12/, 'cipher must require a 12-byte nonce');
+requirePattern(cipher, /TAG_BITS\s*=\s*128/, 'cipher must use a 128-bit GCM tag');
+requirePattern(cipher, /updateAAD/, 'cipher must authenticate caller-provided AAD');
+
+for (const pattern of [
+  /AndroidKeyStore/,
+  /setBlockModes\([^)]*BLOCK_MODE_GCM/,
+  /setEncryptionPaddings\([^)]*ENCRYPTION_PADDING_NONE/,
+  /setKeySize\(256\)/,
+  /setRandomizedEncryptionRequired\(true\)/,
+  /fun\s+seal\s*\(/,
+  /fun\s+open\s*\(/,
+  /fun\s+deleteKey\s*\(/,
+]) {
+  requirePattern(vault, pattern, `Keystore bridge is missing ${pattern}`);
+}
+if (/\b(?:Log\.|println\s*\()/.test(vault)) {
+  throw new Error('Keystore bridge must not log secret-bearing inputs or crypto exceptions');
+}
+
+for (const pattern of [
+  /roundTrip/,
+  /freshNonce/,
+  /tamperedNonce/,
+  /tamperedCiphertext/,
+  /tamperedAad/,
+]) {
+  requirePattern(unitTest, pattern, `JVM crypto tests are missing ${pattern}`);
+}
+for (const pattern of [/assertNull\([^)]*\.encoded/, /deletedKey/, /tamperedCiphertext/]) {
+  requirePattern(
+    instrumentedTest,
+    pattern,
+    `Android Keystore instrumentation tests are missing ${pattern}`,
+  );
+}
+
+for (const pattern of [
+  /openless-android-credentials/,
+  /version:\s*u32/,
+  /account:\s*String/,
+  /nonce:\s*String/,
+  /ciphertext:\s*String/,
+  /serde\(deny_unknown_fields\)/,
+  /KeyMissingOrInvalidated/,
+  /AuthenticationFailed/,
+  /TemporarilyUnavailable/,
+  /mode\(0o600\)/,
+  /sync_all\(\)/,
+]) {
+  requirePattern(rustStore, pattern, `Rust v2 store is missing ${pattern}`);
+}
+if (/Stub:\s*base64 envelope/.test(credentials)) {
+  throw new Error('legacy Base64 stub is still the Android credential writer');
+}
+
+for (const pattern of [/keystore_seal/, /keystore_open/, /keystore_delete_key/, /JByteArray/]) {
+  requirePattern(jni, pattern, `JNI bridge is missing ${pattern}`);
+}
+
+for (const file of [
+  'OpenLessCredentialCipher.kt',
+  'OpenLessCredentialVault.kt',
+  'OpenLessCredentialCipherTest.kt',
+  'OpenLessCredentialVaultInstrumentedTest.kt',
+]) {
+  if (!copyScript.includes(file)) {
+    throw new Error(`Android scaffolding does not copy ${file}`);
+  }
+}
+requirePattern(
+  copyScript,
+  /testInstrumentationRunner[\s\S]*androidx\.test\.runner\.AndroidJUnitRunner/,
+  'generated Android project must declare the AndroidX instrumentation runner',
+);
+
+requirePattern(ci, /testDebugUnitTest/, 'PR CI must execute JVM credential tests');
+requirePattern(ci, /assembleDebugAndroidTest/, 'PR CI must compile instrumentation tests');
+
+console.log('android-credential-keystore-contract.test.mjs passed');

--- a/openless-all/app/scripts/copy-android-scaffolding.mjs
+++ b/openless-all/app/scripts/copy-android-scaffolding.mjs
@@ -6,10 +6,16 @@ import { fileURLToPath } from 'node:url';
 
 const appRoot = fileURLToPath(new URL('..', import.meta.url));
 const kotlinRoot = join(appRoot, 'android/kotlin');
+const kotlinTestRoot = join(kotlinRoot, 'test');
+const kotlinAndroidTestRoot = join(kotlinRoot, 'androidTest');
 const manifestsRoot = join(appRoot, 'android/manifests');
 const androidIconRoot = join(appRoot, 'src-tauri/icons/android');
+const androidAppRoot = join(appRoot, 'src-tauri/gen/android/app');
 const genRoot = join(appRoot, 'src-tauri/gen/android/app/src/main');
 const kotlinDest = join(genRoot, 'java/com/openless/app');
+const kotlinTestDest = join(androidAppRoot, 'src/test/java/com/openless/app');
+const kotlinAndroidTestDest = join(androidAppRoot, 'src/androidTest/java/com/openless/app');
+const androidAppGradle = join(androidAppRoot, 'build.gradle.kts');
 const resDest = join(genRoot, 'res');
 const resXmlDest = join(genRoot, 'res/xml');
 
@@ -19,6 +25,8 @@ const KOTLIN_FILES = [
   'OpenLessPermissionBridge.kt',
   'MicrophonePermissionActivity.kt',
   'OpenLessAndroidPreferences.kt',
+  'OpenLessCredentialCipher.kt',
+  'OpenLessCredentialVault.kt',
   'OpenLessApplication.kt',
   'OpenLessOverlayService.kt',
   'OpenLessOverlayBridge.kt',
@@ -27,6 +35,9 @@ const KOTLIN_FILES = [
   'OverlayPermissionActivity.kt',
   'OpenLessUpdateInstaller.kt',
 ];
+
+const KOTLIN_TEST_FILES = ['OpenLessCredentialCipherTest.kt'];
+const KOTLIN_ANDROID_TEST_FILES = ['OpenLessCredentialVaultInstrumentedTest.kt'];
 
 const XML_FILES = [
   ['res/xml/openless_accessibility_config.xml', 'openless_accessibility_config.xml'],
@@ -136,22 +147,11 @@ function copyDirectoryContents(srcRoot, destRoot, dryRun) {
   }
 }
 
-function main() {
-  const { dryRun } = parseArgs(process.argv.slice(2));
-
-  if (!existsSync(join(appRoot, 'src-tauri/gen/android'))) {
-    throw new Error(
-      `Generated Android project not found under src-tauri/gen/android.\nRun "npm run tauri -- android init --ci" first.`,
-    );
-  }
-
-  ensureDir(kotlinDest, dryRun);
-  ensureDir(resXmlDest, dryRun);
-  copyDirectoryContents(androidIconRoot, resDest, dryRun);
-
-  for (const file of KOTLIN_FILES) {
-    const src = join(kotlinRoot, file);
-    const dest = join(kotlinDest, file);
+function copyNamedFiles(files, srcRoot, destRoot, dryRun) {
+  ensureDir(destRoot, dryRun);
+  for (const file of files) {
+    const src = join(srcRoot, file);
+    const dest = join(destRoot, file);
     if (!existsSync(src)) {
       throw new Error(`Missing scaffolding file: ${src}`);
     }
@@ -162,6 +162,57 @@ function main() {
     copyFileSync(src, dest);
     console.log(`Copied ${file}`);
   }
+}
+
+function ensureInstrumentationRunner(dryRun) {
+  if (!existsSync(androidAppGradle)) {
+    throw new Error(`Missing generated Android Gradle file: ${androidAppGradle}`);
+  }
+  const existing = readFileSync(androidAppGradle, 'utf8');
+  if (existing.includes('testInstrumentationRunner')) {
+    console.log(`Android instrumentation runner already present in ${androidAppGradle}; skipping.`);
+    return;
+  }
+  const defaultConfig = /^(\s*)defaultConfig\s*\{\s*$/m;
+  const match = existing.match(defaultConfig);
+  if (!match) {
+    throw new Error(`defaultConfig block not found in ${androidAppGradle}`);
+  }
+  const runner =
+    `${match[0]}\n${match[1]}    ` +
+    'testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"';
+  const updated = existing.replace(defaultConfig, runner);
+  if (dryRun) {
+    console.log(`[dry-run] Would add testInstrumentationRunner to ${androidAppGradle}`);
+    return;
+  }
+  writeFileSync(androidAppGradle, updated, 'utf8');
+  console.log(`Added Android instrumentation runner to ${androidAppGradle}`);
+}
+
+function main() {
+  const { dryRun } = parseArgs(process.argv.slice(2));
+
+  if (!existsSync(join(appRoot, 'src-tauri/gen/android'))) {
+    throw new Error(
+      `Generated Android project not found under src-tauri/gen/android.\nRun "npm run tauri -- android init --ci" first.`,
+    );
+  }
+
+  ensureDir(kotlinDest, dryRun);
+  ensureDir(kotlinTestDest, dryRun);
+  ensureDir(kotlinAndroidTestDest, dryRun);
+  ensureDir(resXmlDest, dryRun);
+  copyDirectoryContents(androidIconRoot, resDest, dryRun);
+  copyNamedFiles(KOTLIN_FILES, kotlinRoot, kotlinDest, dryRun);
+  copyNamedFiles(KOTLIN_TEST_FILES, kotlinTestRoot, kotlinTestDest, dryRun);
+  copyNamedFiles(
+    KOTLIN_ANDROID_TEST_FILES,
+    kotlinAndroidTestRoot,
+    kotlinAndroidTestDest,
+    dryRun,
+  );
+  ensureInstrumentationRunner(dryRun);
 
   for (const [relSrc, destName] of XML_FILES) {
     const src = join(manifestsRoot, relSrc);

--- a/openless-all/app/src-tauri/src/android/jni.rs
+++ b/openless-all/app/src-tauri/src/android/jni.rs
@@ -251,6 +251,22 @@ pub mod android {
             .map_err(classify_keystore_failure)
     }
 
+    pub(crate) fn keystore_migration_complete() -> Result<bool, AndroidKeystoreFailure> {
+        let payload = call_credential_vault_no_args("migrationComplete")
+            .map_err(classify_keystore_failure)?;
+        match payload.as_slice() {
+            [0] => Ok(false),
+            [1] => Ok(true),
+            _ => Err(AndroidKeystoreFailure::Malformed),
+        }
+    }
+
+    pub(crate) fn keystore_mark_migration_complete() -> Result<(), AndroidKeystoreFailure> {
+        call_credential_vault_no_args("markMigrationComplete")
+            .map(|_| ())
+            .map_err(classify_keystore_failure)
+    }
+
     pub fn start_activity_class(
         env: &mut JNIEnv,
         context: &JObject,

--- a/openless-all/app/src-tauri/src/android/jni.rs
+++ b/openless-all/app/src-tauri/src/android/jni.rs
@@ -107,6 +107,35 @@ pub mod android {
         Ok(jstring(env, value)?.into())
     }
 
+    /// Returns the app-private files directory supplied by Android's Context.
+    pub(crate) fn app_files_dir() -> Result<String, String> {
+        with_android_env(|env, context| {
+            let directory = env
+                .call_method(context, "getFilesDir", "()Ljava/io/File;", &[])
+                .and_then(|value| value.l())
+                .map_err(|error| format!("Context.getFilesDir: {error}"))?;
+            if directory.is_null() {
+                return Err("Context.getFilesDir returned null".to_string());
+            }
+            let path = env
+                .call_method(&directory, "getAbsolutePath", "()Ljava/lang/String;", &[])
+                .and_then(|value| value.l())
+                .map_err(|error| format!("File.getAbsolutePath: {error}"))?;
+            if path.is_null() {
+                return Err("Context files directory has no path".to_string());
+            }
+            let path = env
+                .get_string(&JString::from(path))
+                .map_err(|error| format!("read Context files directory: {error}"))?
+                .to_string_lossy()
+                .into_owned();
+            if path.is_empty() {
+                return Err("Context files directory is empty".to_string());
+            }
+            Ok(path)
+        })
+    }
+
     const CREDENTIAL_VAULT_CLASS: &str = "com.openless.app.OpenLessCredentialVault";
     const KEYSTORE_KEY_MISSING: &str = "openless-keystore-key-missing";
     const KEYSTORE_AUTHENTICATION_FAILED: &str = "openless-keystore-authentication-failed";

--- a/openless-all/app/src-tauri/src/android/jni.rs
+++ b/openless-all/app/src-tauri/src/android/jni.rs
@@ -107,9 +107,33 @@ pub mod android {
         Ok(jstring(env, value)?.into())
     }
 
+    fn with_tao_android_env<R>(
+        f: impl for<'local> FnOnce(&mut JNIEnv<'local>, &JObject<'local>) -> Result<R, String>,
+    ) -> Result<R, String> {
+        let android_context = tao::platform::android::prelude::main_android_context()
+            .ok_or_else(|| "Tao Android context not yet initialized".to_string())?;
+        let vm = unsafe {
+            JavaVM::from_raw(android_context.java_vm.cast())
+                .map_err(|error| format!("attach Android JVM: {error}"))?
+        };
+        let mut env = vm
+            .attach_current_thread()
+            .map_err(|error| format!("attach Android thread: {error}"))?;
+        let raw_context = android_context.context_jobject as jni::sys::jobject;
+        if raw_context.is_null() {
+            return Err("Tao Android context is null".to_string());
+        }
+        // SAFETY: Tao keeps this activity reference alive for the Android
+        // runtime; it is only borrowed for the duration of `f`.
+        let context = unsafe { JObject::from_raw(raw_context) };
+        f(&mut env, &context)
+    }
+
     /// Returns the app-private files directory supplied by Android's Context.
     pub(crate) fn app_files_dir() -> Result<String, String> {
-        with_android_env(|env, context| {
+        // Persistence initializes before mobile_runtime::setup initializes
+        // ndk-context, so use Tao's non-panicking activity registry here.
+        with_tao_android_env(|env, context| {
             let directory = env
                 .call_method(context, "getFilesDir", "()Ljava/io/File;", &[])
                 .and_then(|value| value.l())

--- a/openless-all/app/src-tauri/src/android/jni.rs
+++ b/openless-all/app/src-tauri/src/android/jni.rs
@@ -2,7 +2,7 @@
 
 #[cfg(target_os = "android")]
 pub mod android {
-    use jni::objects::{JClass, JObject, JString, JValue};
+    use jni::objects::{JByteArray, JClass, JObject, JString, JValue};
     use jni::JNIEnv;
     use jni::JavaVM;
 
@@ -105,6 +105,150 @@ pub mod android {
         value: &str,
     ) -> Result<JObject<'local>, String> {
         Ok(jstring(env, value)?.into())
+    }
+
+    const CREDENTIAL_VAULT_CLASS: &str = "com.openless.app.OpenLessCredentialVault";
+    const KEYSTORE_KEY_MISSING: &str = "openless-keystore-key-missing";
+    const KEYSTORE_AUTHENTICATION_FAILED: &str = "openless-keystore-authentication-failed";
+    const KEYSTORE_TEMPORARILY_UNAVAILABLE: &str = "openless-keystore-temporarily-unavailable";
+    const KEYSTORE_MALFORMED: &str = "openless-keystore-malformed";
+
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub(crate) enum AndroidKeystoreFailure {
+        KeyMissingOrInvalidated,
+        AuthenticationFailed,
+        TemporarilyUnavailable,
+        Malformed,
+    }
+
+    fn clear_pending_exception(env: &mut JNIEnv) {
+        if env.exception_check().unwrap_or(false) {
+            let _ = env.exception_clear();
+        }
+    }
+
+    fn keystore_temporarily_unavailable<T>(env: &mut JNIEnv) -> Result<T, String> {
+        clear_pending_exception(env);
+        Err(KEYSTORE_TEMPORARILY_UNAVAILABLE.to_string())
+    }
+
+    fn credential_response(response: Vec<u8>) -> Result<Vec<u8>, String> {
+        let Some((&status, payload)) = response.split_first() else {
+            return Err(KEYSTORE_TEMPORARILY_UNAVAILABLE.to_string());
+        };
+        match status {
+            0 => Ok(payload.to_vec()),
+            1 => Err(KEYSTORE_KEY_MISSING.to_string()),
+            2 => Err(KEYSTORE_AUTHENTICATION_FAILED.to_string()),
+            3 => Err(KEYSTORE_TEMPORARILY_UNAVAILABLE.to_string()),
+            4 => Err(KEYSTORE_MALFORMED.to_string()),
+            _ => Err(KEYSTORE_TEMPORARILY_UNAVAILABLE.to_string()),
+        }
+    }
+
+    fn call_credential_vault_two_arrays(
+        method: &str,
+        first: &[u8],
+        second: &[u8],
+    ) -> Result<Vec<u8>, String> {
+        with_android_env(|env, context| {
+            let class = match load_context_class(env, context, CREDENTIAL_VAULT_CLASS) {
+                Ok(class) => class,
+                Err(_) => return keystore_temporarily_unavailable(env),
+            };
+            let first_array = match env.byte_array_from_slice(first) {
+                Ok(array) => array,
+                Err(_) => return keystore_temporarily_unavailable(env),
+            };
+            let second_array = match env.byte_array_from_slice(second) {
+                Ok(array) => array,
+                Err(_) => return keystore_temporarily_unavailable(env),
+            };
+            let first_object = JObject::from(first_array);
+            let second_object = JObject::from(second_array);
+            let value = match env.call_static_method(
+                class,
+                method,
+                "([B[B)[B",
+                &[
+                    JValue::Object(&first_object),
+                    JValue::Object(&second_object),
+                ],
+            ) {
+                Ok(value) => value,
+                Err(_) => return keystore_temporarily_unavailable(env),
+            };
+            let object = match value.l() {
+                Ok(object) => object,
+                Err(_) => return keystore_temporarily_unavailable(env),
+            };
+            if object.is_null() {
+                return Err(KEYSTORE_TEMPORARILY_UNAVAILABLE.to_string());
+            }
+            let array = JByteArray::from(object);
+            let response = match env.convert_byte_array(&array) {
+                Ok(response) => response,
+                Err(_) => return keystore_temporarily_unavailable(env),
+            };
+            credential_response(response)
+        })
+    }
+
+    fn call_credential_vault_no_args(method: &str) -> Result<Vec<u8>, String> {
+        with_android_env(|env, context| {
+            let class = match load_context_class(env, context, CREDENTIAL_VAULT_CLASS) {
+                Ok(class) => class,
+                Err(_) => return keystore_temporarily_unavailable(env),
+            };
+            let value = match env.call_static_method(class, method, "()[B", &[]) {
+                Ok(value) => value,
+                Err(_) => return keystore_temporarily_unavailable(env),
+            };
+            let object = match value.l() {
+                Ok(object) => object,
+                Err(_) => return keystore_temporarily_unavailable(env),
+            };
+            if object.is_null() {
+                return Err(KEYSTORE_TEMPORARILY_UNAVAILABLE.to_string());
+            }
+            let array = JByteArray::from(object);
+            let response = match env.convert_byte_array(&array) {
+                Ok(response) => response,
+                Err(_) => return keystore_temporarily_unavailable(env),
+            };
+            credential_response(response)
+        })
+    }
+
+    fn classify_keystore_failure(error: String) -> AndroidKeystoreFailure {
+        match error.as_str() {
+            KEYSTORE_KEY_MISSING => AndroidKeystoreFailure::KeyMissingOrInvalidated,
+            KEYSTORE_AUTHENTICATION_FAILED => AndroidKeystoreFailure::AuthenticationFailed,
+            KEYSTORE_MALFORMED => AndroidKeystoreFailure::Malformed,
+            _ => AndroidKeystoreFailure::TemporarilyUnavailable,
+        }
+    }
+
+    pub(crate) fn keystore_seal(
+        plaintext: &[u8],
+        aad: &[u8],
+    ) -> Result<Vec<u8>, AndroidKeystoreFailure> {
+        call_credential_vault_two_arrays("seal", plaintext, aad)
+            .map_err(classify_keystore_failure)
+    }
+
+    pub(crate) fn keystore_open(
+        sealed: &[u8],
+        aad: &[u8],
+    ) -> Result<Vec<u8>, AndroidKeystoreFailure> {
+        call_credential_vault_two_arrays("open", sealed, aad)
+            .map_err(classify_keystore_failure)
+    }
+
+    pub(crate) fn keystore_delete_key() -> Result<(), AndroidKeystoreFailure> {
+        call_credential_vault_no_args("deleteKey")
+            .map(|_| ())
+            .map_err(classify_keystore_failure)
     }
 
     pub fn start_activity_class(

--- a/openless-all/app/src-tauri/src/persistence/android_credentials.rs
+++ b/openless-all/app/src-tauri/src/persistence/android_credentials.rs
@@ -202,7 +202,19 @@ fn recover_verified_v2_temporary(
         Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(()),
         Err(error) => return Err(io_error("read verified v2 recovery", error)),
     };
-    let _ = open_envelope(&persisted, crypto)?;
+    match open_envelope(&persisted, crypto) {
+        Ok(_) => {}
+        Err(StoreError::Crypto(CryptoErrorKind::KeyMissingOrInvalidated)) => {
+            // Match the main-envelope recovery behavior: a permanently
+            // invalidated key cannot decrypt this candidate, so clear both
+            // files and let the caller reconfigure credentials.
+            crypto.delete_key().map_err(StoreError::Crypto)?;
+            secure_remove(&temporary)?;
+            secure_remove(path)?;
+            return Ok(());
+        }
+        Err(error) => return Err(error),
+    }
 
     // Re-establish the non-exportable rollback barrier before promoting the
     // verified recovery candidate. A crash after this point leaves the
@@ -967,6 +979,47 @@ mod tests {
             ReadOutcome::Plaintext(plaintext.to_vec())
         );
         assert!(!verified_v2_temporary_path(&path).exists());
+        remove_test_parent(&path);
+    }
+
+    #[test]
+    fn invalidated_key_clears_pending_v2_recovery_candidate() {
+        let path = test_path("android-v2-pending-missing-key");
+        let plaintext = br#"{"version":1,"active":{"llm":"ark"}}"#;
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(
+            &path,
+            base64::engine::general_purpose::STANDARD.encode(plaintext),
+        )
+        .unwrap();
+        let mut crypto = TestCrypto::default();
+
+        assert!(write_verified_with_fault(
+            &path,
+            plaintext,
+            &mut crypto,
+            &mut |stage| {
+                if stage == WriteStage::AfterVerification {
+                    Err(io::Error::other("inject pending recovery candidate"))
+                } else {
+                    Ok(())
+                }
+            },
+        )
+        .is_err());
+        assert!(verified_v2_temporary_path(&path).exists());
+
+        crypto.fail_next_open = Some(CryptoErrorKind::KeyMissingOrInvalidated);
+        assert_eq!(read(&path, &mut crypto).unwrap(), ReadOutcome::Missing);
+        assert!(!path.exists());
+        assert!(!verified_v2_temporary_path(&path).exists());
+        assert_eq!(crypto.delete_key_calls, 1);
+
+        write_verified(&path, b"reconfigured", &mut crypto).unwrap();
+        assert_eq!(
+            read(&path, &mut crypto).unwrap(),
+            ReadOutcome::Plaintext(b"reconfigured".to_vec())
+        );
         remove_test_parent(&path);
     }
 

--- a/openless-all/app/src-tauri/src/persistence/android_credentials.rs
+++ b/openless-all/app/src-tauri/src/persistence/android_credentials.rs
@@ -146,9 +146,10 @@ pub(super) fn read(
     };
 
     if first != b'{' {
-        // The non-exportable marker is created only after a v2 envelope has
-        // reached durable storage. Once present, a Base64 file is a rollback
-        // or injection attempt rather than a legitimate upgrade source.
+        // The non-exportable marker is created after a v2 temporary envelope
+        // has been verified and before it can replace a legacy envelope. Once
+        // present, a Base64 file is a rollback or injection attempt rather
+        // than a legitimate upgrade source.
         if crypto
             .migration_complete()
             .map_err(StoreError::Crypto)?
@@ -290,10 +291,7 @@ pub(super) fn write_verified(
     plaintext: &[u8],
     crypto: &mut impl AndroidCredentialsCrypto,
 ) -> Result<(), StoreError> {
-    write_verified_with_fault(path, plaintext, crypto, &mut |_| Ok(()))?;
-    crypto
-        .mark_migration_complete()
-        .map_err(StoreError::Crypto)
+    write_verified_with_fault(path, plaintext, crypto, &mut |_| Ok(()))
 }
 
 pub(super) fn rewrite_legacy_without_bearer(
@@ -433,6 +431,13 @@ fn write_verified_with_fault(
         if verified != plaintext {
             return Err(StoreError::VerificationFailed);
         }
+
+        // Retire Base64 envelopes before replacing one. If the process stops
+        // after this point, the old file is deliberately rejected instead of
+        // becoming a downgrade path on the next launch.
+        crypto
+            .mark_migration_complete()
+            .map_err(StoreError::Crypto)?;
         fault(WriteStage::AfterVerification)
             .map_err(|error| io_error("after verifying temporary file", error))?;
 
@@ -842,12 +847,47 @@ mod tests {
         );
         assert!(result.is_err());
         assert_eq!(std::fs::read_to_string(&path).unwrap(), legacy);
+        assert!(matches!(
+            read(&path, &mut crypto),
+            Err(StoreError::InvalidEnvelope)
+        ));
 
         write_verified(&path, plaintext, &mut crypto).unwrap();
         assert_eq!(
             read(&path, &mut crypto).unwrap(),
             ReadOutcome::Plaintext(plaintext.to_vec())
         );
+        remove_test_parent(&path);
+    }
+
+    #[test]
+    fn verified_v2_commit_barrier_rejects_legacy_after_pre_rename_failure() {
+        let path = test_path("android-v2-commit-barrier");
+        let plaintext = br#"{"version":1,"active":{"llm":"ark"}}"#;
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        let legacy = base64::engine::general_purpose::STANDARD.encode(plaintext);
+        std::fs::write(&path, &legacy).unwrap();
+        let mut crypto = TestCrypto::default();
+
+        let result = write_verified_with_fault(
+            &path,
+            plaintext,
+            &mut crypto,
+            &mut |stage| {
+                if stage == WriteStage::AfterVerification {
+                    Err(io::Error::other("injected pre-rename failure"))
+                } else {
+                    Ok(())
+                }
+            },
+        );
+
+        assert!(result.is_err());
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), legacy);
+        assert!(matches!(
+            read(&path, &mut crypto),
+            Err(StoreError::InvalidEnvelope)
+        ));
         remove_test_parent(&path);
     }
 

--- a/openless-all/app/src-tauri/src/persistence/android_credentials.rs
+++ b/openless-all/app/src-tauri/src/persistence/android_credentials.rs
@@ -1,0 +1,788 @@
+use std::fs::{self, File, OpenOptions};
+use std::io::{self, Write};
+use std::path::Path;
+
+use base64::Engine;
+use serde::{Deserialize, Serialize};
+
+#[cfg(unix)]
+use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
+
+const ENVELOPE_FORMAT: &str = "openless-android-credentials";
+const ENVELOPE_VERSION: u32 = 2;
+const ENVELOPE_ACCOUNT: &str = "credentials.v1";
+const NONCE_BYTES: usize = 12;
+const GCM_TAG_BYTES: usize = 16;
+const ENVELOPE_AAD: &[u8] =
+    b"openless-android-credentials\x002\x00com.openless.app\x00credentials.v1";
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub(super) struct EnvelopeV2 {
+    format: String,
+    version: u32,
+    account: String,
+    nonce: String,
+    ciphertext: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct SealedPayload {
+    pub(super) nonce: Vec<u8>,
+    pub(super) ciphertext: Vec<u8>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+pub(super) enum CryptoErrorKind {
+    #[error("authentication failed")]
+    AuthenticationFailed,
+    #[error("key missing or invalidated")]
+    KeyMissingOrInvalidated,
+    #[error("temporarily unavailable")]
+    TemporarilyUnavailable,
+}
+
+pub(super) trait AndroidCredentialsCrypto {
+    fn seal(
+        &mut self,
+        plaintext: &[u8],
+        aad: &[u8],
+    ) -> std::result::Result<SealedPayload, CryptoErrorKind>;
+
+    fn open(
+        &mut self,
+        sealed: &SealedPayload,
+        aad: &[u8],
+    ) -> std::result::Result<Vec<u8>, CryptoErrorKind>;
+
+    fn delete_key(&mut self) -> std::result::Result<(), CryptoErrorKind>;
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) enum ReadOutcome {
+    Missing,
+    Legacy(Vec<u8>),
+    Plaintext(Vec<u8>),
+}
+
+#[derive(Debug, thiserror::Error)]
+pub(super) enum StoreError {
+    #[error("invalid Android credential envelope")]
+    InvalidEnvelope,
+    #[error("Android credential authentication or key operation failed: {0}")]
+    Crypto(#[from] CryptoErrorKind),
+    #[error("Android credential persistence failed during {operation}")]
+    Io {
+        operation: &'static str,
+        #[source]
+        source: io::Error,
+    },
+    #[error("Android credential persistence verification failed")]
+    VerificationFailed,
+    #[error("Android credential envelope serialization failed")]
+    Serialization,
+}
+
+fn io_error(operation: &'static str, source: io::Error) -> StoreError {
+    StoreError::Io { operation, source }
+}
+
+fn validated_envelope(bytes: &[u8]) -> Result<(EnvelopeV2, SealedPayload), StoreError> {
+    let envelope =
+        serde_json::from_slice::<EnvelopeV2>(bytes).map_err(|_| StoreError::InvalidEnvelope)?;
+    if envelope.format != ENVELOPE_FORMAT
+        || envelope.version != ENVELOPE_VERSION
+        || envelope.account != ENVELOPE_ACCOUNT
+    {
+        return Err(StoreError::InvalidEnvelope);
+    }
+
+    let nonce = base64::engine::general_purpose::STANDARD
+        .decode(&envelope.nonce)
+        .map_err(|_| StoreError::InvalidEnvelope)?;
+    let ciphertext = base64::engine::general_purpose::STANDARD
+        .decode(&envelope.ciphertext)
+        .map_err(|_| StoreError::InvalidEnvelope)?;
+    if nonce.len() != NONCE_BYTES || ciphertext.len() < GCM_TAG_BYTES {
+        return Err(StoreError::InvalidEnvelope);
+    }
+
+    Ok((
+        envelope,
+        SealedPayload {
+            nonce,
+            ciphertext,
+        },
+    ))
+}
+
+fn open_envelope(
+    bytes: &[u8],
+    crypto: &mut impl AndroidCredentialsCrypto,
+) -> Result<Vec<u8>, StoreError> {
+    let (_, sealed) = validated_envelope(bytes)?;
+    crypto
+        .open(&sealed, ENVELOPE_AAD)
+        .map_err(StoreError::Crypto)
+}
+
+pub(super) fn read(
+    path: &Path,
+    crypto: &mut impl AndroidCredentialsCrypto,
+) -> Result<ReadOutcome, StoreError> {
+    let bytes = match fs::read(path) {
+        Ok(bytes) => bytes,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(ReadOutcome::Missing),
+        Err(error) => return Err(io_error("read", error)),
+    };
+    let first = bytes.iter().copied().find(|byte| !byte.is_ascii_whitespace());
+    let Some(first) = first else {
+        return Err(StoreError::InvalidEnvelope);
+    };
+
+    if first != b'{' {
+        let plaintext = base64::engine::general_purpose::STANDARD
+            .decode(&bytes)
+            .map_err(|_| StoreError::InvalidEnvelope)?;
+        if plaintext.is_empty() {
+            return Err(StoreError::InvalidEnvelope);
+        }
+        return Ok(ReadOutcome::Legacy(plaintext));
+    }
+
+    match open_envelope(&bytes, crypto) {
+        Ok(plaintext) => Ok(ReadOutcome::Plaintext(plaintext)),
+        Err(StoreError::Crypto(CryptoErrorKind::KeyMissingOrInvalidated)) => {
+            // The ciphertext can no longer be recovered. Reset the alias first;
+            // if that is temporarily unavailable, preserve the file for retry.
+            crypto.delete_key().map_err(StoreError::Crypto)?;
+            secure_remove(path)?;
+            Ok(ReadOutcome::Missing)
+        }
+        Err(error) => Err(error),
+    }
+}
+
+fn envelope_for(sealed: &SealedPayload) -> Result<Vec<u8>, StoreError> {
+    if sealed.nonce.len() != NONCE_BYTES || sealed.ciphertext.len() < GCM_TAG_BYTES {
+        return Err(StoreError::VerificationFailed);
+    }
+    serde_json::to_vec(&EnvelopeV2 {
+        format: ENVELOPE_FORMAT.to_string(),
+        version: ENVELOPE_VERSION,
+        account: ENVELOPE_ACCOUNT.to_string(),
+        nonce: base64::engine::general_purpose::STANDARD.encode(&sealed.nonce),
+        ciphertext: base64::engine::general_purpose::STANDARD.encode(&sealed.ciphertext),
+    })
+    .map_err(|_| StoreError::Serialization)
+}
+
+fn ensure_private_dir(path: &Path) -> Result<(), StoreError> {
+    fs::create_dir_all(path).map_err(|error| io_error("create directory", error))?;
+    #[cfg(unix)]
+    fs::set_permissions(path, fs::Permissions::from_mode(0o700))
+        .map_err(|error| io_error("set directory permissions", error))?;
+    Ok(())
+}
+
+fn set_private_file_mode(path: &Path) -> Result<(), StoreError> {
+    #[cfg(unix)]
+    fs::set_permissions(path, fs::Permissions::from_mode(0o600))
+        .map_err(|error| io_error("set file permissions", error))?;
+    Ok(())
+}
+
+fn sync_parent(path: &Path) -> Result<(), StoreError> {
+    let parent = path.parent().unwrap_or_else(|| Path::new("."));
+    File::open(parent)
+        .and_then(|directory| directory.sync_all())
+        .map_err(|error| io_error("sync parent directory", error))
+}
+
+fn remove_if_present(path: &Path) -> Result<(), StoreError> {
+    match fs::remove_file(path) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(io_error("remove temporary file", error)),
+    }
+}
+
+fn open_private_temp(path: &Path) -> Result<File, StoreError> {
+    let mut options = OpenOptions::new();
+    options.create_new(true).write(true);
+    #[cfg(unix)]
+    options
+        .mode(0o600)
+        .custom_flags(libc::O_CLOEXEC | libc::O_NOFOLLOW);
+    options
+        .open(path)
+        .map_err(|error| io_error("open temporary file", error))
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum WriteStage {
+    TempOpen,
+    AfterTempOpen,
+    AfterTempWrite,
+    AfterTempSync,
+    AfterVerification,
+    Rename,
+    AfterRename,
+    ParentSync,
+}
+
+pub(super) fn write_verified(
+    path: &Path,
+    plaintext: &[u8],
+    crypto: &mut impl AndroidCredentialsCrypto,
+) -> Result<(), StoreError> {
+    write_verified_with_fault(path, plaintext, crypto, &mut |_| Ok(()))
+}
+
+fn write_verified_with_fault(
+    path: &Path,
+    plaintext: &[u8],
+    crypto: &mut impl AndroidCredentialsCrypto,
+    fault: &mut impl FnMut(WriteStage) -> io::Result<()>,
+) -> Result<(), StoreError> {
+    let sealed = crypto
+        .seal(plaintext, ENVELOPE_AAD)
+        .map_err(StoreError::Crypto)?;
+    let reopened = crypto
+        .open(&sealed, ENVELOPE_AAD)
+        .map_err(StoreError::Crypto)?;
+    if reopened != plaintext {
+        return Err(StoreError::VerificationFailed);
+    }
+    let encoded = envelope_for(&sealed)?;
+
+    let parent = path.parent().unwrap_or_else(|| Path::new("."));
+    ensure_private_dir(parent)?;
+    let temporary = path.with_extension("json.tmp");
+    remove_if_present(&temporary)?;
+
+    let result = (|| {
+        fault(WriteStage::TempOpen).map_err(|error| io_error("open temporary file", error))?;
+        let mut output = open_private_temp(&temporary)?;
+        fault(WriteStage::AfterTempOpen)
+            .map_err(|error| io_error("after opening temporary file", error))?;
+        output
+            .write_all(&encoded)
+            .map_err(|error| io_error("write temporary file", error))?;
+        fault(WriteStage::AfterTempWrite)
+            .map_err(|error| io_error("after writing temporary file", error))?;
+        output
+            .flush()
+            .map_err(|error| io_error("flush temporary file", error))?;
+        output
+            .sync_all()
+            .map_err(|error| io_error("sync temporary file", error))?;
+        fault(WriteStage::AfterTempSync)
+            .map_err(|error| io_error("after syncing temporary file", error))?;
+        drop(output);
+        set_private_file_mode(&temporary)?;
+
+        let persisted = fs::read(&temporary)
+            .map_err(|error| io_error("reread temporary file", error))?;
+        let verified = open_envelope(&persisted, crypto)?;
+        if verified != plaintext {
+            return Err(StoreError::VerificationFailed);
+        }
+        fault(WriteStage::AfterVerification)
+            .map_err(|error| io_error("after verifying temporary file", error))?;
+
+        fault(WriteStage::Rename).map_err(|error| io_error("replace credential file", error))?;
+        fs::rename(&temporary, path).map_err(|error| io_error("replace credential file", error))?;
+        fault(WriteStage::AfterRename)
+            .map_err(|error| io_error("after replacing credential file", error))?;
+        set_private_file_mode(path)?;
+        fault(WriteStage::ParentSync)
+            .map_err(|error| io_error("sync parent directory", error))?;
+        sync_parent(path)
+    })();
+
+    if result.is_err() {
+        let _ = fs::remove_file(&temporary);
+    }
+    result
+}
+
+pub(super) fn secure_remove(path: &Path) -> Result<(), StoreError> {
+    match OpenOptions::new().write(true).open(path) {
+        Ok(file) => {
+            file.set_len(0)
+                .map_err(|error| io_error("truncate unrecoverable credential file", error))?;
+            file.sync_all()
+                .map_err(|error| io_error("sync unrecoverable credential file", error))?;
+        }
+        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => return Err(io_error("open unrecoverable credential file", error)),
+    }
+    match fs::remove_file(path) {
+        Ok(()) => sync_parent(path),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(io_error("remove unrecoverable credential file", error)),
+    }
+}
+
+#[cfg(target_os = "android")]
+pub(super) struct AndroidKeystoreCrypto;
+
+#[cfg(target_os = "android")]
+impl AndroidCredentialsCrypto for AndroidKeystoreCrypto {
+    fn seal(
+        &mut self,
+        plaintext: &[u8],
+        aad: &[u8],
+    ) -> std::result::Result<SealedPayload, CryptoErrorKind> {
+        let packet = crate::android::jni::android::keystore_seal(plaintext, aad)
+            .map_err(map_keystore_failure)?;
+        split_packet(&packet)
+    }
+
+    fn open(
+        &mut self,
+        sealed: &SealedPayload,
+        aad: &[u8],
+    ) -> std::result::Result<Vec<u8>, CryptoErrorKind> {
+        crate::android::jni::android::keystore_open(&join_packet(sealed), aad)
+            .map_err(map_keystore_failure)
+    }
+
+    fn delete_key(&mut self) -> std::result::Result<(), CryptoErrorKind> {
+        crate::android::jni::android::keystore_delete_key().map_err(map_keystore_failure)
+    }
+}
+
+#[cfg(target_os = "android")]
+fn map_keystore_failure(
+    failure: crate::android::jni::android::AndroidKeystoreFailure,
+) -> CryptoErrorKind {
+    use crate::android::jni::android::AndroidKeystoreFailure;
+    match failure {
+        AndroidKeystoreFailure::AuthenticationFailed | AndroidKeystoreFailure::Malformed => {
+            CryptoErrorKind::AuthenticationFailed
+        }
+        AndroidKeystoreFailure::KeyMissingOrInvalidated => {
+            CryptoErrorKind::KeyMissingOrInvalidated
+        }
+        AndroidKeystoreFailure::TemporarilyUnavailable => {
+            CryptoErrorKind::TemporarilyUnavailable
+        }
+    }
+}
+
+#[cfg(target_os = "android")]
+fn split_packet(packet: &[u8]) -> std::result::Result<SealedPayload, CryptoErrorKind> {
+    let Some((&nonce_len, body)) = packet.split_first() else {
+        return Err(CryptoErrorKind::TemporarilyUnavailable);
+    };
+    let nonce_len = usize::from(nonce_len);
+    if nonce_len != NONCE_BYTES || body.len() < nonce_len + GCM_TAG_BYTES {
+        return Err(CryptoErrorKind::TemporarilyUnavailable);
+    }
+    Ok(SealedPayload {
+        nonce: body[..nonce_len].to_vec(),
+        ciphertext: body[nonce_len..].to_vec(),
+    })
+}
+
+#[cfg(target_os = "android")]
+fn join_packet(sealed: &SealedPayload) -> Vec<u8> {
+    let mut packet = Vec::with_capacity(1 + sealed.nonce.len() + sealed.ciphertext.len());
+    packet.push(sealed.nonce.len() as u8);
+    packet.extend_from_slice(&sealed.nonce);
+    packet.extend_from_slice(&sealed.ciphertext);
+    packet
+}
+
+#[cfg(test)]
+pub(super) struct TestCrypto {
+    key: [u8; 32],
+    counter: u64,
+    pub(super) fail_next_open: Option<CryptoErrorKind>,
+    pub(super) delete_key_calls: usize,
+}
+
+#[cfg(test)]
+impl Default for TestCrypto {
+    fn default() -> Self {
+        Self {
+            key: [0xA7; 32],
+            counter: 0,
+            fail_next_open: None,
+            delete_key_calls: 0,
+        }
+    }
+}
+
+#[cfg(test)]
+impl TestCrypto {
+    fn authentication_tag(&self, nonce: &[u8], ciphertext: &[u8], aad: &[u8]) -> [u8; 16] {
+        use sha2::{Digest, Sha256};
+
+        let mut digest = Sha256::new();
+        digest.update(self.key);
+        digest.update(aad);
+        digest.update(nonce);
+        digest.update(ciphertext);
+        let digest = digest.finalize();
+        let mut tag = [0_u8; 16];
+        tag.copy_from_slice(&digest[..16]);
+        tag
+    }
+}
+
+#[cfg(test)]
+impl AndroidCredentialsCrypto for TestCrypto {
+    fn seal(
+        &mut self,
+        plaintext: &[u8],
+        aad: &[u8],
+    ) -> std::result::Result<SealedPayload, CryptoErrorKind> {
+        self.counter += 1;
+        let mut nonce = vec![0x51, 0x7A, 0xC3, 0x19];
+        nonce.extend_from_slice(&self.counter.to_be_bytes());
+        let mut ciphertext = plaintext
+            .iter()
+            .enumerate()
+            .map(|(index, byte)| byte ^ self.key[index % self.key.len()])
+            .collect::<Vec<_>>();
+        let tag = self.authentication_tag(&nonce, &ciphertext, aad);
+        ciphertext.extend_from_slice(&tag);
+        Ok(SealedPayload {
+            nonce,
+            ciphertext,
+        })
+    }
+
+    fn open(
+        &mut self,
+        sealed: &SealedPayload,
+        aad: &[u8],
+    ) -> std::result::Result<Vec<u8>, CryptoErrorKind> {
+        if let Some(error) = self.fail_next_open.take() {
+            return Err(error);
+        }
+        if sealed.nonce.len() != NONCE_BYTES || sealed.ciphertext.len() < GCM_TAG_BYTES {
+            return Err(CryptoErrorKind::AuthenticationFailed);
+        }
+        let split = sealed.ciphertext.len() - GCM_TAG_BYTES;
+        let (ciphertext, tag) = sealed.ciphertext.split_at(split);
+        let expected = self.authentication_tag(&sealed.nonce, ciphertext, aad);
+        if expected.as_slice() != tag {
+            return Err(CryptoErrorKind::AuthenticationFailed);
+        }
+        Ok(ciphertext
+            .iter()
+            .enumerate()
+            .map(|(index, byte)| byte ^ self.key[index % self.key.len()])
+            .collect())
+    }
+
+    fn delete_key(&mut self) -> std::result::Result<(), CryptoErrorKind> {
+        self.delete_key_calls += 1;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use base64::Engine;
+    use std::io;
+    #[cfg(unix)]
+    use std::os::unix::fs::PermissionsExt;
+
+    fn test_path(name: &str) -> std::path::PathBuf {
+        std::env::temp_dir()
+            .join(format!("openless-{name}-{}", uuid::Uuid::new_v4()))
+            .join("credentials.enc.json")
+    }
+
+    fn remove_test_parent(path: &std::path::Path) {
+        if let Some(parent) = path.parent() {
+            let _ = std::fs::remove_dir_all(parent);
+        }
+    }
+
+    #[test]
+    fn v2_round_trip_hides_plaintext() {
+        let path = test_path("android-v2-round-trip");
+        let plaintext = br#"{"version":1,"providers":{"llm":{"ark":{"apiKey":"sk-secret-sentinel"}}}}"#;
+        let mut crypto = TestCrypto::default();
+
+        write_verified(&path, plaintext, &mut crypto).unwrap();
+
+        let disk = std::fs::read(&path).unwrap();
+        assert!(!disk.windows(b"sk-secret-sentinel".len()).any(|window| {
+            window == b"sk-secret-sentinel"
+        }));
+        if let Ok(decoded) = base64::engine::general_purpose::STANDARD.decode(&disk) {
+            assert!(!String::from_utf8_lossy(&decoded).contains("sk-secret-sentinel"));
+        }
+        assert_eq!(
+            read(&path, &mut crypto).unwrap(),
+            ReadOutcome::Plaintext(plaintext.to_vec())
+        );
+        remove_test_parent(&path);
+    }
+
+    #[test]
+    fn v2_uses_a_fresh_nonce_for_each_write() {
+        let path = test_path("android-v2-fresh-nonce");
+        let mut crypto = TestCrypto::default();
+
+        write_verified(&path, b"same plaintext", &mut crypto).unwrap();
+        let first: EnvelopeV2 = serde_json::from_slice(&std::fs::read(&path).unwrap()).unwrap();
+        write_verified(&path, b"same plaintext", &mut crypto).unwrap();
+        let second: EnvelopeV2 = serde_json::from_slice(&std::fs::read(&path).unwrap()).unwrap();
+
+        assert_ne!(first.nonce, second.nonce);
+        assert_ne!(first.ciphertext, second.ciphertext);
+        remove_test_parent(&path);
+    }
+
+    #[test]
+    fn v2_rejects_tampered_metadata_and_ciphertext_without_deleting_file() {
+        let path = test_path("android-v2-tamper");
+        let mut crypto = TestCrypto::default();
+        write_verified(&path, b"authenticated secret", &mut crypto).unwrap();
+        let original = std::fs::read(&path).unwrap();
+
+        let mut envelope: EnvelopeV2 = serde_json::from_slice(&original).unwrap();
+        envelope.version += 1;
+        std::fs::write(&path, serde_json::to_vec(&envelope).unwrap()).unwrap();
+        assert!(matches!(
+            read(&path, &mut crypto),
+            Err(StoreError::InvalidEnvelope)
+        ));
+        assert!(path.exists());
+
+        let mut envelope: EnvelopeV2 = serde_json::from_slice(&original).unwrap();
+        envelope.format = "attacker-format".to_string();
+        std::fs::write(&path, serde_json::to_vec(&envelope).unwrap()).unwrap();
+        assert!(matches!(
+            read(&path, &mut crypto),
+            Err(StoreError::InvalidEnvelope)
+        ));
+
+        let mut envelope: EnvelopeV2 = serde_json::from_slice(&original).unwrap();
+        envelope.account = "attacker-account".to_string();
+        std::fs::write(&path, serde_json::to_vec(&envelope).unwrap()).unwrap();
+        assert!(matches!(
+            read(&path, &mut crypto),
+            Err(StoreError::InvalidEnvelope)
+        ));
+
+        let mut envelope: EnvelopeV2 = serde_json::from_slice(&original).unwrap();
+        let mut nonce = base64::engine::general_purpose::STANDARD
+            .decode(&envelope.nonce)
+            .unwrap();
+        nonce[0] ^= 1;
+        envelope.nonce = base64::engine::general_purpose::STANDARD.encode(nonce);
+        std::fs::write(&path, serde_json::to_vec(&envelope).unwrap()).unwrap();
+        assert!(matches!(
+            read(&path, &mut crypto),
+            Err(StoreError::Crypto(CryptoErrorKind::AuthenticationFailed))
+        ));
+
+        let mut envelope: EnvelopeV2 = serde_json::from_slice(&original).unwrap();
+        let mut ciphertext = base64::engine::general_purpose::STANDARD
+            .decode(&envelope.ciphertext)
+            .unwrap();
+        ciphertext[0] ^= 1;
+        envelope.ciphertext = base64::engine::general_purpose::STANDARD.encode(ciphertext);
+        std::fs::write(&path, serde_json::to_vec(&envelope).unwrap()).unwrap();
+        assert!(matches!(
+            read(&path, &mut crypto),
+            Err(StoreError::Crypto(CryptoErrorKind::AuthenticationFailed))
+        ));
+        assert!(path.exists());
+        remove_test_parent(&path);
+    }
+
+    #[test]
+    fn empty_truncated_or_unknown_field_envelopes_fail_closed() {
+        let path = test_path("android-v2-malformed");
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        let mut crypto = TestCrypto::default();
+
+        std::fs::write(&path, b"").unwrap();
+        assert!(matches!(
+            read(&path, &mut crypto),
+            Err(StoreError::InvalidEnvelope)
+        ));
+
+        std::fs::write(&path, br#"{"format":"openless-android-credentials""#).unwrap();
+        assert!(matches!(
+            read(&path, &mut crypto),
+            Err(StoreError::InvalidEnvelope)
+        ));
+
+        write_verified(&path, b"valid", &mut crypto).unwrap();
+        let mut envelope: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(&path).unwrap()).unwrap();
+        envelope["unexpected"] = serde_json::Value::Bool(true);
+        std::fs::write(&path, serde_json::to_vec(&envelope).unwrap()).unwrap();
+        assert!(matches!(
+            read(&path, &mut crypto),
+            Err(StoreError::InvalidEnvelope)
+        ));
+        assert!(path.exists());
+        remove_test_parent(&path);
+    }
+
+    #[test]
+    fn legacy_base64_migrates_only_after_verified_round_trip() {
+        let path = test_path("android-legacy-migration");
+        let plaintext = br#"{"version":1,"active":{"asr":"volcengine","llm":"ark"}}"#;
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        let legacy = base64::engine::general_purpose::STANDARD.encode(plaintext);
+        std::fs::write(&path, &legacy).unwrap();
+        let mut crypto = TestCrypto::default();
+
+        assert_eq!(
+            read(&path, &mut crypto).unwrap(),
+            ReadOutcome::Legacy(plaintext.to_vec())
+        );
+        crypto.fail_next_open = Some(CryptoErrorKind::TemporarilyUnavailable);
+        assert!(write_verified(&path, plaintext, &mut crypto).is_err());
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), legacy);
+
+        let result = write_verified_with_fault(
+            &path,
+            plaintext,
+            &mut crypto,
+            &mut |stage| {
+                if stage == WriteStage::AfterVerification {
+                    Err(io::Error::other("injected post-verification failure"))
+                } else {
+                    Ok(())
+                }
+            },
+        );
+        assert!(result.is_err());
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), legacy);
+
+        write_verified(&path, plaintext, &mut crypto).unwrap();
+        assert_eq!(
+            read(&path, &mut crypto).unwrap(),
+            ReadOutcome::Plaintext(plaintext.to_vec())
+        );
+        remove_test_parent(&path);
+    }
+
+    #[test]
+    fn atomic_update_faults_leave_one_complete_envelope() {
+        let path = test_path("android-atomic-faults");
+        let mut crypto = TestCrypto::default();
+        let stages = [
+            WriteStage::TempOpen,
+            WriteStage::AfterTempOpen,
+            WriteStage::AfterTempWrite,
+            WriteStage::AfterTempSync,
+            WriteStage::AfterVerification,
+            WriteStage::Rename,
+            WriteStage::AfterRename,
+            WriteStage::ParentSync,
+        ];
+
+        for failed_stage in stages {
+            write_verified(&path, b"old complete value", &mut crypto).unwrap();
+            let result = write_verified_with_fault(
+                &path,
+                b"new complete value",
+                &mut crypto,
+                &mut |stage| {
+                    if stage == failed_stage {
+                        Err(io::Error::other(format!("injected {stage:?}")))
+                    } else {
+                        Ok(())
+                    }
+                },
+            );
+            assert!(result.is_err(), "{failed_stage:?} should fail");
+            let expected: &[u8] = if matches!(
+                failed_stage,
+                WriteStage::AfterRename | WriteStage::ParentSync
+            ) {
+                b"new complete value"
+            } else {
+                b"old complete value"
+            };
+            assert_eq!(
+                read(&path, &mut crypto).unwrap(),
+                ReadOutcome::Plaintext(expected.to_vec()),
+                "{failed_stage:?} left an incomplete envelope"
+            );
+            assert!(!path.with_extension("json.tmp").exists());
+        }
+        remove_test_parent(&path);
+    }
+
+    #[test]
+    fn transient_keystore_failure_is_retryable_and_preserves_ciphertext() {
+        let path = test_path("android-transient-keystore");
+        let mut crypto = TestCrypto::default();
+        write_verified(&path, b"retry me", &mut crypto).unwrap();
+        let disk = std::fs::read(&path).unwrap();
+
+        crypto.fail_next_open = Some(CryptoErrorKind::TemporarilyUnavailable);
+        assert!(matches!(
+            read(&path, &mut crypto),
+            Err(StoreError::Crypto(CryptoErrorKind::TemporarilyUnavailable))
+        ));
+        assert_eq!(std::fs::read(&path).unwrap(), disk);
+        assert_eq!(crypto.delete_key_calls, 0);
+        assert_eq!(
+            read(&path, &mut crypto).unwrap(),
+            ReadOutcome::Plaintext(b"retry me".to_vec())
+        );
+        remove_test_parent(&path);
+    }
+
+    #[test]
+    fn errors_never_include_plaintext_secrets() {
+        let path = test_path("android-secret-free-errors");
+        let secret = b"sk-never-include-this-value";
+        let mut crypto = TestCrypto::default();
+        crypto.fail_next_open = Some(CryptoErrorKind::TemporarilyUnavailable);
+
+        let error = write_verified(&path, secret, &mut crypto).unwrap_err();
+
+        assert!(!error.to_string().contains("sk-never-include-this-value"));
+        remove_test_parent(&path);
+    }
+
+    #[test]
+    fn missing_key_clears_unrecoverable_ciphertext() {
+        let path = test_path("android-missing-key");
+        let mut crypto = TestCrypto::default();
+        write_verified(&path, b"unrecoverable", &mut crypto).unwrap();
+
+        crypto.fail_next_open = Some(CryptoErrorKind::KeyMissingOrInvalidated);
+        assert_eq!(read(&path, &mut crypto).unwrap(), ReadOutcome::Missing);
+        assert!(!path.exists());
+        assert_eq!(crypto.delete_key_calls, 1);
+        remove_test_parent(&path);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn credential_file_is_owner_private() {
+        let path = test_path("android-owner-private");
+        let mut crypto = TestCrypto::default();
+        write_verified(&path, b"private", &mut crypto).unwrap();
+
+        let file_mode = std::fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+        let dir_mode = std::fs::metadata(path.parent().unwrap())
+            .unwrap()
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(file_mode, 0o600);
+        assert_eq!(dir_mode, 0o700);
+        remove_test_parent(&path);
+    }
+}

--- a/openless-all/app/src-tauri/src/persistence/android_credentials.rs
+++ b/openless-all/app/src-tauri/src/persistence/android_credentials.rs
@@ -134,6 +134,7 @@ pub(super) fn read(
     path: &Path,
     crypto: &mut impl AndroidCredentialsCrypto,
 ) -> Result<ReadOutcome, StoreError> {
+    recover_verified_sanitized_legacy(path)?;
     let bytes = match fs::read(path) {
         Ok(bytes) => bytes,
         Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(ReadOutcome::Missing),
@@ -179,6 +180,41 @@ pub(super) fn read(
         }
         Err(error) => Err(error),
     }
+}
+
+fn recover_verified_sanitized_legacy(path: &Path) -> Result<(), StoreError> {
+    let temporary = path.with_extension("legacy.tmp");
+    let destination_needs_recovery = match fs::metadata(path) {
+        Ok(metadata) => metadata.len() == 0,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => true,
+        Err(error) => return Err(io_error("inspect legacy recovery destination", error)),
+    };
+    if !destination_needs_recovery {
+        return Ok(());
+    }
+
+    let persisted = match fs::read(&temporary) {
+        Ok(persisted) => persisted,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => return Err(io_error("read sanitized legacy recovery", error)),
+    };
+    let decoded = base64::engine::general_purpose::STANDARD
+        .decode(&persisted)
+        .map_err(|_| StoreError::VerificationFailed)?;
+    if decoded.is_empty() {
+        return Err(StoreError::VerificationFailed);
+    }
+
+    set_private_file_mode(&temporary)?;
+    match fs::remove_file(path) {
+        Ok(()) => {}
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+        Err(error) => return Err(io_error("remove empty legacy recovery target", error)),
+    }
+    fs::rename(&temporary, path)
+        .map_err(|error| io_error("recover sanitized legacy", error))?;
+    set_private_file_mode(path)?;
+    sync_parent(path)
 }
 
 fn envelope_for(sealed: &SealedPayload) -> Result<Vec<u8>, StoreError> {
@@ -278,6 +314,7 @@ fn rewrite_legacy_without_bearer_with_fault(
     let temporary = path.with_extension("legacy.tmp");
     remove_if_present(&temporary)?;
     let mut replaced = false;
+    let mut replacement_verified = false;
 
     let result = (|| {
         fault(WriteStage::TempOpen).map_err(|error| io_error("open sanitized legacy", error))?;
@@ -308,6 +345,7 @@ fn rewrite_legacy_without_bearer_with_fault(
         if verified != sanitized_plaintext {
             return Err(StoreError::VerificationFailed);
         }
+        replacement_verified = true;
         fault(WriteStage::AfterVerification)
             .map_err(|error| io_error("after verifying sanitized legacy", error))?;
 
@@ -328,8 +366,15 @@ fn rewrite_legacy_without_bearer_with_fault(
     })();
 
     if result.is_err() {
-        let _ = fs::remove_file(&temporary);
-        if !replaced {
+        if !replaced && replacement_verified {
+            // Keep the durable bearer-free copy recoverable if the cutover
+            // fails after verification. read() will install it when the
+            // destination is missing or was already truncated.
+            let _ = secure_remove(path);
+        } else {
+            let _ = fs::remove_file(&temporary);
+        }
+        if !replaced && !replacement_verified {
             // A returned migration error must never leave the old bearer
             // recoverable. This deliberately favors token invalidation over
             // availability, matching the pre-v2 Android policy.
@@ -872,6 +917,20 @@ mod tests {
 
             assert!(result.is_err(), "{failed_stage:?} should fail");
             assert_token_absent_from_legacy_candidates(&path, &token);
+            if matches!(
+                failed_stage,
+                WriteStage::AfterVerification
+                    | WriteStage::Rename
+                    | WriteStage::AfterRename
+                    | WriteStage::ParentSync
+            ) {
+                let mut crypto = TestCrypto::default();
+                assert_eq!(
+                    read(&path, &mut crypto).unwrap(),
+                    ReadOutcome::Legacy(sanitized.to_vec()),
+                    "{failed_stage:?} should preserve sanitized credentials"
+                );
+            }
             remove_test_parent(&path);
         }
     }
@@ -904,8 +963,35 @@ mod tests {
 
             assert!(crashed.is_err(), "{crash_stage:?} should simulate a crash");
             assert_token_absent_from_legacy_candidates(&path, &token);
+            let mut crypto = TestCrypto::default();
+            assert_eq!(
+                read(&path, &mut crypto).unwrap(),
+                ReadOutcome::Legacy(br#"{"version":1}"#.to_vec()),
+                "{crash_stage:?} should recover sanitized credentials"
+            );
             remove_test_parent(&path);
         }
+    }
+
+    #[test]
+    fn truncated_legacy_target_recovers_verified_sanitized_copy() {
+        let path = test_path("android-legacy-truncated-recovery");
+        let sanitized = br#"{"version":1,"active":{"llm":"ark"}}"#;
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(&path, b"").unwrap();
+        std::fs::write(
+            path.with_extension("legacy.tmp"),
+            base64::engine::general_purpose::STANDARD.encode(sanitized),
+        )
+        .unwrap();
+        let mut crypto = TestCrypto::default();
+
+        assert_eq!(
+            read(&path, &mut crypto).unwrap(),
+            ReadOutcome::Legacy(sanitized.to_vec())
+        );
+        assert!(!path.with_extension("legacy.tmp").exists());
+        remove_test_parent(&path);
     }
 
     #[test]

--- a/openless-all/app/src-tauri/src/persistence/android_credentials.rs
+++ b/openless-all/app/src-tauri/src/persistence/android_credentials.rs
@@ -1,6 +1,6 @@
 use std::fs::{self, File, OpenOptions};
 use std::io::{self, Write};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use base64::Engine;
 use serde::{Deserialize, Serialize};
@@ -135,6 +135,7 @@ pub(super) fn read(
     crypto: &mut impl AndroidCredentialsCrypto,
 ) -> Result<ReadOutcome, StoreError> {
     recover_verified_sanitized_legacy(path)?;
+    recover_verified_v2_temporary(path, crypto)?;
     let bytes = match fs::read(path) {
         Ok(bytes) => bytes,
         Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(ReadOutcome::Missing),
@@ -181,6 +182,39 @@ pub(super) fn read(
         }
         Err(error) => Err(error),
     }
+}
+
+fn v2_temporary_path(path: &Path) -> PathBuf {
+    path.with_extension("json.tmp")
+}
+
+fn verified_v2_temporary_path(path: &Path) -> PathBuf {
+    path.with_extension("json.pending")
+}
+
+fn recover_verified_v2_temporary(
+    path: &Path,
+    crypto: &mut impl AndroidCredentialsCrypto,
+) -> Result<(), StoreError> {
+    let temporary = verified_v2_temporary_path(path);
+    let persisted = match fs::read(&temporary) {
+        Ok(persisted) => persisted,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => return Err(io_error("read verified v2 recovery", error)),
+    };
+    let _ = open_envelope(&persisted, crypto)?;
+
+    // Re-establish the non-exportable rollback barrier before promoting the
+    // verified recovery candidate. A crash after this point leaves the
+    // candidate available for another recovery attempt instead of admitting
+    // the old Base64 envelope again.
+    crypto
+        .mark_migration_complete()
+        .map_err(StoreError::Crypto)?;
+    set_private_file_mode(&temporary)?;
+    fs::rename(&temporary, path).map_err(|error| io_error("recover verified v2", error))?;
+    set_private_file_mode(path)?;
+    sync_parent(path)
 }
 
 fn recover_verified_sanitized_legacy(path: &Path) -> Result<(), StoreError> {
@@ -247,11 +281,19 @@ fn set_private_file_mode(path: &Path) -> Result<(), StoreError> {
     Ok(())
 }
 
+#[cfg(not(windows))]
 fn sync_parent(path: &Path) -> Result<(), StoreError> {
     let parent = path.parent().unwrap_or_else(|| Path::new("."));
     File::open(parent)
         .and_then(|directory| directory.sync_all())
         .map_err(|error| io_error("sync parent directory", error))
+}
+
+// This module is production-only on Android. Windows only compiles it for
+// host-side unit tests, where opening a directory for `sync_all` is rejected.
+#[cfg(windows)]
+fn sync_parent(_path: &Path) -> Result<(), StoreError> {
+    Ok(())
 }
 
 fn remove_if_present(path: &Path) -> Result<(), StoreError> {
@@ -388,6 +430,7 @@ fn write_verified_with_fault(
     crypto: &mut impl AndroidCredentialsCrypto,
     fault: &mut impl FnMut(WriteStage) -> io::Result<()>,
 ) -> Result<(), StoreError> {
+    recover_verified_v2_temporary(path, crypto)?;
     let sealed = crypto
         .seal(plaintext, ENVELOPE_AAD)
         .map_err(StoreError::Crypto)?;
@@ -401,8 +444,10 @@ fn write_verified_with_fault(
 
     let parent = path.parent().unwrap_or_else(|| Path::new("."));
     ensure_private_dir(parent)?;
-    let temporary = path.with_extension("json.tmp");
+    let temporary = v2_temporary_path(path);
+    let recovery = verified_v2_temporary_path(path);
     remove_if_present(&temporary)?;
+    let mut recovery_prepared = false;
 
     let result = (|| {
         fault(WriteStage::TempOpen).map_err(|error| io_error("open temporary file", error))?;
@@ -432,9 +477,18 @@ fn write_verified_with_fault(
             return Err(StoreError::VerificationFailed);
         }
 
+        // Keep a separately named, durable recovery candidate only after the
+        // reread/decrypt check succeeds. `read` never promotes the ordinary
+        // write temp, so a crash before this point cannot replace a complete
+        // envelope with an unverified write.
+        fs::rename(&temporary, &recovery)
+            .map_err(|error| io_error("prepare verified credential recovery", error))?;
+        recovery_prepared = true;
+        sync_parent(&recovery)?;
+
         // Retire Base64 envelopes before replacing one. If the process stops
-        // after this point, the old file is deliberately rejected instead of
-        // becoming a downgrade path on the next launch.
+        // after this point, `recovery` can be promoted on the next launch;
+        // the old file is never admitted as a downgrade path.
         crypto
             .mark_migration_complete()
             .map_err(StoreError::Crypto)?;
@@ -442,7 +496,7 @@ fn write_verified_with_fault(
             .map_err(|error| io_error("after verifying temporary file", error))?;
 
         fault(WriteStage::Rename).map_err(|error| io_error("replace credential file", error))?;
-        fs::rename(&temporary, path).map_err(|error| io_error("replace credential file", error))?;
+        fs::rename(&recovery, path).map_err(|error| io_error("replace credential file", error))?;
         fault(WriteStage::AfterRename)
             .map_err(|error| io_error("after replacing credential file", error))?;
         set_private_file_mode(path)?;
@@ -452,7 +506,9 @@ fn write_verified_with_fault(
     })();
 
     if result.is_err() {
-        let _ = fs::remove_file(&temporary);
+        if !recovery_prepared {
+            let _ = fs::remove_file(&temporary);
+        }
     }
     result
 }
@@ -564,6 +620,7 @@ pub(super) struct TestCrypto {
     migration_complete: bool,
     pub(super) fail_next_seal: Option<CryptoErrorKind>,
     pub(super) fail_next_open: Option<CryptoErrorKind>,
+    pub(super) fail_next_mark_migration: Option<CryptoErrorKind>,
     pub(super) delete_key_calls: usize,
 }
 
@@ -577,6 +634,7 @@ impl Default for TestCrypto {
             migration_complete: false,
             fail_next_seal: None,
             fail_next_open: None,
+            fail_next_mark_migration: None,
             delete_key_calls: 0,
         }
     }
@@ -664,6 +722,9 @@ impl AndroidCredentialsCrypto for TestCrypto {
     }
 
     fn mark_migration_complete(&mut self) -> std::result::Result<(), CryptoErrorKind> {
+        if let Some(error) = self.fail_next_mark_migration.take() {
+            return Err(error);
+        }
         self.migration_complete = true;
         Ok(())
     }
@@ -847,21 +908,16 @@ mod tests {
         );
         assert!(result.is_err());
         assert_eq!(std::fs::read_to_string(&path).unwrap(), legacy);
-        assert!(matches!(
-            read(&path, &mut crypto),
-            Err(StoreError::InvalidEnvelope)
-        ));
-
-        write_verified(&path, plaintext, &mut crypto).unwrap();
         assert_eq!(
             read(&path, &mut crypto).unwrap(),
             ReadOutcome::Plaintext(plaintext.to_vec())
         );
+        assert!(!verified_v2_temporary_path(&path).exists());
         remove_test_parent(&path);
     }
 
     #[test]
-    fn verified_v2_commit_barrier_rejects_legacy_after_pre_rename_failure() {
+    fn verified_v2_commit_barrier_recovers_verified_temp_after_pre_rename_failure() {
         let path = test_path("android-v2-commit-barrier");
         let plaintext = br#"{"version":1,"active":{"llm":"ark"}}"#;
         std::fs::create_dir_all(path.parent().unwrap()).unwrap();
@@ -884,10 +940,33 @@ mod tests {
 
         assert!(result.is_err());
         assert_eq!(std::fs::read_to_string(&path).unwrap(), legacy);
-        assert!(matches!(
-            read(&path, &mut crypto),
-            Err(StoreError::InvalidEnvelope)
-        ));
+        assert!(verified_v2_temporary_path(&path).exists());
+        assert_eq!(
+            read(&path, &mut crypto).unwrap(),
+            ReadOutcome::Plaintext(plaintext.to_vec())
+        );
+        assert!(!verified_v2_temporary_path(&path).exists());
+        remove_test_parent(&path);
+    }
+
+    #[test]
+    fn verified_v2_recovery_candidate_survives_temporary_marker_failure() {
+        let path = test_path("android-v2-marker-retry");
+        let plaintext = br#"{"version":1,"active":{"llm":"ark"}}"#;
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        let legacy = base64::engine::general_purpose::STANDARD.encode(plaintext);
+        std::fs::write(&path, &legacy).unwrap();
+        let mut crypto = TestCrypto::default();
+        crypto.fail_next_mark_migration = Some(CryptoErrorKind::TemporarilyUnavailable);
+
+        assert!(write_verified(&path, plaintext, &mut crypto).is_err());
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), legacy);
+        assert!(verified_v2_temporary_path(&path).exists());
+        assert_eq!(
+            read(&path, &mut crypto).unwrap(),
+            ReadOutcome::Plaintext(plaintext.to_vec())
+        );
+        assert!(!verified_v2_temporary_path(&path).exists());
         remove_test_parent(&path);
     }
 
@@ -1066,7 +1145,10 @@ mod tests {
             assert!(result.is_err(), "{failed_stage:?} should fail");
             let expected: &[u8] = if matches!(
                 failed_stage,
-                WriteStage::AfterRename | WriteStage::ParentSync
+                WriteStage::AfterVerification
+                    | WriteStage::Rename
+                    | WriteStage::AfterRename
+                    | WriteStage::ParentSync
             ) {
                 b"new complete value"
             } else {
@@ -1078,6 +1160,7 @@ mod tests {
                 "{failed_stage:?} left an incomplete envelope"
             );
             assert!(!path.with_extension("json.tmp").exists());
+            assert!(!verified_v2_temporary_path(&path).exists());
         }
         remove_test_parent(&path);
     }

--- a/openless-all/app/src-tauri/src/persistence/android_credentials.rs
+++ b/openless-all/app/src-tauri/src/persistence/android_credentials.rs
@@ -56,6 +56,10 @@ pub(super) trait AndroidCredentialsCrypto {
     ) -> std::result::Result<Vec<u8>, CryptoErrorKind>;
 
     fn delete_key(&mut self) -> std::result::Result<(), CryptoErrorKind>;
+
+    fn migration_complete(&mut self) -> std::result::Result<bool, CryptoErrorKind>;
+
+    fn mark_migration_complete(&mut self) -> std::result::Result<(), CryptoErrorKind>;
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -141,6 +145,15 @@ pub(super) fn read(
     };
 
     if first != b'{' {
+        // The non-exportable marker is created only after a v2 envelope has
+        // reached durable storage. Once present, a Base64 file is a rollback
+        // or injection attempt rather than a legitimate upgrade source.
+        if crypto
+            .migration_complete()
+            .map_err(StoreError::Crypto)?
+        {
+            return Err(StoreError::InvalidEnvelope);
+        }
         let plaintext = base64::engine::general_purpose::STANDARD
             .decode(&bytes)
             .map_err(|_| StoreError::InvalidEnvelope)?;
@@ -151,7 +164,12 @@ pub(super) fn read(
     }
 
     match open_envelope(&bytes, crypto) {
-        Ok(plaintext) => Ok(ReadOutcome::Plaintext(plaintext)),
+        Ok(plaintext) => {
+            crypto
+                .mark_migration_complete()
+                .map_err(StoreError::Crypto)?;
+            Ok(ReadOutcome::Plaintext(plaintext))
+        }
         Err(StoreError::Crypto(CryptoErrorKind::KeyMissingOrInvalidated)) => {
             // The ciphertext can no longer be recovered. Reset the alias first;
             // if that is temporarily unavailable, preserve the file for retry.
@@ -236,7 +254,89 @@ pub(super) fn write_verified(
     plaintext: &[u8],
     crypto: &mut impl AndroidCredentialsCrypto,
 ) -> Result<(), StoreError> {
-    write_verified_with_fault(path, plaintext, crypto, &mut |_| Ok(()))
+    write_verified_with_fault(path, plaintext, crypto, &mut |_| Ok(()))?;
+    crypto
+        .mark_migration_complete()
+        .map_err(StoreError::Crypto)
+}
+
+pub(super) fn rewrite_legacy_without_bearer(
+    path: &Path,
+    sanitized_plaintext: &[u8],
+) -> Result<(), StoreError> {
+    rewrite_legacy_without_bearer_with_fault(path, sanitized_plaintext, &mut |_| Ok(()))
+}
+
+fn rewrite_legacy_without_bearer_with_fault(
+    path: &Path,
+    sanitized_plaintext: &[u8],
+    fault: &mut impl FnMut(WriteStage) -> io::Result<()>,
+) -> Result<(), StoreError> {
+    let encoded = base64::engine::general_purpose::STANDARD.encode(sanitized_plaintext);
+    let parent = path.parent().unwrap_or_else(|| Path::new("."));
+    ensure_private_dir(parent)?;
+    let temporary = path.with_extension("legacy.tmp");
+    remove_if_present(&temporary)?;
+    let mut replaced = false;
+
+    let result = (|| {
+        fault(WriteStage::TempOpen).map_err(|error| io_error("open sanitized legacy", error))?;
+        let mut output = open_private_temp(&temporary)?;
+        fault(WriteStage::AfterTempOpen)
+            .map_err(|error| io_error("after opening sanitized legacy", error))?;
+        output
+            .write_all(encoded.as_bytes())
+            .map_err(|error| io_error("write sanitized legacy", error))?;
+        fault(WriteStage::AfterTempWrite)
+            .map_err(|error| io_error("after writing sanitized legacy", error))?;
+        output
+            .flush()
+            .map_err(|error| io_error("flush sanitized legacy", error))?;
+        output
+            .sync_all()
+            .map_err(|error| io_error("sync sanitized legacy", error))?;
+        fault(WriteStage::AfterTempSync)
+            .map_err(|error| io_error("after syncing sanitized legacy", error))?;
+        drop(output);
+        set_private_file_mode(&temporary)?;
+
+        let persisted = fs::read(&temporary)
+            .map_err(|error| io_error("reread sanitized legacy", error))?;
+        let verified = base64::engine::general_purpose::STANDARD
+            .decode(&persisted)
+            .map_err(|_| StoreError::VerificationFailed)?;
+        if verified != sanitized_plaintext {
+            return Err(StoreError::VerificationFailed);
+        }
+        fault(WriteStage::AfterVerification)
+            .map_err(|error| io_error("after verifying sanitized legacy", error))?;
+
+        // The replacement is ready and durable. Erase the bearer-bearing
+        // source before installing it, preserving the previous fail-closed
+        // contract while keeping all non-Marketplace credentials recoverable.
+        secure_remove(path)?;
+        fault(WriteStage::Rename).map_err(|error| io_error("replace sanitized legacy", error))?;
+        fs::rename(&temporary, path)
+            .map_err(|error| io_error("replace sanitized legacy", error))?;
+        replaced = true;
+        fault(WriteStage::AfterRename)
+            .map_err(|error| io_error("after replacing sanitized legacy", error))?;
+        set_private_file_mode(path)?;
+        fault(WriteStage::ParentSync)
+            .map_err(|error| io_error("sync sanitized legacy directory", error))?;
+        sync_parent(path)
+    })();
+
+    if result.is_err() {
+        let _ = fs::remove_file(&temporary);
+        if !replaced {
+            // A returned migration error must never leave the old bearer
+            // recoverable. This deliberately favors token invalidation over
+            // availability, matching the pre-v2 Android policy.
+            let _ = secure_remove(path);
+        }
+    }
+    result
 }
 
 fn write_verified_with_fault(
@@ -352,6 +452,16 @@ impl AndroidCredentialsCrypto for AndroidKeystoreCrypto {
     fn delete_key(&mut self) -> std::result::Result<(), CryptoErrorKind> {
         crate::android::jni::android::keystore_delete_key().map_err(map_keystore_failure)
     }
+
+    fn migration_complete(&mut self) -> std::result::Result<bool, CryptoErrorKind> {
+        crate::android::jni::android::keystore_migration_complete()
+            .map_err(map_keystore_failure)
+    }
+
+    fn mark_migration_complete(&mut self) -> std::result::Result<(), CryptoErrorKind> {
+        crate::android::jni::android::keystore_mark_migration_complete()
+            .map_err(map_keystore_failure)
+    }
 }
 
 #[cfg(target_os = "android")]
@@ -400,6 +510,9 @@ fn join_packet(sealed: &SealedPayload) -> Vec<u8> {
 pub(super) struct TestCrypto {
     key: [u8; 32],
     counter: u64,
+    key_present: bool,
+    migration_complete: bool,
+    pub(super) fail_next_seal: Option<CryptoErrorKind>,
     pub(super) fail_next_open: Option<CryptoErrorKind>,
     pub(super) delete_key_calls: usize,
 }
@@ -410,6 +523,9 @@ impl Default for TestCrypto {
         Self {
             key: [0xA7; 32],
             counter: 0,
+            key_present: false,
+            migration_complete: false,
+            fail_next_seal: None,
             fail_next_open: None,
             delete_key_calls: 0,
         }
@@ -440,6 +556,10 @@ impl AndroidCredentialsCrypto for TestCrypto {
         plaintext: &[u8],
         aad: &[u8],
     ) -> std::result::Result<SealedPayload, CryptoErrorKind> {
+        if let Some(error) = self.fail_next_seal.take() {
+            return Err(error);
+        }
+        self.key_present = true;
         self.counter += 1;
         let mut nonce = vec![0x51, 0x7A, 0xC3, 0x19];
         nonce.extend_from_slice(&self.counter.to_be_bytes());
@@ -464,6 +584,9 @@ impl AndroidCredentialsCrypto for TestCrypto {
         if let Some(error) = self.fail_next_open.take() {
             return Err(error);
         }
+        if !self.key_present {
+            return Err(CryptoErrorKind::KeyMissingOrInvalidated);
+        }
         if sealed.nonce.len() != NONCE_BYTES || sealed.ciphertext.len() < GCM_TAG_BYTES {
             return Err(CryptoErrorKind::AuthenticationFailed);
         }
@@ -482,6 +605,16 @@ impl AndroidCredentialsCrypto for TestCrypto {
 
     fn delete_key(&mut self) -> std::result::Result<(), CryptoErrorKind> {
         self.delete_key_calls += 1;
+        self.key_present = false;
+        Ok(())
+    }
+
+    fn migration_complete(&mut self) -> std::result::Result<bool, CryptoErrorKind> {
+        Ok(self.migration_complete)
+    }
+
+    fn mark_migration_complete(&mut self) -> std::result::Result<(), CryptoErrorKind> {
+        self.migration_complete = true;
         Ok(())
     }
 }
@@ -671,6 +804,108 @@ mod tests {
             ReadOutcome::Plaintext(plaintext.to_vec())
         );
         remove_test_parent(&path);
+    }
+
+    #[test]
+    fn successful_v2_rejects_legacy_base64_downgrade() {
+        let path = test_path("android-v2-downgrade");
+        let mut crypto = TestCrypto::default();
+        write_verified(&path, b"authenticated value", &mut crypto).unwrap();
+        let injected = base64::engine::general_purpose::STANDARD
+            .encode(br#"{"version":1,"active":{"llm":"attacker"}}"#);
+        std::fs::write(&path, &injected).unwrap();
+
+        assert!(matches!(
+            read(&path, &mut crypto),
+            Err(StoreError::InvalidEnvelope)
+        ));
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), injected);
+        remove_test_parent(&path);
+    }
+
+    fn assert_token_absent_from_legacy_candidates(path: &Path, token: &str) {
+        for candidate in [path.to_path_buf(), path.with_extension("legacy.tmp")] {
+            let Ok(bytes) = std::fs::read(&candidate) else {
+                continue;
+            };
+            assert!(!String::from_utf8_lossy(&bytes).contains(token));
+            if let Ok(decoded) = base64::engine::general_purpose::STANDARD.decode(&bytes) {
+                assert!(!String::from_utf8_lossy(&decoded).contains(token));
+            }
+        }
+    }
+
+    #[test]
+    fn legacy_bearer_sanitized_rewrite_is_fail_closed_for_every_io_failure() {
+        let stages = [
+            WriteStage::TempOpen,
+            WriteStage::AfterTempOpen,
+            WriteStage::AfterTempWrite,
+            WriteStage::AfterTempSync,
+            WriteStage::AfterVerification,
+            WriteStage::Rename,
+            WriteStage::AfterRename,
+            WriteStage::ParentSync,
+        ];
+
+        for failed_stage in stages {
+            let path = test_path(&format!("android-legacy-bearer-{failed_stage:?}"));
+            let token = format!("gho_legacy_{failed_stage:?}");
+            std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+            let legacy_json =
+                format!(r#"{{"marketplace":{{"githubAccessToken":"{token}"}}}}"#);
+            let legacy = base64::engine::general_purpose::STANDARD.encode(legacy_json.as_bytes());
+            std::fs::write(&path, legacy).unwrap();
+            let sanitized = br#"{"version":1,"active":{"llm":"ark"}}"#;
+
+            let result = rewrite_legacy_without_bearer_with_fault(
+                &path,
+                sanitized,
+                &mut |stage| {
+                    if stage == failed_stage {
+                        Err(io::Error::other(format!("injected {stage:?}")))
+                    } else {
+                        Ok(())
+                    }
+                },
+            );
+
+            assert!(result.is_err(), "{failed_stage:?} should fail");
+            assert_token_absent_from_legacy_candidates(&path, &token);
+            remove_test_parent(&path);
+        }
+    }
+
+    #[test]
+    fn legacy_bearer_is_unrecoverable_at_post_erase_crash_boundaries() {
+        for crash_stage in [
+            WriteStage::Rename,
+            WriteStage::AfterRename,
+            WriteStage::ParentSync,
+        ] {
+            let path = test_path(&format!("android-legacy-crash-{crash_stage:?}"));
+            let token = format!("gho_crash_{crash_stage:?}");
+            std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+            let legacy_json =
+                format!(r#"{{"marketplace":{{"githubAccessToken":"{token}"}}}}"#);
+            let legacy = base64::engine::general_purpose::STANDARD.encode(legacy_json.as_bytes());
+            std::fs::write(&path, legacy).unwrap();
+
+            let crashed = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                let _ = rewrite_legacy_without_bearer_with_fault(
+                    &path,
+                    br#"{"version":1}"#,
+                    &mut |stage| {
+                        assert_ne!(stage, crash_stage, "injected crash at {stage:?}");
+                        Ok(())
+                    },
+                );
+            }));
+
+            assert!(crashed.is_err(), "{crash_stage:?} should simulate a crash");
+            assert_token_absent_from_legacy_candidates(&path, &token);
+            remove_test_parent(&path);
+        }
     }
 
     #[test]

--- a/openless-all/app/src-tauri/src/persistence/credentials.rs
+++ b/openless-all/app/src-tauri/src/persistence/credentials.rs
@@ -1449,12 +1449,13 @@ mod tests {
         std::fs::create_dir_all(&dir).unwrap();
         let path = dir.join("credentials.enc.json");
         std::fs::write(&path, encoded).unwrap();
+        let mut crypto = super::super::android_credentials::TestCrypto::default();
 
-        let loaded = load_android_credentials_from_path(&path)
+        let loaded = load_android_credentials_from_path_with_crypto(&path, &mut crypto)
             .unwrap()
             .expect("credential envelope should load");
         let disk = std::fs::read_to_string(&path).unwrap();
-        let loaded_again = load_android_credentials_from_path(&path)
+        let loaded_again = load_android_credentials_from_path_with_crypto(&path, &mut crypto)
             .unwrap()
             .expect("migrated credential envelope should load");
 

--- a/openless-all/app/src-tauri/src/persistence/credentials.rs
+++ b/openless-all/app/src-tauri/src/persistence/credentials.rs
@@ -418,6 +418,13 @@ fn load_android_credentials_from_path_with_crypto(
         .context("parse Android credential payload")?;
     let cleaned = android_persistable_credentials(&root);
     let contained_marketplace_token = lookup_marketplace_github_token(&root).is_some();
+    if needs_rewrite && contained_marketplace_token {
+        let sanitized = serde_json::to_vec(&cleaned)
+            .context("encode bearer-free Android legacy payload")?;
+        super::android_credentials::rewrite_legacy_without_bearer(path, &sanitized)
+            .map_err(anyhow::Error::new)
+            .context("scrub Marketplace bearer before Android Keystore migration")?;
+    }
     if needs_rewrite || contained_marketplace_token {
         write_android_credentials_envelope_with_crypto(path, &cleaned, crypto)
             .context("migrate Android credential envelope")?;
@@ -1319,10 +1326,10 @@ mod tests {
     use super::{
         android_persistable_credentials, chunk_json_payload, credentials_cache,
         get_android_marketplace_token_at, load_android_credentials_from_path,
-        load_android_credentials_into_cache_with, lookup_marketplace_github_token,
-        parse_extra_headers_json, reset_credentials_cache_for_tests,
-        write_marketplace_github_token, CredsRoot, MarketplaceGithubToken,
-        KEYRING_CHUNK_MAX_UTF16_UNITS,
+        load_android_credentials_from_path_with_crypto, load_android_credentials_into_cache_with,
+        lookup_marketplace_github_token, parse_extra_headers_json,
+        reset_credentials_cache_for_tests, write_marketplace_github_token, CredsRoot,
+        MarketplaceGithubToken, KEYRING_CHUNK_MAX_UTF16_UNITS,
     };
     use anyhow::anyhow;
     use parking_lot::Mutex;
@@ -1476,7 +1483,11 @@ mod tests {
     fn assert_android_secret_unrecoverable(path: &std::path::Path, token: &str) {
         use base64::Engine;
 
-        for candidate in [path.to_path_buf(), path.with_extension("json.tmp")] {
+        for candidate in [
+            path.to_path_buf(),
+            path.with_extension("json.tmp"),
+            path.with_extension("legacy.tmp"),
+        ] {
             let Ok(bytes) = std::fs::read(&candidate) else {
                 continue;
             };
@@ -1493,6 +1504,51 @@ mod tests {
                 );
             }
         }
+    }
+
+    #[test]
+    fn android_bearer_is_scrubbed_before_failed_keystore_migration_returns() {
+        use base64::Engine;
+
+        let token = "gho_must_be_unrecoverable";
+        let provider_secret = "sk_generic_credential_survives";
+        let raw = format!(
+            r#"{{"version":1,"providers":{{"llm":{{"ark":{{"apiKey":"{provider_secret}"}}}}}},"marketplace":{{"githubAccessToken":"{token}"}}}}"#,
+        );
+        let dir = std::env::temp_dir().join(format!(
+            "openless-android-bearer-migration-{}",
+            uuid::Uuid::new_v4()
+        ));
+        let path = dir.join("credentials.enc.json");
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(
+            &path,
+            base64::engine::general_purpose::STANDARD.encode(raw.as_bytes()),
+        )
+        .unwrap();
+        let mut crypto = super::super::android_credentials::TestCrypto::default();
+        crypto.fail_next_seal = Some(
+            super::super::android_credentials::CryptoErrorKind::TemporarilyUnavailable,
+        );
+
+        assert!(load_android_credentials_from_path_with_crypto(&path, &mut crypto).is_err());
+        let sanitized = std::fs::read(&path).unwrap();
+        let sanitized = base64::engine::general_purpose::STANDARD
+            .decode(sanitized)
+            .unwrap();
+        let sanitized = String::from_utf8(sanitized).unwrap();
+        assert!(!sanitized.contains(token));
+        assert!(!sanitized.contains("githubAccessToken"));
+        assert!(sanitized.contains(provider_secret));
+
+        let loaded = load_android_credentials_from_path_with_crypto(&path, &mut crypto)
+            .unwrap()
+            .expect("sanitized legacy credentials should remain retryable");
+        assert_eq!(lookup_marketplace_github_token(&loaded), None);
+        assert!(std::fs::read_to_string(&path)
+            .unwrap()
+            .contains("openless-android-credentials"));
+        let _ = std::fs::remove_dir_all(dir);
     }
 
     #[test]

--- a/openless-all/app/src-tauri/src/persistence/credentials.rs
+++ b/openless-all/app/src-tauri/src/persistence/credentials.rs
@@ -16,15 +16,13 @@
 //!     "marketplace": { "githubAccessToken": "<desktop-only secret>" }
 //!   }
 //!
-//! Android's generic credential envelope is only reversible Base64 today. Until
-//! the Keystore-backed vault lands, Marketplace OAuth is process-memory-only on
-//! Android and is deliberately stripped from `credentials.enc.json`.
+//! Android stores the same payload in a versioned AES-GCM envelope whose key is
+//! non-exportable from Android Keystore. Marketplace OAuth remains
+//! process-memory-only and is deliberately stripped from `credentials.enc.json`.
 //!
 //! "ark.api_key"/"volcengine.app_key" 等账户名按 Swift 语义路由到 active provider。
 
 use std::collections::{BTreeMap, HashMap};
-#[cfg(any(target_os = "android", test))]
-use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::OnceLock;
@@ -389,9 +387,42 @@ fn load_android_credentials() -> Result<Option<CredsRoot>> {
     loaded
 }
 
-#[cfg(any(target_os = "android", test))]
+#[cfg(target_os = "android")]
 fn load_android_credentials_from_path(path: &Path) -> Result<Option<CredsRoot>> {
-    load_android_credentials_from_path_with_fault(path, &mut |_| Ok(()))
+    let mut crypto = super::android_credentials::AndroidKeystoreCrypto;
+    load_android_credentials_from_path_with_crypto(path, &mut crypto)
+}
+
+#[cfg(all(test, not(target_os = "android")))]
+fn load_android_credentials_from_path(path: &Path) -> Result<Option<CredsRoot>> {
+    let mut crypto = super::android_credentials::TestCrypto::default();
+    load_android_credentials_from_path_with_crypto(path, &mut crypto)
+}
+
+#[cfg(any(target_os = "android", test))]
+fn load_android_credentials_from_path_with_crypto(
+    path: &Path,
+    crypto: &mut impl super::android_credentials::AndroidCredentialsCrypto,
+) -> Result<Option<CredsRoot>> {
+    use super::android_credentials::ReadOutcome;
+
+    let loaded = super::android_credentials::read(path, crypto)
+        .map_err(anyhow::Error::new)
+        .context("read Android credential envelope")?;
+    let (bytes, needs_rewrite) = match loaded {
+        ReadOutcome::Missing => return Ok(None),
+        ReadOutcome::Legacy(bytes) => (bytes, true),
+        ReadOutcome::Plaintext(bytes) => (bytes, false),
+    };
+    let root = serde_json::from_slice::<CredsRoot>(&bytes)
+        .context("parse Android credential payload")?;
+    let cleaned = android_persistable_credentials(&root);
+    let contained_marketplace_token = lookup_marketplace_github_token(&root).is_some();
+    if needs_rewrite || contained_marketplace_token {
+        write_android_credentials_envelope_with_crypto(path, &cleaned, crypto)
+            .context("migrate Android credential envelope")?;
+    }
+    Ok(Some(cleaned))
 }
 
 #[cfg(any(target_os = "android", test))]
@@ -426,58 +457,6 @@ fn ensure_android_marketplace_legacy_scrubbed() -> Result<()> {
     ensure_android_marketplace_legacy_scrubbed_at(&path, android_marketplace_legacy_scrubbed())
 }
 
-#[cfg(any(target_os = "android", test))]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum AndroidEnvelopeStage {
-    LegacyOpen,
-    LegacySync,
-    LegacyRemove,
-    ParentSyncAfterErase,
-    AfterErase,
-    TempOpen,
-    AfterTempOpen,
-    TempWrite,
-    AfterTempWrite,
-    TempFlush,
-    AfterTempFlush,
-    TempSync,
-    AfterTempSync,
-    Rename,
-    AfterRename,
-    ParentSyncAfterRename,
-}
-
-#[cfg(any(target_os = "android", test))]
-fn load_android_credentials_from_path_with_fault(
-    path: &Path,
-    fault: &mut impl FnMut(AndroidEnvelopeStage) -> io::Result<()>,
-) -> Result<Option<CredsRoot>> {
-    if !path.exists() {
-        return Ok(None);
-    }
-    let bytes = std::fs::read(path).with_context(|| format!("read failed: {}", path.display()))?;
-    if bytes.is_empty() {
-        return Ok(None);
-    }
-    // Stub: base64 envelope — replace with Keystore-backed AES when JNI lands.
-    use base64::Engine;
-    let decoded = base64::engine::general_purpose::STANDARD
-        .decode(bytes)
-        .context("decode android credentials envelope")?;
-    let mut root =
-        serde_json::from_slice::<CredsRoot>(&decoded).context("parse android credentials json")?;
-    if lookup_marketplace_github_token(&root).is_some() {
-        // Files written by unreleased/dev builds may contain a recoverable
-        // bearer token. Erase that legacy secret durably *before* creating the
-        // sanitized replacement. A crash can therefore lose generic Android
-        // credentials, but can never leave the old bearer recoverable.
-        write_marketplace_github_token(&mut root, None);
-        scrub_android_legacy_envelope_with_fault(path, &root, fault)
-            .context("scrub Marketplace token from Android credential envelope")?;
-    }
-    Ok(Some(root))
-}
-
 #[cfg(target_os = "android")]
 fn save_android_credentials(root: &CredsRoot) -> Result<()> {
     let path = android_credentials_path()?;
@@ -486,115 +465,21 @@ fn save_android_credentials(root: &CredsRoot) -> Result<()> {
 
 #[cfg(target_os = "android")]
 fn write_android_credentials_envelope(path: &Path, root: &CredsRoot) -> Result<()> {
-    write_android_credentials_envelope_with_fault(path, root, false, &mut |_| Ok(()))
+    let mut crypto = super::android_credentials::AndroidKeystoreCrypto;
+    write_android_credentials_envelope_with_crypto(path, root, &mut crypto)
 }
 
 #[cfg(any(target_os = "android", test))]
-fn scrub_android_legacy_envelope_with_fault(
+fn write_android_credentials_envelope_with_crypto(
     path: &Path,
     root: &CredsRoot,
-    fault: &mut impl FnMut(AndroidEnvelopeStage) -> io::Result<()>,
-) -> Result<()> {
-    write_android_credentials_envelope_with_fault(path, root, true, fault)
-}
-
-#[cfg(any(target_os = "android", test))]
-fn sync_android_credentials_parent(path: &Path) -> io::Result<()> {
-    let parent = path.parent().unwrap_or_else(|| Path::new("."));
-    std::fs::File::open(parent)?.sync_all()
-}
-
-#[cfg(any(target_os = "android", test))]
-fn fail_closed_remove_android_envelope(path: &Path, tmp: &Path) {
-    // Truncate+sync first so even a crash that resurrects the directory entry
-    // after unlink cannot resurrect the bearer bytes.
-    if let Ok(file) = std::fs::OpenOptions::new().write(true).open(path) {
-        let _ = file.set_len(0);
-        let _ = file.sync_all();
-    }
-    let _ = std::fs::remove_file(path);
-    let _ = std::fs::remove_file(tmp);
-    let _ = sync_android_credentials_parent(path);
-}
-
-#[cfg(any(target_os = "android", test))]
-fn write_android_credentials_envelope_with_fault(
-    path: &Path,
-    root: &CredsRoot,
-    erase_legacy_secret_first: bool,
-    fault: &mut impl FnMut(AndroidEnvelopeStage) -> io::Result<()>,
+    crypto: &mut impl super::android_credentials::AndroidCredentialsCrypto,
 ) -> Result<()> {
     let cleaned = android_persistable_credentials(root);
-    let json = serde_json::to_string(&cleaned).context("encode credentials failed")?;
-    use base64::Engine;
-    let encoded = base64::engine::general_purpose::STANDARD.encode(json.as_bytes());
-    super::ensure_dir(path.parent().unwrap_or_else(|| Path::new(".")))?;
-    let tmp = path.with_extension("json.tmp");
-    let _ = std::fs::remove_file(&tmp);
-
-    let persisted = (|| -> Result<()> {
-        if erase_legacy_secret_first {
-            fault(AndroidEnvelopeStage::LegacyOpen)?;
-            let legacy = std::fs::OpenOptions::new()
-                .write(true)
-                .truncate(true)
-                .open(path)
-                .with_context(|| format!("open legacy envelope failed: {}", path.display()))?;
-            fault(AndroidEnvelopeStage::LegacySync)?;
-            legacy
-                .sync_all()
-                .with_context(|| format!("sync erased envelope failed: {}", path.display()))?;
-            drop(legacy);
-            fault(AndroidEnvelopeStage::LegacyRemove)?;
-            std::fs::remove_file(path)
-                .with_context(|| format!("remove legacy envelope failed: {}", path.display()))?;
-            fault(AndroidEnvelopeStage::ParentSyncAfterErase)?;
-            sync_android_credentials_parent(path)
-                .with_context(|| format!("sync erased envelope directory: {}", path.display()))?;
-            fault(AndroidEnvelopeStage::AfterErase)?;
-        }
-
-        fault(AndroidEnvelopeStage::TempOpen)?;
-        let mut output = std::fs::OpenOptions::new()
-            .create_new(true)
-            .write(true)
-            .open(&tmp)
-            .with_context(|| format!("open failed: {}", tmp.display()))?;
-        fault(AndroidEnvelopeStage::AfterTempOpen)?;
-        fault(AndroidEnvelopeStage::TempWrite)?;
-        output
-            .write_all(encoded.as_bytes())
-            .with_context(|| format!("write failed: {}", tmp.display()))?;
-        fault(AndroidEnvelopeStage::AfterTempWrite)?;
-        fault(AndroidEnvelopeStage::TempFlush)?;
-        output
-            .flush()
-            .with_context(|| format!("flush failed: {}", tmp.display()))?;
-        fault(AndroidEnvelopeStage::AfterTempFlush)?;
-        fault(AndroidEnvelopeStage::TempSync)?;
-        output
-            .sync_all()
-            .with_context(|| format!("sync failed: {}", tmp.display()))?;
-        fault(AndroidEnvelopeStage::AfterTempSync)?;
-        drop(output);
-        fault(AndroidEnvelopeStage::Rename)?;
-        std::fs::rename(&tmp, path)
-            .with_context(|| format!("replace failed: {}", path.display()))?;
-        fault(AndroidEnvelopeStage::AfterRename)?;
-        fault(AndroidEnvelopeStage::ParentSyncAfterRename)?;
-        sync_android_credentials_parent(path)
-            .with_context(|| format!("sync replacement directory: {}", path.display()))?;
-        Ok(())
-    })();
-
-    if persisted.is_err() {
-        if erase_legacy_secret_first {
-            fail_closed_remove_android_envelope(path, &tmp);
-        } else {
-            let _ = std::fs::remove_file(&tmp);
-        }
-    }
-    persisted
+    let json = serde_json::to_vec(&cleaned).context("encode Android credential payload")?;
+    super::android_credentials::write_verified(path, &json, crypto)
+        .map_err(anyhow::Error::new)
+        .context("write Android credential envelope")
 }
 
 #[cfg(any(target_os = "android", test))]
@@ -1434,14 +1319,13 @@ mod tests {
     use super::{
         android_persistable_credentials, chunk_json_payload, credentials_cache,
         get_android_marketplace_token_at, load_android_credentials_from_path,
-        load_android_credentials_from_path_with_fault, load_android_credentials_into_cache_with,
-        lookup_marketplace_github_token, parse_extra_headers_json,
-        reset_credentials_cache_for_tests, write_marketplace_github_token, AndroidEnvelopeStage,
-        CredsRoot, MarketplaceGithubToken, KEYRING_CHUNK_MAX_UTF16_UNITS,
+        load_android_credentials_into_cache_with, lookup_marketplace_github_token,
+        parse_extra_headers_json, reset_credentials_cache_for_tests,
+        write_marketplace_github_token, CredsRoot, MarketplaceGithubToken,
+        KEYRING_CHUNK_MAX_UTF16_UNITS,
     };
     use anyhow::anyhow;
     use parking_lot::Mutex;
-    use std::io;
 
     #[test]
     fn credential_payload_chunks_stay_under_windows_blob_limit() {
@@ -1563,15 +1447,17 @@ mod tests {
             .unwrap()
             .expect("credential envelope should load");
         let disk = std::fs::read_to_string(&path).unwrap();
-        let decoded = base64::engine::general_purpose::STANDARD
-            .decode(disk)
-            .unwrap();
-        let decoded = String::from_utf8(decoded).unwrap();
+        let loaded_again = load_android_credentials_from_path(&path)
+            .unwrap()
+            .expect("migrated credential envelope should load");
 
         assert_eq!(lookup_marketplace_github_token(&loaded), None);
-        assert!(!decoded.contains(token));
-        assert!(!decoded.contains("githubAccessToken"));
-        assert!(!decoded.contains("marketplace"));
+        assert_eq!(lookup_marketplace_github_token(&loaded_again), None);
+        assert!(disk.starts_with('{'));
+        assert!(disk.contains("openless-android-credentials"));
+        assert!(!disk.contains(token));
+        assert!(!disk.contains("githubAccessToken"));
+        assert!(!disk.contains("marketplace"));
         assert!(!path.with_extension("json.tmp").exists());
         std::fs::remove_dir_all(dir).unwrap();
     }
@@ -1606,75 +1492,6 @@ mod tests {
                     candidate.display()
                 );
             }
-        }
-    }
-
-    #[test]
-    fn android_legacy_scrub_is_fail_closed_for_every_io_failure() {
-        let stages = [
-            AndroidEnvelopeStage::LegacyOpen,
-            AndroidEnvelopeStage::LegacySync,
-            AndroidEnvelopeStage::LegacyRemove,
-            AndroidEnvelopeStage::ParentSyncAfterErase,
-            AndroidEnvelopeStage::TempOpen,
-            AndroidEnvelopeStage::TempWrite,
-            AndroidEnvelopeStage::TempFlush,
-            AndroidEnvelopeStage::TempSync,
-            AndroidEnvelopeStage::Rename,
-            AndroidEnvelopeStage::ParentSyncAfterRename,
-        ];
-
-        for failed_stage in stages {
-            let token = format!("gho_android_fault_{failed_stage:?}");
-            let dir = std::env::temp_dir()
-                .join(format!("openless-android-fault-{}", uuid::Uuid::new_v4()));
-            let path = dir.join("credentials.enc.json");
-            write_legacy_android_envelope(&path, &token);
-
-            let result = load_android_credentials_from_path_with_fault(&path, &mut |stage| {
-                if stage == failed_stage {
-                    Err(io::Error::other(format!("injected {stage:?}")))
-                } else {
-                    Ok(())
-                }
-            });
-
-            assert!(result.is_err(), "{failed_stage:?} should fail");
-            assert_android_secret_unrecoverable(&path, &token);
-            assert!(!path.with_extension("json.tmp").exists());
-            let _ = std::fs::remove_dir_all(dir);
-        }
-    }
-
-    #[test]
-    fn android_legacy_secret_is_unrecoverable_at_every_crash_boundary() {
-        let boundaries = [
-            AndroidEnvelopeStage::AfterErase,
-            AndroidEnvelopeStage::AfterTempOpen,
-            AndroidEnvelopeStage::AfterTempWrite,
-            AndroidEnvelopeStage::AfterTempFlush,
-            AndroidEnvelopeStage::AfterTempSync,
-            AndroidEnvelopeStage::AfterRename,
-        ];
-
-        for crash_stage in boundaries {
-            let token = format!("gho_android_crash_{crash_stage:?}");
-            let dir = std::env::temp_dir()
-                .join(format!("openless-android-crash-{}", uuid::Uuid::new_v4()));
-            let path = dir.join("credentials.enc.json");
-            write_legacy_android_envelope(&path, &token);
-
-            let crashed = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                let _ = load_android_credentials_from_path_with_fault(&path, &mut |stage| {
-                    assert_ne!(stage, crash_stage, "injected crash at {stage:?}");
-                    Ok(())
-                });
-            }));
-
-            assert!(crashed.is_err(), "{crash_stage:?} should simulate a crash");
-            assert_android_secret_unrecoverable(&path, &token);
-            let _ = std::fs::remove_file(path.with_extension("json.tmp"));
-            let _ = std::fs::remove_dir_all(dir);
         }
     }
 

--- a/openless-all/app/src-tauri/src/persistence/credentials.rs
+++ b/openless-all/app/src-tauri/src/persistence/credentials.rs
@@ -374,17 +374,77 @@ fn keyring_entry_for(account: &str) -> Result<keyring::Entry> {
 
 #[cfg(target_os = "android")]
 fn android_credentials_path() -> Result<PathBuf> {
-    Ok(super::data_dir()?.join(ANDROID_CREDENTIALS_FILE))
+    let files_dir = crate::android::jni::android::app_files_dir()
+        .map_err(|error| anyhow::anyhow!("resolve Android credential directory: {error}"))?;
+    Ok(PathBuf::from(files_dir)
+        .join("OpenLess")
+        .join(ANDROID_CREDENTIALS_FILE))
+}
+
+#[cfg(target_os = "android")]
+fn android_legacy_credentials_paths(current_path: &Path) -> Vec<PathBuf> {
+    let mut paths = Vec::new();
+    let mut add_path = |path: PathBuf| {
+        if path != current_path && !paths.contains(&path) {
+            paths.push(path);
+        }
+    };
+    if let Ok(dir) = std::env::var("TAURI_ANDROID_APP_DATA_DIR") {
+        add_path(
+            PathBuf::from(dir)
+                .join("OpenLess")
+                .join(ANDROID_CREDENTIALS_FILE),
+        );
+    }
+    add_path(
+        std::env::temp_dir()
+            .join("OpenLess")
+            .join(ANDROID_CREDENTIALS_FILE),
+    );
+    paths
+}
+
+#[cfg(target_os = "android")]
+fn remove_migrated_android_legacy_credentials(current_path: &Path) -> Result<()> {
+    for legacy_path in android_legacy_credentials_paths(current_path) {
+        super::android_credentials::secure_remove(&legacy_path)
+            .map_err(anyhow::Error::new)
+            .with_context(|| {
+                format!(
+                    "remove migrated Android legacy envelope {}",
+                    legacy_path.display()
+                )
+            })?;
+    }
+    Ok(())
 }
 
 #[cfg(target_os = "android")]
 fn load_android_credentials() -> Result<Option<CredsRoot>> {
     let path = android_credentials_path()?;
-    let loaded = load_android_credentials_from_path(&path);
-    if loaded.is_ok() {
-        *android_marketplace_legacy_scrubbed().lock() = true;
+    let mut crypto = super::android_credentials::AndroidKeystoreCrypto;
+    let loaded = match load_android_credentials_from_path_with_crypto(&path, &mut crypto)? {
+        Some(root) => Some(root),
+        None => {
+            let mut migrated = None;
+            for legacy_path in android_legacy_credentials_paths(&path) {
+                if let Some(root) = load_android_credentials_from_source_with_crypto(
+                    &legacy_path,
+                    &path,
+                    &mut crypto,
+                )? {
+                    migrated = Some(root);
+                    break;
+                }
+            }
+            migrated
+        }
+    };
+    if loaded.is_some() {
+        remove_migrated_android_legacy_credentials(&path)?;
     }
-    loaded
+    *android_marketplace_legacy_scrubbed().lock() = true;
+    Ok(loaded)
 }
 
 #[cfg(target_os = "android")]
@@ -404,9 +464,18 @@ fn load_android_credentials_from_path_with_crypto(
     path: &Path,
     crypto: &mut impl super::android_credentials::AndroidCredentialsCrypto,
 ) -> Result<Option<CredsRoot>> {
+    load_android_credentials_from_source_with_crypto(path, path, crypto)
+}
+
+#[cfg(any(target_os = "android", test))]
+fn load_android_credentials_from_source_with_crypto(
+    source_path: &Path,
+    destination_path: &Path,
+    crypto: &mut impl super::android_credentials::AndroidCredentialsCrypto,
+) -> Result<Option<CredsRoot>> {
     use super::android_credentials::ReadOutcome;
 
-    let loaded = super::android_credentials::read(path, crypto)
+    let loaded = super::android_credentials::read(source_path, crypto)
         .map_err(anyhow::Error::new)
         .context("read Android credential envelope")?;
     let (bytes, needs_rewrite) = match loaded {
@@ -421,13 +490,23 @@ fn load_android_credentials_from_path_with_crypto(
     if needs_rewrite && contained_marketplace_token {
         let sanitized = serde_json::to_vec(&cleaned)
             .context("encode bearer-free Android legacy payload")?;
-        super::android_credentials::rewrite_legacy_without_bearer(path, &sanitized)
+        super::android_credentials::rewrite_legacy_without_bearer(source_path, &sanitized)
             .map_err(anyhow::Error::new)
             .context("scrub Marketplace bearer before Android Keystore migration")?;
     }
-    if needs_rewrite || contained_marketplace_token {
-        write_android_credentials_envelope_with_crypto(path, &cleaned, crypto)
+    if needs_rewrite || contained_marketplace_token || source_path != destination_path {
+        write_android_credentials_envelope_with_crypto(destination_path, &cleaned, crypto)
             .context("migrate Android credential envelope")?;
+    }
+    if source_path != destination_path {
+        super::android_credentials::secure_remove(source_path)
+            .map_err(anyhow::Error::new)
+            .with_context(|| {
+                format!(
+                    "remove migrated Android legacy envelope {}",
+                    source_path.display()
+                )
+            })?;
     }
     Ok(Some(cleaned))
 }
@@ -460,8 +539,8 @@ fn get_android_marketplace_token_at(
 
 #[cfg(target_os = "android")]
 fn ensure_android_marketplace_legacy_scrubbed() -> Result<()> {
-    let path = android_credentials_path()?;
-    ensure_android_marketplace_legacy_scrubbed_at(&path, android_marketplace_legacy_scrubbed())
+    let _ = load_android_credentials()?;
+    Ok(())
 }
 
 #[cfg(target_os = "android")]
@@ -1331,6 +1410,8 @@ mod tests {
         reset_credentials_cache_for_tests, write_marketplace_github_token, CredsRoot,
         MarketplaceGithubToken, KEYRING_CHUNK_MAX_UTF16_UNITS,
     };
+    #[cfg(not(windows))]
+    use super::load_android_credentials_from_source_with_crypto;
     use anyhow::anyhow;
     use parking_lot::Mutex;
 
@@ -1468,6 +1549,43 @@ mod tests {
         assert!(!disk.contains("marketplace"));
         assert!(!path.with_extension("json.tmp").exists());
         std::fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn android_legacy_root_migrates_to_private_destination_and_is_erased() {
+        use base64::Engine;
+
+        let root_dir = std::env::temp_dir().join(format!(
+            "openless-android-cross-root-migration-{}",
+            uuid::Uuid::new_v4()
+        ));
+        let legacy_path = root_dir.join("legacy").join("credentials.enc.json");
+        let destination_path = root_dir.join("files").join("credentials.enc.json");
+        let plaintext = br#"{"version":1,"providers":{"llm":{"ark":{"apiKey":"sk-migrate"}}}}"#;
+        std::fs::create_dir_all(legacy_path.parent().unwrap()).unwrap();
+        std::fs::write(
+            &legacy_path,
+            base64::engine::general_purpose::STANDARD.encode(plaintext),
+        )
+        .unwrap();
+        let mut crypto = super::super::android_credentials::TestCrypto::default();
+
+        assert!(load_android_credentials_from_source_with_crypto(
+            &legacy_path,
+            &destination_path,
+            &mut crypto,
+        )
+        .unwrap()
+        .is_some());
+        assert!(!legacy_path.exists());
+        assert!(std::fs::read_to_string(&destination_path)
+            .unwrap()
+            .contains("openless-android-credentials"));
+        assert!(load_android_credentials_from_path_with_crypto(&destination_path, &mut crypto)
+            .unwrap()
+            .is_some());
+        std::fs::remove_dir_all(root_dir).unwrap();
     }
 
     fn write_legacy_android_envelope(path: &std::path::Path, token: &str) {

--- a/openless-all/app/src-tauri/src/persistence/mod.rs
+++ b/openless-all/app/src-tauri/src/persistence/mod.rs
@@ -25,6 +25,8 @@ use serde::Deserialize;
 use uuid::Uuid;
 
 mod activity;
+#[cfg(any(target_os = "android", test))]
+mod android_credentials;
 mod correction;
 mod credentials;
 mod dictionary;

--- a/openless-all/app/src-tauri/src/persistence/mod.rs
+++ b/openless-all/app/src-tauri/src/persistence/mod.rs
@@ -81,9 +81,10 @@ fn data_dir() -> Result<PathBuf> {
 
     #[cfg(target_os = "android")]
     {
-        let files_dir = crate::android::jni::android::app_files_dir()
-            .map_err(|error| anyhow::anyhow!("resolve Android app files directory: {error}"))?;
-        Ok(PathBuf::from(files_dir).join("OpenLess"))
+        if let Ok(dir) = std::env::var("TAURI_ANDROID_APP_DATA_DIR") {
+            return Ok(PathBuf::from(dir).join("OpenLess"));
+        }
+        Ok(std::env::temp_dir().join("OpenLess"))
     }
 }
 

--- a/openless-all/app/src-tauri/src/persistence/mod.rs
+++ b/openless-all/app/src-tauri/src/persistence/mod.rs
@@ -81,10 +81,9 @@ fn data_dir() -> Result<PathBuf> {
 
     #[cfg(target_os = "android")]
     {
-        if let Ok(dir) = std::env::var("TAURI_ANDROID_APP_DATA_DIR") {
-            return Ok(PathBuf::from(dir).join("OpenLess"));
-        }
-        Ok(std::env::temp_dir().join("OpenLess"))
+        let files_dir = crate::android::jni::android::app_files_dir()
+            .map_err(|error| anyhow::anyhow!("resolve Android app files directory: {error}"))?;
+        Ok(PathBuf::from(files_dir).join("OpenLess"))
     }
 }
 


### PR DESCRIPTION
### **User description**
Fixes #817

## Summary

- replace the reversible Android Base64 credential envelope with AndroidKeyStore-backed AES-256-GCM
- add a strict authenticated envelope, verified crash-safe legacy migration, rollback marker, and fixed JNI status boundary
- keep the Marketplace bearer process-memory-only on Android
- add JVM, instrumentation, Rust migration/fault-injection tests, plus x86_64 Android CI coverage

## Validation

- bundle SHA-256 verified: `8d015882b6d549288f5762baac281c802913d1b1bbe7d0bff213767cc25e1238`
- imported bundle HEAD verified: `a1dacbafea0463c71cf17f251ed23b57a5f54135`
- CI-only and test-fixture follow-ups culminate at `f8296bff48d4e855a5d4718b39cef5c68c052957`
- `npm test` passed all 24 frontend/contract tests after initializing the pinned submodule
- targeted Rust Android credential tests: 5 passed after reusing one simulated Keystore instance across the migration reload
- Android Gradle/JVM/instrumentation and emulator coverage passed in PR CI


___

### **PR Type**
Bug fix, Enhancement, Tests


___

### **Description**
- Protect Android credentials with Keystore-backed AES-256-GCM

- Add crash-safe migration scrubbing Marketplace tokens

- Implement JNI bridge and Kotlin Keystore vault classes

- Add JVM, instrumentation, and CI test coverage


___

### Diagram Walkthrough


```mermaid
flowchart LR
    legacy["Base64 Envelope"] -->|read & sanitize| sanitized["Bearer-free Base64"]
    sanitized -->|migrate| new_env["V2 AES-GCM Envelope"]
    new_env -->|decrypt/encrypt| keystore["Android KeyStore"]
    keystore -->|rollback barrier| marker["Migration Complete Marker"]
    new_env -->|fail-closed| secure_remove["Secure Erase on Failure"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>android_credentials.rs</strong><dd><code>New Keystore-backed credential store module</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/838/files#diff-4dfd8de4042be7160286eb277e351906f9cd619a362cfa3e07e2ed6ea0872433">+1285/-0</a></td>

</tr>

<tr>
  <td><strong>credentials.rs</strong><dd><code>Integrate Keystore vault with migration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/838/files#diff-6ed5731fbd0b7f6d98a59e85ec178d77591b097310b5b8d52cd6d7361ee86a01">+237/-245</a></td>

</tr>

<tr>
  <td><strong>jni.rs</strong><dd><code>Add JNI bridge for Keystore operations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/838/files#diff-93adf06036f4ca07a2dfb21e3304bc6aaf2957dc3bac7304d4428280e6fb4cb0">+214/-1</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>OpenLessCredentialVault.kt</strong><dd><code>Kotlin Keystore vault facade</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/838/files#diff-74af1e3a7103370d2057b4d6713ce39d9c0cd6c1a82fd49bb9f7ccab3767cacb">+184/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>OpenLessCredentialCipher.kt</strong><dd><code>Pure AES-GCM packet codec</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/838/files#diff-5048a9956b9f471f7780c3c964a3c81ec0da482be37fa8887dc34b2cd594d283">+45/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>mod.rs</strong><dd><code>Register android_credentials module</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/838/files#diff-c6f879589aedbb998c007604be59fc0f5545c843b0da4e3c48527b58ea856b05">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>copy-android-scaffolding.mjs</strong><dd><code>Copy test scaffolding to generated project</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/838/files#diff-5508ac8264d324360bedc6d9b5091c69de559884cd7c2ee61d37ab11b9fc0eac">+65/-14</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>ci.yml</strong><dd><code>Add Android x86_64 CI and emulator tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/838/files#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03f">+63/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>OpenLessCredentialCipherTest.kt</strong><dd><code>JVM unit tests for AES-GCM cipher</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/838/files#diff-a41ea819cb6b094f3c2090473090ce3cbe333d308e8b431d0f76fb625bba5edb">+111/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>OpenLessCredentialVaultInstrumentedTest.kt</strong><dd><code>Instrumented Keystore integration tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/838/files#diff-572e4e1abc9bd38b48e0da7812e973cc53f9b540a4ae436de859c9734486750d">+89/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>android-credential-keystore-contract.test.mjs</strong><dd><code>Contract tests for Keystore implementation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/838/files#diff-8f9ae37652badcba12cdaba8b44d66180a37359d090b1e0f8a39b7b55d59f92b">+248/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

