### PR TITLE
fix(history): 详情面板同层 key 去重，切换条目不再残留「播放录音」按钮

### DIFF
--- a/openless-all/app/scripts/history-detail-sibling-keys.test.mjs
+++ b/openless-all/app/scripts/history-detail-sibling-keys.test.mjs
@@ -6,8 +6,8 @@
 // 但 reconcile 无法正确匹配旧 fiber，每切换一次条目就在 DOM 里残留一个「播放录音」按钮，
 // 长时间开着不关的窗口会叠出一整列。
 //
-// 这条契约锁的是「同层 key 表达式互不相同」，而不是某个具体命名，后续再往详情面板加
-// 带 key 的兄弟组件时同样会被拦下。
+// 这条契约锁的是「同层 key 在运行时互不相同」，而不是某个具体命名，后续再往详情面板
+// 加带 key 的兄弟组件时同样会被拦下。
 
 import { readFile } from 'node:fs/promises';
 
@@ -59,24 +59,40 @@ if (detailKeys.length < 2) {
   );
 }
 
-const seen = new Map();
-for (const { expression } of detailKeys) {
-  if (seen.has(expression)) {
-    throw new Error(
-      `历史详情面板出现重复的同层 key：\`${expression}\` 用了 ${seen.get(expression) + 1} 次。`
-        + '重复 key 会让 React 无法正确删除旧节点，切换条目时残留重复的「播放录音」按钮，'
-        + '请给每个组件加上各自的前缀（如 `audio-${item.id}` / `repolish-${item.id}`）。',
-    );
-  }
-  seen.set(expression, 1);
-}
-
 // 每个 key 仍要跟着条目 id 变化，否则切换条目时组件不重挂载，上一条的播放/润色状态会串台。
 for (const { expression } of detailKeys) {
   if (!expression.includes('item.id')) {
     throw new Error(
       `历史详情面板的 key \`${expression}\` 未随条目 id 变化，切换条目时状态会串到下一条`,
     );
+  }
+}
+
+/**
+ * React 会把非 undefined 的 key 转成字符串后参与 sibling reconciliation。
+ * 在样例条目上求值，避免 `item.id` / `String(item.id)` 这类不同源码表达式绕过唯一性检查。
+ */
+function evaluateKey(expression, itemId) {
+  const value = Function('item', `'use strict'; return (${expression});`)({ id: itemId });
+  if (value === undefined) {
+    throw new Error(`历史详情面板的 key \`${expression}\` 求值为 undefined`);
+  }
+  return String(value);
+}
+
+for (const itemId of ['history-key-contract-a', 'history-key-contract-b']) {
+  const seen = new Map();
+  for (const { expression } of detailKeys) {
+    const key = evaluateKey(expression, itemId);
+    if (seen.has(key)) {
+      throw new Error(
+        `历史详情面板出现重复的运行时 key：\`${key}\`（表达式 \`${expression}\` 与 `
+          + `\`${seen.get(key)}\` 冲突）。重复 key 会让 React 无法正确删除旧节点，`
+          + '切换条目时残留重复的「播放录音」按钮，请给每个组件加上各自的前缀（如 '
+          + '`audio-${item.id}` / `repolish-${item.id}`）。',
+      );
+    }
+    seen.set(key, expression);
   }
 }
 

