### PR TITLE
fix(less-computer): 「hotkey disabled」只在状态翻转时打一次——日志不再被它刷爆

### DIFF
--- a/openless-all/app/src-tauri/src/coordinator/hotkey_loops.rs
+++ b/openless-all/app/src-tauri/src/coordinator/hotkey_loops.rs
@@ -250,6 +250,16 @@ pub(super) fn coding_agent_hotkey_supervisor_loop(inner: Arc<Inner>) {
     }
 }
 
+/// 「Less Computer 语音键已禁用」是否已经打过日志。
+///
+/// supervisor 每 5s 轮询一次，没配语音键的用户每轮都会落到同一条禁用分支。无条件
+/// 打印会稳定产出 720 行/小时的同一句话 —— 实测一份跑了六天的 openless.log 里它占
+/// 了 95% 以上，真正有用的会话日志被冲得很难找，日志轮转也被它提前触发。
+/// 只在状态翻转成禁用时打一次；重新装上语音键时清掉，下次禁用还会再打。
+#[cfg(target_os = "macos")]
+static LESS_COMPUTER_HOTKEY_DISABLED_LOGGED: std::sync::atomic::AtomicBool =
+    std::sync::atomic::AtomicBool::new(false);
+
 pub(super) fn update_coding_agent_hotkey_binding_now(inner: &Arc<Inner>) {
     #[cfg(not(target_os = "macos"))]
     {
@@ -263,13 +273,16 @@ pub(super) fn update_coding_agent_hotkey_binding_now(inner: &Arc<Inner>) {
         let prefs = inner.prefs.get();
         let Some(binding) = prefs.coding_agent_voice_hotkey.clone() else {
             take_coding_agent_hotkeys_on_main_thread(inner);
-            log::info!("[less-computer] hotkey disabled");
+            if !LESS_COMPUTER_HOTKEY_DISABLED_LOGGED.swap(true, Ordering::SeqCst) {
+                log::info!("[less-computer] hotkey disabled");
+            }
             return;
         };
         if !prefs.coding_agent_enabled || is_unconfigured_shortcut(&binding) {
             take_coding_agent_hotkeys_on_main_thread(inner);
             return;
         }
+        LESS_COMPUTER_HOTKEY_DISABLED_LOGGED.store(false, Ordering::SeqCst);
 
         if let Some(modifier_binding) = less_computer_modifier_binding(&binding) {
             take_coding_agent_combo_hotkey_on_main_thread(inner);


### PR DESCRIPTION
### **User description**
## 问题

`coding_agent_hotkey_supervisor_loop` 每 5s 轮询一次绑定。**没有配置 Less Computer 语音键**的用户，每一轮都会落到 `update_coding_agent_hotkey_binding_now` 里同一条禁用分支，并无条件打一行 `[less-computer] hotkey disabled` —— 稳定 720 行/小时。

实测一份连续跑了六天的 `openless.log`：

| | |
|---|---|
| 总行数 | 132,416 |
| 其中 `hotkey disabled` | ~127,000（**95%+**） |
| 文件大小 | 11 MB |

后果不只是"日志有点吵"：

1. 真正有用的会话日志、ASR/润色报错被冲得很难翻，用户"导出日志"给我们排查时基本要先写脚本过滤；
2. 触发 `rotate_log_if_too_large` 提前轮转，把更早的历史挤掉 —— 排查间歇性问题时经常发现要看的那段已经被这行冲没了。

有点讽刺的是，它刷得最凶的恰恰是**没在用这个功能**的人：一旦配上语音键，函数会走到安装分支提前 return，反而一行都不打。

## 改动

只在状态真正**翻转**成"禁用"时打一次；重新装上语音键时清掉标志位，下次禁用仍会再打。

禁用/启用的行为本身一行没动，只动日志。`take_coding_agent_hotkeys_on_main_thread` 的调用时机、返回路径都保持原样。

## 为什么不是直接降成 `debug`

降 `debug` 会让这条信息在默认日志里彻底消失。"语音键当前是禁用的"这个状态本身是有诊断价值的（能一眼确认用户没配），只是不需要每 5 秒重复一遍。保留 `info` + 去重，既留住信息又不刷屏。

## 验证

- `cargo check` 通过，无新增 warning
- 逻辑上：首次进入禁用态打 1 行；后续每 5s 轮询静默；配上语音键后标志位复位；再次清空绑定会重新打 1 行


___

### **PR Type**
Bug fix


___

### **Description**
- Suppress repeated `[less-computer] hotkey disabled` log spam

- Add macOS-only atomic flag to log only on state transitions

- Reset flag when a valid voice hotkey binding is installed

- Reduce log volume for users without Less Computer configured


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Supervisor loop every 5s"] --> B{"Binding configured?"}
  B -- "No" --> C{"Already logged?"}
  C -- "No" --> D["Log 'hotkey disabled' once"]
  C -- "Yes" --> E["Skip log"]
  B -- "Yes" --> F["Reset logged flag and install hotkey"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>hotkey_loops.rs</strong><dd><code>Gate hotkey disabled log behind state transition flag</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src-tauri/src/coordinator/hotkey_loops.rs

<ul><li>Add <code>LESS_COMPUTER_HOTKEY_DISABLED_LOGGED</code> atomic flag on macOS<br> <li> Log <code>[less-computer] hotkey disabled</code> only when state flips to disabled<br> <li> Clear the flag when a valid hotkey binding is present and enabled<br> <li> Avoid ~720 redundant log lines per hour for unconfigured users</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/873/files#diff-6ac2653587479859e5a792fd19c46c7ba3c553387935bd4e090c68d61b7144ac">+14/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

