### PR TITLE
chore(ci): optimize CI caching, concurrency, and Tauri security

### DIFF
--- a/.github/workflows/android-apk.yml
+++ b/.github/workflows/android-apk.yml
@@ -13,6 +13,11 @@ on:
       - 'v*-tauri'
   workflow_dispatch:
 
+# 同一 tag 重复推送只跑最新一次；workflow_dispatch 用 run_id 隔离避免互相取消。
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'workflow_dispatch' && github.run_id || github.ref }}
+  cancel-in-progress: false
+
 jobs:
   build-android-apk:
     permissions:
@@ -25,8 +30,8 @@ jobs:
       OPENLESS_RELEASE_CHANNEL: ${{ (endsWith(github.ref_name, '-beta-tauri') || contains(github.ref_name, '-Beta.')) && 'beta' || 'stable' }}
     steps:
       - uses: actions/checkout@v4
-        with:
-          submodules: recursive
+        # vendor/qwen-asr 仅 macOS 上 build.rs 会编译；Android APK 构建完全不需要
+        # 子模块，去掉递归拉取省一次网络 fetch + 失败点。
 
       - name: Detect build mode
         id: mode
@@ -136,7 +141,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: "22"
           cache: npm
           cache-dependency-path: openless-all/app/package-lock.json
 

--- a/.github/workflows/android-apk.yml
+++ b/.github/workflows/android-apk.yml
@@ -16,7 +16,7 @@ on:
 # 同一 tag 重复推送只跑最新一次；workflow_dispatch 用 run_id 隔离避免互相取消。
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'workflow_dispatch' && github.run_id || github.ref }}
-  cancel-in-progress: false
+  cancel-in-progress: ${{ github.event_name == 'push' }}
 
 jobs:
   build-android-apk:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,9 +13,9 @@ on:
     branches: [main, beta]
   workflow_dispatch:
 
-# 同一 PR / 分支快速重复推送时，取消旧运行省并发额度。
+# 同一 PR 快速重复推送时取消旧运行；workflow_dispatch 用 run_id 隔离。
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name == 'workflow_dispatch' && github.run_id || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,11 @@ on:
     branches: [main, beta]
   workflow_dispatch:
 
+# 同一 PR / 分支快速重复推送时，取消旧运行省并发额度。
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   android-check:
     name: Android cargo check
@@ -22,9 +27,8 @@ jobs:
         working-directory: openless-all/app
     steps:
       - uses: actions/checkout@v4
-        with:
-          submodules: recursive
-
+        # vendor/qwen-asr 仅 macOS 上 build.rs 会编译（build.rs:49 build_qwen_asr_macos）；
+        # Android/Linux 的 cargo check 不需要，去掉递归拉取省一次网络 fetch + 失败点。
       - name: Setup Android SDK + NDK
         uses: android-actions/setup-android@v3
         with:
@@ -70,6 +74,10 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: aarch64-linux-android,x86_64-linux-android
+
+      - uses: swatinem/rust-cache@v2
+        with:
+          workspaces: 'openless-all/app/src-tauri -> target'
 
       - uses: gradle/actions/setup-gradle@v4
 
@@ -170,9 +178,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          # vendor/qwen-asr 是 macOS 上 build.rs 必须的 git submodule。Windows
-          # checkout 也拉一份保持与 release-tauri.yml 一致，开销几秒可以忽略。
-          submodules: recursive
+          # vendor/qwen-asr 仅 macOS 上 build.rs 会编译（build.rs:49 build_qwen_asr_macos）。
+          # Windows/Linux 的 cargo check 不需要子模块；用矩阵条件避免非 macOS job
+          # 多拉一次 git submodule（省网络 fetch + 去掉一个失败点）。
+          submodules: ${{ matrix.os == 'macos-latest' && 'recursive' || 'false' }}
 
       - uses: actions/setup-node@v4
         with:
@@ -181,6 +190,10 @@ jobs:
           cache-dependency-path: openless-all/app/package-lock.json
 
       - uses: dtolnay/rust-toolchain@stable
+
+      - uses: swatinem/rust-cache@v2
+        with:
+          workspaces: 'openless-all/app/src-tauri -> target'
 
       - name: Install Linux check dependencies
         if: runner.os == 'Linux'

