### PR TITLE
fix(asr): 删除 retranscribe 里重复的 ElevenLabs 匹配分支

### DIFF
--- a/openless-all/app/src-tauri/src/coordinator.rs
+++ b/openless-all/app/src-tauri/src/coordinator.rs
@@ -2154,12 +2154,6 @@ impl Coordinator {
                     .map_err(|_| "重新转录超时".to_string())?
                     .map_err(|e| e.to_string())?
             }
-            ActiveAsr::ElevenLabs(e) => {
-                tokio::time::timeout(elevenlabs_timeout, e.transcribe())
-                    .await
-                    .map_err(|_| "重新转录超时".to_string())?
-                    .map_err(|e| e.to_string())?
-            }
             #[cfg(target_os = "windows")]
             ActiveAsr::FoundryLocalWhisper(local) => {
                 let audio_secs = (local.buffer_duration_ms() as f64) / 1000.0;


### PR DESCRIPTION
### **User description**
## 问题

`coordinator.rs` 的 retranscribe 路径里，`ActiveAsr::ElevenLabs(e) => { ... }` 连续出现了两次，两个分支逐字节相同。第二条永远走不到，`cargo check` 会报：

```
warning: unreachable pattern
    --> src/coordinator.rs:2157:13
     |
2151 |             ActiveAsr::ElevenLabs(e) => {
     |             ------------------------ matches all the relevant values
```

引入于 8a2febf5（#851），此后一直在 `beta` 上。

## 改动

删掉重复的第二条分支，共 6 行。纯死代码清理，无行为变化。

## 验证

修复后 `cargo check` 通过，`unreachable pattern` 警告数为 0。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Bug fix


___

### **Description**
- Remove duplicate ElevenLabs retranscribe match branch.

- Eliminates unreachable pattern compiler warning.

- Pure dead code cleanup with no behavior change.


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>coordinator.rs</strong><dd><code>Remove duplicate ElevenLabs transcribe match arm</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openless-all/app/src-tauri/src/coordinator.rs

<ul><li>Deletes the second identical <code>ActiveAsr::ElevenLabs</code> match arm in the <br>retranscribe path.<br> <li> Removes the <code>unreachable pattern</code> warning reported by <code>cargo check</code>.<br> <li> Introduces no functional changes; the first branch already handled the <br>case.</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/906/files#diff-73d8c004670b27293f74f0f3991b9a6fc28f0ff0b883214de2b078b1e09797ca">+0/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

