### PR TITLE
[cask] openless 1.3.15 (auto from release)

### DIFF
--- a/Casks/openless.rb
+++ b/Casks/openless.rb
@@ -1,9 +1,9 @@
 cask "openless" do
   arch arm: "aarch64", intel: "x64"
 
-  version "1.3.14"
-  sha256 arm:   "4bfa85f48714626ec010b92d22a5ab98c834f60b5c7e5f6281e12a11ad90ad9f",
-         intel: "929ad6c047fc8942724b7e1edb5dc0d88affbd2ec4184b2dd3d482c0e06d999f"
+  version "1.3.15"
+  sha256 arm:   "206a0189af6876d727fcdc8ec50c362d20721080f3ce0904ec683fa3cd3d8414",
+         intel: "b5502dc1bb8b86c42158df767e61c7aa380ea12ae3a11f4be6fef625e54fc42b"
 
   url "https://github.com/Open-Less/openless/releases/download/v#{version}-tauri/OpenLess_#{version}_#{arch}.dmg"
   name "OpenLess"


### PR DESCRIPTION
### **User description**
Homebrew cask 版本同步（stable 发布流水线的 update-homebrew-cask job 因 beta 分支保护改为 PR-only 而失败，手工补上）：

- version 1.3.14 → 1.3.15
- sha256 arm: `206a0189af...d8414`（aarch64 dmg）
- sha256 intel: `b5502dc1bb...c42b`（x64 dmg）

链接已是 Open-Less/openless（迁移后地址），未回写 appergb。


___

### **PR Type**
Enhancement


___

### **Description**
- Bump openless cask to 1.3.15

- Update sha256 for arm and intel

- Manual sync due to CI failure


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>openless.rb</strong><dd><code>Update openless cask version and hashes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Casks/openless.rb

<ul><li>Version updated from 1.3.14 to 1.3.15<br> <li> sha256 updated for arm (aarch64) and intel (x64)</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/899/files#diff-e7c9f13357bfa65862250bdbdb0d2af908f271746881dd0f40af443a5099daa4">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

