### PR TITLE
fix(linux): fcitx5 plugin crash on empty triggerKeyList with raw hotkey

### DIFF
--- a/openless-all/scripts/linux-fcitx5-plugin/openless.cpp
+++ b/openless-all/scripts/linux-fcitx5-plugin/openless.cpp
@@ -139,10 +139,20 @@ public:
                             }
                             return false;
                         }())) {
-                        auto dsym = triggerRawSym_ != 0 ? triggerRawSym_
-                            : static_cast<uint32_t>(triggerKeyList_[0].sym());
-                        auto dstates = triggerRawStates_ != 0 ? triggerRawStates_
-                            : static_cast<uint32_t>(triggerKeyList_[0].states());
+                        // 修复崩溃: raw 路径(SetHotkeyRaw)匹配时若 triggerRawStates_==0,
+                        // 原代码会无条件取 triggerKeyList_[0];而 raw 模式常伴随空 KeyList
+                        // (见 openless.conf: TriggerKey= 为空), 对空 vector 取下标 [0]
+                        // 是未定义行为, 直接导致 fcitx5 段错误 (Key::states 读野指针)。
+                        // 修正: 只有 KeyList 路径匹配时才访问列表, raw 路径直接用 raw 值。
+                        uint32_t dsym = triggerRawSym_;
+                        uint32_t dstates = triggerRawStates_;
+                        if (triggerRawSym_ == 0 && !triggerKeyList_.empty()) {
+                            dsym = static_cast<uint32_t>(triggerKeyList_[0].sym());
+                            dstates = static_cast<uint32_t>(triggerKeyList_[0].states());
+                        }
+                        if (dsym == 0) {
+                            return;
+                        }
                         if (!hasCustomDictationKey_ && isModifierKeySym(dsym)) {
                             dictationTriggerHeld_ = isPress;
                             if (isPress) {


### PR DESCRIPTION
### **User description**
## 问题现象
在linux环境下（CachyOS）安装 openless 后，按下听写热键（如 Alt 键），fcitx5 直接段错误崩溃（SIGSEGV），整个输入法进程消失，用户无法输入中文。

## 根音分析

  1. App 端通过 `SetHotkeyRaw(sym, 0)` 设置热键，`states` 恒为 0
  2. 插件在热键匹配成功后：
     ```cpp
     auto dstates = triggerRawStates_ != 0 ? triggerRawStates_
         : static_cast<uint32_t>(triggerKeyList_[0].states());
     ```
  3. raw 路径匹配（`triggerRawSym_ != 0`）但 `triggerRawStates_ == 0` 时，代码去取 `triggerKeyList_[0]`
  4. raw 模式下 KeyList 往往为空（`TriggerKey=`），对空 vector 取下标 `[0]` 是未定义行为，读野指针导致段错误
  
## 修复方案

  只允许 KeyList 路径匹配时访问列表；raw 路径匹配时直接用 raw 值；兜底 `dsym==0` 时忽略按键不吞事件。

## 验证

  - 环境：CachyOS / fcitx5 5.1.21 / GNOME Wayland
  - 用 uinput 模拟真实 Alt 键按下/抬起：fcitx5 不再崩溃
  - DBus 正常发出 `DictationKeyEvent` 信号
  - 长时间运行稳定，无新增 coredump


___

### **PR Type**
Bug fix


___

### **Description**
- Fix fcitx5 segfault when triggerKeyList is empty in raw hotkey mode

- Guard KeyList access; use raw sym/states for raw path only

- Ignore event when resolved dsym is zero


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Hotkey event"] --> B{"Raw sym matched?"}
  B -- "Yes" --> C["Use raw sym/states"]
  B -- "No" --> D{"KeyList non-empty?"}
  D -- "Yes" --> E["Use first KeyList entry"]
  D -- "No" --> F["Ignore event dsym==0"]
  C --> G{"dsym==0?"}
  E --> G
  G -- "Yes" --> F
  G -- "No" --> H["Process dictation key"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>openless.cpp</strong><dd><code>Fix empty triggerKeyList crash in fcitx5 plugin</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/scripts/linux-fcitx5-plugin/openless.cpp

<ul><li>Replace unconditional triggerKeyList_[0] access with guarded lookup<br> <li> Use raw hotkey values when raw path matches, independent of KeyList<br> <li> Return early if resolved dsym is zero to skip invalid events</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/883/files#diff-4e4cff4f87c85d6635f0b30fb7007d3bf9a94b72bb872716ca01859f5f8847bd">+14/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