--- a/openless-all/app/scripts/history-detail-sibling-keys.test.mjs
+++ b/openless-all/app/scripts/history-detail-sibling-keys.test.mjs
@@ -1,0 +1,83 @@
+// 历史详情面板的同层 key 必须唯一。
+//
+// 背景：AudioRecordingPlayer 与 RepolishPanel 是详情 Card 里的兄弟节点，两者都靠 key
+// 在切换历史条目时强制重挂载以重置自身状态。曾经两个 key 都直接写 `item.id`，同一层出现
+// 重复 key —— React 只警告不报错（"Encountered two children with the same key"），
+// 但 reconcile 无法正确匹配旧 fiber，每切换一次条目就在 DOM 里残留一个「播放录音」按钮，
+// 长时间开着不关的窗口会叠出一整列。
+//
+// 这条契约锁的是「同层 key 表达式互不相同」，而不是某个具体命名，后续再往详情面板加
+// 带 key 的兄弟组件时同样会被拦下。
+
+import { readFile } from 'node:fs/promises';
+
+const historyTsx = await readFile(
+  new URL('../src/pages/History.tsx', import.meta.url),
+  'utf-8',
+);
+
+/** 从 `key={` 之后开始按花括号配对取出完整表达式（模板串里的 `${}` 不会截断）。 */
+function readKeyExpressions(source) {
+  const keys = [];
+  const marker = 'key={';
+  let cursor = 0;
+  for (;;) {
+    const start = source.indexOf(marker, cursor);
+    if (start === -1) return keys;
+    let depth = 1;
+    let index = start + marker.length;
+    while (index < source.length && depth > 0) {
+      if (source[index] === '{') depth += 1;
+      else if (source[index] === '}') depth -= 1;
+      index += 1;
+    }
+    keys.push({
+      expression: source.slice(start + marker.length, index - 1).trim(),
+      index: start,
+    });
+    cursor = index;
+  }
+}
+
+// 详情面板 = 右栏那张 Card。取「桌面端总是渲染 / 移动端展开才渲染」的条件到 Card 收尾之间。
+const detailStart = historyTsx.indexOf('{(!mobile || mobileDetailOpen) && (');
+if (detailStart === -1) {
+  throw new Error('未定位到历史详情面板（右栏 Card）的起始位置，契约测试需要同步更新');
+}
+const detailEnd = historyTsx.indexOf('</Card>', detailStart);
+if (detailEnd === -1) {
+  throw new Error('未定位到历史详情面板的结束位置，契约测试需要同步更新');
+}
+
+const detailSource = historyTsx.slice(detailStart, detailEnd);
+// 列表项的 key 在左栏，不在这段里；这里拿到的都是详情面板同层组件的 key。
+const detailKeys = readKeyExpressions(detailSource);
+
+if (detailKeys.length < 2) {
+  throw new Error(
+    `历史详情面板里应至少有两个带 key 的组件（播放器与重新润色面板），实际 ${detailKeys.length} 个`,
+  );
+}
+
+const seen = new Map();
+for (const { expression } of detailKeys) {
+  if (seen.has(expression)) {
+    throw new Error(
+      `历史详情面板出现重复的同层 key：\`${expression}\` 用了 ${seen.get(expression) + 1} 次。`
+        + '重复 key 会让 React 无法正确删除旧节点，切换条目时残留重复的「播放录音」按钮，'
+        + '请给每个组件加上各自的前缀（如 `audio-${item.id}` / `repolish-${item.id}`）。',
+    );
+  }
+  seen.set(expression, 1);
+}
+
+// 每个 key 仍要跟着条目 id 变化，否则切换条目时组件不重挂载，上一条的播放/润色状态会串台。
+for (const { expression } of detailKeys) {
+  if (!expression.includes('item.id')) {
+    throw new Error(
+      `历史详情面板的 key \`${expression}\` 未随条目 id 变化，切换条目时状态会串到下一条`,
+    );
+  }
+}
+
+console.log(`history-detail-sibling-keys: ${detailKeys.length} 个同层 key 均唯一且随条目 id 变化`);

