### PR TITLE
chore(release): prepare 1.3.15（正式版版本号）+ 修复 bump 脚本误改依赖版本

### DIFF
--- a/openless-all/app/package-lock.json
+++ b/openless-all/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openless-app",
-  "version": "1.3.15-Beta.4",
+  "version": "1.3.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openless-app",
-      "version": "1.3.15-Beta.4",
+      "version": "1.3.15",
       "dependencies": {
         "@base-ui/react": "^1.6.0",
         "@formkit/auto-animate": "^0.9.0",

--- a/openless-all/app/package.json
+++ b/openless-all/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openless-app",
   "private": true,
-  "version": "1.3.15-Beta.4",
+  "version": "1.3.15",
   "type": "module",
   "scripts": {
     "pretest": "npm run build",

--- a/openless-all/app/src-tauri/Cargo.lock
+++ b/openless-all/app/src-tauri/Cargo.lock
@@ -3909,7 +3909,7 @@ dependencies = [
 
 [[package]]
 name = "openless"
-version = "1.3.15-Beta.4"
+version = "1.3.15"
 dependencies = [
  "anyhow",
  "arboard",

--- a/openless-all/app/src-tauri/Cargo.toml
+++ b/openless-all/app/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openless"
-version = "1.3.15-Beta.4"
+version = "1.3.15"
 description = "OpenLess — local voice input that types where your cursor is"
 authors = ["OpenLess"]
 edition = "2021"

--- a/openless-all/app/src-tauri/tauri.conf.json
+++ b/openless-all/app/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "OpenLess",
-  "version": "1.3.15-Beta.4",
+  "version": "1.3.15",
   "identifier": "com.openless.app",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -55,11 +55,14 @@ sed -E -i.bak \
   "$TAURI_CONF"
 rm "$TAURI_CONF.bak"
 
-# Cargo.toml：用 awk 替换文件里第一个 version = "X.Y.Z" 行（顶层 [package].version）。
+# Cargo.toml：用 awk 替换 [package] 段里的 version = "X.Y.Z" 行。
+# 必须锚定 [package] 段：文件里先出现的纯 X.Y.Z 版本行可能是依赖版本
+# （如 keyring 的 `version = "3.6.3"`），不带锚定会把依赖版本误改成新版本号。
 # 不用 GNU sed 的 `0,/.../` 行号范围地址（macOS BSD sed 不支持）。
 echo "▶ 升 Cargo.toml → $NEW"
 awk -v new="$NEW" '
-  !done && /^version = "[0-9]+\.[0-9]+\.[0-9]+"$/ {
+  /^\[package\]$/ { in_package = 1 }
+  in_package && !done && /^version = "[0-9]+\.[0-9]+\.[0-9]+"$/ {
     sub(/"[0-9]+\.[0-9]+\.[0-9]+"/, "\"" new "\"")
     done = 1
   }


### PR DESCRIPTION
### **User description**
正式版 1.3.15 版本号同步（5 个文件一致）：

- package.json / package-lock.json（root + nested）/ tauri.conf.json / Cargo.toml / Cargo.lock（openless 块）：1.3.15-Beta.4 → 1.3.15
- 顺带修复 `scripts/bump-version.sh` 的 awk 潜在 bug：原实现匹配「第一个纯 X.Y.Z 版本行」，当 [package].version 带 `-Beta.N` 后缀时会误把 macOS keyring 依赖版本（3.6.3）改成新版本号——本次发布已手工纠正，脚本加 [package] 段锚定防再犯

合并后 beta 与 main 版本号一致，CI green 后即可推 `v1.3.15-tauri` 发正式版。


___

### **PR Type**
Bug fix, Other


___

### **Description**
- Bump version from 1.3.15-Beta.4 to 1.3.15

- Update package.json, Cargo.toml, tauri.conf.json

- Fix bump-version.sh awk [package] anchoring

- Prevent accidental dependency version replacement


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Release 1.3.15"] --> B["Update app manifests"]
  A --> C["Fix bump-version.sh"]
  B --> D["package.json"]
  B --> E["Cargo.toml"]
  B --> F["tauri.conf.json"]
  C --> G["Anchor [package] section"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>bump-version.sh</strong><dd><code>Anchor Cargo.toml version replacement to package</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

scripts/bump-version.sh

<ul><li>Added <code>in_package</code> state to awk script<br> <li> Only replaces version inside <code>[package]</code> section<br> <li> Added comments explaining keyring dependency risk</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/893/files#diff-3b95b9d4ed59d1bb3424d2ccd660cef1ab56873d654c1ee1e47babb65331b012">+5/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>package.json</strong><dd><code>Bump app package version to 1.3.15</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/package.json

- Updated version from `1.3.15-Beta.4` to `1.3.15`


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/893/files#diff-2650f8aa2f7ec97aa8af47f1f8a7c9ae4677fb69754b20d554e1d542507cf4ea">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Cargo.toml</strong><dd><code>Bump Cargo package version to 1.3.15</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src-tauri/Cargo.toml

- Updated `[package]` version from `1.3.15-Beta.4` to `1.3.15`


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/893/files#diff-334952ba03e62939865bbf0351f0916ea88c6457f8ea1259336e73ee4e2f088b">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>tauri.conf.json</strong><dd><code>Bump Tauri config version to 1.3.15</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src-tauri/tauri.conf.json

- Updated version from `1.3.15-Beta.4` to `1.3.15`


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/893/files#diff-e9c2f15638ea988f61c82aeb2257147fb9cc96d7bda8709e8bad6b6517f5369c">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

