### PR TITLE
fix(android): hide overview activity heatmap on mobile (#861)

### DIFF
--- a/openless-all/app/src/pages/Overview.tsx
+++ b/openless-all/app/src/pages/Overview.tsx
@@ -76,15 +76,17 @@ export function Overview({ onOpenHistory }: OverviewProps) {
   }, []);
 
   // 年度活动热力图数据（独立于历史内容存储，清空历史不影响）。加载失败仅隐藏卡片。
+  // 移动端跳过 IPC 与渲染（issue #861）：热力图横向宽度固定，窄屏易溢出并拖慢 WebView。
   const [activity, setActivity] = useState<ActivityDay[] | null>(null);
   useEffect(() => {
+    if (mobile) return;
     getActivityStats()
       .then(setActivity)
       .catch(error => {
         console.error('[overview] failed to load activity stats', error);
         setActivity(null);
       });
-  }, []);
+  }, [mobile]);
 
   const refreshCredentials = useCallback(() => {
     const requestSeq = credentialsRequestSeq.current + 1;
@@ -204,10 +206,14 @@ export function Overview({ onOpenHistory }: OverviewProps) {
 
       {/* 年度活动热力图（8starlabs Heatmap 规格）：过去一年每日听写次数。
           数据来自独立的 activity 计数存储，与历史保留策略解耦；
-          可在设置 → 通用 → 外观 里单独关闭。 */}
-      {prefs?.showOverviewActivityHeatmap !== false && activity && activity.length > 0 && (
-        <ActivityHeatmapCard activity={activity} />
-      )}
+          可在设置 → 通用 → 外观 里单独关闭。
+          移动端（useMobileLayout）不渲染，避免窄屏横向溢出（issue #861）。 */}
+      {!mobile &&
+        prefs?.showOverviewActivityHeatmap !== false &&
+        activity &&
+        activity.length > 0 && (
+          <ActivityHeatmapCard activity={activity} />
+        )}
 
       {/* 底部一行 = flex:1 撑满剩余高度（父 wrapper 是 display:flex/column）。
           只有「最近识别」内部允许滚动；其他卡片按内容自然高度，不破裂底部圆角。


### PR DESCRIPTION
### **User description**
## Summary
- Skip `getActivityStats()` IPC when `useMobileLayout()` is true so Android / narrow screens do not fetch 365-day activity data.
- Do not render `ActivityHeatmapCard` on mobile layout, avoiding fixed-width heatmap overflow that broke bottom-nav alignment.
- Desktop Overview behavior and the Theme settings toggle are unchanged.

Closes #861

## Test plan
- [ ] Android / narrow window (<720px): Overview has no「年度活动」card; no `getActivityStats` call
- [ ] Desktop: heatmap still shows when prefs allow; Theme → activity heatmap toggle still works
- [ ] Mobile bottom nav width/alignment OK, no horizontal overflow
- [ ] Resize from narrow → wide: heatmap data loads and card appears (effect depends on `mobile`)

Made with [Cursor](https://cursor.com)


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Skip activity data request when useMobileLayout is true

- Hide ActivityHeatmapCard on narrow screens to avoid overflow

- Fix bottom-nav alignment and improve mobile performance


___

### Diagram Walkthrough


```mermaid
flowchart LR
    A[Overview.tsx] --> B{mobile layout?}
    B -- Yes --> C[Skip getActivityStats & render]
    B -- No --> D[Fetch activity & show heatmap]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Overview.tsx</strong><dd><code>Conditionally skip heatmap on mobile</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src/pages/Overview.tsx

<ul><li>Added early return in useEffect for mobile to skip getActivityStats <br>IPC<br> <li> Conditionally render ActivityHeatmapCard only when not mobile<br> <li> Updated code comments to document the mobile handling (issue #861)</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/863/files#diff-87ea690f4abf573183a65635bee8aae0f788da0bc4b4f030f53756fa16f8aae2">+11/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

