### PR TITLE
fix(provider): allow custom LLM HTTP hostnames (#929)

### DIFF
--- a/openless-all/app/src-tauri/src/asr/elevenlabs.rs
+++ b/openless-all/app/src-tauri/src/asr/elevenlabs.rs
@@ -157,17 +157,6 @@ pub fn speech_to_text_url(base_url: &str) -> Result<String> {
         .map_err(anyhow::Error::msg)
         .context("validate ElevenLabs endpoint")?;
     let parsed = reqwest::Url::parse(base_url.trim()).context("parse ElevenLabs base URL")?;
-    let loopback_http = parsed.scheme() == "http"
-        && parsed.host_str().is_some_and(|host| {
-            let host = host.trim_start_matches('[').trim_end_matches(']');
-            host.eq_ignore_ascii_case("localhost")
-                || host
-                    .parse::<std::net::IpAddr>()
-                    .is_ok_and(|ip| ip.is_loopback())
-        });
-    if parsed.scheme() != "https" && !loopback_http {
-        anyhow::bail!("ElevenLabs endpoint must use HTTPS (HTTP is allowed only for loopback)");
-    }
     let mut url = parsed.clone();
     let path = parsed.path().trim_end_matches('/');
     let next_path = if path.ends_with("/speech-to-text") {
@@ -277,20 +266,22 @@ mod tests {
     }
 
     #[test]
-    fn url_rejects_insecure_non_loopback_endpoint() {
-        let error = speech_to_text_url("http://api.example.com/v1").unwrap_err();
-        assert!(format!("{error:#}").to_ascii_lowercase().contains("https"));
-
-        assert!(speech_to_text_url("http://127.0.0.1:8080/v1").is_ok());
-        assert!(speech_to_text_url("http://localhost:8080/v1").is_ok());
-        assert!(speech_to_text_url("http://[::1]:8080/v1").is_ok());
-    }
-
-    #[test]
-    fn url_rejects_sensitive_network_targets() {
-        assert!(speech_to_text_url("https://169.254.169.254/v1").is_err());
-        assert!(speech_to_text_url("https://100.64.0.1/v1").is_err());
-        assert!(speech_to_text_url("https://metadata.google.internal/v1").is_err());
+    fn url_accepts_explicitly_configured_http_endpoints() {
+        for base_url in [
+            "http://api.example.com/v1",
+            "http://192.168.1.50:8080/v1",
+            "http://127.0.0.1:8080/v1",
+            "http://localhost:8080/v1",
+            "http://[::1]:8080/v1",
+            "http://169.254.169.254/v1",
+            "http://100.64.0.1/v1",
+            "http://metadata.google.internal/v1",
+        ] {
+            assert!(
+                speech_to_text_url(base_url).is_ok(),
+                "explicitly configured endpoint should be accepted: {base_url}"
+            );
+        }
     }
 
     #[test]

--- a/openless-all/app/src-tauri/src/commands/providers.rs
+++ b/openless-all/app/src-tauri/src/commands/providers.rs
@@ -271,11 +271,10 @@ fn read_openai_provider_config(scope: &ProviderScope) -> Result<ProviderConfig, 
     if base_url.trim().is_empty() {
         return Err("Endpoint 为空".to_string());
     }
-    // issue #609 F-01 孪生 gap（@claude 复审 #617 指出）：ASR / provider 自定义 endpoint
-    // 同样是 attacker-controlled，且 ASR 请求也带 API Key。复用 LLM 路径已有的 SSRF 配置
-    // 校验，拒绝指向内网/回环/link-local/CGNAT/IPv6 ULA/元数据服务的地址；localhost/
-    // 127.0.0.1/::1 仍放行 http（本地 Whisper 服务）。覆盖 validate_provider_credentials
-    // (asr/llm) 连通性测试与 list_provider_models 模型列表两条 HTTP 路径。
+    // endpoint 校验：仅保证是合法 http(s) URL，地址不设任何限制（公网/局域网/内网
+    // DNS/hosts 别名/本地均可）——端点由用户显式配置，选择权在用户；前端对 http://
+    // 输入展示明文风险提示。覆盖 validate_provider_credentials 连通性测试与
+    // list_provider_models 模型列表两条 HTTP 路径。
     crate::endpoint_security::validate_http_endpoint(&base_url)
         .map_err(|_| "endpointInvalid".to_string())?;
     Ok(ProviderConfig {
@@ -1452,26 +1451,33 @@ mod tests {
     }
 
     #[test]
-    fn asr_endpoint_rejects_metadata_cgnat_and_non_https_public() {
-        // 元数据 / CGNAT / 非 https 外网：拒绝，避免带 API Key 的 ASR 请求被指向高价值目标 / 明文外泄。
-        assert!(validate_http_endpoint("http://169.254.169.254/v1/audio/transcriptions").is_err());
-        assert!(validate_http_endpoint("http://100.64.0.1/v1/audio/transcriptions").is_err());
-        assert!(validate_http_endpoint("http://api.example.com/v1/audio/transcriptions").is_err());
-    }
-
-    #[test]
-    fn asr_endpoint_accepts_public_https_localhost_and_lan() {
+    fn asr_endpoint_accepts_any_http_or_https_url() {
+        // 地址选择权完全交给用户：公网 / 局域网 / 元数据地址一律放行，
+        // 前端对 http:// 输入展示明文风险提示。
+        validate_http_endpoint("http://169.254.169.254/v1/audio/transcriptions")
+            .expect("用户显式配置的 endpoint 必须放行");
+        validate_http_endpoint("http://100.64.0.1/v1/audio/transcriptions")
+            .expect("用户显式配置的 endpoint 必须放行");
+        validate_http_endpoint("http://api.example.com/v1/audio/transcriptions")
+            .expect("公网 http ASR endpoint 必须放行");
         // 公网 https（如自建 Whisper 网关）放行。
         validate_http_endpoint("https://api.example.com/v1/audio/transcriptions")
             .expect("公网 https ASR endpoint 必须通过");
         // 本地 Whisper 服务：localhost / 127.0.0.1 http 放行。
         validate_http_endpoint("http://localhost:9000/v1").expect("本地 Whisper http 必须通过");
         validate_http_endpoint("http://127.0.0.1:9000/v1").expect("本地 Whisper http 必须通过");
-        // F-01 放宽：局域网（RFC1918）http ASR 网关放行（用户局域网自托管 Whisper）。
+        // 局域网（RFC1918）http ASR 网关放行（用户局域网自托管 Whisper）。
         validate_http_endpoint("http://192.168.1.50:9000/v1/audio/transcriptions")
             .expect("局域网 http ASR endpoint 必须通过");
         // Mimo 官方默认 endpoint（https）放行。
         validate_http_endpoint(crate::asr::mimo::DEFAULT_ENDPOINT)
             .expect("Mimo 官方默认 endpoint 必须通过");
+    }
+
+    #[test]
+    fn asr_endpoint_rejects_malformed_or_non_http_urls() {
+        assert!(validate_http_endpoint("not a url").is_err());
+        assert!(validate_http_endpoint("ftp://example.com/").is_err());
+        assert!(validate_http_endpoint("wss://example.com/").is_err());
     }
 }

--- a/openless-all/app/src-tauri/src/coordinator.rs
+++ b/openless-all/app/src-tauri/src/coordinator.rs
@@ -3321,8 +3321,12 @@ fn resolve_ark_endpoint_with_policy(
     if api_key.trim().is_empty() && endpoint.is_none() {
         anyhow::bail!("API Key 为空");
     }
-    Ok(endpoint
-        .unwrap_or_else(|| "https://ark.cn-beijing.volces.com/api/v3/chat/completions".to_string()))
+    let resolved = endpoint
+        .unwrap_or_else(|| "https://ark.cn-beijing.volces.com/api/v3/chat/completions".to_string());
+    // 与 validate_provider_credentials / list_provider_models 同一校验函数：仅保证是
+    // 合法 http(s) URL，地址不设限制（用户显式配置，前端有 http 风险提示）。
+    crate::endpoint_security::validate_http_endpoint(&resolved)?;
+    Ok(resolved)
 }
 
 #[cfg(test)]
@@ -4370,6 +4374,40 @@ mod tests {
         )
         .unwrap();
         assert_eq!(endpoint, "https://example.com/v1/chat/completions");
+    }
+
+    #[test]
+    fn resolve_ark_endpoint_allows_any_custom_endpoint() {
+        // 地址选择权完全交给用户：http 域名、局域网 IP、元数据地址均放行，
+        // 前端对 http:// 输入展示明文风险提示。
+        let endpoint = resolve_ark_endpoint_with_policy(
+            "",
+            Some("http://example.com:12345/v1/chat/completions".to_string()),
+        )
+        .expect("custom LLM HTTP hostname with a custom port must remain usable");
+        assert_eq!(endpoint, "http://example.com:12345/v1/chat/completions");
+
+        resolve_ark_endpoint_with_policy(
+            "",
+            Some("http://192.168.1.50:12345/v1/chat/completions".to_string()),
+        )
+        .expect("custom LLM LAN HTTP endpoint must remain usable");
+
+        resolve_ark_endpoint_with_policy(
+            "",
+            Some("http://169.254.169.254/latest/meta-data/".to_string()),
+        )
+        .expect("user-explicitly-configured endpoint must be allowed (user decides)");
+    }
+
+    #[test]
+    fn resolve_ark_endpoint_rejects_malformed_endpoint() {
+        let error = resolve_ark_endpoint_with_policy(
+            "",
+            Some("ftp://example.com/v1/chat/completions".to_string()),
+        )
+        .expect_err("non-http(s) scheme must be rejected");
+        assert!(error.to_string().contains("http 或 https"));
     }
 
     #[test]

--- a/openless-all/app/src-tauri/src/endpoint_security.rs
+++ b/openless-all/app/src-tauri/src/endpoint_security.rs
@@ -1,8 +1,15 @@
 //! Shared validation for user-configurable HTTP endpoints.
 //!
-//! Provider validation and the real request path must call the same policy;
+//! Provider validation and the real request path must call the same function;
 //! otherwise a saved endpoint can bypass the checks performed by the
 //! "validate connection" button.
+//!
+//! Only URL well-formedness is enforced: the value must be a valid URL with a
+//! host and an `http`/`https` scheme. Address reachability is deliberately not
+//! restricted — endpoints are explicitly configured by the user (LAN gateways,
+//! internal DNS names, hosts-file aliases, public hosts, etc.), and the
+//! settings UI shows an in-app warning when an `http://` endpoint is entered.
+//! The user decides.
 
 use std::net::IpAddr;
 
@@ -11,74 +18,21 @@ pub(crate) struct ResolvedEndpoint {
     pub(crate) addrs: Vec<std::net::SocketAddr>,
 }
 
+/// Validate a user-configured endpoint. Format-only: must be a valid `http(s)`
+/// URL with a host. No SSRF-style address restrictions are applied.
 pub(crate) fn validate_http_endpoint(raw: &str) -> anyhow::Result<()> {
     let url = url::Url::parse(raw).map_err(|e| anyhow::anyhow!("endpoint 不是合法 URL：{e}"))?;
-    let host = url
-        .host_str()
-        .ok_or_else(|| anyhow::anyhow!("endpoint 缺少主机名"))?
-        .to_ascii_lowercase();
-
-    const METADATA_HOSTS: [&str; 2] = ["metadata.google.internal", "169.254.169.254"];
-    if METADATA_HOSTS
-        .iter()
-        .any(|metadata| host.contains(metadata))
-    {
-        anyhow::bail!("endpoint 指向云元数据服务，已拒绝：{host}");
+    url.host_str()
+        .ok_or_else(|| anyhow::anyhow!("endpoint 缺少主机名"))?;
+    if !matches!(url.scheme(), "http" | "https") {
+        anyhow::bail!("endpoint 必须使用 http 或 https：{raw}");
     }
-
-    let scheme = url.scheme();
-    let bare_host = host
-        .strip_prefix('[')
-        .and_then(|value| value.strip_suffix(']'))
-        .unwrap_or(host.as_str());
-
-    let Ok(ip) = bare_host.parse::<IpAddr>() else {
-        if bare_host == "localhost" {
-            return Ok(());
-        }
-        if scheme != "https" {
-            anyhow::bail!("endpoint 必须使用 https（仅 localhost / 局域网允许 http）：{raw}");
-        }
-        return Ok(());
-    };
-
-    let canonical = match ip {
-        IpAddr::V6(v6) => v6.to_ipv4_mapped().map(IpAddr::V4).unwrap_or(ip),
-        v4 => v4,
-    };
-
-    let is_lan = match canonical {
-        IpAddr::V4(v4) => v4.is_loopback() || v4.is_private(),
-        IpAddr::V6(v6) => v6.is_loopback() || (v6.segments()[0] & 0xfe00) == 0xfc00,
-    };
-    if is_lan {
-        return Ok(());
-    }
-
-    let is_blocked = match canonical {
-        IpAddr::V4(v4) => {
-            let octets = v4.octets();
-            let is_cgnat = octets[0] == 100 && (64..=127).contains(&octets[1]);
-            v4.is_link_local() || v4.is_unspecified() || v4.is_broadcast() || is_cgnat
-        }
-        IpAddr::V6(v6) => {
-            let is_link_local = (v6.segments()[0] & 0xffc0) == 0xfe80;
-            v6.is_unspecified() || is_link_local
-        }
-    };
-    if is_blocked {
-        anyhow::bail!("endpoint 指向保留/危险地址，已拒绝（防 SSRF）：{ip}");
-    }
-
-    if scheme != "https" {
-        anyhow::bail!("endpoint 必须使用 https（仅 localhost / 局域网允许 http）：{raw}");
-    }
-
     Ok(())
 }
 
-/// Resolve a hostname once, validate every result, and return the addresses so
-/// the HTTP client can pin this exact resolution and avoid DNS rebinding.
+/// Resolve a hostname once, and return the addresses so the HTTP client can pin
+/// this exact resolution and avoid DNS rebinding. No address restrictions are
+/// applied to the resolved results.
 pub(crate) async fn resolve_http_endpoint(raw: &str) -> anyhow::Result<Option<ResolvedEndpoint>> {
     validate_http_endpoint(raw)?;
     let url = url::Url::parse(raw)?;
@@ -95,15 +49,43 @@ pub(crate) async fn resolve_http_endpoint(raw: &str) -> anyhow::Result<Option<Re
     if addrs.is_empty() {
         anyhow::bail!("endpoint 主机名无法解析：{host}");
     }
-    for addr in &addrs {
-        let host = match addr.ip() {
-            IpAddr::V4(ip) => ip.to_string(),
-            IpAddr::V6(ip) => format!("[{ip}]"),
-        };
-        validate_http_endpoint(&format!("{}://{host}", url.scheme()))?;
-    }
     Ok(Some(ResolvedEndpoint {
         host: host.to_string(),
         addrs,
     }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::validate_http_endpoint;
+
+    #[test]
+    fn accepts_http_anywhere_user_chooses() {
+        // 地址选择权完全交给用户：公网域名、局域网、公网 IP、本地、元数据地址一律
+        // 放行，前端对 http:// 输入展示明文风险提示（user decides）。
+        validate_http_endpoint("http://example.com:12345/")
+            .expect("public HTTP hostname must be allowed");
+        validate_http_endpoint("http://api.example.com/v1/audio/transcriptions")
+            .expect("public HTTP hostname must be allowed");
+        validate_http_endpoint("http://1.2.3.4/v1").expect("public literal IP HTTP must be allowed");
+        validate_http_endpoint("http://192.168.1.50:9000/v1")
+            .expect("LAN HTTP endpoint must be allowed");
+        validate_http_endpoint("http://localhost:9000/v1")
+            .expect("localhost HTTP endpoint must be allowed");
+        validate_http_endpoint("http://169.254.169.254/v1")
+            .expect("metadata address must be allowed (user decides)");
+        validate_http_endpoint("http://100.64.0.1/v1")
+            .expect("CGNAT address must be allowed (user decides)");
+        validate_http_endpoint("http://metadata.google.internal/v1")
+            .expect("metadata hostname must be allowed (user decides)");
+        validate_http_endpoint("https://example.com:12345/")
+            .expect("HTTPS hostname must be allowed");
+    }
+
+    #[test]
+    fn rejects_malformed_or_non_http_urls() {
+        assert!(validate_http_endpoint("not a url").is_err());
+        assert!(validate_http_endpoint("ftp://example.com/").is_err());
+        assert!(validate_http_endpoint("wss://example.com/").is_err());
+    }
 }

--- a/openless-all/app/src/i18n/en.ts
+++ b/openless-all/app/src/i18n/en.ts
@@ -1045,6 +1045,7 @@ export const en: typeof zhCN = {
       validateFailed: 'Connection check failed.',
       providerHttpStatus: 'Provider returned HTTP {{status}}. Check the API key permissions or endpoint.',
       endpointMustUseHttps: 'HTTP endpoints are allowed, but API keys and audio content may leak in transit.',
+      endpointHttpWarning: 'HTTP endpoints are allowed, but API keys and request content may leak in transit.',
       endpointInvalid: 'Endpoint format is invalid.',
       bailianEndpointSchemeInvalid: 'Bailian realtime ASR uses the DashScope WebSocket gateway: the endpoint must start with wss:// (default: wss://dashscope.aliyuncs.com/api-ws/v1/inference/). An https:// compatible-mode URL will not work here.',
       qwen3EndpointSchemeInvalid: 'Qwen3 realtime ASR uses the DashScope Realtime WebSocket gateway: the endpoint must start with wss:// (default: wss://dashscope.aliyuncs.com/api-ws/v1/realtime). An https:// URL will not work here.',

--- a/openless-all/app/src/i18n/ja.ts
+++ b/openless-all/app/src/i18n/ja.ts
@@ -1047,6 +1047,7 @@ export const ja: typeof zhCN = {
       validateFailed: '接続チェックに失敗しました。',
       providerHttpStatus: 'サプライヤーが {{status}} を返しました。API Key 権限またはエンドポイントを確認してください。',
       endpointMustUseHttps: 'HTTP Endpoint も使用できますが、API Key と音声内容が通信中に漏えいする可能性があります。',
+      endpointHttpWarning: 'HTTP Endpoint も使用できますが、API Key とリクエスト内容が通信中に漏えいする可能性があります。',
       endpointInvalid: 'Endpoint の形式が無効です。',
       bailianEndpointSchemeInvalid: 'Bailian リアルタイム ASR は DashScope の WebSocket ゲートウェイを使用します。エンドポイントは wss:// で始まる必要があります（既定: wss://dashscope.aliyuncs.com/api-ws/v1/inference/）。https:// の互換モード URL はここでは使用できません。',
       qwen3EndpointSchemeInvalid: 'Qwen3 リアルタイム ASR は DashScope Realtime WebSocket ゲートウェイを使用します。エンドポイントは wss:// で始まる必要があります（既定: wss://dashscope.aliyuncs.com/api-ws/v1/realtime）。https:// の URL はここでは使用できません。',

--- a/openless-all/app/src/i18n/ko.ts
+++ b/openless-all/app/src/i18n/ko.ts
@@ -1047,6 +1047,7 @@ export const ko: typeof zhCN = {
       validateFailed: '연결 확인에 실패했습니다.',
       providerHttpStatus: '공급자가 {{status}} 를 반환했습니다. API Key 권한 또는 Endpoint 를 확인해 주세요.',
       endpointMustUseHttps: 'HTTP Endpoint 를 사용할 수 있지만, API Key 와 음성 내용이 전송 중 유출될 수 있습니다.',
+      endpointHttpWarning: 'HTTP Endpoint 를 사용할 수 있지만, API Key 와 요청 내용이 전송 중 유출될 수 있습니다.',
       endpointInvalid: 'Endpoint 형식이 올바르지 않습니다.',
       bailianEndpointSchemeInvalid: 'Bailian 실시간 ASR은 DashScope WebSocket 게이트웨이를 사용합니다. 엔드포인트는 wss://로 시작해야 합니다(기본값: wss://dashscope.aliyuncs.com/api-ws/v1/inference/). https:// 호환 모드 주소는 여기서 사용할 수 없습니다.',
       qwen3EndpointSchemeInvalid: 'Qwen3 실시간 ASR은 DashScope Realtime WebSocket 게이트웨이를 사용합니다. 엔드포인트는 wss://로 시작해야 합니다(기본값: wss://dashscope.aliyuncs.com/api-ws/v1/realtime). https:// 주소는 여기서 사용할 수 없습니다.',

--- a/openless-all/app/src/i18n/zh-CN.ts
+++ b/openless-all/app/src/i18n/zh-CN.ts
@@ -1043,6 +1043,7 @@ export const zhCN = {
       validateFailed: '连接检查未通过。',
       providerHttpStatus: '供应商接口返回 {{status}}，请检查 API Key 权限或 Endpoint。',
       endpointMustUseHttps: '允许使用 HTTP Endpoint，但请注意：API Key 和音频内容可能在传输中泄漏。',
+      endpointHttpWarning: '允许使用 HTTP Endpoint，但请注意：API Key 和请求内容可能在传输中泄漏。',
       endpointInvalid: 'Endpoint 格式不合法。',
       bailianEndpointSchemeInvalid: '百炼实时 ASR 走 DashScope WebSocket 网关，接口地址必须以 wss:// 开头（默认 wss://dashscope.aliyuncs.com/api-ws/v1/inference/）；https:// 的兼容模式地址在此不可用。',
       qwen3EndpointSchemeInvalid: 'Qwen3 实时 ASR 走 DashScope Realtime WebSocket 网关，接口地址必须以 wss:// 开头（默认 wss://dashscope.aliyuncs.com/api-ws/v1/realtime）；https:// 地址在此不可用。',

--- a/openless-all/app/src/i18n/zh-TW.ts
+++ b/openless-all/app/src/i18n/zh-TW.ts
@@ -1045,6 +1045,7 @@ export const zhTW: typeof zhCN = {
       validateFailed: '連接檢查未通過。',
       providerHttpStatus: '供應商接口返回 {{status}}，請檢查 API Key 權限或 Endpoint。',
       endpointMustUseHttps: '允許使用 HTTP Endpoint，但請注意：API Key 和音訊內容可能在傳輸中外洩。',
+      endpointHttpWarning: '允許使用 HTTP Endpoint，但請注意：API Key 和請求內容可能在傳輸中外洩。',
       endpointInvalid: 'Endpoint 格式不合法。',
       bailianEndpointSchemeInvalid: '百煉即時 ASR 走 DashScope WebSocket 閘道，接口地址必須以 wss:// 開頭（預設 wss://dashscope.aliyuncs.com/api-ws/v1/inference/）；https:// 的相容模式地址在此不可用。',
       qwen3EndpointSchemeInvalid: 'Qwen3 即時 ASR 走 DashScope Realtime WebSocket 閘道，接口地址必須以 wss:// 開頭（預設 wss://dashscope.aliyuncs.com/api-ws/v1/realtime）；https:// 地址在此不可用。',

--- a/openless-all/app/src/pages/settings/ProvidersSection.tsx
+++ b/openless-all/app/src/pages/settings/ProvidersSection.tsx
@@ -1027,7 +1027,7 @@ function CredentialField({ label, account, provider, placeholder, mono, mask, de
 
   const inputType = mask && !revealed ? 'password' : 'text';
   const disabled = !loaded;
-  const showInsecureAsrEndpointWarning = account === 'asr.endpoint'
+  const showInsecureEndpointWarning = (account === 'ark.endpoint' || account === 'asr.endpoint' || account === 'omni.endpoint')
     && value.trim().toLowerCase().startsWith('http://');
 
   return (
@@ -1120,9 +1120,9 @@ function CredentialField({ label, account, provider, placeholder, mono, mask, de
             </span>
           )}
         </div>
-        {showInsecureAsrEndpointWarning && (
+        {showInsecureEndpointWarning && (
           <span style={{ fontSize: 11, color: 'var(--ol-warn)', lineHeight: 1.45 }}>
-            {t('settings.providers.endpointMustUseHttps')}
+            {t('settings.providers.endpointHttpWarning')}
           </span>
         )}
       </div>


### PR DESCRIPTION
## Summary

- 完全放开 http(s) 端点限制：公网/私网/本地/元数据地址一律放行，校验仅保留 URL 格式检查（合法 http(s) URL + 主机名）。
- LLM / ASR / Omni 三条路径（连通性测试、模型列表、运行时）共用同一校验。
- 运行时 `resolve_ark_endpoint` 补上同一校验，修复「保存端点绕过验证按钮检查」gap。
- 前端对 `ark`/`asr`/`omni` endpoint 的 `http://` 输入展示明文风险提示（5 个 locale）。
- Closes #929

## Validation

- `npm test` — passed，43 frontend tests。
- `cargo test --lib endpoint_security::tests` — passed。
- `cargo test --lib resolve_ark_endpoint -- --test-threads=1` — passed。
- `cargo test --lib asr_endpoint -- --test-threads=1` — passed。