--- a/openless-all/app/src/pages/History.tsx
+++ b/openless-all/app/src/pages/History.tsx
@@ -469,11 +469,15 @@ export function History() {
                   <Btn icon="trash" variant="ghost" size="sm" onClick={onDelete}>{t('common.delete')}</Btn>
                 </div>
               </div>
+              {/* key 必须带组件前缀：下面的 RepolishPanel 是同一层的兄弟节点，两个都写
+                  裸 `item.id` 会让同层出现重复 key，React 只警告不报错，但 reconcile 匹配
+                  不上旧 fiber —— 每切换一次历史条目就在 DOM 里残留一个「播放录音」按钮，
+                  开着不关的窗口能叠出一整列。 */}
               {item.hasAudioRecording && !audioMissingIds.has(item.id) && (
                 <AudioRecordingPlayer
                   sessionId={item.id}
                   onMissing={() => markAudioMissing(item.id)}
-                  key={item.id}
+                  key={`audio-${item.id}`}
                 />
               )}
               {/* 流水线明细：识别 / 润色 / 插入 三步各占一行 —— 左列步骤名、中列
@@ -563,15 +567,15 @@ export function History() {
               </div>
               {/* 重新润色：拿这条的原文再跑一次 LLM。没有原文就没得润色（转录失败条目），
                   此时整块不渲染；QA 记录的原文是问题而不是待润色文本，同样不渲染。
-                  key={item.id} 让切换记录时结果与状态一起重置，
-                  避免把上一条的结果留在新条目下面。 */}
+                  key 让切换记录时结果与状态一起重置，避免把上一条的结果留在新条目下面；
+                  前缀是为了跟上面播放器的 key 区分开（同层重复 key 会残留旧节点）。 */}
               {item.rawTranscript.trim() && item.errorCode !== 'qaSession' && (
                 <RepolishPanel
                   session={item}
                   mobile={mobile}
                   allPacks={allPacks}
                   packsError={packsError}
-                  key={item.id}
+                  key={`repolish-${item.id}`}
                 />
               )}
             </>


### PR DESCRIPTION
## 现象

历史记录详情页，「播放录音」按钮会一个接一个地叠出来，把下面的流水线信息挤走。用户反馈的窗口连开了几天，攒到 6~7 个。

![重复的播放录音按钮](https://raw.githubusercontent.com/bigsongeth/openless/pr964-assets/.github/assets/history-dup-play-buttons-1.png)

过一会儿又多一个（6 → 7），下面的内容继续被往下推：

![又多一个](https://raw.githubusercontent.com/bigsongeth/openless/pr964-assets/.github/assets/history-dup-play-buttons-2.png)

## 根因

详情面板里 `AudioRecordingPlayer` 和 `RepolishPanel` 是**同一层的兄弟节点**，两个都用裸 `item.id` 当 key：

```tsx
<AudioRecordingPlayer … key={item.id} />
…
<RepolishPanel … key={item.id} />
```

同层重复 key，React 只在 dev 打警告、不报错：

```
Warning: Encountered two children with the same key, `<id>`.
Non-unique keys may cause children to be duplicated and/or omitted
    at Card (src/pages/_atoms.tsx)
    at History (src/pages/History.tsx)
```

reconcile 匹配不上旧 fiber，旧播放器的 DOM 节点删不掉：**每切换一次历史条目就残留一个「播放录音」按钮**。fiber 树里始终只有一个播放器，多出来的都是 React 已经不再管的僵尸节点——所以它们点了也没反应，只能靠切页面/重启窗口清掉。

不是 WebKit 渲染问题，Chromium 里同样复现。

## 改动

- `key` 加各自前缀：`audio-${item.id}` / `repolish-${item.id}`。key 仍跟着条目 id 变，切换条目照旧重挂载、重置播放与润色状态，只是同层不再撞车。
- 新增契约测试 `scripts/history-detail-sibling-keys.test.mjs`：扫详情面板里所有 key 表达式，断言互不相同、且都带 `item.id`。以后再往这层加带 key 的兄弟组件会被直接拦下。

## 验证

浏览器 dev 模式（把 mock 条目的 `hasAudioRecording` 临时打开），连续切换条目 12 次：

| | 播放按钮数量 | 重复 key 警告 |
| --- | --- | --- |
| 修复前 | 1 → 12（每切一次 +1） | 每次切换都刷 |
| 修复后 | 恒为 1 | 0 条 |

`npm test`（tsc + vite build + 全部前端测试，含新增契约测试）exit=0。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
