### PR TITLE
fix(linux): avoid audio OSD on startup and exit (#968)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "openless-all/app/src-tauri/vendor/qwen-asr"]
 	path = openless-all/app/src-tauri/vendor/qwen-asr
 	url = https://github.com/Open-Less/qwen-asr.git
+[submodule "openless-all/app/src-tauri/vendor/qwen3-asr-rs"]
+	path = openless-all/app/src-tauri/vendor/qwen3-asr-rs
+	url = https://github.com/Open-Less/qwen3_asr_rs.git

--- a/openless-all/app/src-tauri/src/permissions.rs
+++ b/openless-all/app/src-tauri/src/permissions.rs
@@ -335,26 +335,40 @@ mod platform {
 
     /// Windows 的麦克风权限走系统设置 → 隐私 → 麦克风；
     /// 这里用 cpal 建立一次短生命周期输入流，避免只查设备格式时误报已授权。
+    /// Linux 没有对应的应用级权限状态，只检查设备是否存在，避免 PipeWire
+    /// 因权限探测建立临时输入流而触发桌面音量 OSD（issue #968）。
     pub fn check_microphone() -> PermissionStatus {
-        if windows_microphone_registry_denied() {
-            log::warn!("[mic] Windows microphone privacy registry is denied");
-            return PermissionStatus::Denied;
+        #[cfg(target_os = "linux")]
+        {
+            return if has_microphone_input_device() {
+                PermissionStatus::Granted
+            } else {
+                PermissionStatus::NoDevice
+            };
         }
 
-        let host = cpal::default_host();
-        let Some(device) = host.default_input_device() else {
-            log::warn!("[mic] no default input device");
-            return PermissionStatus::NoDevice;
-        };
-        let supported = match device.default_input_config() {
-            Ok(config) => config,
-            Err(err) => return classify_audio_probe_error(err.to_string()),
-        };
-        let sample_format = supported.sample_format();
-        let config: StreamConfig = supported.config();
-        match probe_input_stream(&device, &config, sample_format) {
-            Ok(()) => PermissionStatus::Granted,
-            Err(message) => classify_audio_probe_error(message),
+        #[cfg(not(target_os = "linux"))]
+        {
+            if windows_microphone_registry_denied() {
+                log::warn!("[mic] Windows microphone privacy registry is denied");
+                return PermissionStatus::Denied;
+            }
+
+            let host = cpal::default_host();
+            let Some(device) = host.default_input_device() else {
+                log::warn!("[mic] no default input device");
+                return PermissionStatus::NoDevice;
+            };
+            let supported = match device.default_input_config() {
+                Ok(config) => config,
+                Err(err) => return classify_audio_probe_error(err.to_string()),
+            };
+            let sample_format = supported.sample_format();
+            let config: StreamConfig = supported.config();
+            match probe_input_stream(&device, &config, sample_format) {
+                Ok(()) => PermissionStatus::Granted,
+                Err(message) => classify_audio_probe_error(message),
+            }
         }
     }
 

--- a/openless-all/app/src/components/AudioCue.tsx
+++ b/openless-all/app/src/components/AudioCue.tsx
@@ -1,8 +1,10 @@
 // 录音提示音：监听 capsule:state 事件，在"开始录音"边沿播放合成提示音。
-// 独立组件，不依赖胶囊窗口显示——Linux 上胶囊隐藏也能正常工作。
-// Android Web Audio 输出会触发部分设备的录音输入路由切换，移动端禁用。
+// 独立组件，不依赖胶囊窗口显示——胶囊隐藏时也能正常工作。
+// Linux 的 Web Audio 输出会被 PipeWire/KDE 当作 sink-input，启动/退出时触发音量 OSD；
+// Android 也可能因 Web Audio 输出切换录音输入路由，因此这两个平台禁用。
 
 import { useEffect, useRef } from 'react';
+import { detectOS } from './WindowChrome';
 import { isAndroid, isTauri } from '../lib/ipc';
 import { playRecordStartCue, primeAudioCue, stopAudioCue } from '../lib/audioCue';
 import type { CapsuleState, UserPreferences } from '../lib/types';
@@ -18,7 +20,7 @@ interface CapsulePayload {
 export function AudioCueListener() {
   const audioCueEnabledRef = useRef<boolean>(true);
   const prevStateRef = useRef<CapsuleState>('idle' as CapsuleState);
-  const audioCueRuntimeEnabled = !isAndroid();
+  const audioCueRuntimeEnabled = !isAndroid() && detectOS() !== 'linux';
 
   // 读取设置（默认开启）
   useEffect(() => {

--- a/openless-all/app/src/pages/settings/RecordingInputSection.tsx
+++ b/openless-all/app/src/pages/settings/RecordingInputSection.tsx
@@ -424,32 +424,34 @@ export function RecordingInputSection() {
         <SettingRow label={t('settings.recording.muteDuringRecordingLabel')} desc={t('settings.recording.muteDuringRecordingDesc')}>
           <Toggle on={prefs.muteDuringRecording} onToggle={onMuteDuringRecordingChange} />
         </SettingRow>
-        <SettingRow
-          label={t('settings.recording.audioCueLabel')}
-          desc={t('settings.recording.audioCueDesc')}
-        >
-          <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
-            <Toggle on={prefs.audioCueOnRecord} onToggle={onAudioCueChange} />
-            <button
-              type="button"
-              onClick={() => playRecordStartCue()}
-              style={{
-                padding: '5px 12px',
-                fontSize: 12,
-                fontWeight: 500,
-                fontFamily: 'inherit',
-                border: '0.5px solid var(--ol-line-strong)',
-                borderRadius: 8,
-                background: 'var(--ol-surface-2)',
-                color: 'var(--ol-ink-2)',
-                cursor: 'default',
-                transition: 'background 0.16s var(--ol-motion-quick)',
-              }}
-            >
-              {t('settings.recording.audioCuePreview')}
-            </button>
-          </div>
-        </SettingRow>
+        {os !== 'linux' && (
+          <SettingRow
+            label={t('settings.recording.audioCueLabel')}
+            desc={t('settings.recording.audioCueDesc')}
+          >
+            <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+              <Toggle on={prefs.audioCueOnRecord} onToggle={onAudioCueChange} />
+              <button
+                type="button"
+                onClick={() => playRecordStartCue()}
+                style={{
+                  padding: '5px 12px',
+                  fontSize: 12,
+                  fontWeight: 500,
+                  fontFamily: 'inherit',
+                  border: '0.5px solid var(--ol-line-strong)',
+                  borderRadius: 8,
+                  background: 'var(--ol-surface-2)',
+                  color: 'var(--ol-ink-2)',
+                  cursor: 'default',
+                  transition: 'background 0.16s var(--ol-motion-quick)',
+                }}
+              >
+                {t('settings.recording.audioCuePreview')}
+              </button>
+            </div>
+          </SettingRow>
+        )}
         {os === 'linux' && (
         <SettingRow label={t('settings.advanced.streamingInsertLabel')}>
           <Toggle


### PR DESCRIPTION
Closes #968

## Summary
- Linux microphone permission checks only enumerate the default input device instead of opening a cpal probe stream.
- Disable Linux Web Audio recording cues and hide their setting and preview, preventing sink-input lifecycle changes from triggering KDE/PipeWire volume OSD.

## Verification
- npm.cmd run build
- npm.cmd test (51 tests)
- npx.cmd tsx src/lib/audioCue.test.ts
- cargo test --lib permissions::tests
- cargo test --lib net::tests::system_proxy_toggle_updates_flag_and_rebuilds_shared_client