### PR TITLE
fix(asr): 修复百炼 ASR 连通性校验死锁并透出详细错误信息

### DIFF
--- a/openless-all/app/src-tauri/src/asr/bailian.rs
+++ b/openless-all/app/src-tauri/src/asr/bailian.rs
@@ -486,6 +486,7 @@ impl BailianRealtimeASR {
         if let Some(tx) = tx {
             let _ = tx.send(Err(error));
         }
+        self.task_started.notify_waiters();
         self.close_on_runtime();
     }
 

--- a/openless-all/app/src/pages/settings/ProvidersSection.tsx
+++ b/openless-all/app/src/pages/settings/ProvidersSection.tsx
@@ -698,6 +698,9 @@ function providerErrorMessage(error: unknown, t: ReturnType<typeof useTranslatio
   if (message.includes('API Key')) return t('settings.providers.apiKeyMissing');
   if (message.includes('Endpoint')) return t('settings.providers.endpointMissing');
   if (message.includes('timeout') || message.includes('超时')) return t('settings.providers.requestTimeout');
+  if (message.startsWith('task failed:') || message.startsWith('connection failed:') || message.startsWith('send failed:')) {
+    return message;
+  }
   return t('common.operationFailed');
 }
 


### PR DESCRIPTION
## 摘要

修复阿里云百炼（Bailian/DashScope）实时 ASR 供应商点击验证始终显示「操作失败」的问题。

## 修复

1. **后端死锁**（bailian.rs）：inish_error() 未调用 self.task_started.notify_waiters()。当 WebSocket 连接或 DashScope 会话建立过程中发生错误时，send_last_frame() 中等待 	ask_started 的异步 Notify 无法收到唤醒信号，导致 5 秒超时，最终抛出 FinalResultTimeout，掩盖了真实的 DashScope 错误原因。

2. **前端错误吞没**（ProvidersSection.tsx）：providerErrorMessage() 中所有未匹配特定前缀的错误消息均降级为 	('common.operationFailed')（「操作失败」）。现已放行 	ask failed: / connection failed: / send failed: 等后端原始错误文案，使用户能看到具体的失败原因。

## 兼容

- 不包含破坏性变更
- 对现有用户无影响
- 构建流程无变化

## 测试计划

- 使用 Node.js 脚本验证 DashScope WebSocket 协议：run-task → send silence → finish-task → task-finished 流程正常
- 验证错误 API Key 场景下不再 5 秒超时而是快速返回具体错误