### PR TITLE
[cask] openless 1.3.16 (auto from release) [skip ci]

### DIFF
--- a/Casks/openless.rb
+++ b/Casks/openless.rb
@@ -1,9 +1,9 @@
 cask "openless" do
   arch arm: "aarch64", intel: "x64"
 
-  version "1.3.15"
-  sha256 arm:   "206a0189af6876d727fcdc8ec50c362d20721080f3ce0904ec683fa3cd3d8414",
-         intel: "b5502dc1bb8b86c42158df767e61c7aa380ea12ae3a11f4be6fef625e54fc42b"
+  version "1.3.16"
+  sha256 arm:   "2cb55858b1c2104ac4ae818edfac1f125e7eb8547283fabcf756276548fed5ca",
+         intel: "bd86763ac3226fd90e9206766539bd5a986e1421ac01e94a45a0027b2d1d252d"
 
   url "https://github.com/Open-Less/openless/releases/download/v#{version}-tauri/OpenLess_#{version}_#{arch}.dmg"
   name "OpenLess"


### PR DESCRIPTION
### **User description**
update-homebrew-cask job 直接 push 被 branch protection 拦截（预期行为），手工补 PR：version 1.3.15 → 1.3.16，arm/intel sha256 从下载的 release dmg 计算。


___

### **PR Type**
Enhancement


___

### **Description**
- Bump OpenLess cask version to 1.3.16

- Refresh arm and intel SHA256 checksums


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>openless.rb</strong><dd><code>Update openless cask to v1.3.16</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Casks/openless.rb

<ul><li>Update version from 1.3.15 to 1.3.16<br> <li> Replace arm SHA256 with <br>2cb55858b1c2104ac4ae818edfac1f125e7eb8547283fabcf756276548fed5ca<br> <li> Replace intel SHA256 with <br>bd86763ac3226fd90e9206766539bd5a986e1421ac01e94a45a0027b2d1d252d</ul>


</details>


  </td>
  <td><a href="https://github.com/Open-Less/openless/pull/921/files#diff-e7c9f13357bfa65862250bdbdb0d2af908f271746881dd0f40af443a5099daa4">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

