### PR TITLE
fix(asr): WebSocket 建连补超时——握手挂死不再让热键彻底失灵（只能重启 app）

### DIFF
--- a/openless-all/app/src-tauri/src/asr/bailian.rs
+++ b/openless-all/app/src-tauri/src/asr/bailian.rs
@@ -31,6 +31,10 @@ pub const DEFAULT_MODEL: &str = "fun-asr-realtime";
 pub const TARGET_AUDIO_CHUNK_BYTES: usize = 3_200;
 const BYTES_PER_MS: u64 = 32;
 const FINAL_RESULT_TIMEOUT: Duration = Duration::from_secs(12);
+/// WebSocket 建连（TCP + TLS + HTTP upgrade）本身的上限。没有它 `connect_async` 会无限
+/// 等，而 `open_session` 是在串行的 hotkey bridge 线程上 `block_on` 等的 —— 卡住就意味着
+/// 热键彻底失灵（开不了也停不了，只能退出重开）。详见 stepfun_realtime.rs 同名常量。
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
 
 type WsStream = WebSocketStream<MaybeTlsStream<TcpStream>>;
 type WsSink = futures_util::stream::SplitSink<WsStream, Message>;
@@ -149,8 +153,14 @@ impl BailianRealtimeASR {
                 .map_err(|e| BailianASRError::ConnectionFailed(e.to_string()))?,
         );
 
-        let (ws, _resp) = connect_async(request)
+        let (ws, _resp) = tokio::time::timeout(CONNECT_TIMEOUT, connect_async(request))
             .await
+            .map_err(|_| {
+                BailianASRError::ConnectionFailed(format!(
+                    "连接超时（{} ms）",
+                    CONNECT_TIMEOUT.as_millis()
+                ))
+            })?
             .map_err(|e| BailianASRError::ConnectionFailed(e.to_string()))?;
         let (write, read) = ws.split();
         *self.writer.lock().await = Some(write);

--- a/openless-all/app/src-tauri/src/asr/qwen_realtime.rs
+++ b/openless-all/app/src-tauri/src/asr/qwen_realtime.rs
@@ -43,6 +43,10 @@ const BYTES_PER_MS: u64 = 32;
 const FINAL_RESULT_TIMEOUT: Duration = Duration::from_secs(12);
 const SESSION_READY_TIMEOUT: Duration = Duration::from_secs(5);
 const WRITE_TIMEOUT: Duration = Duration::from_secs(5);
+/// WebSocket 建连（TCP + TLS + HTTP upgrade）本身的上限。没有它 `connect_async` 会无限
+/// 等，而 `open_session` 是在串行的 hotkey bridge 线程上 `block_on` 等的 —— 卡住就意味着
+/// 热键彻底失灵（开不了也停不了，只能退出重开）。详见 stepfun_realtime.rs 同名常量。
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
 /// server_vad 断句静默阈值。官方默认 400ms；取 500ms 降低说话中途换气被切断的概率。
 const VAD_SILENCE_DURATION_MS: u32 = 500;
 
