### PR TITLE
feat(hotkey): 会话激活期间 Esc 由 OpenLess 独占——不再透传宿主应用

### DIFF
--- a/openless-all/app/src-tauri/src/coordinator.rs
+++ b/openless-all/app/src-tauri/src/coordinator.rs
@@ -3356,6 +3356,34 @@ mod tests {
         assert_eq!(coordinator.inner.state.lock().phase, SessionPhase::Idle);
     }
 
+    #[tokio::test]
+    async fn stale_capsule_idle_schedule_does_not_hide_newer_state() {
+        let coordinator = Coordinator::new();
+        // 旧 schedule 触发时若期间有更新的 emit，应跳过隐藏（voice agent 取消双 emit 竞争）。
+        emit_capsule(&coordinator.inner, CapsuleState::Done, 0.0, 0, None, None);
+        schedule_capsule_idle(&coordinator.inner, 30);
+        emit_capsule(&coordinator.inner, CapsuleState::Cancelled, 0.0, 0, None, None);
+        tokio::time::sleep(std::time::Duration::from_millis(120)).await;
+        assert_eq!(
+            coordinator.inner.last_capsule_state.lock().as_ref().copied(),
+            Some(CapsuleState::Cancelled),
+            "旧 schedule 不应把更新的 Cancelled 状态提前隐藏"
+        );
+    }
+
+    #[tokio::test]
+    async fn capsule_idle_schedule_hides_when_no_newer_state() {
+        let coordinator = Coordinator::new();
+        emit_capsule(&coordinator.inner, CapsuleState::Done, 0.0, 0, None, None);
+        schedule_capsule_idle(&coordinator.inner, 30);
+        tokio::time::sleep(std::time::Duration::from_millis(120)).await;
+        assert_eq!(
+            coordinator.inner.last_capsule_state.lock().as_ref().copied(),
+            Some(CapsuleState::Idle),
+            "无新 emit 时 schedule 应隐藏胶囊"
+        );
+    }
+
     #[test]
     fn cancel_session_state_machine_is_table_driven() {
         let cases = [
@@ -3933,9 +3961,16 @@ fn set_phase_idle_if_session_matches(inner: &Arc<Inner>, session_id: SessionId) 
 }
 
 fn schedule_capsule_idle(inner: &Arc<Inner>, delay_ms: u64) {
+    // 记录触发时胶囊显示的状态；到点时若期间有更新的 emit（last_capsule_state 已变），
+    // 说明本次状态已被后续 emit 取代，隐藏交给那次 emit 自己的 schedule——避免旧
+    // schedule 把新状态提前隐藏（如 voice agent 取消路径 cancel_session 与收尾双 emit）。
+    let expect = inner.last_capsule_state.lock().as_ref().copied();
     let inner_clone = Arc::clone(inner);
     async_runtime::spawn(async move {
         tokio::time::sleep(std::time::Duration::from_millis(delay_ms)).await;
+        if inner_clone.last_capsule_state.lock().as_ref().copied() != expect {
+            return;
+        }
         // 必须 dictation **和** QA 同时空闲才能隐藏胶囊。否则旧 dictation Done timer
         // 的尾巴会在新 QA 录音/思考中把胶囊意外收掉（issue #118 v2 复现）。
         let dictation_idle = inner_clone.state.lock().phase == SessionPhase::Idle;

--- a/openless-all/app/src-tauri/src/coordinator/capsule_focus.rs
+++ b/openless-all/app/src-tauri/src/coordinator/capsule_focus.rs
@@ -378,6 +378,16 @@ pub(super) fn hide_capsule_window_if_present() {
 #[cfg(not(target_os = "windows"))]
 pub(super) fn hide_capsule_window_if_present() {}
 
+/// Esc 独占判定：胶囊显示「进行中」（录音/转写/润色）且确为 dictation 会话（phase 非
+/// Idle）时为 true——tap/hook 吞掉 Esc 不透传宿主应用。phase 条件专门排除 QA：QA 也走
+/// 胶囊，但它的 Esc 由聚焦浮窗处理（#161），全局吞键反而会把它挡掉。纯函数便于表格测试。
+fn esc_exclusive_for_capsule(state: CapsuleState, phase: SessionPhase) -> bool {
+    matches!(
+        state,
+        CapsuleState::Recording | CapsuleState::Transcribing | CapsuleState::Polishing
+    ) && !matches!(phase, SessionPhase::Idle)
+}
+
 pub(super) fn emit_capsule(
     inner: &Arc<Inner>,
     state: CapsuleState,
@@ -395,10 +405,7 @@ pub(super) fn emit_capsule(
     // QA：QA 会话也走胶囊，但它的 Esc 由聚焦的浮窗窗口处理，吞键反而会把它挡掉。
     // 终止帧（Done/Cancelled/Error/Idle）自然清除。emit_capsule 是所有会话状态变化的
     // 单一出口（含 #77 审计保证的全部终止路径），在此维护不会漏路径。
-    let esc_exclusive = matches!(
-        state,
-        CapsuleState::Recording | CapsuleState::Transcribing | CapsuleState::Polishing
-    ) && !matches!(inner.state.lock().phase, SessionPhase::Idle);
+    let esc_exclusive = esc_exclusive_for_capsule(state, inner.state.lock().phase);
     crate::hotkey::set_esc_exclusive(esc_exclusive);
     let app_opt = inner.app.lock().clone();
     let Some(app) = app_opt else { return };
@@ -701,5 +708,52 @@ pub(super) fn maybe_position_capsule_bottom_center<R: tauri::Runtime>(
     if crate::position_capsule_bottom_center(window, translation_active).is_ok() {
         let mut last = inner.capsule_layout.lock();
         *last = Some(next);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::CapsuleState;
+
+    #[test]
+    fn esc_exclusive_flag_matches_capsule_and_phase() {
+        // 进行中胶囊 + dictation phase 非 Idle → 独占 Esc（不透传宿主应用）。
+        for (state, phase) in [
+            (CapsuleState::Recording, SessionPhase::Listening),
+            (CapsuleState::Transcribing, SessionPhase::Processing),
+            (CapsuleState::Polishing, SessionPhase::Processing),
+            (CapsuleState::Recording, SessionPhase::Inserting),
+        ] {
+            assert!(
+                esc_exclusive_for_capsule(state, phase),
+                "{state:?} @ {phase:?} 应独占 Esc"
+            );
+        }
+
+        // 终止帧（Done/Cancelled/Error/Idle）→ 清除独占。
+        for (state, phase) in [
+            (CapsuleState::Done, SessionPhase::Idle),
+            (CapsuleState::Cancelled, SessionPhase::Idle),
+            (CapsuleState::Error, SessionPhase::Idle),
+            (CapsuleState::Idle, SessionPhase::Idle),
+        ] {
+            assert!(
+                !esc_exclusive_for_capsule(state, phase),
+                "{state:?} @ {phase:?} 不应独占 Esc"
+            );
+        }
+
+        // QA 场景：胶囊显示进行中但 dictation phase=Idle → 不独占（Esc 归浮窗，#161）。
+        for (state, phase) in [
+            (CapsuleState::Recording, SessionPhase::Idle),
+            (CapsuleState::Transcribing, SessionPhase::Idle),
+            (CapsuleState::Polishing, SessionPhase::Idle),
+        ] {
+            assert!(
+                !esc_exclusive_for_capsule(state, phase),
+                "{state:?} @ {phase:?}（QA）不应独占 Esc"
+            );
+        }
     }
 }

--- a/openless-all/app/src-tauri/src/coordinator/capsule_focus.rs
+++ b/openless-all/app/src-tauri/src/coordinator/capsule_focus.rs
@@ -389,6 +389,17 @@ pub(super) fn emit_capsule(
     // 在 app 句柄校验之前记录，便于无 GUI 的测试断言「按下热键 → 弹了哪种胶囊」。
     // replace 顺带取回上一帧 state，用于判断本次是不是「入场帧」（见下方 defer_capsule_emit）。
     let prev_state = inner.last_capsule_state.lock().replace(state);
+    // Esc 独占窗口：胶囊显示进行中（录音/转写/润色）且确为 dictation 会话（phase 非
+    // Idle）时，tap/hook 吞掉 Esc 不透传宿主应用——此刻 Esc 的语义是「取消这个会话」，
+    // 双重派发会顺带触发宿主应用的 Esc（如取消 Claude 正在生成的回复）。phase 条件排除
+    // QA：QA 会话也走胶囊，但它的 Esc 由聚焦的浮窗窗口处理，吞键反而会把它挡掉。
+    // 终止帧（Done/Cancelled/Error/Idle）自然清除。emit_capsule 是所有会话状态变化的
+    // 单一出口（含 #77 审计保证的全部终止路径），在此维护不会漏路径。
+    let esc_exclusive = matches!(
+        state,
+        CapsuleState::Recording | CapsuleState::Transcribing | CapsuleState::Polishing
+    ) && !matches!(inner.state.lock().phase, SessionPhase::Idle);
+    crate::hotkey::set_esc_exclusive(esc_exclusive);
     let app_opt = inner.app.lock().clone();
     let Some(app) = app_opt else { return };
     let translation = inner.translation_modifier_seen.load(Ordering::SeqCst);

--- a/openless-all/app/src-tauri/src/coordinator/dictation.rs
+++ b/openless-all/app/src-tauri/src/coordinator/dictation.rs
@@ -1005,6 +1005,13 @@ pub(super) async fn run_voice_agent_transcript(
         }
         None => outcome,
     };
+    // 审批等待期间会话被取消（Esc）：把结果强制为 Cancelled，避免把第一轮拦截文本
+    // 当 Done 收尾（cancelled 旗标已置、插入被跳过；胶囊/浮窗语义应一致显示「已取消」）。
+    let final_outcome = if inner.state.lock().cancelled {
+        LessComputerOutcome::Cancelled
+    } else {
+        final_outcome
+    };
 
     {
         let mut state = inner.state.lock();
@@ -1356,10 +1363,19 @@ async fn maybe_request_approval(
         }),
     );
 
-    // 等用户点 Approve/Deny；90s 无响应按 Deny 处理并清理注册表项。
-    let approved = match tokio::time::timeout(std::time::Duration::from_secs(90), rx).await {
-        Ok(Ok(v)) => v,
-        _ => {
+    // 等用户点 Approve/Deny；90s 无响应按 Deny 处理并清理注册表项。会话被取消
+    // （Esc → esc-cancel-bridge → cancel_session 置 cancelled，PR #855 场景）时
+    // 同样按 Deny 处理并清理——否则审批挂起期间 Esc 被独占吞掉却毫无效果。
+    let approved = tokio::select! {
+        v = rx => v.unwrap_or(false),
+        _ = tokio::time::sleep(std::time::Duration::from_secs(90)) => {
+            less_computer_approvals()
+                .lock()
+                .ok()
+                .map(|mut m| m.remove(&token));
+            false
+        }
+        _ = wait_for_processing_cancel(inner) => {
             less_computer_approvals()
                 .lock()
                 .ok()
@@ -3729,6 +3745,25 @@ mod tests {
         ChineseScriptPreference, CorrectionRule, DictationSession, InsertStatus, PolishMode,
     };
     use uuid::Uuid;
+
+    #[tokio::test]
+    async fn approval_request_is_denied_when_session_cancelled_during_wait() {
+        let coordinator = crate::coordinator::Coordinator::new();
+        {
+            let mut state = coordinator.inner.state.lock();
+            state.cancelled = true; // 模拟审批挂起期间用户按 Esc（cancel_session 置位）
+        }
+        let outcome = super::LessComputerOutcome::Done {
+            text: "permission denied: rm -rf".into(),
+            cost_usd: None,
+        };
+        let result = super::maybe_request_approval(&coordinator.inner, &outcome).await;
+        assert_eq!(result, None, "会话取消后审批应按 Deny 处理");
+        assert!(
+            super::less_computer_approvals().lock().unwrap().is_empty(),
+            "取消后审批注册表应被清理"
+        );
+    }
 
     #[test]
     fn silent_retry_replaces_initial_asr_attribution() {

--- a/openless-all/app/src-tauri/src/hotkey.rs
+++ b/openless-all/app/src-tauri/src/hotkey.rs
@@ -200,6 +200,22 @@ fn send_cancel_or_log(tx: &Sender<()>) {
     }
 }
 
+/// 会话激活期间（胶囊显示录音/转写/润色中）Esc 由 OpenLess 独占：tap/hook 吞掉
+/// keydown 不透传宿主应用。否则一次 Esc 双重生效——既取消 OpenLess 会话，又触发
+/// 宿主应用自己的 Esc 语义（如取消 Claude 正在生成的回复）。对照输入法的行为：
+/// 组合窗激活时 Esc 只取消候选词、宿主应用收不到。keyup 不吞：宿主应用几乎都在
+/// keydown 上响应 Esc，孤儿 keyup 无害，且窗口期内会话结束时吞 up 不吞 down 反而
+/// 会造成不成对。由 coordinator 的 emit_capsule 在胶囊状态变化时更新。
+static ESC_EXCLUSIVE: AtomicBool = AtomicBool::new(false);
+
+pub fn set_esc_exclusive(active: bool) {
+    ESC_EXCLUSIVE.store(active, std::sync::atomic::Ordering::SeqCst);
+}
+
+fn esc_exclusive() -> bool {
+    ESC_EXCLUSIVE.load(std::sync::atomic::Ordering::SeqCst)
+}
+
 type StartupTx<T> = mpsc::Sender<Result<T, HotkeyInstallError>>;
 
 struct ListenerThread<T> {
@@ -300,7 +316,7 @@ mod platform {
     use std::sync::Arc;
 
     use super::{
-        install_error, reset_shared_held_state, send_cancel_or_log, send_or_log,
+        esc_exclusive, install_error, reset_shared_held_state, send_cancel_or_log, send_or_log,
         start_listener_thread, update_shared_binding, update_shared_modifier_shortcuts,
         HotkeyAdapter, HotkeyEvent, Shared, StartupTx,
     };
@@ -560,6 +576,11 @@ mod platform {
                 handle_key_down(ctx, event);
                 let keycode = unsafe { CGEventGetIntegerValueField(event, KEYBOARD_EVENT_KEYCODE) };
                 crate::side_aware_combo::platform::dispatch_keycode(keycode, false, 0, true);
+                // 会话激活期间独占消费 Esc：返回 null 删除事件（active tap），宿主应用
+                // 收不到，避免「取消会话」与宿主 Esc 语义双重生效。见 esc_exclusive 注释。
+                if keycode == ESC_KEYCODE && esc_exclusive() {
+                    return std::ptr::null_mut();
+                }
             }
             KEY_UP => {
                 let keycode = unsafe { CGEventGetIntegerValueField(event, KEYBOARD_EVENT_KEYCODE) };
@@ -807,7 +828,7 @@ mod platform {
     };
 
     use super::{
-        install_error, reset_shared_held_state, send_cancel_or_log, send_or_log,
+        esc_exclusive, install_error, reset_shared_held_state, send_cancel_or_log, send_or_log,
         start_listener_thread, update_shared_binding, update_shared_modifier_shortcuts,
         HotkeyAdapter, HotkeyEvent, Shared, StartupTx,
     };
@@ -988,7 +1009,9 @@ mod platform {
     fn dispatch_keyboard_event(ctx: &CallbackContext, vk_code: u32, message: usize) -> bool {
         if vk_code == VK_ESCAPE && (message == WM_KEYDOWN || message == WM_SYSKEYDOWN) {
             send_cancel_or_log(&ctx.cancel_tx);
-            return false;
+            // 会话激活期间独占消费 Esc（返回 true → LRESULT(1) 吞掉），宿主应用收不到，
+            // 避免「取消会话」与宿主 Esc 语义双重生效。见 esc_exclusive 注释。
+            return esc_exclusive();
         }
 
         let pressed = matches!(message, WM_KEYDOWN | WM_SYSKEYDOWN);

--- a/openless-all/app/src-tauri/src/mobile_stubs/hotkey.rs
+++ b/openless-all/app/src-tauri/src/mobile_stubs/hotkey.rs
@@ -15,6 +15,9 @@ pub enum HotkeyEvent {
     QaShortcutPressed,
 }
 
+/// Mobile 无全局键盘监听，Esc 独占为 no-op。
+pub fn set_esc_exclusive(_active: bool) {}
+
 pub struct HotkeyMonitor;
 
 impl HotkeyMonitor {


### PR DESCRIPTION
### **User description**
> **依赖 [#853](https://github.com/Open-Less/openless/pull/853),请先合并那个。** 没有独立取消通道的话,Processing 期间吞掉的 Esc 无法真正触发取消,会退化成「吃掉按键但什么都不做」。

## 问题

胶囊转圈(录音/转写/润色)时按 Esc,OpenLess 取消会话的同时,**宿主应用也收到了这个 Esc**——一次按键双重生效。典型场景:在 Claude 里边对话边听写,按 Esc 想取消转写,结果顺带把 Claude 正在生成的回复也取消了。

## 交互模型

参照输入法:组合窗激活时按 Esc,取消的是候选词,宿主应用收不到这个键——因为此刻用户的意图对象显然是输入法。胶囊显示进行中的会话时完全同构:Esc 的语义就是「取消这个会话」,应当被独占消费。一次输入触发两个语义(且第二个是破坏性的)违反基本交互原则。

Windows 底层钩子**本来就吞掉听写触发键**(返回 `LRESULT(1)`),唯独 Esc 一直放行——本 PR 是把同一语义补齐到 Esc,并给 macOS 补上对应能力(active tap 返回 null 删除事件)。

## 实现

- `hotkey.rs`:进程级 `ESC_EXCLUSIVE` 旗标 + `set_esc_exclusive()`。置位期间 macOS tap 对 Esc keydown 返回 null,Windows 钩子返回 `LRESULT(1)`。keyup 不吞(宿主应用几乎都在 keydown 响应 Esc,孤儿 keyup 无害)。
- `capsule_focus.rs`:在 `emit_capsule`(所有会话状态变化的单一出口,含 #77 审计保证的全部终止路径)维护旗标——胶囊为 `Recording/Transcribing/Polishing` **且 dictation phase 非 Idle** 时置位,终止帧(Done/Cancelled/Error/Idle)自然清除。
- **phase 条件专门排除 QA 会话**:QA 也走胶囊,但它的 Esc 由聚焦的浮窗窗口自行处理(#161 的路由),全局吞键反而会把浮窗的 Esc 挡掉。QA 行为完全不变。
- 卡死风险有界:万一 Processing 挂住,吞键窗口由转写全局超时兜底,不会永久吃掉全系统的 Esc;进程退出则 tap 一并消失。

## 验证

- `cargo check --tests` 干净;`cargo test` 794 passed。
- daily 构建 dogfood 实测通过(macOS):转写/润色中按 Esc → 会话取消且宿主应用无反应;空闲时 Esc 正常透传;QA 浮窗 Esc 行为不变。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Bug fix, Enhancement, Tests


___

### **Description**
- Add process-wide `ESC_EXCLUSIVE` flag, maintained by `emit_capsule`.

- macOS tap and Windows hook consume Esc during active dictation.

- Exclude QA sessions; Esc remains owned by focused floating panel.

- Harden capsule idle scheduling and approval cancellation races.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Esc["Esc keydown"] --> Listener["Platform listener (macOS tap / Windows hook)"]
  Listener --> Check{"esc_exclusive?"}
  Check -- "yes" --> Consume["Return null / LRESULT(1)"]
  Check -- "no" --> Host["Pass to host app"]
  emit_capsule["emit_capsule state change"] --> Flag["set_esc_exclusive"]
  Flag --> Check
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>coordinator.rs</strong><dd><code>Guard capsule idle timers and approval cancellation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src-tauri/src/coordinator.rs

<ul><li>Add tests for stale capsule idle schedule and idle hide behavior.<br> <li> Modify <code>schedule_capsule_idle</code> to skip stale timers when a newer state <br>is emitted.<br> <li> Force final outcome to <code>Cancelled</code> when session is cancelled after <br>approval wait.<br> <li> Treat cancellation during approval wait as Deny and clean up the <br>approval registry.</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/855/files#diff-73d8c004670b27293f74f0f3991b9a6fc28f0ff0b883214de2b078b1e09797ca">+35/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>dictation.rs</strong><dd><code>Handle cancellation during approval wait</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src-tauri/src/coordinator/dictation.rs

<ul><li>Force final outcome to <code>Cancelled</code> when cancelled flag is set after <br>approval.<br> <li> Use <code>tokio::select!</code> to abort approval wait on processing cancel.<br> <li> Clean up approval registry on session cancellation.<br> <li> Add unit test for approval denied on session cancel.</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/855/files#diff-4cf79887f41f4811eb2b1ef682c62ee34c14a0ab969362a9ba1046de59c8578b">+39/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>capsule_focus.rs</strong><dd><code>Maintain Esc exclusivity in capsule state emit</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src-tauri/src/coordinator/capsule_focus.rs

<ul><li>Add pure helper <code>esc_exclusive_for_capsule</code> for Esc exclusivity <br>decisions.<br> <li> Update <code>ESC_EXCLUSIVE</code> flag in <code>emit_capsule</code> based on capsule state and <br>dictation phase.<br> <li> Add table-driven tests covering active, terminal, and QA scenarios.</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/855/files#diff-33748f0457086ffe0757eff826cdd9f835f70a86f7a6a9a1071038ff8b64892e">+65/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>hotkey.rs</strong><dd><code>Consume Esc in platform listeners when exclusive</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src-tauri/src/hotkey.rs

<ul><li>Add process-wide <code>ESC_EXCLUSIVE</code> atomic flag and <code>set_esc_exclusive</code> <br>helper.<br> <li> macOS active tap returns null for Esc keydown when exclusive.<br> <li> Windows low-level hook returns <code>LRESULT(1)</code> for Esc keydown when <br>exclusive.</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/855/files#diff-f37b55b08938663b38e59e53ba8da02d59954d3f07dfbfa3a6c84aa7a43a3148">+26/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Miscellaneous</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>hotkey.rs</strong><dd><code>Add mobile stub for Esc exclusivity</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src-tauri/src/mobile_stubs/hotkey.rs

- Add no-op `set_esc_exclusive` stub for mobile platforms.


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/855/files#diff-114d8aa503a4ba9c2a9bcca56499268189dbac8c6dbdcb9058f0036587865227">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

