### PR TITLE
fix(settings): 选区润色快捷键录制改用通用修饰键

### DIFF
--- a/openless-all/app/src/pages/settings/SelectionPolishSection.tsx
+++ b/openless-all/app/src/pages/settings/SelectionPolishSection.tsx
@@ -38,7 +38,10 @@ export function SelectionPolishSection() {
       >
         <ShortcutRecorder
           value={prefs.selectionPolishHotkey}
-          sideSpecificModifiers
+          // 注意：不能开 sideSpecificModifiers —— 后端 set_selection_polish_hotkey 用
+          // reject_side_specific_non_dictation 拒绝非听写功能的侧键修饰（side-aware hook
+          // 仅听写支持多 owner），开启会把录制出的 ctrl-left/alt-right 等标签全部打回，
+          // 前端 catch 后误报「该快捷键组合不可用」（上游 #851 引入的自相矛盾）。
           onSave={async binding => {
             await setSelectionPolishHotkey(binding);
             await refresh();


### PR DESCRIPTION
## 问题

设置里给「选区润色」录制触发快捷键时，**带修饰键的组合保存必然失败**，且提示误导性的「该快捷键组合不可用」。

### 根因（上游 #851 引入的自相矛盾）

- 前端 `SelectionPolishSection.tsx` 给 `ShortcutRecorder` 传了 `sideSpecificModifiers`：录制把修饰键转成侧特异性标签（`alt-left` / `ctrl-right`…）
- 但同一 PR 的后端 `set_selection_polish_hotkey` 命令用 `reject_side_specific_non_dictation` **拒绝非听写功能的侧键**——side-aware hook 只支持听写 start/stop 的多个 owner，选区润色走普通 `global-hotkey` 注册，无法承载侧键语义
- 前端 `ShortcutRecorder.finish` 的 catch 是无差别捕获，任何失败都显示 `comboConflict`（"该快捷键组合不可用"），掩盖了真实原因

## 修复

去掉 `SelectionPolishSection` 的 `sideSpecificModifiers`，录制回落到通用修饰键格式（`alt` / `ctrl` / `shift` / `super`），与后端约束一致。听写快捷键（`ShortcutsSection` / `RecordingInputSection`）的侧键能力不受影响。