### PR TITLE
fix(android): install Marketplace packs from app cache

### DIFF
--- a/openless-all/app/scripts/marketplace-install-contract.test.mjs
+++ b/openless-all/app/scripts/marketplace-install-contract.test.mjs
@@ -1,0 +1,15 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const appRoot = dirname(dirname(fileURLToPath(import.meta.url)));
+const marketplaceSource = readFileSync(join(appRoot, 'src/pages/Marketplace.tsx'), 'utf8');
+
+if (marketplaceSource.includes('await logClientError(')) {
+  throw new Error('Marketplace install must not await client error logging');
+}
+if (!marketplaceSource.includes('void logClientError(clientFailureLog)')) {
+  throw new Error('Marketplace install failure logging must be fire-and-forget');
+}
+
+console.log('marketplace-install-contract.test.mjs passed');

--- a/openless-all/app/src-tauri/src/android/jni.rs
+++ b/openless-all/app/src-tauri/src/android/jni.rs
@@ -160,6 +160,35 @@ pub mod android {
         })
     }
 
+    /// Returns the app-private cache directory supplied by Android's Context.
+    pub(crate) fn app_cache_dir() -> Result<String, String> {
+        with_android_env(|env, context| {
+            let directory = env
+                .call_method(context, "getCacheDir", "()Ljava/io/File;", &[])
+                .and_then(|value| value.l())
+                .map_err(|error| format!("Context.getCacheDir: {error}"))?;
+            if directory.is_null() {
+                return Err("Context.getCacheDir returned null".to_string());
+            }
+            let path = env
+                .call_method(&directory, "getAbsolutePath", "()Ljava/lang/String;", &[])
+                .and_then(|value| value.l())
+                .map_err(|error| format!("File.getAbsolutePath: {error}"))?;
+            if path.is_null() {
+                return Err("Context cache directory has no path".to_string());
+            }
+            let path = env
+                .get_string(&JString::from(path))
+                .map_err(|error| format!("read Context cache directory: {error}"))?
+                .to_string_lossy()
+                .into_owned();
+            if path.is_empty() {
+                return Err("Context cache directory is empty".to_string());
+            }
+            Ok(path)
+        })
+    }
+
     const CREDENTIAL_VAULT_CLASS: &str = "com.openless.app.OpenLessCredentialVault";
     const KEYSTORE_KEY_MISSING: &str = "openless-keystore-key-missing";
     const KEYSTORE_AUTHENTICATION_FAILED: &str = "openless-keystore-authentication-failed";

--- a/openless-all/app/src-tauri/src/android/updater.rs
+++ b/openless-all/app/src-tauri/src/android/updater.rs
@@ -136,22 +136,8 @@ mod android_impl {
     }
 
     fn updates_cache_dir() -> Result<PathBuf, String> {
-        crate::android::jni::android::with_android_env(|env, context| {
-            let cache = env
-                .call_method(context, "getCacheDir", "()Ljava/io/File;", &[])
-                .and_then(|value| value.l())
-                .map_err(|e| format!("getCacheDir: {e}"))?;
-            let path = env
-                .call_method(&cache, "getAbsolutePath", "()Ljava/lang/String;", &[])
-                .and_then(|value| value.l())
-                .map_err(|e| format!("cache path: {e}"))?;
-            let text = env
-                .get_string(&jni::objects::JString::from(path))
-                .map_err(|e| format!("read cache path: {e}"))?
-                .to_string_lossy()
-                .into_owned();
-            Ok(PathBuf::from(text).join("updates"))
-        })
+        crate::android::jni::android::app_cache_dir()
+            .map(|path| PathBuf::from(path).join("updates"))
     }
 
     pub async fn download_and_install(

--- a/openless-all/app/src-tauri/src/commands/marketplace.rs
+++ b/openless-all/app/src-tauri/src/commands/marketplace.rs
@@ -238,6 +238,51 @@ fn marketplace_auth_error_for_status(status: reqwest::StatusCode) -> Option<&'st
     (status == reqwest::StatusCode::UNAUTHORIZED).then_some(MARKETPLACE_REAUTH_REQUIRED)
 }
 
