### PR TITLE
chore(release): prepare 1.3.15-Beta.4

### DIFF
--- a/openless-all/app/package-lock.json
+++ b/openless-all/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openless-app",
-  "version": "1.3.15-Beta.3",
+  "version": "1.3.15-Beta.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openless-app",
-      "version": "1.3.15-Beta.3",
+      "version": "1.3.15-Beta.4",
       "dependencies": {
         "@base-ui/react": "^1.6.0",
         "@formkit/auto-animate": "^0.9.0",

--- a/openless-all/app/package.json
+++ b/openless-all/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openless-app",
   "private": true,
-  "version": "1.3.15-Beta.3",
+  "version": "1.3.15-Beta.4",
   "type": "module",
   "scripts": {
     "pretest": "npm run build",

--- a/openless-all/app/src-tauri/Cargo.lock
+++ b/openless-all/app/src-tauri/Cargo.lock
@@ -3909,7 +3909,7 @@ dependencies = [
 
 [[package]]
 name = "openless"
-version = "1.3.15-Beta.3"
+version = "1.3.15-Beta.4"
 dependencies = [
  "anyhow",
  "arboard",

--- a/openless-all/app/src-tauri/Cargo.toml
+++ b/openless-all/app/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openless"
-version = "1.3.15-Beta.3"
+version = "1.3.15-Beta.4"
 description = "OpenLess — local voice input that types where your cursor is"
 authors = ["OpenLess"]
 edition = "2021"

--- a/openless-all/app/src-tauri/tauri.conf.json
+++ b/openless-all/app/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "OpenLess",
-  "version": "1.3.15-Beta.3",
+  "version": "1.3.15-Beta.4",
   "identifier": "com.openless.app",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
### **User description**
5 文件版本同步 1.3.15-Beta.3 → 1.3.15-Beta.4（package.json / package-lock.json / tauri.conf.json / Cargo.toml / Cargo.lock），版本同步闸门要求。

内容：胶囊样式可选（#887）+ 此前全部合并项。Beta.4 发布前的版本准备。


___

### **PR Type**
Other


___

### **Description**
- Bump app version from `1.3.15-Beta.3` to `1.3.15-Beta.4`

- Sync version across `package.json`, `Cargo.toml`, and `tauri.conf.json`

- Prepare the Beta.4 release build


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>package.json</strong><dd><code>Bump npm package version to Beta.4</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/package.json

- Bump npm app version from `1.3.15-Beta.3` to `1.3.15-Beta.4`


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/889/files#diff-2650f8aa2f7ec97aa8af47f1f8a7c9ae4677fb69754b20d554e1d542507cf4ea">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Cargo.toml</strong><dd><code>Bump Rust crate version to Beta.4</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src-tauri/Cargo.toml

- Update Rust crate version from `1.3.15-Beta.3` to `1.3.15-Beta.4`


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/889/files#diff-334952ba03e62939865bbf0351f0916ea88c6457f8ea1259336e73ee4e2f088b">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>tauri.conf.json</strong><dd><code>Bump Tauri app version to Beta.4</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src-tauri/tauri.conf.json

- Set Tauri app version to `1.3.15-Beta.4`


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/889/files#diff-e9c2f15638ea988f61c82aeb2257147fb9cc96d7bda8709e8bad6b6517f5369c">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

