### PR TITLE
feat(android): expose advanced debug tools on mobile

### DIFF
--- a/openless-all/app/src/pages/settings/DebugToolsSection.tsx
+++ b/openless-all/app/src/pages/settings/DebugToolsSection.tsx
@@ -5,6 +5,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { exportErrorLog } from '../../lib/ipc';
+import { useMobileLayout } from '../../lib/useMobileLayout';
 import { useHotkeySettings } from '../../state/HotkeySettingsContext';
 import { Btn, Card } from '../_atoms';
 import { SettingRow, Toggle, SectionTitle, inputStyle } from './shared';
@@ -13,6 +14,7 @@ const clamp = (n: number, min: number, max: number) => Math.max(min, Math.min(ma
 
 export function DebugToolsSection() {
   const { t } = useTranslation();
+  const mobile = useMobileLayout();
   const { prefs, updatePrefs: savePrefs } = useHotkeySettings();
   const [exportStatus, setExportStatus] = useState<'idle' | 'busy' | 'ok' | 'err'>('idle');
   const [exportMessage, setExportMessage] = useState<string>('');
@@ -71,25 +73,30 @@ export function DebugToolsSection() {
         <Toggle on={prefs.recordAudioForDebug} onToggle={onRecordAudioForDebugChange} />
       </SettingRow>
       <SettingRow label={t('settings.recording.audioRecordingMaxEntriesLabel')}>
-        <input
-          type="number"
-          min={1}
-          max={200}
-          placeholder="200"
-          value={prefs.audioRecordingMaxEntries ?? ''}
-          onChange={e => onAudioRecordingMaxEntriesChange(e.target.value)}
-          style={{ ...inputStyle, width: 80, textAlign: 'right' }}
-          disabled={!prefs.recordAudioForDebug}
-        />
+        <div style={{ display: 'flex', flexDirection: mobile ? 'column' : 'row', gap: 8, alignItems: mobile ? 'stretch' : 'center', width: '100%' }}>
+          <input
+            type="number"
+            min={1}
+            max={200}
+            placeholder="200"
+            value={prefs.audioRecordingMaxEntries ?? ''}
+            onChange={e => onAudioRecordingMaxEntriesChange(e.target.value)}
+            style={{ ...inputStyle, width: mobile ? '100%' : 80, textAlign: 'right' }}
+            disabled={!prefs.recordAudioForDebug}
+          />
+          <span style={{ fontSize: 11, color: 'var(--ol-ink-4)', lineHeight: 1.45 }}>
+            {t('settings.recording.audioRecordingMaxEntriesDesc')}
+          </span>
+        </div>
       </SettingRow>
       <SettingRow label={t('modal.about.exportErrorLog')}>
-        <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+        <div style={{ display: 'flex', gap: 8, alignItems: 'center', flexWrap: 'wrap' }}>
           <Btn variant="ghost" size="sm" disabled={exportStatus === 'busy'} onClick={onExportLog}>
             {exportStatus === 'busy' ? t('modal.about.exporting') : t('modal.about.exportErrorLogBtn')}
           </Btn>
           {exportStatus === 'ok' && (
             <span
-              style={{ fontSize: 11, color: 'var(--ol-ok)', whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis', maxWidth: 220 }}
+              style={{ fontSize: 11, color: 'var(--ol-ok)', whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis', maxWidth: mobile ? '100%' : 220 }}
               title={exportMessage}
             >
               {t('modal.about.exportSuccess')}
@@ -97,7 +104,7 @@ export function DebugToolsSection() {
           )}
           {exportStatus === 'err' && (
             <span
-              style={{ fontSize: 11, color: 'var(--ol-err)', lineHeight: 1.45, wordBreak: 'break-word', maxWidth: 280 }}
+              style={{ fontSize: 11, color: 'var(--ol-err)', lineHeight: 1.45, wordBreak: 'break-word', maxWidth: mobile ? '100%' : 280 }}
               title={exportMessage}
             >
               {t('modal.about.exportFailed')}

--- a/openless-all/app/src/pages/settings/DebugToolsSection.tsx
+++ b/openless-all/app/src/pages/settings/DebugToolsSection.tsx
@@ -84,9 +84,11 @@ export function DebugToolsSection() {
             style={{ ...inputStyle, width: mobile ? '100%' : 80, textAlign: 'right' }}
             disabled={!prefs.recordAudioForDebug}
           />
-          <span style={{ fontSize: 11, color: 'var(--ol-ink-4)', lineHeight: 1.45 }}>
-            {t('settings.recording.audioRecordingMaxEntriesDesc')}
-          </span>
+          {mobile && (
+            <span style={{ fontSize: 11, color: 'var(--ol-ink-4)', lineHeight: 1.45 }}>
+              {t('settings.recording.audioRecordingMaxEntriesDesc')}
+            </span>
+          )}
         </div>
       </SettingRow>
       <SettingRow label={t('modal.about.exportErrorLog')}>
@@ -96,10 +98,19 @@ export function DebugToolsSection() {
           </Btn>
           {exportStatus === 'ok' && (
             <span
-              style={{ fontSize: 11, color: 'var(--ol-ok)', whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis', maxWidth: mobile ? '100%' : 220 }}
+              style={{
+                fontSize: 11,
+                color: 'var(--ol-ok)',
+                whiteSpace: mobile ? 'normal' : 'nowrap',
+                overflow: mobile ? 'visible' : 'hidden',
+                textOverflow: mobile ? 'clip' : 'ellipsis',
+                wordBreak: 'break-word',
+                maxWidth: mobile ? '100%' : 220,
+              }}
               title={exportMessage}
             >
               {t('modal.about.exportSuccess')}
+              {mobile && exportMessage ? `：${exportMessage}` : ''}
             </span>
           )}
           {exportStatus === 'err' && (

--- a/openless-all/app/src/pages/settings/tabs.tsx
+++ b/openless-all/app/src/pages/settings/tabs.tsx
@@ -101,16 +101,20 @@ export function PrivacyTab() {
 
 // 高级：只留真正的实验性/开发者功能 —— Less Computer · Claude 控制台 · 调试工具。
 // （本地模型移入「服务」、更新相关移入「关于」，这个 tab 不再是杂物抽屉。）
+// 调试工具本身是跨端的：Android 复用同一份 prefs / 录音导出入口；
+// 这里只做平台 gating，不把桌面特有能力耦合进移动端运行时。
 export function AdvancedTab() {
   const os = detectOS();
   const platformCaps = usePlatformCaps();
   const showDesktopAdvanced = platformCaps?.platform === 'desktop';
+  const showDebugTools =
+    platformCaps?.platform === 'desktop' || platformCaps?.platform === 'android';
 
   return (
     <>
       {showDesktopAdvanced && os !== 'win' && <CodingAgentSection />}
       {showDesktopAdvanced && os !== 'win' && <ClaudeConsoleSection />}
-      {showDesktopAdvanced && <DebugToolsSection />}
+      {showDebugTools && <DebugToolsSection />}
     </>
   );
 }


### PR DESCRIPTION
### **User description**
## Summary
- Show **Advanced -> Debug tools** on Android (record raw audio, export error log).
- Backend SAF log export and filesDir logging already landed in #877; this PR only adds UI gating and mobile layout.

## Related issues
Relates to #877, #865

## Test plan
- [ ] CI green (PR checks)
- [ ] Signed release APK built via workflow_dispatch
- [ ] Device: Settings -> Advanced -> Debug tools visible
- [ ] Toggle recordAudioForDebug saves prefs
- [ ] Export error log via SAF succeeds (content://)
- [ ] Desktop Advanced tab unchanged

Made with [Cursor](https://cursor.com)


___

### **PR Type**
Enhancement


___

### **Description**
- Show Advanced debug tools on Android

- Add mobile-friendly layout for debug section

- Display full export path on mobile success

- Gate debug tools to desktop and Android


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["AdvancedTab"] --> B["Detect platform"]
  B -- "desktop or android" --> C["DebugToolsSection"]
  B -- "desktop non-Windows" --> D["CodingAgent + ClaudeConsole"]
  C --> E["Mobile layout + full export path"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>DebugToolsSection.tsx</strong><dd><code>Mobile-friendly debug tools layout</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src/pages/settings/DebugToolsSection.tsx

<ul><li>Add mobile layout detection via useMobileLayout<br> <li> Stack audio max entries input vertically on mobile<br> <li> Show description hint next to input on mobile<br> <li> Allow success/error messages to wrap and show full export path</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/890/files#diff-9c0123bd6afb6219dab2dfff4de4f896483d75a1878b1451cc55568ecd50b6d9">+31/-13</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>tabs.tsx</strong><dd><code>Enable debug tools on Android</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src/pages/settings/tabs.tsx

<ul><li>Add Android to showDebugTools platform gating<br> <li> Keep desktop-only sections gated to desktop<br> <li> Clarify cross-platform intent with comments</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/890/files#diff-8131e39468f6b90867c09347e29db06f7142de7b0917342149010d537d94fab9">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