+fn marketplace_log_value(value: &str) -> String {
+    const MAX_LOG_VALUE_LEN: usize = 1024;
+    let mut sanitized = value
+        .chars()
+        .map(|character| {
+            if character.is_control() {
+                ' '
+            } else {
+                character
+            }
+        })
+        .collect::<String>();
+    if sanitized.len() > MAX_LOG_VALUE_LEN {
+        let mut end = MAX_LOG_VALUE_LEN;
+        while !sanitized.is_char_boundary(end) {
+            end -= 1;
+        }
+        sanitized.truncate(end);
+        sanitized.push_str("…(truncated)");
+    }
+    sanitized
+}
+
+fn log_marketplace_install_failure(phase: &str, pack_id: &str, error: &str) {
+    log::error!(
+        "[marketplace-install] stage=failed phase={} pack_id={} error={}",
+        marketplace_log_value(phase),
+        marketplace_log_value(pack_id),
+        marketplace_log_value(error),
+    );
+}
+
+const MARKETPLACE_INSTALL_IN_PROGRESS: &str =
+    "marketplace_install_in_progress: another style pack installation is already running";
+
+static MARKETPLACE_INSTALL_LOCK: std::sync::OnceLock<tokio::sync::Mutex<()>> =
+    std::sync::OnceLock::new();
+
+fn try_acquire_marketplace_install_lock() -> Result<tokio::sync::MutexGuard<'static, ()>, String> {
+    MARKETPLACE_INSTALL_LOCK
+        .get_or_init(|| tokio::sync::Mutex::new(()))
+        .try_lock()
+        .map_err(|_| MARKETPLACE_INSTALL_IN_PROGRESS.to_string())
+}
+
 fn require_valid_marketplace_auth_with(
     status: reqwest::StatusCode,
     clear_credential: impl FnOnce() -> Result<(), String>,
@@ -386,53 +431,137 @@ pub async fn marketplace_install(
     coord: CoordinatorState<'_>,
     pack_id: String,
 ) -> Result<StylePack, String> {
+    log::info!(
+        "[marketplace-install] stage=start pack_id={}",
+        marketplace_log_value(&pack_id)
+    );
     // 安全校验：pack_id 来自远端 backend，可能含路径遍历 segment。
     // 用跟 read_audio_recording 同样的 UUID-v4 白名单挡住 ../ / 绝对路径等。
     // backend 当前用 Uuid::new_v4 生成所有 id，合法 id 必然匹配。
     if !is_valid_session_id(&pack_id) {
+        log_marketplace_install_failure("validate", &pack_id, "invalid pack id");
         return Err("invalid pack id".into());
     }
+    let _install_guard = match try_acquire_marketplace_install_lock() {
+        Ok(guard) => guard,
+        Err(error) => {
+            log_marketplace_install_failure("lock", &pack_id, &error);
+            return Err(error);
+        }
+    };
     let prefs = coord.prefs().get();
     let base = marketplace_url_from_prefs(&prefs);
 
     // 先拉 detail 拿 authorLogin —— 装好后本地写 originAuthorLogin，
     // 后续编辑+发布时 backend 据此判 supersede（原作者）vs derivative（他人 fork）。
-    let detail: serde_json::Value = execute_public_marketplace_with(
+    let detail_response = match execute_public_marketplace_with(
         &base,
         MarketplacePublicEndpoint::Detail {
             pack_id: pack_id.clone(),
         },
     )
-    .await?
-    .json()
     .await
-    .map_err(|e| format!("parse detail failed: {e}"))?;
+    {
+        Ok(response) => response,
+        Err(error) => {
+            log_marketplace_install_failure("detail", &pack_id, &error);
+            return Err(error);
+        }
+    };
+    let detail: serde_json::Value = match detail_response.json().await {
+        Ok(detail) => detail,
+        Err(error) => {
+            let error = format!("parse detail failed: {error}");
+            log_marketplace_install_failure("detail", &pack_id, &error);
+            return Err(error);
+        }
+    };
+    log::info!("[marketplace-install] stage=detail-ok pack_id={pack_id}");
     let origin_author_login = detail
         .get("authorLogin")
         .and_then(|v| v.as_str())
         .map(|s| s.to_string());
 
-    let response = execute_public_marketplace_with(
+    let response = match execute_public_marketplace_with(
         &base,
         MarketplacePublicEndpoint::Download {
             pack_id: pack_id.clone(),
         },
     )
-    .await?;
-    let bytes = read_marketplace_archive_response(response).await?;
+    .await
+    {
+        Ok(response) => response,
+        Err(error) => {
+            log_marketplace_install_failure("download", &pack_id, &error);
+            return Err(error);
+        }
+    };
+    let bytes = match read_marketplace_archive_response(response).await {
+        Ok(bytes) => bytes,
+        Err(error) => {
+            log_marketplace_install_failure("download", &pack_id, &error);
+            return Err(error);
+        }
+    };
+    log::info!(
+        "[marketplace-install] stage=download-ok pack_id={pack_id} bytes={}",
+        bytes.len()
+    );
 
     // 每次安装使用 create_new 的唯一临时路径；Drop 覆盖导入成功和所有错误分支。
-    let tmp = MarketplaceTempArchive::create(&pack_id, &bytes)?;
-    let imported = coord
-        .style_packs()
-        .import_from_zip(tmp.path())
-        .map_err(|e| e.to_string())?;
+    let temp_root = match marketplace_temp_root() {
+        Ok(root) => root,
+        Err(error) => {
+            log_marketplace_install_failure("temp-root", &pack_id, &error);
+            return Err(error);
+        }
+    };
+    log::info!(
+        "[marketplace-install] stage=temp-root-ok pack_id={pack_id} path={}",
+        marketplace_log_value(&temp_root.display().to_string())
+    );
+    let tmp = match MarketplaceTempArchive::create_empty_in(&temp_root, &pack_id) {
+        Ok(tmp) => tmp,
+        Err(error) => {
+            log_marketplace_install_failure("temp-create", &pack_id, &error);
+            return Err(error);
+        }
+    };
+    log::info!("[marketplace-install] stage=temp-create-ok pack_id={pack_id}");
+    if let Err(error) = tmp.write_bytes(&bytes) {
+        log_marketplace_install_failure("temp-write", &pack_id, &error);
+        return Err(error);
+    }
+    log::info!("[marketplace-install] stage=temp-write-ok pack_id={pack_id}");
+    let imported = match coord.style_packs().import_from_zip(tmp.path()) {
+        Ok(imported) => imported,
+        Err(error) => {
+            let error = error.to_string();
+            log_marketplace_install_failure("import", &pack_id, &error);
+            return Err(error);
+        }
+    };
+    log::info!(
+        "[marketplace-install] stage=import-ok pack_id={pack_id} local_pack_id={}",
+        marketplace_log_value(&imported.id)
+    );
 
     // 绑定 origin —— 后续编辑+发布走 derivative / supersede 分支。
-    coord
+    match coord
         .style_packs()
-        .set_origin(&imported.id, Some(pack_id), origin_author_login)
-        .map_err(|e| format!("set origin failed: {e}"))
+        .set_origin(&imported.id, Some(pack_id.clone()), origin_author_login)
+    {
+        Ok(pack) => {
+            log::info!("[marketplace-install] stage=origin-ok pack_id={pack_id}");
+            log::info!("[marketplace-install] stage=done pack_id={pack_id}");
+            Ok(pack)
+        }
+        Err(error) => {
+            let error = format!("set origin failed: {error}");
+            log_marketplace_install_failure("origin", &pack_id, &error);
+            Err(error)
+        }
+    }
 }
 
 fn validate_marketplace_archive_content_length(content_length: Option<u64>) -> Result<(), String> {
@@ -483,31 +612,67 @@ struct MarketplaceTempArchive {
 }
 
 impl MarketplaceTempArchive {
-    fn create(pack_id: &str, bytes: &[u8]) -> Result<Self, String> {
-        let path = std::env::temp_dir().join(format!(
+    fn create_empty_in(root: &std::path::Path, pack_id: &str) -> Result<Self, String> {
+        std::fs::create_dir_all(root).map_err(|error| {
+            format!("create marketplace temporary archive directory failed: {error}")
+        })?;
+        let path = root.join(format!(
             "openless-marketplace-{pack_id}-{}.zip",
             uuid::Uuid::new_v4().simple()
         ));
+        std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&path)
+            .map_err(|error| format!("create marketplace temporary archive failed: {error}"))?;
+        Ok(Self { path })
+    }
+
+    fn create_empty(pack_id: &str) -> Result<Self, String> {
+        let root = marketplace_temp_root()?;
+        Self::create_empty_in(&root, pack_id)
+    }
+
+    fn write_bytes(&self, bytes: &[u8]) -> Result<(), String> {
+        self.write_bytes_with(bytes, |file, bytes| file.write_all(bytes))
+    }
+
+    fn write_bytes_with(
+        &self,
+        bytes: &[u8],
+        write: impl FnOnce(&mut std::fs::File, &[u8]) -> std::io::Result<()>,
+    ) -> Result<(), String> {
         let write_result = (|| -> std::io::Result<()> {
             let mut file = std::fs::OpenOptions::new()
                 .write(true)
-                .create_new(true)
-                .open(&path)?;
-            file.write_all(bytes)?;
+                .truncate(true)
+                .open(&self.path)?;
+            write(&mut file, bytes)?;
             file.sync_all()
         })();
-        if let Err(error) = write_result {
-            let _ = std::fs::remove_file(&path);
-            return Err(format!(
-                "write marketplace temporary archive failed: {error}"
-            ));
-        }
-        Ok(Self { path })
+        write_result.map_err(|error| format!("write marketplace temporary archive failed: {error}"))
     }
 
     fn path(&self) -> &std::path::Path {
         &self.path
     }
+}
+
+fn marketplace_temp_root() -> Result<std::path::PathBuf, String> {
+    #[cfg(target_os = "android")]
+    let root = {
+        let cache_dir = crate::android::jni::android::app_cache_dir()?;
+        marketplace_temp_root_from_cache_dir(std::path::Path::new(&cache_dir))
+    };
+    #[cfg(not(target_os = "android"))]
+    let root = std::env::temp_dir();
+    std::fs::create_dir_all(&root)
+        .map_err(|error| format!("marketplace temp root create failed: {error}"))?;
+    Ok(root)
+}
+
+fn marketplace_temp_root_from_cache_dir(cache_dir: &std::path::Path) -> std::path::PathBuf {
+    cache_dir.join("openless-marketplace")
 }
 
 impl Drop for MarketplaceTempArchive {
@@ -540,13 +705,12 @@ pub async fn marketplace_upload(
         .or_else(|| local_pack.origin_pack_id.clone());
 
     // 先 export 本地 pack → 临时 ZIP
-    let tmp = std::env::temp_dir().join(format!("openless-marketplace-upload-{pack_id}.zip"));
+    let tmp = MarketplaceTempArchive::create_empty(&pack_id)?;
     coord
         .style_packs()
-        .export_to_zip(&pack_id, &tmp)
+        .export_to_zip(&pack_id, tmp.path())
         .map_err(|e| format!("export local pack failed: {e}"))?;
-    let bytes = std::fs::read(&tmp).map_err(|e| format!("read exported zip: {e}"))?;
-    let _ = std::fs::remove_file(&tmp);
+    let bytes = std::fs::read(tmp.path()).map_err(|e| format!("read exported zip: {e}"))?;
 
     let resp = execute_authenticated_marketplace(
         &base,
@@ -605,8 +769,22 @@ pub async fn marketplace_like(
 
 #[cfg(test)]
 mod archive_download_tests {
-    use super::{append_marketplace_archive_chunk, validate_marketplace_archive_content_length};
+    use super::{
+        append_marketplace_archive_chunk, marketplace_log_value,
+        marketplace_temp_root_from_cache_dir, try_acquire_marketplace_install_lock,
+        validate_marketplace_archive_content_length, MarketplaceTempArchive,
+        MARKETPLACE_INSTALL_IN_PROGRESS,
+    };
     use crate::persistence::STYLE_PACK_ARCHIVE_MAX_COMPRESSED_BYTES;
+    use std::io::Write;
+    use std::path::PathBuf;
+
+    fn test_root(name: &str) -> PathBuf {
+        std::env::temp_dir().join(format!(
+            "openless-marketplace-test-{name}-{}",
+            uuid::Uuid::new_v4().simple()
+        ))
+    }
 
     #[test]
     fn marketplace_archive_rejects_oversized_declared_content_length() {
@@ -634,6 +812,91 @@ mod archive_download_tests {
         append_marketplace_archive_chunk(&mut body, b"x").expect("exact limit is valid");
 
         assert_eq!(body.len(), STYLE_PACK_ARCHIVE_MAX_COMPRESSED_BYTES);
+    }
+
+    #[test]
+    fn temporary_archives_are_unique_and_drop_cleans_them() {
+        let root = test_root("unique");
+        let first = MarketplaceTempArchive::create_empty_in(&root, "pack").unwrap();
+        first.write_bytes(b"first").unwrap();
+        let second = MarketplaceTempArchive::create_empty_in(&root, "pack").unwrap();
+        second.write_bytes(b"second").unwrap();
+        assert_ne!(first.path(), second.path());
+        assert_eq!(std::fs::read(first.path()).unwrap(), b"first");
+        assert_eq!(std::fs::read(second.path()).unwrap(), b"second");
+
+        let first_path = first.path().to_path_buf();
+        let second_path = second.path().to_path_buf();
+        drop(first);
+        drop(second);
+        assert!(!first_path.exists());
+        assert!(!second_path.exists());
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn empty_archive_can_be_overwritten_for_upload() {
+        let root = test_root("upload");
+        let archive = MarketplaceTempArchive::create_empty_in(&root, "pack").unwrap();
+        archive.write_bytes(b"exported zip bytes").unwrap();
+        assert_eq!(
+            std::fs::read(archive.path()).unwrap(),
+            b"exported zip bytes"
+        );
+        drop(archive);
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn failed_write_leaves_no_archive_file() {
+        let root = test_root("write-failure");
+        let archive = MarketplaceTempArchive::create_empty_in(&root, "pack").unwrap();
+        let path = archive.path().to_path_buf();
+        let error = archive
+            .write_bytes_with(b"must not persist", |file, bytes| {
+                file.write_all(&bytes[..4])?;
+                Err(std::io::Error::other("injected write failure"))
+            })
+            .expect_err("injected write failure must fail");
+        assert!(error.contains("injected write failure"));
+        drop(archive);
+        assert!(!path.exists());
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn android_cache_root_uses_private_cache_subdirectory() {
+        let root = marketplace_temp_root_from_cache_dir(std::path::Path::new(
+            "/data/user/0/com.openless.app/cache",
+        ));
+        assert_eq!(
+            root,
+            PathBuf::from("/data/user/0/com.openless.app/cache/openless-marketplace")
+        );
+        assert!(!root.starts_with("/data/local/tmp"));
+    }
+
+    #[test]
+    fn marketplace_log_value_removes_controls_and_preserves_utf8_boundaries() {
+        let sanitized = marketplace_log_value("first\nsecond\r\tthird");
+        assert_eq!(sanitized, "first second  third");
+
+        let truncated = marketplace_log_value(&"界".repeat(600));
+        assert!(truncated.ends_with("…(truncated)"));
+        assert!(truncated.is_char_boundary(truncated.len()));
+        assert!(!truncated.chars().any(char::is_control));
+    }
+
+    #[test]
+    fn marketplace_install_lock_rejects_concurrent_install() {
+        let first = try_acquire_marketplace_install_lock().expect("first install lock");
+        let error = match try_acquire_marketplace_install_lock() {
+            Ok(_) => panic!("second install must be rejected while first is active"),
+            Err(error) => error,
+        };
+        assert_eq!(error, MARKETPLACE_INSTALL_IN_PROGRESS);
+        drop(first);
+        assert!(try_acquire_marketplace_install_lock().is_ok());
     }
 }
 

--- a/openless-all/app/src-tauri/src/persistence/style_pack_tests.rs
+++ b/openless-all/app/src-tauri/src/persistence/style_pack_tests.rs
@@ -473,6 +473,7 @@ fn style_pack_archive_round_trip_preserves_valid_pack_and_png_icon() {
     pack.icon_path = Some(icon_path.to_string_lossy().into_owned());
     let source = test_store(&root.path().join("source"), vec![pack.clone()]);
     let zip_path = root.path().join("roundtrip.zip");
+    fs::write(&zip_path, b"stale pre-created archive contents").expect("pre-create zip target");
     source
         .export_to_zip(&pack.id, &zip_path)
         .expect("export valid pack");

--- a/openless-all/app/src/i18n/en.ts
+++ b/openless-all/app/src/i18n/en.ts
@@ -118,6 +118,7 @@ export const en: typeof zhCN = {
     loadFailed: 'Load failed: {{err}}',
     noDescription: '(no description)',
     installBtn: 'Install',
+    installingBtn: 'Installing…',
     likeBtn: 'Like',
     installed: 'Installed "{{name}}" locally',
     uploaded: 'Uploaded — waiting for review',

--- a/openless-all/app/src/i18n/ja.ts
+++ b/openless-all/app/src/i18n/ja.ts
@@ -120,6 +120,7 @@ export const ja: typeof zhCN = {
     loadFailed: '読み込み失敗：{{err}}',
     noDescription: '（説明なし）',
     installBtn: 'インストール',
+    installingBtn: 'インストール中…',
     likeBtn: 'いいね',
     installed: '「{{name}}」をローカルにインストールしました',
     uploaded: 'アップロード完了、審査中',

--- a/openless-all/app/src/i18n/ko.ts
+++ b/openless-all/app/src/i18n/ko.ts
@@ -120,6 +120,7 @@ export const ko: typeof zhCN = {
     loadFailed: '불러오기 실패: {{err}}',
     noDescription: '(설명 없음)',
     installBtn: '설치',
+    installingBtn: '설치 중…',
     likeBtn: '좋아요',
     installed: '"{{name}}"을(를) 로컬에 설치했습니다',
     uploaded: '업로드 완료, 심사 대기 중',

--- a/openless-all/app/src/i18n/zh-CN.ts
+++ b/openless-all/app/src/i18n/zh-CN.ts
@@ -116,6 +116,7 @@ export const zhCN = {
     loadFailed: '加载失败：{{err}}',
     noDescription: '（暂无描述）',
     installBtn: '安装到本地',
+    installingBtn: '安装中…',
     likeBtn: '点赞',
     installed: '已安装「{{name}}」到本地风格包',
     uploaded: '上传成功，等待审核',

--- a/openless-all/app/src/i18n/zh-TW.ts
+++ b/openless-all/app/src/i18n/zh-TW.ts
@@ -118,6 +118,7 @@ export const zhTW: typeof zhCN = {
     loadFailed: '載入失敗：{{err}}',
     noDescription: '（暫無描述）',
     installBtn: '安裝到本機',
+    installingBtn: '安裝中…',
     likeBtn: '點讚',
     installed: '已安裝「{{name}}」到本機風格包',
     uploaded: '上傳成功，等待審核',

--- a/openless-all/app/src/lib/marketplaceInstall.test.ts
+++ b/openless-all/app/src/lib/marketplaceInstall.test.ts
@@ -1,0 +1,24 @@
+import {
+    canStartMarketplaceInstall,
+    isMarketplaceInstallActive,
+    isMarketplaceInstallErrorForPack,
+    shouldCloseMarketplaceDetail,
+    type MarketplaceInstallError,
+} from "./marketplaceInstall"
+
+function assert(condition: boolean, message: string) {
+    if (!condition) throw new Error(message)
+}
+
+assert(canStartMarketplaceInstall(null), "an idle marketplace can start an install")
+assert(!canStartMarketplaceInstall("pack-a"), "a second marketplace install is blocked")
+assert(isMarketplaceInstallActive("pack-a", "pack-a"), "active state belongs to its pack")
+assert(!isMarketplaceInstallActive("pack-a", "pack-b"), "active state does not leak to another pack")
+assert(shouldCloseMarketplaceDetail("pack-a", "pack-a"), "completed pack closes its own detail")
+assert(!shouldCloseMarketplaceDetail("pack-b", "pack-a"), "completed pack does not close another detail")
+
+const error: MarketplaceInstallError = { packId: "pack-a", message: "install failed" }
+assert(isMarketplaceInstallErrorForPack(error, "pack-a"), "error is shown for its pack")
+assert(!isMarketplaceInstallErrorForPack(error, "pack-b"), "error is hidden from another pack")
+
+console.log("marketplaceInstall.test.ts passed")

--- a/openless-all/app/src/lib/marketplaceInstall.ts
+++ b/openless-all/app/src/lib/marketplaceInstall.ts
@@ -1,0 +1,29 @@
+export type MarketplaceInstallError = {
+    packId: string
+    message: string
+}
+
+export function canStartMarketplaceInstall(installingPackId: string | null): boolean {
+    return installingPackId === null
+}
+
+export function isMarketplaceInstallActive(
+    installingPackId: string | null,
+    packId: string,
+): boolean {
+    return installingPackId === packId
+}
+
+export function isMarketplaceInstallErrorForPack(
+    error: MarketplaceInstallError | null,
+    packId: string,
+): error is MarketplaceInstallError {
+    return error?.packId === packId
+}
+
+export function shouldCloseMarketplaceDetail(
+    selectedId: string | null,
+    completedPackId: string,
+): boolean {
+    return selectedId === completedPackId
+}

--- a/openless-all/app/src/pages/Marketplace.tsx
+++ b/openless-all/app/src/pages/Marketplace.tsx
@@ -25,6 +25,7 @@ import {
   likeMarketplacePack,
   listMarketplace,
   listStylePacks,
+  logClientError,
   marketplaceDelete,
   marketplaceAuthStatus,
   marketplaceMyLikes,
@@ -37,6 +38,13 @@ import {
 } from '../lib/ipc';
 import { useHotkeySettings } from '../state/HotkeySettingsContext';
 import type { MarketplaceDetail, MarketplaceListItem, MarketplaceMyPackItem, StylePack } from '../lib/types';
+import {
+  canStartMarketplaceInstall,
+  isMarketplaceInstallActive,
+  isMarketplaceInstallErrorForPack,
+  shouldCloseMarketplaceDetail,
+  type MarketplaceInstallError,
+} from '../lib/marketplaceInstall';
 import { Btn, Card, PageHeader, Pill } from './_atoms';
 
 type SortMode = 'popular' | 'new' | 'liked';
@@ -56,6 +64,8 @@ export function Marketplace() {
   const [detail, setDetail] = useState<MarketplaceDetail | null>(null);
   const [detailLoading, setDetailLoading] = useState(false);
   const [actionMsg, setActionMsg] = useState<{ kind: 'ok' | 'err'; text: string } | null>(null);
+  const [installingPackId, setInstallingPackId] = useState<string | null>(null);
+  const [installError, setInstallError] = useState<MarketplaceInstallError | null>(null);
 
   const [showUpload, setShowUpload] = useState(false);
   const [uploadOriginPackId, setUploadOriginPackId] = useState<string | null>(null);
@@ -225,6 +235,7 @@ export function Marketplace() {
     setSelectedId(id);
     setDetail(null);
     setDetailLoading(true);
+    setInstallError(previous => previous?.packId === id ? previous : null);
     // 差量缓存命中：list 已经带 version+updatedAt，按三元组匹配本机 detail。
     // 命中 = 直接渲染、跳过网络；未命中 = 走 fetchMarketplaceDetail。
     const listItem = items.find(it => it.id === id);
@@ -259,13 +270,25 @@ export function Marketplace() {
   };
 
   const onInstall = async () => {
-    if (!detail) return;
+    if (!detail || !canStartMarketplaceInstall(installingPackId)) return;
+    const packId = detail.id;
+    const packName = detail.name;
+    setInstallingPackId(packId);
+    setInstallError(null);
+    let clientFailureLog: string | null = null;
     try {
-      await installMarketplacePack(detail.id);
-      setActionMsg({ kind: 'ok', text: t('marketplace.installed', { name: detail.name }) });
-      setSelectedId(null);
+      await installMarketplacePack(packId);
+      setActionMsg({ kind: 'ok', text: t('marketplace.installed', { name: packName }) });
+      setSelectedId(current => shouldCloseMarketplaceDetail(current, packId) ? null : current);
     } catch (error) {
-      setActionMsg({ kind: 'err', text: t('marketplace.errors.install', { err: errorMessage(error) }) });
+      const errorText = errorMessage(error);
+      const message = t('marketplace.errors.install', { err: errorText });
+      setInstallError({ packId, message });
+      setActionMsg({ kind: 'err', text: message });
+      clientFailureLog = `[marketplace-install] stage=ipc-failed pack_id=${packId} error=${errorText}`;
+    } finally {
+      setInstallingPackId(current => current === packId ? null : current);
+      if (clientFailureLog) void logClientError(clientFailureLog);
     }
   };
 
@@ -658,7 +681,7 @@ export function Marketplace() {
 
       {/* 详情弹窗 */}
       {selectedId && (
-        <Modal onClose={() => setSelectedId(null)}>
+        <Modal onClose={() => { setSelectedId(null); setInstallError(null); }}>
           {detailLoading || !detail ? (
             <div
               style={{
@@ -718,6 +741,11 @@ export function Marketplace() {
               >
                 {detail.prompt}
               </div>
+              {isMarketplaceInstallErrorForPack(installError, detail.id) && (
+                <div role="alert" style={{ color: '#ef4444', fontSize: 12, whiteSpace: 'normal', overflowWrap: 'anywhere', marginBottom: 10 }}>
+                  {installError.message}
+                </div>
+              )}
               <div style={{ display: 'flex', justifyContent: 'space-between', gap: 8, alignItems: 'center' }}>
                 <div>
                   {marketplaceSignedIn && detail.authorLogin === currentLogin && currentLogin.length > 0 && (
@@ -758,11 +786,18 @@ export function Marketplace() {
                     </span>
                     {detail.likeCount}
                   </motion.button>
-                  <Btn variant="ghost" size="sm" onClick={() => setSelectedId(null)}>
-                    {t('common.cancel')}
+                  <Btn variant="ghost" size="sm" onClick={() => { setSelectedId(null); setInstallError(null); }}>
+                    {installingPackId !== null ? t('common.close') : t('common.cancel')}
                   </Btn>
-                  <Btn variant="blue" size="sm" onClick={() => void onInstall()}>
-                    {t('marketplace.installBtn')}
+                  <Btn
+                    variant="blue"
+                    size="sm"
+                    disabled={!canStartMarketplaceInstall(installingPackId)}
+                    onClick={() => void onInstall()}
+                  >
+                    {isMarketplaceInstallActive(installingPackId, detail.id)
+                      ? t('marketplace.installingBtn')
+                      : t('marketplace.installBtn')}
                   </Btn>
                 </div>
               </div>


### PR DESCRIPTION
### **User description**
## Summary

- Store Marketplace install/upload temporary ZIPs under Android app-private `Context.getCacheDir()` while preserving the existing desktop temp-directory behavior.
- Use unique RAII-managed archives, serialize concurrent installs, and add phase-specific sanitized logs for diagnosis.
- Add installing/disabled UI state, pack-scoped inline failure details, translations, and regression tests.

## Root cause

On Android 12 and earlier, `std::env::temp_dir()` can resolve to `/data/local/tmp`, where the app cannot create the downloaded Marketplace ZIP. The existing app-private persistence fix did not cover this intermediate archive.

## Scope

- Based on the latest `upstream/beta`.
- Contains only the Marketplace install/upload, shared Android cache helper, UI feedback, logging, and tests.
- Excludes all ADB specialist tooling and CI debug-only changes from `special/android-adb-debug-kit`.

## Validation

- `npm test` passed: frontend production build plus 28 tests.
- Android Cargo metadata validation passed for `aarch64-linux-android`.
- Android debug CI compiled and uploaded all ABI artifacts: https://github.com/HKLHaoBin/openless/actions/runs/30736275536
- Verified by the reporting user on Honor Play 20 / Magic UI 4.0 / Android 10: “Install locally” now succeeds.

Fixes #878


___

### **PR Type**
Bug fix, Tests, Enhancement


___

### **Description**
- Fix Android Marketplace install temp directory to use app cache.

- Add unique RAII temp archives and serialize concurrent installs.

- Add installing/disabled UI state with inline error messages.

- Add sanitized phase logging and regression tests.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  UI["Marketplace install UI"] --> CMD["marketplace_install"]
  CMD --> ROOT["marketplace_temp_root"]
  ROOT --> CACHE["Android app cache dir"]
  ROOT --> TMP["Desktop temp dir"]
  CMD --> ARCH["unique temp archive"]
  ARCH --> IMPORT["StylePack import"]
  CMD --> LOCK["serialize installs"]
  CMD --> LOG["sanitized phase logs"]
  IMPORT --> RESULT["UI installed/error feedback"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>jni.rs</strong><dd><code>Add app_cache_dir JNI helper for Android cache</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/879/files#diff-93adf06036f4ca07a2dfb21e3304bc6aaf2957dc3bac7304d4428280e6fb4cb0">+29/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>marketplaceInstall.ts</strong><dd><code>Add marketplace install state helper functions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/879/files#diff-1367a5f046eb4a02d3b39c803348400f9946f7989b857cd0fb2005031ee41490">+29/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>Marketplace.tsx</strong><dd><code>Add installing state, inline errors, and client logging</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/879/files#diff-99913f7adfcb885c62181b1429572f6eae311993ce2aa224fd2e9b0c20af2f23">+45/-10</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Refactoring</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>updater.rs</strong><dd><code>Reuse shared app_cache_dir in updates cache path</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/879/files#diff-b8689c38bd1a56dc7101f684e50b394adb4cb9ba830530de2fa300bf89dba30c">+2/-16</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>marketplace.rs</strong><dd><code>Use app cache for temp archives, add lock and logs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/879/files#diff-54e1459dfe3ca7ebde1b7adfb3c610769a09f1bc11ff1cc6b1b5826543771f47">+295/-32</a></td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>style_pack_tests.rs</strong><dd><code>Pre-create stale zip to cover overwrite round-trip</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/879/files#diff-10b87a66f8a6453afab2af956eb0b493684522ab69e2788df7615a4cb1a660d6">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>marketplaceInstall.test.ts</strong><dd><code>Add tests for marketplace install state helpers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/879/files#diff-6a4a9a6fd530b7827b845c95d6c635e1ee65832b517a3ba070875cdb170ca773">+24/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>marketplace-install-contract.test.mjs</strong><dd><code>Add contract test for fire-and-forget error logging</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/879/files#diff-bff92a7ab0573defd49e2210408e85266b60479e9c13db248c7b289368690cfa">+15/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Localization</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>en.ts</strong><dd><code>Add English installing button translation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/879/files#diff-bb2f4fa05787923f8aeb23b6f11ad8705e02d9ff03a45790f9181e4615c79d83">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ja.ts</strong><dd><code>Add Japanese installing button translation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/879/files#diff-be57f0090cf34e3ff924cfa35f13d5d9e6514d3af5a1ebfdeb92bd7d36ed9cf4">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ko.ts</strong><dd><code>Add Korean installing button translation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/879/files#diff-daf35bcb6a2f8a31565b83d119cb59b69c1dededbabfccfd0d56693fdb3726ca">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>zh-CN.ts</strong><dd><code>Add Simplified Chinese installing button translation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/879/files#diff-571576f3c7b6c4a78ae0f91accdccc5da5cbed00409955c9914c046fee6c80ea">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>zh-TW.ts</strong><dd><code>Add Traditional Chinese installing button translation</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Open-Less/openless/pull/879/files#diff-a8d5953f9c76bc3c90ec583270be04c852bd7540297500e6ff3260760fc61ea4">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