@@ -170,8 +174,14 @@ impl Qwen3RealtimeASR {
             .headers_mut()
             .insert("OpenAI-Beta", HeaderValue::from_static("realtime=v1"));
 
-        let (ws, _resp) = connect_async(request)
+        let (ws, _resp) = tokio::time::timeout(CONNECT_TIMEOUT, connect_async(request))
             .await
+            .map_err(|_| {
+                Qwen3ASRError::ConnectionFailed(format!(
+                    "连接超时（{} ms）",
+                    CONNECT_TIMEOUT.as_millis()
+                ))
+            })?
             .map_err(|e| Qwen3ASRError::ConnectionFailed(e.to_string()))?;
         let (write, read) = ws.split();
         *self.writer.lock().await = Some(write);

--- a/openless-all/app/src-tauri/src/asr/stepfun_realtime.rs
+++ b/openless-all/app/src-tauri/src/asr/stepfun_realtime.rs
@@ -48,6 +48,17 @@ const BYTES_PER_MS: u64 = 32;
 const FINAL_RESULT_TIMEOUT: Duration = Duration::from_secs(12);
 const SESSION_READY_TIMEOUT: Duration = Duration::from_secs(5);
 const WRITE_TIMEOUT: Duration = Duration::from_secs(5);
+/// WebSocket 建连（TCP + TLS + HTTP upgrade）本身的上限。
+///
+/// 没有它，`connect_async` 会无限等：握手打到一半断网、公司网关 / 酒店门户静默丢包、
+/// 服务端黑洞掉连接，这个 await 就永远不返回。而 `open_session` 是在 hotkey bridge
+/// 线程上 `block_on` 等的（那条 bridge 为修 #468/#475 的 latch 竞态改成了串行），
+/// 一旦卡住，按下 / 松开全都排在队里没人处理 —— 用户的表现是「热键突然完全失灵，
+/// 录音开不了也停不了，只能退出重开」，而且没有任何提示。
+///
+/// 与 SESSION_READY_TIMEOUT 的区别：那个管的是「连上之后等 session.updated 回应」，
+/// 这个管的是「连上」本身，之前完全没人管。取值与 volcengine 侧一致。
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
 /// server_vad 断句静默阈值，与 qwen_realtime 取齐（500ms 降低换气误切概率）。
 const VAD_SILENCE_DURATION_MS: u32 = 500;
 /// 收尾补送的静音时长：必须 > VAD_SILENCE_DURATION_MS 并留网络余量，
@@ -200,8 +211,14 @@ impl StepfunRealtimeASR {
                 .map_err(|e| StepfunASRError::ConnectionFailed(e.to_string()))?,
         );
 
-        let (ws, _resp) = connect_async(request)
+        let (ws, _resp) = tokio::time::timeout(CONNECT_TIMEOUT, connect_async(request))
             .await
+            .map_err(|_| {
+                StepfunASRError::ConnectionFailed(format!(
+                    "连接超时（{} ms）",
+                    CONNECT_TIMEOUT.as_millis()
+                ))
+            })?
             .map_err(|e| StepfunASRError::ConnectionFailed(e.to_string()))?;
         let (write, read) = ws.split();
         *self.writer.lock().await = Some(write);
@@ -1085,5 +1102,43 @@ mod tests {
             "delayed speech"
         );
         server.await.unwrap();
+    }
+
+    // 服务端收下 TCP 却永不完成 WebSocket 握手（断网、公司网关 / 酒店门户静默丢包、
+    // 服务端黑洞）时，open_session 必须超时返回错误，而不是把调用方永远挂住 ——
+    // 它是在串行的 hotkey bridge 线程上 block_on 等的，一旦挂住，按下 / 松开全都排在
+    // 队列里没人处理，用户表现为「热键彻底失灵，录音开不了也停不了，只能退出重开」。
+    #[tokio::test]
+    async fn open_session_times_out_when_handshake_never_completes() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        // 收下连接后什么都不回，连接一直挂着。
+        let _server = tokio::spawn(async move {
+            let _accepted = listener.accept().await;
+            std::future::pending::<()>().await;
+        });
+
+        let asr = Arc::new(StepfunRealtimeASR::new(StepfunRealtimeCredentials {
+            api_key: "sk-test".to_string(),
+            endpoint: format!("ws://{addr}"),
+            model: String::new(),
+            prompt: None,
+        }));
+
+        let started = Instant::now();
+        let err = asr
+            .open_session()
+            .await
+            .expect_err("握手不完成时必须超时失败，不能永远挂着");
+        assert!(
+            matches!(&err, StepfunASRError::ConnectionFailed(msg) if msg.contains("连接超时")),
+            "应报连接超时，实际: {err:?}"
+        );
+        // 上限给足余量，只为证明它真的有界（没有 CONNECT_TIMEOUT 时这里会永远不返回）。
+        assert!(
+            started.elapsed() < CONNECT_TIMEOUT * 3,
+            "超时应在 CONNECT_TIMEOUT 量级返回，实际耗时 {:?}",
+            started.elapsed()
+        );
     }
 }


### PR DESCRIPTION
### **User description**
## 问题：一次挂死的建连 = 热键彻底失灵，只能重启 app

三个实时 ASR 供应商的 WebSocket 建连（`connect_async`）**没有任何超时**：

| 供应商 | 建连超时 | |
|---|---|---|
| StepFun 实时 | ❌ 无 | `asr/stepfun_realtime.rs` |
| 百炼 Qwen3 实时 | ❌ 无 | `asr/qwen_realtime.rs` |
| 百炼 | ❌ 无 | `asr/bailian.rs` |
| 火山引擎 | ✅ `CONNECT_TIMEOUT` + 有限重试 | `asr/volcengine.rs` |

这些 provider 后面都有超时（等 `session.updated` 5s、等最终结果 12s、写 5s），**唯独最外层「连上服务器」本身是无限等**。握手打到一半断网、公司网关 / 酒店门户静默丢包、服务端黑洞掉连接 —— 这个 `await` 就永远不返回。

后果不止是「这次听写失败」。`open_session` 是在 hotkey bridge 线程上 `block_on` 等的，而那条 bridge 为修 #468/#475 的 latch 竞态改成了**串行**（一次只处理一个事件，处理完才 recv 下一个）。所以它一挂：

- 按热键**开不了**录音
- 也**停不了**（松开事件同样排在队列里）
- 没有任何提示，胶囊不出现 —— 用户只会以为「热键坏了」
- **只能退出 app 重开**

## 真机复现

dogfood 构建，StepFun 实时，Auto 模式 + 左 Option。9 秒内连续开了 6 次会话（在 Notion 里打字用 Option 组合键，每次都是开会话→立刻撤销），第 6 次的建连没有返回：

