### PR TITLE
fix(hotkey): Esc 取消改走独立通道——修复转写/润色期间按 Esc 停不下来

### DIFF
--- a/openless-all/app/src-tauri/src/coordinator.rs
+++ b/openless-all/app/src-tauri/src/coordinator.rs
@@ -1443,7 +1443,8 @@ impl Coordinator {
         let (tx, rx) = mpsc::channel::<HotkeyEvent>();
         #[cfg(target_os = "linux")]
         let (fcitx_tx, fcitx_binding) = (tx.clone(), binding.clone());
-        match HotkeyMonitor::start(binding, tx) {
+        let cancel_tx = spawn_esc_cancel_bridge(&self.inner);
+        match HotkeyMonitor::start(binding, tx, cancel_tx) {
             Ok(monitor) => {
                 let adapter = monitor.kind();
                 *self.inner.hotkey.lock() = Some(monitor);

--- a/openless-all/app/src-tauri/src/coordinator/hotkey_loops.rs
+++ b/openless-all/app/src-tauri/src/coordinator/hotkey_loops.rs
@@ -28,10 +28,14 @@ pub(super) fn esc_cancel_bridge_loop(inner: Arc<Inner>, rx: mpsc::Receiver<()>) 
 pub(super) fn spawn_esc_cancel_bridge(inner: &Arc<Inner>) -> mpsc::Sender<()> {
     let (cancel_tx, cancel_rx) = mpsc::channel::<()>();
     let bridge_inner = Arc::clone(inner);
-    std::thread::Builder::new()
+    if let Err(e) = std::thread::Builder::new()
         .name("openless-esc-cancel-bridge".into())
         .spawn(move || esc_cancel_bridge_loop(bridge_inner, cancel_rx))
-        .ok();
+    {
+        // 线程建不起来 = 取消通道没有消费者，Esc 取消会静默失效——这正是本 PR 想修的
+        // bug 以另一种方式回归，必须留 error 日志以便排查。
+        log::error!("[hotkey] esc-cancel-bridge 线程启动失败，Esc 取消将不可用: {e}");
+    }
     cancel_tx
 }
 
@@ -1225,5 +1229,118 @@ pub(super) fn window_key_matches_trigger(trigger: crate::types::HotkeyTrigger, k
         HotkeyTrigger::MediaPlayPause => false,
         // Custom 走 global-hotkey crate，不走 window hotkey fallback
         HotkeyTrigger::Custom => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// 轮询 `inner.state.cancelled` 直到满足条件，超时返回 false。
+    fn wait_until(mut cond: impl FnMut() -> bool, timeout: std::time::Duration) -> bool {
+        let deadline = std::time::Instant::now() + timeout;
+        while std::time::Instant::now() < deadline {
+            if cond() {
+                return true;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(10));
+        }
+        false
+    }
+
+    /// 构造一个处于 Processing 阶段、cancelled=false 的 Coordinator。
+    fn coordinator_in_processing() -> Coordinator {
+        let coordinator = Coordinator::new();
+        let mut state = coordinator.inner.state.lock();
+        state.phase = SessionPhase::Processing;
+        state.cancelled = false;
+        drop(state);
+        coordinator
+    }
+
+    /// 后台运行 esc_cancel_bridge_loop，返回 sender 与 join handle。
+    fn spawn_loop(inner: &Arc<Inner>) -> (mpsc::Sender<()>, std::thread::JoinHandle<()>) {
+        let (tx, rx) = mpsc::channel::<()>();
+        let bridge_inner = Arc::clone(inner);
+        let handle = std::thread::spawn(move || esc_cancel_bridge_loop(bridge_inner, rx));
+        (tx, handle)
+    }
+
+    #[test]
+    fn esc_cancel_bridge_sets_cancelled_during_processing() {
+        let coordinator = coordinator_in_processing();
+        let (tx, handle) = spawn_loop(&coordinator.inner);
+
+        tx.send(()).unwrap();
+        assert!(
+            wait_until(
+                || coordinator.inner.state.lock().cancelled,
+                std::time::Duration::from_secs(2)
+            ),
+            "取消信号应置 cancelled 旗标"
+        );
+        // #798 语义：Processing 阶段保持 phase=Processing，由 end_session 自行收尾。
+        assert_eq!(
+            coordinator.inner.state.lock().phase,
+            SessionPhase::Processing
+        );
+
+        drop(tx);
+        handle.join().unwrap();
+    }
+
+    #[test]
+    fn esc_cancel_bridge_skips_while_shortcut_recording_active() {
+        let coordinator = coordinator_in_processing();
+        let (tx, handle) = spawn_loop(&coordinator.inner);
+
+        coordinator.set_shortcut_recording_active(true);
+        tx.send(()).unwrap();
+        std::thread::sleep(std::time::Duration::from_millis(120));
+        assert!(
+            !coordinator.inner.state.lock().cancelled,
+            "录制快捷键期间按 Esc 应被忽略"
+        );
+
+        // 录制结束后 Esc 恢复生效。
+        coordinator.set_shortcut_recording_active(false);
+        tx.send(()).unwrap();
+        assert!(
+            wait_until(
+                || coordinator.inner.state.lock().cancelled,
+                std::time::Duration::from_secs(2)
+            ),
+            "录制结束后取消信号应恢复生效"
+        );
+
+        drop(tx);
+        handle.join().unwrap();
+    }
+
+    #[test]
+    fn esc_cancel_bridge_is_idempotent_on_repeat_signals() {
+        let coordinator = coordinator_in_processing();
+        let (tx, handle) = spawn_loop(&coordinator.inner);
+
+        for _ in 0..3 {
+            tx.send(()).unwrap();
+        }
+        assert!(
+            wait_until(
+                || coordinator.inner.state.lock().cancelled,
+                std::time::Duration::from_secs(2)
+            ),
+            "首个取消信号应置 cancelled 旗标"
+        );
+        // 连按 Esc / 双通道重复触发时 cancel_session 幂等：不 panic、状态不回写。
+        tx.send(()).unwrap();
+        std::thread::sleep(std::time::Duration::from_millis(120));
+        assert_eq!(
+            coordinator.inner.state.lock().phase,
+            SessionPhase::Processing
+        );
+
+        drop(tx);
+        handle.join().unwrap();
     }
 }

--- a/openless-all/app/src-tauri/src/coordinator/hotkey_loops.rs
+++ b/openless-all/app/src-tauri/src/coordinator/hotkey_loops.rs
@@ -9,6 +9,32 @@ use super::*;
 
 // ─────────────────────────── hotkey bridging ───────────────────────────
 
+/// Esc 取消专用消费线程。为什么不并入 `hotkey_bridge_loop`：bridge 为修 #468/#475
+/// 的 latch 竞态把 Pressed/Released 改成了串行 block_on —— Hold 松手后 `end_session`
+/// 会在 bridge 线程上同步跑完整段转写 + 润色，期间 bridge 无法 recv。若 Esc 与其同
+/// 队列，取消事件只能排队等流程跑完（此时 phase 已回 Idle，cancel 变 no-op），#798
+/// 在 `end_session` 里的 select! 取消赛跑永远等不到 `cancelled` 旗标 ——「转写 / 润色
+/// 中按 Esc 停不下来」。独立通道 + 本线程保证 `cancel_session` 随到随执行（它是纯同步
+/// 快路径：置旗标 + 清资源，不 await）。
+pub(super) fn esc_cancel_bridge_loop(inner: Arc<Inner>, rx: mpsc::Receiver<()>) {
+    while rx.recv().is_ok() {
+        if inner.shortcut_recording_active.load(Ordering::SeqCst) {
+            continue;
+        }
+        cancel_session(&inner);
+    }
+}
+
+pub(super) fn spawn_esc_cancel_bridge(inner: &Arc<Inner>) -> mpsc::Sender<()> {
+    let (cancel_tx, cancel_rx) = mpsc::channel::<()>();
+    let bridge_inner = Arc::clone(inner);
+    std::thread::Builder::new()
+        .name("openless-esc-cancel-bridge".into())
+        .spawn(move || esc_cancel_bridge_loop(bridge_inner, cancel_rx))
+        .ok();
+    cancel_tx
+}
+
 pub(super) fn hotkey_supervisor_loop(inner: Arc<Inner>) {
     let mut attempts: u32 = 0;
     let capability = HotkeyMonitor::capability();
@@ -54,7 +80,8 @@ pub(super) fn hotkey_supervisor_loop(inner: Arc<Inner>) {
         let (tx, rx) = mpsc::channel::<HotkeyEvent>();
         #[cfg(target_os = "linux")]
         let (fcitx_tx, fcitx_binding) = (tx.clone(), binding.clone());
-        match HotkeyMonitor::start(binding, tx) {
+        let cancel_tx = spawn_esc_cancel_bridge(&inner);
+        match HotkeyMonitor::start(binding, tx, cancel_tx) {
             Ok(monitor) => {
                 let adapter = monitor.kind();
                 *inner.hotkey.lock() = Some(monitor);
@@ -278,7 +305,10 @@ pub(super) fn update_coding_agent_hotkey_binding_now(inner: &Arc<Inner>) {
                 return;
             }
             let (tx, rx) = mpsc::channel::<HotkeyEvent>();
-            match HotkeyMonitor::start(modifier_binding, tx) {
+            // Less Computer 的独立 tap 也转发 Esc 取消（与主 monitor 双保险；
+            // cancel_session 幂等，重复触发无害）。
+            let cancel_tx = spawn_esc_cancel_bridge(inner);
+            match HotkeyMonitor::start(modifier_binding, tx, cancel_tx) {
                 Ok(monitor) => {
                     *inner.coding_agent_modifier_hotkey.lock() = Some(monitor);
                     log::info!(
@@ -362,7 +392,6 @@ pub(super) fn less_computer_modifier_bridge_loop(inner: Arc<Inner>, rx: mpsc::Re
                     handle_less_computer_released(&inner_cloned).await
                 });
             }
-            HotkeyEvent::Cancelled => cancel_session(&inner_cloned),
             HotkeyEvent::TranslationModifierPressed | HotkeyEvent::QaShortcutPressed => {}
         }
     }
@@ -1036,9 +1065,8 @@ pub(super) fn hotkey_bridge_loop(inner: Arc<Inner>, rx: mpsc::Receiver<HotkeyEve
                     handle_released_edge(&inner_cloned, at).await;
                 });
             }
-            HotkeyEvent::Cancelled => {
-                cancel_session(&inner_cloned);
-            }
+            // Esc 取消不在此枚举里：走独立的 esc_cancel_bridge_loop，避免被上面
+            // Released → end_session 的同步转写流程堵在队列里（见该函数注释）。
             HotkeyEvent::TranslationModifierPressed => {
                 let translation_hotkey = inner_cloned.prefs.get().translation_hotkey;
                 if is_builtin_translation_shift(&translation_hotkey)

--- a/openless-all/app/src-tauri/src/hotkey.rs
+++ b/openless-all/app/src-tauri/src/hotkey.rs
@@ -8,6 +8,12 @@
 //! - Linux：fcitx5 插件提供热键事件（DBus 信号 `DictationKeyEvent`）。
 //!
 //! 仅产出"边沿"事件，toggle vs hold 由 Coordinator 解释。
+//!
+//! Esc（取消）**不走** `HotkeyEvent` 通道，而是独立的 `Sender<()>`：Pressed/Released
+//! 的 bridge 线程为了修 #468/#475 的 latch 竞态改成了串行 block_on，Released 会在
+//! bridge 线程上同步跑完整个转写 + 润色流程 —— 若 Esc 与它们同队列，Processing 期间
+//! 的取消事件只能排队等流程跑完，#798 的 select! 取消赛跑永远等不到 cancelled 旗标
+//! （「转写中按 Esc 停不下来」）。独立通道 + 专用消费线程保证取消随到随处理。
 
 use std::sync::atomic::AtomicBool;
 use std::sync::mpsc::{self, Sender};
@@ -23,7 +29,6 @@ use crate::types::{HotkeyAdapterKind, HotkeyBinding, HotkeyCapability, HotkeyIns
 pub enum HotkeyEvent {
     Pressed { at: Instant },
     Released { at: Instant },
-    Cancelled,
     /// Shift（或未来配置项指定的修饰键）按下边沿。可在录音过程中任何时刻产生；
     /// 上层据此切换到翻译输出管线。详见 issue #4。
     TranslationModifierPressed,
@@ -131,12 +136,16 @@ impl HotkeyMonitor {
     /// Spawn the listener thread and **wait synchronously** for it to confirm
     /// the OS-level hook installed so the caller can surface an actual adapter
     /// status instead of silently dropping events.
+    ///
+    /// `cancel_tx`：Esc 按下即发一个 `()`。独立于 `tx`，见模块注释——不能与
+    /// Pressed/Released 挤同一条串行 bridge，否则 Processing 期间取消排不上队。
     pub fn start(
         binding: HotkeyBinding,
         tx: Sender<HotkeyEvent>,
+        cancel_tx: Sender<()>,
     ) -> Result<Self, HotkeyInstallError> {
         Ok(Self {
-            adapter: platform::start_adapter(binding, tx)?,
+            adapter: platform::start_adapter(binding, tx, cancel_tx)?,
         })
     }
 
@@ -185,6 +194,12 @@ fn send_or_log(tx: &Sender<HotkeyEvent>, evt: HotkeyEvent) {
     }
 }
 
+fn send_cancel_or_log(tx: &Sender<()>) {
+    if let Err(e) = tx.send(()) {
+        log::warn!("[hotkey] 取消事件发送失败: {e}");
+    }
+}
+
 type StartupTx<T> = mpsc::Sender<Result<T, HotkeyInstallError>>;
 
 struct ListenerThread<T> {
@@ -195,13 +210,14 @@ struct ListenerThread<T> {
 fn start_listener_thread<T, F>(
     binding: HotkeyBinding,
     tx: Sender<HotkeyEvent>,
+    cancel_tx: Sender<()>,
     thread_name: &str,
     startup_timeout_message: &'static str,
     run_listen_loop: F,
 ) -> Result<ListenerThread<T>, HotkeyInstallError>
 where
     T: Send + 'static,
-    F: FnOnce(Arc<Shared>, Sender<HotkeyEvent>, StartupTx<T>) + Send + 'static,
+    F: FnOnce(Arc<Shared>, Sender<HotkeyEvent>, Sender<()>, StartupTx<T>) + Send + 'static,
 {
     let shared = Arc::new(Shared {
         binding: RwLock::new(binding),
@@ -217,7 +233,7 @@ where
     let (status_tx, status_rx) = mpsc::channel::<Result<T, HotkeyInstallError>>();
     std::thread::Builder::new()
         .name(thread_name.into())
-        .spawn(move || run_listen_loop(thread_shared, tx, status_tx))
+        .spawn(move || run_listen_loop(thread_shared, tx, cancel_tx, status_tx))
         .map_err(|e| install_error("spawn_failed", format!("hotkey 线程启动失败: {e}")))?;
 
     match status_rx.recv_timeout(Duration::from_secs(3)) {
@@ -284,19 +300,21 @@ mod platform {
     use std::sync::Arc;
 
     use super::{
-        install_error, reset_shared_held_state, send_or_log, start_listener_thread,
-        update_shared_binding, update_shared_modifier_shortcuts, HotkeyAdapter, HotkeyEvent,
-        Shared, StartupTx,
+        install_error, reset_shared_held_state, send_cancel_or_log, send_or_log,
+        start_listener_thread, update_shared_binding, update_shared_modifier_shortcuts,
+        HotkeyAdapter, HotkeyEvent, Shared, StartupTx,
     };
     use crate::types::{HotkeyAdapterKind, HotkeyBinding, HotkeyInstallError, HotkeyTrigger};
 
     pub fn start_adapter(
         binding: HotkeyBinding,
         tx: Sender<HotkeyEvent>,
+        cancel_tx: Sender<()>,
     ) -> Result<Box<dyn HotkeyAdapter>, HotkeyInstallError> {
         let listener = start_listener_thread(
             binding,
             tx,
+            cancel_tx,
             "openless-hotkey-mac-event-tap",
             "hotkey hook 启动超时",
             run_listen_loop,
@@ -452,6 +470,8 @@ mod platform {
     struct CallbackContext {
         shared: Arc<Shared>,
         tx: Sender<HotkeyEvent>,
+        /// Esc 专用通道，见模块注释——不与 tx 挤同一条串行 bridge。
+        cancel_tx: Sender<()>,
         /// 与 MacHotkeyAdapter 共享的 (tap, runloop) refs。tap re-enable on
         /// TAP_DISABLED_BY_TIMEOUT 走 handles.tap；adapter shutdown 也走这两个 lock。
         handles: Arc<MacShutdownHandles>,
@@ -463,6 +483,7 @@ mod platform {
     fn run_listen_loop(
         shared: Arc<Shared>,
         tx: Sender<HotkeyEvent>,
+        cancel_tx: Sender<()>,
         status_tx: StartupTx<Arc<MacShutdownHandles>>,
     ) {
         let mask: CgEventMask = (1u64 << FLAGS_CHANGED)
@@ -475,6 +496,7 @@ mod platform {
         let context = Box::into_raw(Box::new(CallbackContext {
             shared,
             tx,
+            cancel_tx,
             handles: Arc::clone(&handles),
         }));
 
@@ -632,7 +654,7 @@ mod platform {
     fn handle_key_down(ctx: &CallbackContext, event: CgEventRef) {
         let keycode = unsafe { CGEventGetIntegerValueField(event, KEYBOARD_EVENT_KEYCODE) };
         if keycode == ESC_KEYCODE {
-            send_or_log(&ctx.tx, HotkeyEvent::Cancelled);
+            send_cancel_or_log(&ctx.cancel_tx);
         }
     }
 
@@ -691,10 +713,12 @@ mod platform {
 
         fn callback_context(shared: Arc<Shared>) -> (CallbackContext, mpsc::Receiver<HotkeyEvent>) {
             let (tx, rx) = mpsc::channel();
+            let (cancel_tx, _cancel_rx) = mpsc::channel();
             (
                 CallbackContext {
                     shared,
                     tx,
+                    cancel_tx,
                     handles: Arc::new(MacShutdownHandles {
                         tap: std::sync::Mutex::new(None),
                         runloop: std::sync::Mutex::new(None),
@@ -783,9 +807,9 @@ mod platform {
     };
 
     use super::{
-        install_error, reset_shared_held_state, send_or_log, start_listener_thread,
-        update_shared_binding, update_shared_modifier_shortcuts, HotkeyAdapter, HotkeyEvent,
-        Shared, StartupTx,
+        install_error, reset_shared_held_state, send_cancel_or_log, send_or_log,
+        start_listener_thread, update_shared_binding, update_shared_modifier_shortcuts,
+        HotkeyAdapter, HotkeyEvent, Shared, StartupTx,
     };
     use crate::types::{HotkeyAdapterKind, HotkeyBinding, HotkeyInstallError, HotkeyTrigger};
 
@@ -813,10 +837,12 @@ mod platform {
     pub fn start_adapter(
         binding: HotkeyBinding,
         tx: Sender<HotkeyEvent>,
+        cancel_tx: Sender<()>,
     ) -> Result<Box<dyn HotkeyAdapter>, HotkeyInstallError> {
         let listener = start_listener_thread(
             binding,
             tx,
+            cancel_tx,
             "openless-hotkey-win-ll-hook",
             "Windows hotkey hook 启动超时",
             run_listen_loop,
@@ -866,17 +892,25 @@ mod platform {
     struct CallbackContext {
         shared: Arc<Shared>,
         tx: Sender<HotkeyEvent>,
+        /// Esc 专用通道，见模块注释——不与 tx 挤同一条串行 bridge。
+        cancel_tx: Sender<()>,
         hook: std::sync::Mutex<Option<HHOOK>>,
     }
 
     unsafe impl Send for CallbackContext {}
     unsafe impl Sync for CallbackContext {}
 
-    fn run_listen_loop(shared: Arc<Shared>, tx: Sender<HotkeyEvent>, status_tx: StartupTx<u32>) {
+    fn run_listen_loop(
+        shared: Arc<Shared>,
+        tx: Sender<HotkeyEvent>,
+        cancel_tx: Sender<()>,
+        status_tx: StartupTx<u32>,
+    ) {
         let thread_id = unsafe { GetCurrentThreadId() };
         let context = Box::into_raw(Box::new(CallbackContext {
             shared,
             tx,
+            cancel_tx,
             hook: std::sync::Mutex::new(None),
         }));
         HOOK_CONTEXT.store(context, AtomicOrdering::SeqCst);
@@ -953,7 +987,7 @@ mod platform {
 
     fn dispatch_keyboard_event(ctx: &CallbackContext, vk_code: u32, message: usize) -> bool {
         if vk_code == VK_ESCAPE && (message == WM_KEYDOWN || message == WM_SYSKEYDOWN) {
-            send_or_log(&ctx.tx, HotkeyEvent::Cancelled);
+            send_cancel_or_log(&ctx.cancel_tx);
             return false;
         }
 
@@ -1103,10 +1137,12 @@ mod platform {
 
         fn callback_context(shared: Arc<Shared>) -> (CallbackContext, mpsc::Receiver<HotkeyEvent>) {
             let (tx, rx) = mpsc::channel();
+            let (cancel_tx, _cancel_rx) = mpsc::channel();
             (
                 CallbackContext {
                     shared,
                     tx,
+                    cancel_tx,
                     hook: std::sync::Mutex::new(None),
                 },
                 rx,
@@ -1276,6 +1312,7 @@ mod platform {
     pub fn start_adapter(
         _binding: HotkeyBinding,
         _tx: Sender<HotkeyEvent>,
+        _cancel_tx: Sender<()>,
     ) -> Result<Box<dyn HotkeyAdapter>, HotkeyInstallError> {
         log::info!("[hotkey] Linux — fcitx5 plugin handles hotkeys");
         Ok(Box::new(PlaceholderAdapter { _tx }))

--- a/openless-all/app/src-tauri/src/mobile_stubs/hotkey.rs
+++ b/openless-all/app/src-tauri/src/mobile_stubs/hotkey.rs
@@ -11,7 +11,6 @@ use crate::types::{
 pub enum HotkeyEvent {
     Pressed { at: Instant },
     Released { at: Instant },
-    Cancelled,
     TranslationModifierPressed,
     QaShortcutPressed,
 }
@@ -22,6 +21,7 @@ impl HotkeyMonitor {
     pub fn start(
         _binding: HotkeyBinding,
         _tx: Sender<HotkeyEvent>,
+        _cancel_tx: Sender<()>,
     ) -> Result<Self, HotkeyInstallError> {
         Err(HotkeyInstallError {
             code: "unavailable".into(),


### PR DESCRIPTION
### **User description**
## 问题

转写（Transcribing）和 LLM 润色（Polishing）期间按 Esc 完全没有反应，必须干等整段流程跑完。#798 已经给 `end_session` 加了「转写 vs 取消」的 `tokio::select!` 赛跑、润色流也有 `should_cancel` 检查——但取消信号本身送不进来。

## 根因

Esc 的 `HotkeyEvent::Cancelled` 与 Pressed/Released **共用同一条 mpsc channel + 同一条 bridge 线程**。bridge 为修 #468/#475 的 latch 竞态改成了串行 `block_on`（#489），Hold 松手后 `end_session` 就在 bridge 线程上同步跑完整段转写 + 润色：

1. 用户松开听写键 → bridge `block_on(end_session)`，线程被占死；
2. 用户按 Esc → `Cancelled` 进 channel 排队，**没有人能 recv**；
3. `wait_for_processing_cancel` 每 75ms 轮询的 `cancelled` 旗标只有 `cancel_session` 会设置，而 `cancel_session` 正等着这条被堵死的线程来调——#798 的 select! 赛跑永远等不到信号；
4. 流程跑完、bridge 空出来才取出 `Cancelled`，此时 phase 已回 Idle，cancel 变 no-op。

**听写键为修饰键（默认 fn 等）时必现**；自定义组合键用户不受影响（按键事件走 `ComboHotkeyMonitor` 的独立线程，主 monitor 的 channel 空闲）——这也是 #798 验证时没暴露的原因。

## 修法

把 `Cancelled` 从 `HotkeyEvent` 枚举中拆出（编译器强制所有平台改到位），Esc 在 tap/hook 回调里改发独立的 `Sender<()>`，由专用 `esc-cancel-bridge` 线程消费并调 `cancel_session`（纯同步快路径，不 await）：

- `hotkey.rs`：`HotkeyMonitor::start` 新增 `cancel_tx: Sender<()>` 参数；macOS CGEventTap 与 Windows `WH_KEYBOARD_LL` 的 Esc 分支改发 cancel 通道；Linux 占位 adapter / mobile stub 同步签名。
- `hotkey_loops.rs`：新增 `esc_cancel_bridge_loop` + `spawn_esc_cancel_bridge`；两个 bridge loop 删除 `Cancelled` 臂；Less Computer 修饰键 monitor 的 Esc 转发同样迁移（`cancel_session` 幂等，双 tap 重复触发无害）。

Pressed/Released 的串行化语义（#468/#475）完全不动。

## 验证

- `cargo check` / `cargo check --tests` 通过；`cargo test` 794 passed。
- 取消旗标置位后，转写阶段由 #798 的 select! 立即 drop 在途请求，润色阶段由 `should_cancel` 停止流式输出——两个阶段均恢复可中断。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Route Esc cancel through dedicated `esc_cancel_bridge` thread

- Remove `HotkeyEvent::Cancelled` and use `Sender<()>` cancel channel

- Update macOS/Windows listeners plus Linux/mobile stubs

- Add unit tests for recording-skip and idempotent cancel


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>hotkey_loops.rs</strong><dd><code>Add dedicated Esc cancel bridge loop and tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src-tauri/src/coordinator/hotkey_loops.rs

<ul><li>Add <code>esc_cancel_bridge_loop</code> and <code>spawn_esc_cancel_bridge</code> for a dedicated <br>cancel consumer.<br> <li> Remove <code>HotkeyEvent::Cancelled</code> handling from hotkey and less-computer <br>bridge loops.<br> <li> Spawn cancel bridge and pass <code>cancel_tx</code> to <code>HotkeyMonitor::start</code>.<br> <li> Add unit tests covering Processing cancel, recording skip, and <br>repeated signals.</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/853/files#diff-6ac2653587479859e5a792fd19c46c7ba3c553387935bd4e090c68d61b7144ac">+151/-6</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>hotkey.rs</strong><dd><code>Split Esc cancel into dedicated channel</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src-tauri/src/hotkey.rs

<ul><li>Remove <code>Cancelled</code> variant from <code>HotkeyEvent</code>.<br> <li> Thread <code>Sender<()></code> cancel channel through monitor, adapters, listener <br>loops, and contexts.<br> <li> macOS <code>handle_key_down</code> and Windows <code>dispatch_keyboard_event</code> send Esc on <br>cancel channel.<br> <li> Linux placeholder adapter accepts the new cancel channel parameter.</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/853/files#diff-f37b55b08938663b38e59e53ba8da02d59954d3f07dfbfa3a6c84aa7a43a3148">+50/-13</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Miscellaneous</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>hotkey.rs</strong><dd><code>Update mobile hotkey stub for cancel channel</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src-tauri/src/mobile_stubs/hotkey.rs

<ul><li>Remove <code>Cancelled</code> variant from mobile stub <code>HotkeyEvent</code>.<br> <li> Add <code>_cancel_tx</code> parameter to <code>HotkeyMonitor::start</code>.</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/853/files#diff-114d8aa503a4ba9c2a9bcca56499268189dbac8c6dbdcb9058f0036587865227">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>coordinator.rs</strong><dd><code>Wire Esc cancel bridge into hotkey startup</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src-tauri/src/coordinator.rs

<ul><li>Spawn <code>esc_cancel_bridge</code> before each <code>HotkeyMonitor::start</code> call.<br> <li> Pass cancel channel to initial and supervisor hotkey monitors.<br> <li> Update less-computer modifier monitor to forward Esc cancel.</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/853/files#diff-73d8c004670b27293f74f0f3991b9a6fc28f0ff0b883214de2b078b1e09797ca">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