--- a/.github/workflows/release-tauri.yml
+++ b/.github/workflows/release-tauri.yml
@@ -24,7 +24,7 @@ on:
 # 同一 tag 重复推送只跑最新一次；workflow_dispatch 用 run_id 隔离避免互相取消。
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'workflow_dispatch' && github.run_id || github.ref }}
-  cancel-in-progress: false
+  cancel-in-progress: ${{ github.event_name == 'push' }}
 
 jobs:
   build:

--- a/.github/workflows/release-tauri.yml
+++ b/.github/workflows/release-tauri.yml
@@ -21,6 +21,11 @@ on:
       - 'v*-tauri'
   workflow_dispatch:
 
+# 同一 tag 重复推送只跑最新一次；workflow_dispatch 用 run_id 隔离避免互相取消。
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'workflow_dispatch' && github.run_id || github.ref }}
+  cancel-in-progress: false
+
 jobs:
   build:
     permissions:
@@ -60,13 +65,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          # vendor/qwen-asr 是 macOS 上 build.rs 必须的 git submodule（cc-rs 编译
-          # Open-Less/qwen-asr fork 的 C 源），不拉就会在 mac 端 cargo build 阶段挂掉。
-          submodules: recursive
+          # vendor/qwen-asr 仅 macOS 上 build.rs 会编译（build.rs:49 build_qwen_asr_macos）；
+          # Windows/Linux 的 cargo build 不需要子模块，去掉非 macOS job 的递归拉取。
+          submodules: ${{ startsWith(matrix.platform, 'macos') && 'recursive' || 'false' }}
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: "22"
           cache: npm
           cache-dependency-path: 'openless-all/app/package-lock.json'
 

--- a/openless-all/app/package-lock.json
+++ b/openless-all/app/package-lock.json
@@ -17,7 +17,6 @@
         "@tauri-apps/plugin-dialog": "^2.7.2",
         "@tauri-apps/plugin-shell": "^2.3.5",
         "@tauri-apps/plugin-updater": "^2.10.1",
