### PR TITLE
Add Atlas Cloud LLM provider preset

### DIFF
--- a/openless-all/app/src-tauri/src/commands/credentials.rs
+++ b/openless-all/app/src-tauri/src/commands/credentials.rs
@@ -83,6 +83,7 @@ fn llm_provider_default_endpoint(provider: &str) -> Option<&'static str> {
         "ark" => Some("https://ark.cn-beijing.volces.com/api/v3"),
         "deepseek" => Some("https://api.deepseek.com/v1"),
         "siliconflow" => Some("https://api.siliconflow.cn/v1"),
+        "atlascloud" => Some("https://api.atlascloud.ai/v1"),
         "openai" => Some("https://api.openai.com/v1"),
         // 谷歌 Gemini 原生 API（v1beta）。后端 llm_gemini.rs 会拼成
         // `{baseUrl}/models/{model}:generateContent`，认证用 x-goog-api-key 头。

--- a/openless-all/app/src-tauri/src/commands/mod.rs
+++ b/openless-all/app/src-tauri/src/commands/mod.rs
@@ -566,6 +566,22 @@ mod tests {
         ));
     }
 
+    #[test]
+    fn credentials_status_requires_api_key_for_atlascloud() {
+        let keyless = CredentialsSnapshot {
+            ark_endpoint: Some("https://api.atlascloud.ai/v1".into()),
+            ark_model_id: Some("qwen/qwen3.5-flash".into()),
+            ..snapshot()
+        };
+        assert!(!llm_configured_for_provider("atlascloud", &keyless));
+
+        let ready = CredentialsSnapshot {
+            ark_api_key: Some("key".into()),
+            ..keyless
+        };
+        assert!(llm_configured_for_provider("atlascloud", &ready));
+    }
+
     impl SettingsWriter for FakeSettingsWriter {
         fn read_settings(&self) -> UserPreferences {
             self.saved.lock().unwrap().clone().unwrap_or_default()

--- a/openless-all/app/src/i18n/en.ts
+++ b/openless-all/app/src/i18n/en.ts
@@ -773,6 +773,7 @@ export const en: typeof zhCN = {
         ark: 'ARK (Volcengine Ark)',
         deepseek: 'DeepSeek',
         siliconflow: 'SiliconFlow',
+        atlascloud: 'Atlas Cloud',
         openai: 'OpenAI',
         gemini: 'Google Gemini',
         codexOAuth: 'Codex OAuth',

--- a/openless-all/app/src/i18n/ja.ts
+++ b/openless-all/app/src/i18n/ja.ts
@@ -775,6 +775,7 @@ export const ja: typeof zhCN = {
         ark: 'ARK（Volcengine Ark）',
         deepseek: 'DeepSeek',
         siliconflow: 'SiliconFlow',
+        atlascloud: 'Atlas Cloud',
         openai: 'OpenAI',
         gemini: 'Google Gemini',
         codexOAuth: 'Codex OAuth',

--- a/openless-all/app/src/i18n/ko.ts
+++ b/openless-all/app/src/i18n/ko.ts
@@ -775,6 +775,7 @@ export const ko: typeof zhCN = {
         ark: 'ARK (Volcengine Ark)',
         deepseek: 'DeepSeek',
         siliconflow: 'SiliconFlow',
+        atlascloud: 'Atlas Cloud',
         openai: 'OpenAI',
         gemini: 'Google Gemini',
         codexOAuth: 'Codex OAuth',

--- a/openless-all/app/src/i18n/zh-CN.ts
+++ b/openless-all/app/src/i18n/zh-CN.ts
@@ -771,6 +771,7 @@ export const zhCN = {
         ark: 'ARK（火山方舟）',
         deepseek: 'DeepSeek',
         siliconflow: '硅基流动',
+        atlascloud: 'Atlas Cloud',
         openai: 'OpenAI',
         gemini: 'Google Gemini',
         codexOAuth: 'Codex OAuth',

--- a/openless-all/app/src/i18n/zh-TW.ts
+++ b/openless-all/app/src/i18n/zh-TW.ts
@@ -773,6 +773,7 @@ export const zhTW: typeof zhCN = {
         ark: 'ARK（火山方舟）',
         deepseek: 'DeepSeek',
         siliconflow: '硅基流動',
+        atlascloud: 'Atlas Cloud',
         openai: 'OpenAI',
         gemini: 'Google Gemini',
         codexOAuth: 'Codex OAuth',

--- a/openless-all/app/src/pages/Overview.tsx
+++ b/openless-all/app/src/pages/Overview.tsx
@@ -36,6 +36,7 @@ const LLM_NAME_KEY_BY_ID: Record<string, string> = {
   ark: 'ark',
   deepseek: 'deepseek',
   siliconflow: 'siliconflow',
+  atlascloud: 'atlascloud',
   openai: 'openai',
   codex_oauth: 'codexOAuth',
   mimo: 'mimo',

--- a/openless-all/app/src/pages/settings/ProvidersSection.test.ts
+++ b/openless-all/app/src/pages/settings/ProvidersSection.test.ts
@@ -1,0 +1,15 @@
+import { LLM_PRESETS } from './ProvidersSection';
+
+const atlascloudPreset = LLM_PRESETS.find(p => p.id === 'atlascloud');
+
+if (!atlascloudPreset) {
+  throw new Error('Atlas Cloud LLM preset is missing');
+}
+
+if (atlascloudPreset.baseUrl !== 'https://api.atlascloud.ai/v1') {
+  throw new Error(`unexpected Atlas Cloud base URL: ${atlascloudPreset.baseUrl}`);
+}
+
+if (atlascloudPreset.modelPlaceholder !== 'qwen/qwen3.5-flash') {
+  throw new Error(`unexpected Atlas Cloud default model: ${atlascloudPreset.modelPlaceholder}`);
+}

--- a/openless-all/app/src/pages/settings/ProvidersSection.tsx
+++ b/openless-all/app/src/pages/settings/ProvidersSection.tsx
@@ -47,7 +47,7 @@ function LlmThinkingToggle({ enabled, onToggle }: { enabled: boolean; onToggle: 
   );
 }
 
-const LLM_PRESETS = [
+export const LLM_PRESETS = [
   {
     id: 'ark',
     nameKey: 'ark',
@@ -65,6 +65,12 @@ const LLM_PRESETS = [
     nameKey: 'siliconflow',
     baseUrl: 'https://api.siliconflow.cn/v1',
     modelPlaceholder: 'Qwen/Qwen2.5-7B-Instruct',
+  },
+  {
+    id: 'atlascloud',
+    nameKey: 'atlascloud',
+    baseUrl: 'https://api.atlascloud.ai/v1',
+    modelPlaceholder: 'qwen/qwen3.5-flash',
   },
   {
     id: 'openai',


### PR DESCRIPTION
### **User description**
## Summary
- add Atlas Cloud to the existing LLM provider presets in settings
- prefill the OpenAI-compatible base URL and Qwen3.5 Flash model placeholder while keeping the API key user-provided
- add localized provider labels and a focused preset regression test

## Validation
- `npx tsx src/pages/settings/ProvidersSection.test.ts`
- `npm run build`
- `git diff --check`
- Atlas live catalog returned `qwen/qwen3.5-flash` and `deepseek-ai/deepseek-v4-pro`

README: no README changes; no sponsor/logo/credits/partner promotion.


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Add Atlas Cloud LLM provider preset

- Add localization labels for Atlas Cloud across multiple languages

- Add backend endpoint and frontend mapping for Atlas Cloud

- Add regression test for Atlas Cloud preset configuration


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["ProvidersSection.tsx"] --> B["LLM_PRESETS add atlascloud"]
  A --> C["ProvidersSection.test.ts"]
  B --> D["i18n localization files"]
  B --> E["Overview.tsx mapping"]
  E --> F["credentials.rs endpoint"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>credentials.rs</strong><dd><code>Add Atlas Cloud endpoint</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/844/files#diff-8d658e9fd5232f39056b70074eebd9a30437059e28f5118e37a6ba3c3c0ad80f">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>Overview.tsx</strong><dd><code>Add atlascloud mapping to LLM name key</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/844/files#diff-87ea690f4abf573183a65635bee8aae0f788da0bc4b4f030f53756fa16f8aae2">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ProvidersSection.tsx</strong><dd><code>Add Atlas Cloud preset configuration and export</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/844/files#diff-8fc332d1eb5b010583185b704ea439954650f6aff2d0195e00cd0cb76e526e7b">+7/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>mod.rs</strong><dd><code>Add test for Atlas Cloud API key requirement</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/844/files#diff-927cec8f506f8369417751238e7d018c43bad50133e1488750ee0f9feb5f6449">+16/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ProvidersSection.test.ts</strong><dd><code>Add regression test for Atlas Cloud preset</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/844/files#diff-c23923742e38c5e2b0a254b5f6db3afc1c1212ce06b29744a041c423c0925c91">+15/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Localization</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>en.ts</strong><dd><code>Add English label for Atlas Cloud</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/844/files#diff-bb2f4fa05787923f8aeb23b6f11ad8705e02d9ff03a45790f9181e4615c79d83">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ja.ts</strong><dd><code>Add Japanese label for Atlas Cloud</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/844/files#diff-be57f0090cf34e3ff924cfa35f13d5d9e6514d3af5a1ebfdeb92bd7d36ed9cf4">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ko.ts</strong><dd><code>Add Korean label for Atlas Cloud</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/844/files#diff-daf35bcb6a2f8a31565b83d119cb59b69c1dededbabfccfd0d56693fdb3726ca">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>zh-CN.ts</strong><dd><code>Add Chinese (Simplified) label for Atlas Cloud</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/844/files#diff-571576f3c7b6c4a78ae0f91accdccc5da5cbed00409955c9914c046fee6c80ea">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>zh-TW.ts</strong><dd><code>Add Chinese (Traditional) label for Atlas Cloud</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/844/files#diff-a8d5953f9c76bc3c90ec583270be04c852bd7540297500e6ff3260760fc61ea4">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

