### PR TITLE
fix(settings): 把远程输入重新挂回通用设置

### DIFF
--- a/openless-all/app/src/pages/settings/tabs.tsx
+++ b/openless-all/app/src/pages/settings/tabs.tsx
@@ -4,6 +4,7 @@
 import { useTranslation } from 'react-i18next';
 import { useEffect, useState } from 'react';
 import { RecordingInputSection } from './RecordingInputSection';
+import { RemoteInputSection } from './RemoteInputSection';
 import { ShortcutsSection } from './ShortcutsSection';
 import { SelectionPolishSection } from './SelectionPolishSection';
 import { LanguageSection } from './LanguageSection';
@@ -36,14 +37,16 @@ function usePlatformCaps(): PlatformCapabilities | null {
   return platformCaps;
 }
 
-// 通用：录音与输入 · 快捷键 · 主题 · 语言。
+// 通用：录音与输入 · 远程输入 · 快捷键 · 主题 · 语言。
 export function GeneralTab() {
   const platformCaps = usePlatformCaps();
   const showDesktopShortcuts = platformCaps?.supportsDesktopHotkey === true;
+  const showRemoteInput = platformCaps?.platform === 'desktop';
 
   return (
     <>
       <RecordingInputSection />
+      {showRemoteInput && <RemoteInputSection />}
       <SelectionPolishSection />
       {showDesktopShortcuts && <ShortcutsSection />}
       <ThemeSection />


### PR DESCRIPTION
## Summary

- 把已有的 `RemoteInputSection` 重新挂回设置「通用」页。组件、后端、i18n、prefs 都还在，1.3.14 拆 `tabs.tsx` 时漏挂了。
- 仅桌面端显示。远程输入是电脑上的 HTTPS 服务，Android 不该看到这个开关。

Fixes #977

## Test plan

- [ ] 桌面：设置 → 通用，录音输入下方出现「远程输入」折叠组
- [ ] 打开开关后出现访问网址和 6 位配对码
- [ ] 关闭开关后面板收起，服务停
- [ ] Android 设置「通用」不出现远程输入