-        "@types/dompurify": "^3.0.5",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "dompurify": "^3.4.8",
@@ -33,6 +32,7 @@
       },
       "devDependencies": {
         "@tauri-apps/cli": "^2.1.0",
+        "@types/dompurify": "^3.0.5",
         "@types/react": "^18.3.12",
         "@types/react-dom": "^18.3.1",
         "@vitejs/plugin-react": "^4.3.3",
@@ -2320,6 +2320,7 @@
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/@types/dompurify/-/dompurify-3.0.5.tgz",
       "integrity": "sha512-1Wg0g3BtQF7sSb27fJQAKck1HECM6zV1EB66j8JH9i3LCjYabJa0FSdiSgsD5K/RbrsR0SiraKacLB+T8ZVYAg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/trusted-types": "*"
@@ -2363,6 +2364,7 @@
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/validate-npm-package-name": {

--- a/openless-all/app/package.json
+++ b/openless-all/app/package.json
@@ -41,7 +41,6 @@
     "@tauri-apps/plugin-dialog": "^2.7.2",
     "@tauri-apps/plugin-shell": "^2.3.5",
     "@tauri-apps/plugin-updater": "^2.10.1",
-    "@types/dompurify": "^3.0.5",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "dompurify": "^3.4.8",
@@ -57,6 +56,7 @@
   },
   "devDependencies": {
     "@tauri-apps/cli": "^2.1.0",
+    "@types/dompurify": "^3.0.5",
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",
     "@vitejs/plugin-react": "^4.3.3",

--- a/openless-all/app/scripts/package-lock-root-contract.test.mjs
+++ b/openless-all/app/scripts/package-lock-root-contract.test.mjs
@@ -1,0 +1,34 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+
+const packageJson = JSON.parse(
+  await readFile(new URL('../package.json', import.meta.url), 'utf8'),
+);
+const packageLock = JSON.parse(
+  await readFile(new URL('../package-lock.json', import.meta.url), 'utf8'),
+);
+const lockRoot = packageLock.packages?.[''];
+
+assert.ok(lockRoot, 'package-lock.json must contain the root package entry');
+assert.deepEqual(
+  lockRoot.dependencies,
+  packageJson.dependencies,
+  'package-lock root dependencies must match package.json',
+);
+assert.deepEqual(
+  lockRoot.devDependencies,
+  packageJson.devDependencies,
+  'package-lock root devDependencies must match package.json',
+);
+
+const dompurifyTypes = packageLock.packages['node_modules/@types/dompurify'];
+const trustedTypes = packageLock.packages['node_modules/@types/trusted-types'];
+
+assert.equal(dompurifyTypes?.dev, true, '@types/dompurify must remain development-only');
+assert.equal(
+  Boolean(trustedTypes?.dev || trustedTypes?.devOptional),
+  true,
+  '@types/trusted-types must not be classified as a production-only dependency',
+);
+
+console.log('package-lock-root-contract.test.mjs passed');

--- a/openless-all/app/scripts/tauri-api-surface-contract.test.mjs
+++ b/openless-all/app/scripts/tauri-api-surface-contract.test.mjs
@@ -1,0 +1,42 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+
+const config = JSON.parse(
+  await readFile(new URL('../src-tauri/tauri.conf.json', import.meta.url), 'utf8'),
+);
+const lifecycleE2e = await readFile(
+  new URL('./windows-openless-lifecycle-e2e.py', import.meta.url),
+  'utf8',
+);
+const miscCommands = await readFile(
+  new URL('../src-tauri/src/commands/misc.rs', import.meta.url),
+  'utf8',
+);
+
+assert.equal(
+  config.app.withGlobalTauri,
+  false,
+  'the application must not expose the global Tauri API bundle',
+);
+assert.match(
+  lifecycleE2e,
+  /window\.__TAURI_INTERNALS__\.invoke\(/,
+  'the Windows lifecycle E2E must invoke through the Tauri IPC bridge',
+);
+assert.doesNotMatch(
+  lifecycleE2e,
+  /window\.__TAURI__\./,
+  'the Windows lifecycle E2E must not depend on the disabled global Tauri API',
+);
+assert.match(
+  miscCommands,
+  /window\.__TAURI_INTERNALS__\.invoke\(/,
+  'the cursor-context debug example must use the available Tauri IPC bridge',
+);
+assert.doesNotMatch(
+  miscCommands,
+  /\b__TAURI__\./,
+  'debug documentation must not recommend the disabled global Tauri API',
+);
+
+console.log('tauri-api-surface-contract.test.mjs passed');

--- a/openless-all/app/scripts/windows-openless-lifecycle-e2e.py
+++ b/openless-all/app/scripts/windows-openless-lifecycle-e2e.py
@@ -74,7 +74,7 @@ class CdpClient:
         args_json = json.dumps(args or {}, ensure_ascii=False)
         expression = f"""
         (async () => {{
-          const value = await window.__TAURI__.core.invoke({json.dumps(command)}, {args_json});
+          const value = await window.__TAURI_INTERNALS__.invoke({json.dumps(command)}, {args_json});
           return JSON.stringify(value ?? null);
         }})()
         """

--- a/openless-all/app/scripts/workflow-concurrency-contract.test.mjs
+++ b/openless-all/app/scripts/workflow-concurrency-contract.test.mjs
@@ -1,0 +1,42 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+
+const workflows = {
+  android: await readFile(new URL('../../../.github/workflows/android-apk.yml', import.meta.url), 'utf8'),
+  ci: await readFile(new URL('../../../.github/workflows/ci.yml', import.meta.url), 'utf8'),
+  tauriRelease: await readFile(
+    new URL('../../../.github/workflows/release-tauri.yml', import.meta.url),
+    'utf8',
+  ),
+};
+
+const tagGroup =
+  "group: ${{ github.workflow }}-${{ github.event_name == 'workflow_dispatch' && github.run_id || github.ref }}";
+const cancelSupersededTagPush = "cancel-in-progress: ${{ github.event_name == 'push' }}";
+
+for (const [name, source] of [
+  ['Android release', workflows.android],
+  ['Tauri release', workflows.tauriRelease],
+]) {
+  assert.ok(
+    source.includes(tagGroup),
+    `${name} workflow must isolate manual runs while grouping repeated pushes of the same tag`,
+  );
+  assert.ok(
+    source.includes(cancelSupersededTagPush),
+    `${name} workflow must cancel an older run when the same tag is pushed again`,
+  );
+}
+
+assert.ok(
+  workflows.ci.includes('group: ${{ github.workflow }}-${{ github.ref }}'),
+  'PR CI must group runs by workflow and ref',
+);
+assert.ok(
+  workflows.ci.includes(
+    "cancel-in-progress: ${{ github.event_name == 'pull_request' }}",
+  ),
+  'PR CI must cancel superseded pull-request runs without cancelling branch pushes',
+);
+
+console.log('workflow-concurrency-contract.test.mjs passed');

--- a/openless-all/app/scripts/workflow-concurrency-contract.test.mjs
+++ b/openless-all/app/scripts/workflow-concurrency-contract.test.mjs
@@ -10,7 +10,7 @@ const workflows = {
   ),
 };
 
-const tagGroup =
+const isolatedManualGroup =
   "group: ${{ github.workflow }}-${{ github.event_name == 'workflow_dispatch' && github.run_id || github.ref }}";
 const cancelSupersededTagPush = "cancel-in-progress: ${{ github.event_name == 'push' }}";
 
@@ -19,7 +19,7 @@ for (const [name, source] of [
   ['Tauri release', workflows.tauriRelease],
 ]) {
   assert.ok(
-    source.includes(tagGroup),
+    source.includes(isolatedManualGroup),
     `${name} workflow must isolate manual runs while grouping repeated pushes of the same tag`,
   );
   assert.ok(
@@ -29,8 +29,8 @@ for (const [name, source] of [
 }
 
 assert.ok(
-  workflows.ci.includes('group: ${{ github.workflow }}-${{ github.ref }}'),
-  'PR CI must group runs by workflow and ref',
+  workflows.ci.includes(isolatedManualGroup),
+  'PR CI must isolate manual runs while grouping pull-request and branch runs by ref',
 );
 assert.ok(
   workflows.ci.includes(

--- a/openless-all/app/src-tauri/src/commands/misc.rs
+++ b/openless-all/app/src-tauri/src/commands/misc.rs
@@ -222,7 +222,7 @@ fn resolve_openless_log_path() -> Result<std::path::PathBuf, String> {
 /// 微信里点进输入框，探针在那时才真正开始读。
 ///
 /// ```js
-/// await __TAURI__.core.invoke('debug_read_cursor_context', { delayMs: 3000 })
+/// await window.__TAURI_INTERNALS__.invoke('debug_read_cursor_context', { delayMs: 3000 })
 /// ```
 #[tauri::command]
 pub async fn debug_read_cursor_context(

--- a/openless-all/app/src-tauri/tauri.conf.json
+++ b/openless-all/app/src-tauri/tauri.conf.json
@@ -10,7 +10,7 @@
     "frontendDist": "../dist"
   },
   "app": {
-    "withGlobalTauri": true,
+    "withGlobalTauri": false,
     "macOSPrivateApi": true,
     "windows": [
       {


### PR DESCRIPTION
Address CI/CD efficiency, release-safety, dependency-metadata, and Tauri API-surface gaps identified during project optimization analysis. The changes reduce repeated PR work, prevent stale tag builds from publishing release artifacts, tighten the Tauri frontend API surface, and eliminate unnecessary submodule fetches on non-macOS jobs.

CI workflow improvements:
- Add Swatinem/rust-cache@v2 to both ci.yml jobs (android-check and cross-platform), matching the cache already used by release-tauri.yml. This reuses dependency build artifacts between runs; the actual time saved depends on cache warmth and dependency changes.
- Add concurrency groups to all three workflows. Superseded pull-request runs are cancelled. Re-pushing the same release tag cancels the older run so only the latest commit can publish. Manual workflow_dispatch runs use run_id-based groups and remain isolated from one another.
- Unify Node.js on version 22 across ci.yml, release-tauri.yml, and android-apk.yml.

Submodule and Tauri hardening:
- Fetch the vendor/qwen-asr submodule only for macOS jobs. Its build inputs are guarded by macOS cfgs; Linux, Windows, and Android builds do not require the checkout.
- Set withGlobalTauri to false in tauri.conf.json. The application frontend continues to use @tauri-apps/api imports. The Windows lifecycle E2E now invokes through window.__TAURI_INTERNALS__.invoke, so the regression tooling remains functional without exposing the global Tauri API bundle.

Dependency hygiene:
- Move @types/dompurify from dependencies to devDependencies and synchronize package-lock.json, including the development-only flags for its transitive type dependency. This keeps runtime dependency metadata and lockfile-based audit/SBOM output accurate.

Regression coverage:
- Add contract tests for package.json/package-lock.json root dependency parity, the disabled global Tauri API plus E2E IPC bridge, and the intended PR/tag/manual workflow concurrency policies.