### PR TITLE
fix(capsule): 入场帧强制重注册 Space 贴附——胶囊不再被 macOS 26 钉死在单个桌面

### DIFF
--- a/openless-all/app/src-tauri/src/coordinator.rs
+++ b/openless-all/app/src-tauri/src/coordinator.rs
@@ -158,10 +158,11 @@ fn capsule_state_log_name(state: CapsuleState) -> &'static str {
 fn show_capsule_window_for_recording<R: tauri::Runtime>(
     app: &AppHandle<R>,
     window: &tauri::WebviewWindow<R>,
+    reassert_spaces: bool,
 ) {
     let mut needs_fallback = true;
     if capsule_show_strategy_for_platform() == CapsuleShowStrategy::NoActivate {
-        needs_fallback = !show_capsule_window_no_activate(app, window);
+        needs_fallback = !show_capsule_window_no_activate(app, window, reassert_spaces);
         if needs_fallback && !CAPSULE_NO_ACTIVATE_FALLBACK_WARNED.swap(true, Ordering::SeqCst) {
             // 产品取舍：no-activate 是 macOS/AeroSpace 的主路径；但如果 ns_window
             // 暂不可用，仍优先保住录音反馈，不让用户以为听写没启动。fallback 可能

--- a/openless-all/app/src-tauri/src/coordinator/capsule_focus.rs
+++ b/openless-all/app/src-tauri/src/coordinator/capsule_focus.rs
@@ -245,6 +245,7 @@ pub(super) fn capture_ime_submit_target() -> Option<ImeSubmitTarget> {
 pub(super) fn show_capsule_window_no_activate<R: tauri::Runtime>(
     _app: &AppHandle<R>,
     window: &tauri::WebviewWindow<R>,
+    _reassert_spaces: bool,
 ) -> bool {
     use raw_window_handle::{HasWindowHandle, RawWindowHandle};
     use windows::Win32::Foundation::HWND;
@@ -284,8 +285,9 @@ pub(super) fn show_capsule_window_no_activate<R: tauri::Runtime>(
 
 #[cfg(target_os = "macos")]
 pub(super) fn show_capsule_window_no_activate<R: tauri::Runtime>(
-    _app: &AppHandle<R>,
+    app: &AppHandle<R>,
     window: &tauri::WebviewWindow<R>,
+    reassert_spaces: bool,
 ) -> bool {
     use objc2::msg_send;
     use objc2::runtime::AnyObject;
@@ -314,14 +316,53 @@ pub(super) fn show_capsule_window_no_activate<R: tauri::Runtime>(
     // 外加 setLevel(25)：光有 FULL_SCREEN_AUXILIARY 只是「被允许」进全屏 Space，但窗口层级
     // 若停在 alwaysOnTop 的浮动层(~3) 仍会被全屏 app 的窗口盖住而看不见；抬到菜单栏(24)之上
     // 的 25（与 show_less_computer_glow 同款）才能真正叠在全屏之上。
+    const CAN_JOIN_ALL_SPACES: usize = 1 << 0;
+    const STATIONARY: usize = 1 << 4;
+    const FULL_SCREEN_AUXILIARY: usize = 1 << 8;
+    const BEHAVIOR: usize = CAN_JOIN_ALL_SPACES | STATIONARY | FULL_SCREEN_AUXILIARY;
     unsafe {
-        const CAN_JOIN_ALL_SPACES: usize = 1 << 0;
-        const STATIONARY: usize = 1 << 4;
-        const FULL_SCREEN_AUXILIARY: usize = 1 << 8;
-        let behavior = CAN_JOIN_ALL_SPACES | STATIONARY | FULL_SCREEN_AUXILIARY;
         let _: () = msg_send![ns_window, setLevel: 25i64];
-        let _: () = msg_send![ns_window, setCollectionBehavior: behavior];
+        if reassert_spaces {
+            // 值若被外部改动过，留一条证据 —— 用于分辨「值被改」与「值没变但
+            // WindowServer 侧注册失效」（2026-07-31 事故属于后者：值一直是 273，
+            // 注册却缺了桌面，窗口被钉死在单个 Space）。
+            let current: usize = msg_send![ns_window, collectionBehavior];
+            if current != BEHAVIOR {
+                log::warn!(
+                    "[capsule] collectionBehavior drifted to {current} (expected {BEHAVIOR}); re-registering"
+                );
+            }
+            // 入场帧先以「无 CanJoinAllSpaces 位」的低值上屏（保留 Stationary/
+            // FullScreenAuxiliary，全屏叠加不受影响）。体外实验（macOS 26）证明：
+            // 只有「窗口可见时 CanJoinAllSpaces 位发生 0→1 转变」才触发 WindowServer
+            // 重新注册贴附；隐藏时改值、或同一个 runloop tick 里连写两个值（被合并）
+            // 都是 no-op。所以 273 必须等 orderFront 之后的下一个 tick 再写（见下方）。
+            let low = STATIONARY | FULL_SCREEN_AUXILIARY;
+            let _: () = msg_send![ns_window, setCollectionBehavior: low];
+        } else {
+            let _: () = msg_send![ns_window, setCollectionBehavior: BEHAVIOR];
+        }
         let _: () = msg_send![ns_window, orderFrontRegardless];
+    }
+    if reassert_spaces {
+        // 换线程再回主线程，保证落在 orderFront 之后的另一个 runloop tick——
+        // run_on_main_thread 在主线程上会内联执行，起不到隔 tick 的作用。
+        // 30ms 间隙里窗口以低值可见于当前桌面（用户正看着的那个），无可感知差异。
+        let app = app.clone();
+        let window = window.clone();
+        std::thread::spawn(move || {
+            std::thread::sleep(std::time::Duration::from_millis(30));
+            let _ = app.run_on_main_thread(move || {
+                let Ok(handle) = window.ns_window() else { return };
+                let ns_window = handle as *mut AnyObject;
+                if ns_window.is_null() {
+                    return;
+                }
+                unsafe {
+                    let _: () = msg_send![ns_window, setCollectionBehavior: BEHAVIOR];
+                }
+            });
+        });
     }
     true
 }
@@ -330,6 +371,7 @@ pub(super) fn show_capsule_window_no_activate<R: tauri::Runtime>(
 pub(super) fn show_capsule_window_no_activate<R: tauri::Runtime>(
     _app: &AppHandle<R>,
     _window: &tauri::WebviewWindow<R>,
+    _reassert_spaces: bool,
 ) -> bool {
     true
 }
@@ -338,6 +380,7 @@ pub(super) fn show_capsule_window_no_activate<R: tauri::Runtime>(
 pub(super) fn show_capsule_window_no_activate<R: tauri::Runtime>(
     _app: &AppHandle<R>,
     _window: &tauri::WebviewWindow<R>,
+    _reassert_spaces: bool,
 ) -> bool {
     false
 }
@@ -567,7 +610,16 @@ pub(super) fn emit_capsule(
                     capsule_state_log_name(state)
                 );
             }
-            show_capsule_window_for_recording(&app_for_main, &window);
+            // 入场帧（隐藏→可见）强制重注册 Space 贴附：macOS 26 观测到系统会在运行中
+            // 把窗口从「全 Space 贴附」剥离（2026-07-31 实测：胶囊被钉死单个 Space，
+            // 其它桌面上听写全程不可见），而 setCollectionBehavior 写入相同值是 no-op，
+            // 之后每帧重写 273 都救不回来。只在入场帧做一次 0→273 的翻转即可恢复注册，
+            // 30Hz 的 level 帧不做（每帧翻转会让 WindowServer 反复重排窗口）。
+            show_capsule_window_for_recording(
+                &app_for_main,
+                &window,
+                payload_for_deferred_emit.is_some(),
+            );
             // macOS/Windows 优先走 no-activate show，避免录音胶囊抢走当前工作 app 焦点。
             // 若 fallback 到 show()，OpenLess 已是前台 app 时再把 key window 还给 main。
             #[cfg(target_os = "macos")]

--- a/openless-all/app/src-tauri/src/lib.rs
+++ b/openless-all/app/src-tauri/src/lib.rs
@@ -2464,6 +2464,7 @@ pub(crate) fn show_less_computer_glow<R: tauri::Runtime>(app: &AppHandle<R>) {
     // issue #470：通知 glow 前端「可见」，恢复发光动画（隐藏时会 emit(false) 卸载发光层以释放 GPU）。
     let _ = window.emit("less-computer-glow:active", true);
     let window_clone = window.clone();
+    let app_for_reassert = app.clone();
     let _ = app.run_on_main_thread(move || {
         use objc2::msg_send;
         use objc2::runtime::AnyObject;
@@ -2476,11 +2477,32 @@ pub(crate) fn show_less_computer_glow<R: tauri::Runtime>(app: &AppHandle<R>) {
                     unsafe {
                         // 抬到菜单栏(24)/Dock 之上，让描边能真正贴到屏幕最外缘（含顶部菜单栏区域）。
                         let _: () = msg_send![ns, setLevel: 25i64];
-                        // 所有 Space 都显示、不参与窗口循环、全屏 app 上也叠加。
-                        let _: () = msg_send![ns, setCollectionBehavior: 273u64];
+                        // 所有 Space 都显示、不参与窗口循环、全屏 app 上也叠加（273 =
+                        // CanJoinAllSpaces|Stationary|FullScreenAuxiliary）。macOS 26 会在
+                        // 运行中把窗口从「全 Space 贴附」剥离且同值写入救不回（详见
+                        // show_capsule_window_no_activate 的重注册注释）；glow show 频率低，
+                        // 每次都走重注册序列：先以去掉 CanJoinAllSpaces 位的 272 上屏，
+                        // 下一个 tick 再写 273 —— 可见状态下的位翻转才触发重新注册。
+                        let _: () = msg_send![ns, setCollectionBehavior: 272u64];
                         let _: () = msg_send![ns, setIgnoresMouseEvents: true];
                         let _: () = msg_send![ns, orderFrontRegardless];
                     }
+                    let window_for_reassert = window_clone.clone();
+                    std::thread::spawn(move || {
+                        std::thread::sleep(std::time::Duration::from_millis(30));
+                        let _ = app_for_reassert.run_on_main_thread(move || {
+                            let Ok(handle) = window_for_reassert.ns_window() else {
+                                return;
+                            };
+                            let ns = handle as *mut AnyObject;
+                            if ns.is_null() {
+                                return;
+                            }
+                            unsafe {
+                                let _: () = msg_send![ns, setCollectionBehavior: 273u64];
+                            }
+                        });
+                    });
                 }
             }
             Err(_) => {


### PR DESCRIPTION
### **User description**
## 症状

用户报告「微信里不弹录音胶囊、Claude 里又有」。实测按**桌面（Space）**分而不按 App 分：胶囊被钉死在某一个桌面，用户在其它桌面听写时，麦克风开着却没有任何 UI 指示（最长观测到 78 秒无提示录音）。

## 取证（2026-07-31，macOS 26 / Darwin 25.5）

- 坏状态下，会话期间后端以 ~30Hz 调 `orderFrontRegardless`，CGWindowList 显示窗口位置/level 全对，但 `onscreen=0` 贯穿全程；
- `CGSCopySpacesForWindows`：坏状态胶囊 `spaces=[3]`（应为 `[3,5]`）；重启 App 恢复；
- **体外复现**：用 `CGSRemoveWindowsFromSpaces` 对同款设置的测试窗口人工制造相同坏状态（值仍 273、注册残缺），然后跑遍救法：

| 救法 | 结果 |
|---|---|
| 重写同值 273 + orderFront（现行为，30Hz 在干的事） | ❌ 无效 |
| 纯 hide + show | ❌ 无效 |
| 隐藏时翻转 0→273 再显示 | ❌ 无效 |
| 同一 tick 连写 0、273 | ❌ 无效（被合并） |
| **可见状态下 CanJoinAllSpaces 位 0→1 转变** | ✅ 完整恢复 |
| 跨显示器移动 | ✅ 恢复（与野外「外接屏意外自愈」观察一致） |

结论：macOS 26 上贴附注册只在「窗口可见时 CanJoinAllSpaces 位发生真实转变」时刷新；AppKit 同值写入是 no-op——这就是坏状态一旦出现便不可恢复（除重启）的机制。剥离的野生触发点未定位（拔/插显示器、新建桌面均实测良性），但修复不依赖触发点。

## 修法

- 入场帧（隐藏→可见）先以 272（去 CanJoinAllSpaces 位，保留 Stationary|FullScreenAuxiliary）上屏，30ms 后下一个主线程 tick 写回 273，强制重注册；
- 30Hz level 帧不参与（避免 WindowServer 反复重排）；
- 写前读当前值，漂移打 warn 留证据；
- glow 窗口同款写法一并加固。

## 验证

- 修复配方在体外实验中对人工制造的坏状态 100% 恢复（含紧凑 async 时序版本）；
- `cargo check` 通过（仅存量 warning）；
- 跨进程无法对真胶囊人工制造坏状态（系统限制），端到端复发场景待野外验证——修复为幂等低风险操作，正常状态下执行无副作用；复发时日志的 drift warn 可直接指认。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Bug fix


___

### **Description**
- Fix macOS 26 Space pinning of capsule window

- Reassert Spaces registration on entry frame

- Flip CanJoinAllSpaces only while window visible

- Mirror fix in glow window and log drift


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Entry["Capsule enter visible"] --> Low["setCollectionBehavior 272"]
  Low --> Show["orderFrontRegardless"]
  Show --> Wait["30ms later"]
  Wait --> Full["setCollectionBehavior 273"]
  Full --> Register["WindowServer re-registers Spaces attachment"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>coordinator.rs</strong><dd><code>Plumb reassert-spaces flag through capsule show path</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src-tauri/src/coordinator.rs

<ul><li>Adds <code>reassert_spaces</code> parameter to <code>show_capsule_window_for_recording</code><br> <li> Passes the flag through to the macOS no-activate show path<br> <li> Enables reassertion only when entering a visible capsule frame</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/875/files#diff-73d8c004670b27293f74f0f3991b9a6fc28f0ff0b883214de2b078b1e09797ca">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>capsule_focus.rs</strong><dd><code>Reassert macOS Spaces attachment via visible bit flip</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src-tauri/src/coordinator/capsule_focus.rs

<ul><li>Defines constants for <code>CanJoinAllSpaces</code>, <code>Stationary</code>, and <br><code>FullScreenAuxiliary</code><br> <li> On reassert, sets 272 (without <code>CanJoinAllSpaces</code>) before <br><code>orderFrontRegardless</code><br> <li> Writes 273 back after 30ms to trigger WindowServer re-registration<br> <li> Logs collectionBehavior drift and updates non-macOS signatures</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/875/files#diff-33748f0457086ffe0757eff826cdd9f835f70a86f7a6a9a1071038ff8b64892e">+59/-7</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>lib.rs</strong><dd><code>Apply Spaces reassert sequence to glow window</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src-tauri/src/lib.rs

<ul><li>Applies the same 272-then-273 reassert sequence to the glow window<br> <li> Sets 272 before <code>orderFrontRegardless</code>, then schedules the 273 write<br> <li> Clones the app handle for async main-thread reassert callback</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/875/files#diff-6b8eb1bbf8e378bab914f1a12962f7add5cc4ba9e013c37c9921a1032fa5e110">+24/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

