### PR TITLE
fix(capsule): 润色/插入失败改走 error 态——失败提示不再被前端丢掉

### DIFF
--- a/openless-all/app/src-tauri/src/coordinator/dictation.rs
+++ b/openless-all/app/src-tauri/src/coordinator/dictation.rs
@@ -3581,9 +3581,24 @@ pub(super) async fn end_session(inner: &Arc<Inner>) -> Result<(), String> {
         default_done_message(status, polish_error.is_some())
     };
 
+    // 胶囊只在 error 态渲染 message —— done 态按设计是「冻结光效淡出、不带文字」
+    // （见 Capsule.tsx 的 VoiceOrbStage：`state === 'error' && <span>{message}</span>`）。
+    // 所以失败信息必须走 error 态才看得见，否则文案算出来就被前端丢掉。
+    //
+    // 最典型的受害者是润色失败：它会静默回退成未润色的原文，而胶囊照常显示成功态，
+    // 用户界面上没有任何痕迹。实际后果是 LLM 凭证失效后，用户连着十几个小时每句话
+    // 都在拿原文，只能靠「今天出来的字怎么变笨了」察觉，日志里其实每一句都报了错。
+    let session_failed =
+        tsf_required_insert_failed || polish_error.is_some() || status == InsertStatus::Failed;
+    let capsule_state = if session_failed {
+        CapsuleState::Error
+    } else {
+        CapsuleState::Done
+    };
+
     emit_capsule(
         inner,
-        CapsuleState::Done,
+        capsule_state,
         0.0,
         elapsed,
         done_message,


### PR DESCRIPTION
### **User description**
## 问题

胶囊**只在 `error` 态渲染 `message`**。`done` 态按设计是「冻结光效淡出、不带文字」：

```tsx
// Capsule.tsx, VoiceOrbStage
{state === 'error' && (<span style={errorGlowTextStyle}>{message || t('capsule.error')}</span>)}
```

但 `end_session` 无论成败都发 `CapsuleState::Done`。于是 `default_done_message` 拼出来的失败文案，**全部在前端被丢弃**——算了、传了、不显示。

最典型的受害者是**润色失败**：LLM 调用失败时会静默回退成未润色的原文，而胶囊照常显示成功态，界面上没有任何痕迹。

`default_done_message` 里那句注释写着「polish 失败优先告知用户，即使 insert 成功也要让用户知道这版是原文」——意图完全正确，只是这句话从来没能显示出来。

## 实际影响

我在排查一台机器上的问题时撞上的：LLM 凭证意外失效后，**连续十几个小时、每一句听写都在拿未润色的原文**。日志里每一句都老老实实 `[ERROR] polish failed, falling back to raw`，但界面上一切正常。

用户的体感是「今天出来的字怎么变笨了」，完全不知道该往凭证那边查——只能靠感觉察觉，这对一个每天用几百次的功能来说代价挺大。

## 改动

按结果选状态，文案生成逻辑一行没动：

| 情况 | 改前 | 改后 |
|---|---|---|
| 润色失败（回退原文） | `Done`，提示被吞 | `Error`，红字提示 |
| 插入失败 | `Done`，提示被吞 | `Error`，红字提示 |
| TSF 未上屏 | `Done`，提示被吞 | `Error`，红字提示 |
| 正常成功 | `Done` | `Done`（不变） |

下游对三种终态（Done/Cancelled/Error）的处理是一致的（见 `capsule_focus.rs` 的终态自动清除），不需要额外适配。

## 两个想听听维护者意见的点

**1. `PasteSent` / `CopiedFallback` 的文案同样显示不出来**

`default_done_message` 还会产出「已尝试粘贴」和「已复制，请粘贴」。后者是**需要用户动手**的——粘贴失败退回复制，用户不粘贴就什么都没有。但它们不是错误，套 `error` 的红色发光样式我觉得偏重了，所以这个 PR 没动。

如果你们觉得该显示，我倾向给 `done` 态加一种中性文字样式（不是红字），可以另开 PR。想先听听你们对「done 态是否允许带文字」的设计取向。

**2. 一闪而过可能还是不够**

`CAPSULE_AUTO_HIDE_DELAY_MS` 是 2 秒。凭证失效这类问题不是偶发，是会一直错下去的，红字闪两秒仍可能被错过。或许值得在**连续失败 N 次**后于托盘/设置里挂个持久标记。这属于产品判断，没放进这个 PR。

## 验证

`cargo check` 通过，无新增 warning。


___

### **PR Type**
Bug fix


___

### **Description**
- `end_session` now sends `CapsuleState::Error` when insert/polish fails

- Previously all sessions sent `Done`, hiding failure messages

- Polish failures silently fell back to raw text with no UI indication

- Success sessions still send `CapsuleState::Done` as before


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["end_session"] --> B{"Session failed?"}
  B -- "Yes" --> C["CapsuleState::Error"]
  B -- "No" --> D["CapsuleState::Done"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>dictation.rs</strong><dd><code>Route failed sessions to error capsule state</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src-tauri/src/coordinator/dictation.rs

<ul><li>Compute <code>session_failed</code> from TSF insert failure, polish error, or <br>failed insert status<br> <li> Choose <code>CapsuleState::Error</code> for failures and <code>CapsuleState::Done</code> for <br>success<br> <li> Added comments explaining why failure messages must use error state<br> <li> Failure messages are now visible in the UI, preventing silent fallback <br>confusion</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/874/files#diff-4cf79887f41f4811eb2b1ef682c62ee34c14a0ab969362a9ba1046de59c8578b">+16/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

