### PR TITLE
fix(windows): 主窗口改为不透明——消除录音时 DWM/GPU 饱和导致的系统卡顿

### DIFF
--- a/openless-all/app/src-tauri/tauri.windows.conf.json
+++ b/openless-all/app/src-tauri/tauri.windows.conf.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "https://schema.tauri.app/config/2",
+  "app": {
+    "windows": [
+      {
+        "label": "main",
+        "title": "OpenLess",
+        "width": 1240,
+        "height": 800,
+        "minWidth": 980,
+        "minHeight": 640,
+        "resizable": true,
+        "decorations": true,
+        "transparent": false,
+        "shadow": true,
+        "hiddenTitle": true,
+        "titleBarStyle": "Overlay",
+        "trafficLightPosition": {
+          "x": 14,
+          "y": 20
+        },
+        "visible": false,
+        "acceptFirstMouse": true
+      },
+      {
+        "label": "capsule",
+        "url": "index.html?window=capsule",
+        "title": "OpenLess Capsule",
+        "width": 460,
+        "height": 180,
+        "decorations": false,
+        "transparent": true,
+        "shadow": false,
+        "alwaysOnTop": true,
+        "skipTaskbar": true,
+        "resizable": false,
+        "focus": false,
+        "visible": false,
+        "center": false,
+        "acceptFirstMouse": true
+      }
+    ]
+  }
+}


### PR DESCRIPTION
### **User description**
## 问题

Windows 版录音期间出现三个症状（用户报告，v1.3.14）：

1. 录音时其他软件全部无响应
2. 软件本身偶尔莫名卡死（后端日志无停顿，卡在渲染/UI 层）
3. 录音时右键任务栏图标 → GPU 占用猛增

## 根因

`tauri.conf.json` 中 `main` 窗口（1240×800）为 `transparent: true`，导致 WebView2 内容整页走 per-pixel alpha 分层合成。但主窗口 UI 所有大面积层（winchrome / shell / sidebar / 内容区）都是**不透明背景**（`--ol-window-bg`、`--ol-app-shell-bg`、`--ol-sidebar-bg`、`--ol-surface`），Windows 的 Mica 磨砂（`apply_mica`）实际被完全盖住——透明是纯 GPU 成本、零视觉收益。

录音期间叠加胶囊窗口 60fps WebGL（SiriGL）+ 30Hz `capsule:state` 事件，GPU/DWM 被拖到饱和后：

- DWM 无法按时合成其他应用的帧 → 其他软件"无响应"
- 任务栏右键触发缩略图生成 / 强制重合成透明分层窗口 → GPU 飙升

> 佐证：日志分析显示 3 个月 356 次录音会话中音频回调**零停滞**——卡死不在后端，而在 WebView2 渲染/合成层，与 DWM 饱和模型一致。

## 改动

新增 `tauri.windows.conf.json` 平台覆盖（与既有 `tauri.linux.conf.json` 同机制）：

- `main` 窗口 `transparent: true → false`（唯一行为变化）
- `capsule` 窗口保持 `transparent: true`（真透明浮窗，纯光效无底，视觉依赖 alpha）
- macOS / Linux 不受影响

> 注意：Tauri 平台配置合并用 `json_patch::merge`（RFC 7386），数组整体替换，因此平台文件必须完整列出所有窗口。

## 验证建议

- 录音时对比任务管理器 GPU 占用（改动前 vs 后）
- 确认其他软件录音期间不再卡顿
- 确认主窗口视觉无变化（UI 全不透明，Mica 本就不可见）


___

### **PR Type**
Bug fix


___

### **Description**
- Add Windows platform override disabling main window transparency

- Prevent per-pixel alpha compositing that saturated GPU/DWM

- Preserve capsule window transparency for overlay UI

- Reduce system-wide stutter during recording on Windows


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["tauri.windows.conf.json"] --> B["main window transparent: false"]
  A --> C["capsule window transparent: true"]
  B --> D["No per-pixel alpha compositing"]
  C --> E["Preserved capsule overlay"]
  D --> F["Reduced GPU/DWM load"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>tauri.windows.conf.json</strong><dd><code>Add Windows config disabling main window transparency</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src-tauri/tauri.windows.conf.json

<ul><li>Add Windows-specific Tauri config platform override<br> <li> Set main window transparent to false with shadow enabled<br> <li> Keep capsule window transparent, alwaysOnTop, and skipTaskbar<br> <li> Mirror main window dimensions, title bar style, and visibility flags</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/882/files#diff-a10df7951ec615da3ffdf613ff290c3b94de37f93575c857dce35a70d6f51d2b">+44/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