```
07:20:12.595  [coord] hotkey pressed (mode=Auto, phase=Idle)
07:20:12.812  [coord] recorder started (asr=stepfun, phase=Starting)
07:20:12.916  [coord] hotkey combined with another key —— 取消本次按下开出的会话
07:20:12.936  [recorder] cpal Stream dropped (mic released)
07:20:14.201  [hotkey] 触发键与其他键组合按下 —— 撤销本次触发     ← tap 还活着
07:20:15.985  [hotkey] 触发键与其他键组合按下 —— 撤销本次触发     ← tap 还活着
                                                                  ↑ 但没有任何 hotkey pressed
```

注意后两行**前面没有 `hotkey pressed`**：键盘监听器好好的，它看见了按键；是 bridge 线程没能把「按下」处理掉。`/usr/bin/sample` 确认：

```
openless-hotkey-bridge   → __psynch_cvwait        （卡在 block_on 等 future）
com.apple.main-thread    → 正常 run loop
openless-hotkey-mac-event-tap → 正常
```

## 改动

三个文件各补一个 `CONNECT_TIMEOUT`（5s，与 volcengine 取值一致），把裸 `connect_async` 包进 `tokio::time::timeout`，超时报 `ConnectionFailed("连接超时（N ms）")`，走既有错误路径弹胶囊，**热键继续可用**。

与 `SESSION_READY_TIMEOUT` 的区别：那个管「连上之后等 `session.updated` 回应」，本次补的是「连上」本身，之前完全没人管。

只影响「连不上」这条已经坏掉的路径 —— 连得上时行为一字不变。

## 测试

新增用例：服务端收下 TCP 但永不完成 WebSocket 握手时，`open_session` 必须**有界**返回错误。没有 `CONNECT_TIMEOUT` 时这个用例会永远挂住。

```
test asr::stepfun_realtime::tests::open_session_times_out_when_handshake_never_completes ... ok
test result: ok. 795 passed; 0 failed
```

## 不在本 PR 的深层问题

真正的结构问题是 **`begin_session` 跑在串行 hotkey bridge 上**：任何一个慢 IO 都有能力冻住整个热键。本 PR 只是把「无限等」变成「有界等」，让最常见的触发方式不再致命。

把 `begin_session` 从 bridge 上挪开才是根治，但串行正是当初为修 #468/#475 的 latch 竞态引入的，动它风险高，建议单独立项。


___

### **PR Type**
Bug fix


___

### **Description**
- Add a 5s `CONNECT_TIMEOUT` to WebSocket `connect_async` in StepFun, Qwen3, and Bailian realtime ASR providers.

- Prevent hung handshakes from stalling the serial hotkey bridge, keeping hotkey recording toggles responsive.

- Add a test verifying `open_session` times out when the server accepts TCP but never completes the WebSocket handshake.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["StepFun/Qwen/Bailian connect_async"] -- "CONNECT_TIMEOUT 5s" --> B["tokio::time::timeout"]
  B -- "timeout" --> C["ConnectionFailed(连接超时)"]
  C --> D["Error path: capsule shows, hotkeys remain usable"]
  B -- "success" --> E["Session proceeds as before"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>bailian.rs</strong><dd><code>Add WebSocket connect timeout to Bailian ASR</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src-tauri/src/asr/bailian.rs

<ul><li>Add <code>CONNECT_TIMEOUT</code> constant (5s) for the WebSocket handshake.<br> <li> Wrap <code>connect_async</code> with <code>tokio::time::timeout</code> and map timeout to <br><code>ConnectionFailed</code>.</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/871/files#diff-143936d94ea5692befd16a4fac03dd1af84c868d0134ba7231b7b8a873fc44d4">+11/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>qwen_realtime.rs</strong><dd><code>Add WebSocket connect timeout to Qwen3 ASR</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src-tauri/src/asr/qwen_realtime.rs

<ul><li>Add <code>CONNECT_TIMEOUT</code> constant (5s) for the WebSocket handshake.<br> <li> Wrap <code>connect_async</code> with <code>tokio::time::timeout</code> and map timeout to <br><code>ConnectionFailed</code>.</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/871/files#diff-31a1a5d948d67f593cc84901886dfe0757c2c7595b2d089d199761b6b4d4cde6">+11/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>stepfun_realtime.rs</strong><dd><code>Add WebSocket connect timeout and test to StepFun ASR</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src-tauri/src/asr/stepfun_realtime.rs

<ul><li>Add <code>CONNECT_TIMEOUT</code> constant (5s) with detailed rationale comments.<br> <li> Wrap <code>connect_async</code> with <code>tokio::time::timeout</code> and map timeout to <br><code>ConnectionFailed</code>.<br> <li> Add <code>open_session_times_out_when_handshake_never_completes</code> test <br>covering a stalled handshake.</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/871/files#diff-8a461760eb51de563ae45851fc340271769bbe1c8ba52be55525ebeb7e0739ad">+56/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

