### PR TITLE
fix(linux): 屏蔽 Less Computer / Claude 控制台入口

### DIFF
--- a/openless-all/app/src/pages/settings/CodingAgentSection.tsx
+++ b/openless-all/app/src/pages/settings/CodingAgentSection.tsx
@@ -89,7 +89,9 @@ export function CodingAgentSection() {
     }
   }
 
-  if (os === 'win') return null
+  // Less Computer 仅 macOS 开放：后端只在 macOS 注册热键/创建窗口，
+  // Windows / Linux 不渲染配置入口，避免用户看到无法使用的功能。
+  if (os === 'win' || os === 'linux') return null
 
   if (!prefs) {
     return (

--- a/openless-all/app/src/pages/settings/tabs.tsx
+++ b/openless-all/app/src/pages/settings/tabs.tsx
@@ -115,8 +115,9 @@ export function AdvancedTab() {
 
   return (
     <>
-      {showDesktopAdvanced && os !== 'win' && <CodingAgentSection />}
-      {showDesktopAdvanced && os !== 'win' && <ClaudeConsoleSection />}
+      {/* Less Computer / Claude 控制台仅 macOS 开放：后端只在 macOS 注册热键/创建窗口 */}
+      {showDesktopAdvanced && os === 'mac' && <CodingAgentSection />}
+      {showDesktopAdvanced && os === 'mac' && <ClaudeConsoleSection />}
       <MultimodalPipelineSection />
       {showDebugTools && <DebugToolsSection />}
     </>


### PR DESCRIPTION
## 背景

Less Computer（语音 Agent）功能目前仅在 macOS 后端注册热键和创建窗口，Windows/Linux 不生效。为避免 Linux 用户看到无法使用的功能入口，本 PR 在设置页屏蔽相关入口。

## 改动

| 文件 | 修改 |
|---|---|
| `openless-all/app/src/pages/settings/CodingAgentSection.tsx` | `os === 'win'` → `os === 'win' \|\| os === 'linux'` |
| `openless-all/app/src/pages/settings/tabs.tsx` | AdvancedTab 中两个 Section 从 `os !== 'win'` 改为 `os === 'mac'` |

## 已有门控

- **Rust 后端**：窗口创建/show/hide 使用 `#[cfg(target_os = "macos")]`，非 macOS 为 no-op stub
- **Rust 热键**：非 macOS 直接 early return
- **前端打包**：`TAURI_ENV_PLATFORM='linux'` 时 `LESS_COMPUTER_BUNDLED = false`，面板 chunk 不进入构建产物
- **快捷键设置页**：语音快捷键行已用 `os === 'mac'` 门控

## 验证

- Linux 构建产物中不包含 less-computer JS chunk
- Rust 编译通过