### PR TITLE
feat(asr): 支持 Qwen-Audio-3.0-ASR-Flash 整段转写

### DIFF
--- a/openless-all/app/src-tauri/src/asr/dashscope_multimodal.rs
+++ b/openless-all/app/src-tauri/src/asr/dashscope_multimodal.rs
@@ -1,6 +1,7 @@
 //! 阿里云百炼（DashScope）多模态生成同步接口的批量 ASR 客户端。
 //!
-//! `fun-asr-flash` 系列是**非实时录音文件识别**模型，走 DashScope 私有的
+//! `fun-asr-flash` 与 `qwen-audio-3.0-asr-flash` 系列是**非实时录音文件识别**
+//! 模型，走 DashScope 私有的
 //! `multimodal-generation/generation` HTTP 接口，既不是实时 WebSocket 双工
 //! （见 `bailian.rs`），也不是 OpenAI 兼容的 `/audio/transcriptions`
 //! （见 `whisper.rs`）。因此单独成一路批量客户端：录音结束后把整段 PCM 编成
@@ -28,6 +29,7 @@ pub const PROVIDER_ID: &str = "bailian-fun-asr-flash";
 pub const DEFAULT_ENDPOINT: &str =
     "https://dashscope.aliyuncs.com/api/v1/services/aigc/multimodal-generation/generation";
 pub const DEFAULT_MODEL: &str = "fun-asr-flash-2026-06-15";
+pub const QWEN_AUDIO_MODEL: &str = "qwen-audio-3.0-asr-flash";
 
 pub struct DashScopeMultimodalASR {
     api_key: String,
@@ -119,6 +121,11 @@ impl DashScopeMultimodalASR {
     }
 }
 
+pub fn is_supported_model(model: &str) -> bool {
+    let model = model.trim();
+    model == DEFAULT_MODEL || model == QWEN_AUDIO_MODEL
+}
+
 impl crate::recorder::AudioConsumer for DashScopeMultimodalASR {
     fn consume_pcm_chunk(&self, pcm: &[u8]) {
         self.buffer.lock().extend_from_slice(pcm);
@@ -154,6 +161,8 @@ pub fn dashscope_multimodal_body(model: &str, wav: &[u8]) -> Value {
         "data:audio/wav;base64,{}",
         base64::engine::general_purpose::STANDARD.encode(wav)
     );
+    // qwen-audio-3.0-asr-flash 还支持 vocabulary 与 language_hints；当前批量客户端
+    // 尚未将这两项设置映射到请求体，暂时保持自动语言检测且不传热词。
     serde_json::json!({
         "model": model,
         "input": {
@@ -262,17 +271,19 @@ mod tests {
 
     #[test]
     fn body_uses_multimodal_generation_shape() {
-        let body = dashscope_multimodal_body(DEFAULT_MODEL, b"wav");
-        assert_eq!(body["model"], DEFAULT_MODEL);
-        let audio = &body["input"]["messages"][0]["content"][0];
-        assert_eq!(audio["type"], "input_audio");
-        assert!(audio["input_audio"]["data"]
-            .as_str()
-            .unwrap()
-            .starts_with("data:audio/wav;base64,"));
-        assert_eq!(body["parameters"]["format"], "wav");
-        assert_eq!(body["parameters"]["sample_rate"], "16000");
-        assert!(body["parameters"].get("vocabulary_id").is_none());
+        for model in [DEFAULT_MODEL, QWEN_AUDIO_MODEL] {
+            let body = dashscope_multimodal_body(model, b"wav");
+            assert_eq!(body["model"], model);
+            let audio = &body["input"]["messages"][0]["content"][0];
+            assert_eq!(audio["type"], "input_audio");
+            assert!(audio["input_audio"]["data"]
+                .as_str()
+                .unwrap()
+                .starts_with("data:audio/wav;base64,"));
+            assert_eq!(body["parameters"]["format"], "wav");
+            assert_eq!(body["parameters"]["sample_rate"], "16000");
+            assert!(body["parameters"].get("vocabulary_id").is_none());
+        }
     }
 
     #[test]

--- a/openless-all/app/src-tauri/src/commands/providers.rs
+++ b/openless-all/app/src-tauri/src/commands/providers.rs
@@ -45,6 +45,7 @@ pub async fn list_provider_models(kind: String) -> Result<ProviderModelsResult, 
                 crate::asr::qwen_realtime::DEFAULT_MODEL.to_string(),
                 "qwen3-asr-flash-realtime-2026-02-10".to_string(),
                 "qwen3-asr-flash-realtime-2025-10-27".to_string(),
+                crate::asr::dashscope_multimodal::QWEN_AUDIO_MODEL.to_string(),
                 crate::asr::dashscope_multimodal::DEFAULT_MODEL.to_string(),
             ],
         });
@@ -81,7 +82,10 @@ pub async fn list_provider_models(kind: String) -> Result<ProviderModelsResult, 
     {
         // multimodal-generation 无模型列表 HTTP 接口；与 mimo 同，返回静态别名。
         return Ok(ProviderModelsResult {
-            models: vec![crate::asr::dashscope_multimodal::DEFAULT_MODEL.to_string()],
+            models: vec![
+                crate::asr::dashscope_multimodal::QWEN_AUDIO_MODEL.to_string(),
+                crate::asr::dashscope_multimodal::DEFAULT_MODEL.to_string(),
+            ],
         });
     }
     if kind == "asr" && CredentialsVault::get_active_asr() == crate::asr::elevenlabs::PROVIDER_ID {
@@ -388,7 +392,8 @@ async fn validate_elevenlabs_asr_provider() -> Result<(), String> {
     })
 }
 
-/// fun-asr-flash 官方公开示例音频，用于连通性校验。该模型对纯静音会返回
+/// DashScope 录音文件 ASR 官方公开示例音频，用于两个已支持模型的连通性校验。
+/// 这类模型对纯静音会返回
 /// 400（"no speech" 类错误），无法像 Whisper/Mimo 那样发静音探活；改用这段
 /// 阿里官方文档在案的示例 wav（由 DashScope 侧拉取），key/endpoint/model 有效
 /// 即返回 200。

--- a/openless-all/app/src-tauri/src/coordinator.rs
+++ b/openless-all/app/src-tauri/src/coordinator.rs
@@ -315,7 +315,8 @@ pub(crate) fn active_asr_provider_kind(id: &str) -> ActiveAsrProviderKind {
 /// 统一「阿里云百炼」入口的模型 → 底层协议 id 路由。
 ///
 /// 三条百炼协议（fun-asr-realtime 经典实时 / qwen3-asr-flash-realtime Realtime /
-/// fun-asr-flash 录音文件）在 UI 上收成一个 provider `bailian`（一把 key），**构建时**
+/// fun-asr-flash 与 qwen-audio-3.0-asr-flash 录音文件）在 UI 上收成一个
+/// provider `bailian`（一把 key），**构建时**
 /// 按所选模型二次路由到具体协议客户端。凭据 / 「已配置」判定仍看真实 active
 /// `bailian`（→ ApiKeyOnly，一把 key），只有这里的 build 分发用得上 effective id。
 ///
@@ -349,11 +350,11 @@ pub(crate) fn resolve_effective_asr_provider(
         Ok(crate::asr::bailian::PROVIDER_ID.to_string())
     } else if model.starts_with("qwen3-asr-flash-realtime") {
         Ok(crate::asr::qwen_realtime::PROVIDER_ID.to_string())
-    } else if model == crate::asr::dashscope_multimodal::DEFAULT_MODEL {
+    } else if crate::asr::dashscope_multimodal::is_supported_model(model) {
         Ok(crate::asr::dashscope_multimodal::PROVIDER_ID.to_string())
     } else {
         Err(format!(
-            "不支持的百炼 ASR 模型：{model}。支持 fun-asr-realtime、paraformer-realtime、sensevoice-realtime、qwen3-asr-flash-realtime 和 fun-asr-flash-2026-06-15"
+            "不支持的百炼 ASR 模型：{model}。支持 fun-asr-realtime、paraformer-realtime、sensevoice-realtime、qwen3-asr-flash-realtime、qwen-audio-3.0-asr-flash 和 fun-asr-flash-2026-06-15"
         ))
     }
 }
@@ -372,11 +373,11 @@ pub(crate) fn stepfun_model_is_stream(model: &str) -> bool {
 
 pub(crate) fn validate_dashscope_multimodal_model(model: &str) -> Result<(), String> {
     let model = model.trim();
-    if model.is_empty() || model == crate::asr::dashscope_multimodal::DEFAULT_MODEL {
+    if model.is_empty() || crate::asr::dashscope_multimodal::is_supported_model(model) {
         return Ok(());
     }
     Err(format!(
-        "不支持的 DashScope 录音文件 ASR 模型：{model}。该协议仅支持 fun-asr-flash-2026-06-15；fun-asr-flash-8k-realtime 系列属于 8 kHz 实时 WebSocket 模型，当前尚未支持"
+        "不支持的 DashScope 录音文件 ASR 模型：{model}。该协议支持 qwen-audio-3.0-asr-flash 和 fun-asr-flash-2026-06-15；fun-asr-flash-8k-realtime 系列属于 8 kHz 实时 WebSocket 模型，当前尚未支持"
     ))
 }
 
@@ -3048,6 +3049,10 @@ mod tests {
             crate::asr::dashscope_multimodal::PROVIDER_ID
         );
         assert_eq!(
+            resolve_effective_asr_provider(bailian, "qwen-audio-3.0-asr-flash").unwrap(),
+            crate::asr::dashscope_multimodal::PROVIDER_ID
+        );
+        assert_eq!(
             resolve_effective_asr_provider(bailian, "paraformer-realtime-v2").unwrap(),
             crate::asr::bailian::PROVIDER_ID
         );
@@ -3080,6 +3085,18 @@ mod tests {
         )
         .unwrap_err();
         assert!(error.contains("不支持的百炼 ASR 模型"));
+    }
+
+    #[test]
+    fn validates_only_supported_dashscope_multimodal_models() {
+        assert!(validate_dashscope_multimodal_model("").is_ok());
+        assert!(
+            validate_dashscope_multimodal_model("fun-asr-flash-2026-06-15").is_ok()
+        );
+        assert!(validate_dashscope_multimodal_model("qwen-audio-3.0-asr-flash").is_ok());
+        assert!(
+            validate_dashscope_multimodal_model("qwen-audio-3.0-asr-flash-streaming").is_err()
+        );
     }
 
     #[test]

--- a/openless-all/app/src/pages/settings/ProvidersSection.tsx
+++ b/openless-all/app/src/pages/settings/ProvidersSection.tsx
@@ -554,12 +554,14 @@ export function ProvidersSection({ kind = 'all' }: ProvidersSectionProps = {}) {
 // 统一「阿里云百炼」下,按模型名判断走哪种协议(与后端
 // coordinator::resolve_effective_asr_provider 保持一致):qwen3-asr-flash-realtime* 与
 // fun-asr-realtime* 与 fun-asr-flash-8k-realtime* 都是实时模型；当前支持的
-// fun-asr-flash-2026-06-15 是「录音文件·说完转写」。
+// fun-asr-flash-2026-06-15 / qwen-audio-3.0-asr-flash 是「录音文件·说完转写」。
 function bailianModelIsRecordedFile(model: string): boolean {
   const m = model.trim();
-  return m === 'fun-asr-flash-2026-06-15';
+  return m === 'fun-asr-flash-2026-06-15' || m === 'qwen-audio-3.0-asr-flash';
 }
 
+// qwen-audio-3.0-asr-flash 官方支持热词，但批量协议尚未把该设置写入请求体；
+// 在后端接入前不展示一个实际不生效的热词输入框。
 function bailianModelSupportsVocabulary(model: string): boolean {
   const m = model.trim();
   return !m


### PR DESCRIPTION
### **User description**
## 摘要

为阿里云百炼 ASR 增加 `qwen-audio-3.0-asr-flash` 模型支持。

该模型复用现有 DashScope `multimodal-generation/generation` 录音文件转写实现。

参考文档：
https://help.aliyun.com/en/model-studio/non-realtime-speech-recognition-user-guide

## 新增

- 在阿里云百炼模型列表中增加 `qwen-audio-3.0-asr-flash`。
- 增加该模型的路由和配置校验。
- 增加对应的请求体、模型路由及白名单测试。

## 测试计划

- [x] `INSTALL=0 ./scripts/build-mac.sh`
- [x] macOS ARM64 release 构建成功并生成 DMG。
- [x] 在 OpenLess 中选择 `qwen-audio-3.0-asr-flash`，完成录音并确认转写结果正常插入。


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Add `qwen-audio-3.0-asr-flash` to DashScope batch ASR

- Unify routing, validation, and provider model lists

- Update frontend recorded-file detection for new model

- Extend tests for routing, validation, and request body


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Bailian model selected"] --> B{"Is qwen-audio-3.0-asr-flash or fun-asr-flash?"}
  B -- "Yes" --> C["DashScope multimodal ASR client"]
  B -- "No" --> D["Other Bailian protocol"]
  C --> E["Recorded-file batch transcription"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>dashscope_multimodal.rs</strong><dd><code>Add qwen-audio model constant and validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src-tauri/src/asr/dashscope_multimodal.rs

<ul><li>Add <code>QWEN_AUDIO_MODEL</code> constant for the new model<br> <li> Introduce <code>is_supported_model</code> helper for both models<br> <li> Extend body-shape tests to cover the new model</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/876/files#diff-fc2b6eca7c0d3f8724039eb38f5475853309d588bd15ee5ad19d51f3ebc4b2c1">+23/-12</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>providers.rs</strong><dd><code>Expose qwen-audio model in provider model lists</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src-tauri/src/commands/providers.rs

<ul><li>Add new model to the Bailian provider model list<br> <li> Add new model to DashScope multimodal static aliases<br> <li> Update connectivity sample comment to cover both models</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/876/files#diff-be85f4e6da802ac2f767525263e432add7c7ed2cc175d0d400e888cb2d672ece">+7/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>coordinator.rs</strong><dd><code>Route and validate qwen-audio multimodal ASR model</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src-tauri/src/coordinator.rs

<ul><li>Route <code>qwen-audio-3.0-asr-flash</code> to multimodal provider<br> <li> Use <code>is_supported_model</code> in routing and validation<br> <li> Update error messages with new supported models<br> <li> Add routing and validation tests</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/876/files#diff-73d8c004670b27293f74f0f3991b9a6fc28f0ff0b883214de2b078b1e09797ca">+22/-5</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ProvidersSection.tsx</strong><dd><code>Recognize qwen-audio model as recorded-file ASR</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src/pages/settings/ProvidersSection.tsx

<ul><li>Recognize new model as recorded-file ASR in UI<br> <li> Add comment that vocabulary field is not yet wired</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/876/files#diff-8fc332d1eb5b010583185b704ea439954650f6aff2d0195e00cd0cb76e526e7b">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

