### PR TITLE
feat: replace desktop QA popup with egui

### DIFF
--- a/openless-all/app/src-tauri/Cargo.lock
+++ b/openless-all/app/src-tauri/Cargo.lock
@@ -20,66 +20,43 @@ checksum = "366ffbaa4442f4684d91e2cd7c5ea7c4ed8add41959a31447066e279e432b618"
 
 [[package]]
 name = "accesskit"
-version = "0.24.1"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3b7f7f85a7e5f68090000ed7622545829afd484d210358702ae4cb97dd0c320"
-dependencies = [
- "uuid",
-]
+checksum = "cf203f9d3bd8f29f98833d1fbef628df18f759248a547e7e01cfbf63cda36a99"
 
 [[package]]
 name = "accesskit_atspi_common"
-version = "0.18.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e8c61bee90b42a772d39d06a740207dc71a4e780004ace1db8d99fb1baaa954"
+checksum = "890d241cf51fc784f0ac5ac34dfc847421f8d39da6c7c91a0fcc987db62a8267"
 dependencies = [
  "accesskit",
- "accesskit_consumer 0.36.0",
+ "accesskit_consumer",
  "atspi-common",
- "phf",
  "serde",
+ "thiserror 1.0.69",
  "zvariant 5.15.0",
 ]
 
 [[package]]
 name = "accesskit_consumer"
-version = "0.35.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53cf47daed85312e763fbf85ceca136e0d7abc68e0a7e12abe11f48172bc3b10"
+checksum = "db81010a6895d8707f9072e6ce98070579b43b717193d2614014abd5cb17dd43"
 dependencies = [
  "accesskit",
- "hashbrown 0.16.1",
-]
-
-[[package]]
-name = "accesskit_consumer"
-version = "0.36.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25e0d7e25d06f4dc21d1774d67146e9e80d6789216cbd4d1e88185b0095dba60"
-dependencies = [
- "accesskit",
- "hashbrown 0.16.1",
-]
-
-[[package]]
-name = "accesskit_consumer"
-version = "0.38.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d10a236f96f87d70732e44520046785431ef01d5bcd6b041317bfadd2f88245"
-dependencies = [
- "accesskit",
- "hashbrown 0.16.1",
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
 name = "accesskit_macos"
-version = "0.26.3"
+version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce02dc63b43f0c9296af9ac946312a2dc8814427d7a64d2d600971dac55b6076"
+checksum = "a0089e5c0ac0ca281e13ea374773898d9354cc28d15af9f0f7394d44a495b575"
 dependencies = [
  "accesskit",
- "accesskit_consumer 0.38.0",
- "hashbrown 0.16.1",
+ "accesskit_consumer",
+ "hashbrown 0.15.5",
  "objc2 0.5.2",
  "objc2-app-kit 0.2.2",
  "objc2-foundation 0.2.2",
@@ -87,9 +64,9 @@ dependencies = [
 
 [[package]]
 name = "accesskit_unix"
-version = "0.21.1"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b016ca8db0ea0ea2ceff29a9d6240391492d960716aa471967c00e8cc8cb197c"
+checksum = "301e55b39cfc15d9c48943ce5f572204a551646700d0e8efa424585f94fec528"
 dependencies = [
  "accesskit",
  "accesskit_atspi_common",
@@ -105,23 +82,23 @@ dependencies = [
 
 [[package]]
 name = "accesskit_windows"
-version = "0.32.1"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eff7009f1a532e917d66970a1e80c965140c6cfbbabbdde3d64e5431e6c78e21"
+checksum = "d2d63dd5041e49c363d83f5419a896ecb074d309c414036f616dc0b04faca971"
 dependencies = [
  "accesskit",
- "accesskit_consumer 0.35.0",
- "hashbrown 0.16.1",
+ "accesskit_consumer",
+ "hashbrown 0.15.5",
  "static_assertions",
- "windows 0.62.2",
- "windows-core 0.62.2",
+ "windows 0.61.3",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
 name = "accesskit_winit"
-version = "0.32.2"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fe9a94394896352cc4660ca2288bd4ef883d83238853c038b44070c8f134313"
+checksum = "c8cfabe59d0eaca7412bfb1f70198dd31e3b0496fee7e15b066f9c36a1a140a0"
 dependencies = [
  "accesskit",
  "accesskit_macos",
@@ -521,19 +498,20 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "atspi"
-version = "0.29.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c77886257be21c9cd89a4ae7e64860c6f0eefca799bb79127913052bd0eefb3d"
+checksum = "c83247582e7508838caf5f316c00791eee0e15c0bf743e6880585b867e16815c"
 dependencies = [
  "atspi-common",
+ "atspi-connection",
  "atspi-proxies",
 ]
 
 [[package]]
 name = "atspi-common"
-version = "0.13.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20c5617155740c98003016429ad13fe43ce7a77b007479350a9f8bf95a29f63d"
+checksum = "33dfc05e7cdf90988a197803bf24f5788f94f7c94a69efa95683e8ffe76cfdfb"
 dependencies = [
  "enumflags2",
  "serde",
@@ -546,10 +524,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "atspi-proxies"
-version = "0.13.0"
+name = "atspi-connection"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2230e48787ed3eb4088996eab66a32ca20c0b67bbd4fd6cdfe79f04f1f04c9fc"
+checksum = "4193d51303d8332304056ae0004714256b46b6635a5c556109b319c0d3784938"
+dependencies = [
+ "atspi-common",
+ "atspi-proxies",
+ "futures-lite",
+ "zbus 5.19.0",
+]
+
+[[package]]
+name = "atspi-proxies"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2eebcb9e7e76f26d0bcfd6f0295e1cd1e6f33bedbc5698a971db8dc43d7751c"
 dependencies = [
  "atspi-common",
  "serde",
@@ -700,16 +690,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
 dependencies = [
- "bit-vec 0.8.0",
-]
-
-[[package]]
-name = "bit-set"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ec2f926cc3060f09db9ebc5b52823d85268d24bb917e472c0c4bea35780a7d"
-dependencies = [
- "bit-vec 0.9.1",
+ "bit-vec",
 ]
 
 [[package]]
@@ -717,12 +698,6 @@ name = "bit-vec"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
-
-[[package]]
-name = "bit-vec"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b71798fca2c1fe1086445a7258a4bc81e6e49dcd24c8d0dd9a1e57395b603f51"
 
 [[package]]
 name = "bitflags"
@@ -1263,20 +1238,11 @@ dependencies = [
 
 [[package]]
 name = "codespan-reporting"
-version = "0.13.1"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af491d569909a7e4dee0ad7db7f5341fef5c614d5b8ec8cf765732aba3cff681"
+checksum = "fe6d2e5af09e8c8ad56c969f2157a3d4238cebc7c55f0a517728c38f7b200f81"
 dependencies = [
  "unicode-width",
-]
-
-[[package]]
-name = "color"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ec7c5eb7a16992b1904d76c517d170ab353b0e0b3d5a0c81a8a0cd1037893cf"
-dependencies = [
- "bytemuck",
 ]
 
 [[package]]
@@ -1971,7 +1937,7 @@ version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521e380c0c8afb8d9a1e83a1822ee03556fc3e3e7dbc1fd30be14e37f9cb3f89"
 dependencies = [
- "bit-set 0.8.0",
+ "bit-set",
  "cssparser",
  "foldhash 0.2.0",
  "html5ever",
@@ -2039,9 +2005,9 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "ecolor"
-version = "0.36.1"
+version = "0.33.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc883f505d446814c0226bef4b64564b9adb9966fc00c88c57ce6d827dd152d6"
+checksum = "71ddb8ac7643d1dba1bb02110e804406dd459a838efcb14011ced10556711a8e"
 dependencies = [
  "bytemuck",
  "emath",
@@ -2049,9 +2015,9 @@ dependencies = [
 
 [[package]]
 name = "eframe"
-version = "0.36.1"
+version = "0.33.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2afc0cbcdb6896b7bfb1dbbebaf7b9af9635ff38fd01e89bdd0174c1717b1857"
+checksum = "457481173e6db5ca9fa2be93a58df8f4c7be639587aeb4853b526c6cf87db4e6"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -2066,15 +2032,16 @@ dependencies = [
  "image",
  "js-sys",
  "log",
- "objc2 0.6.4",
- "objc2-app-kit 0.3.2",
- "objc2-foundation 0.3.2",
+ "objc2 0.5.2",
+ "objc2-app-kit 0.2.2",
+ "objc2-foundation 0.2.2",
  "parking_lot",
  "percent-encoding",
  "profiling",
  "raw-window-handle",
  "static_assertions",
  "wasm-bindgen",
+ "wasm-bindgen-futures",
  "web-sys",
  "web-time",
  "windows-sys 0.61.2",
@@ -2083,29 +2050,27 @@ dependencies = [
 
 [[package]]
 name = "egui"
-version = "0.36.1"
+version = "0.33.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c977ac91dfaa651633fd9722e4ce9ccb32cda4c748b89a5cb57e504036e37c13"
+checksum = "6a9b567d356674e9a5121ed3fedfb0a7c31e059fe71f6972b691bcd0bfc284e3"
 dependencies = [
  "accesskit",
  "ahash",
  "bitflags 2.13.1",
  "emath",
  "epaint",
- "itertools 0.15.0",
  "log",
  "nohash-hasher",
  "profiling",
  "smallvec",
  "unicode-segmentation",
- "web-sys",
 ]
 
 [[package]]
 name = "egui-wgpu"
-version = "0.36.1"
+version = "0.33.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fc362cc6bc8c1d7169c9cb0e7741ff1e03063681373d6e55cc3b25fd21213f3"
+checksum = "5e4d209971c84b2352a06174abdba701af1e552ce56b144d96f2bd50a3c91236"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -2123,36 +2088,40 @@ dependencies = [
 
 [[package]]
 name = "egui-winit"
-version = "0.36.1"
+version = "0.33.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9327fc8edef2c57db9bcbcacc82c8a4b1e8cc64cd41a67db4419dcf643d88c83"
+checksum = "ec6687e5bb551702f4ad10ac428bab12acf9d53047ebb1082d4a0ed8c6251a29"
 dependencies = [
  "accesskit_winit",
  "arboard",
  "bytemuck",
  "egui",
  "log",
- "objc2 0.6.4",
- "objc2-foundation 0.3.2",
- "objc2-ui-kit 0.3.2",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
+ "objc2-ui-kit 0.2.2",
  "profiling",
  "raw-window-handle",
  "smithay-clipboard",
  "web-time",
+ "webbrowser",
  "winit",
 ]
 
 [[package]]
 name = "egui_glow"
-version = "0.36.1"
+version = "0.33.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69b65e45f8d8d7c6d848b3ec41f642b54ad828033f1511d4b4c9adc09040166a"
+checksum = "6420863ea1d90e750f75075231a260030ad8a9f30a7cef82cdc966492dc4c4eb"
 dependencies = [
  "bytemuck",
  "egui",
  "glow",
  "log",
+ "memoffset",
  "profiling",
+ "wasm-bindgen",
+ "web-sys",
  "winit",
 ]
 
@@ -2164,9 +2133,9 @@ checksum = "252afb9ae5eaa683babdc6a068b3f5726eb19e05070c731f9b2a23a7c3e8ed34"
 
 [[package]]
 name = "emath"
-version = "0.36.1"
+version = "0.33.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce03cf1604f74515830012c29991beb0b58f69e4e43f5afe22fa7afed65ccd5"
+checksum = "491bdf728bf25ddd9ad60d4cf1c48588fa82c013a2440b91aa7fc43e34a07c32"
 dependencies = [
  "bytemuck",
 ]
@@ -2277,34 +2246,27 @@ dependencies = [
 
 [[package]]
 name = "epaint"
-version = "0.36.1"
+version = "0.33.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11863a6b2b7823010c1090ddf4706947bdda46766742def0673195cbf7ff4a73"
+checksum = "009d0dd3c2163823a0abdb899451ecbc78798dec545ee91b43aff1fa790bab62"
 dependencies = [
+ "ab_glyph",
  "ahash",
  "bytemuck",
  "ecolor",
  "emath",
  "epaint_default_fonts",
- "font-types",
- "harfrust",
  "log",
  "nohash-hasher",
  "parking_lot",
  "profiling",
- "self_cell",
- "skrifa",
- "smallvec",
- "unicode-general-category",
- "unicode-segmentation",
- "vello_cpu",
 ]
 
 [[package]]
 name = "epaint_default_fonts"
-version = "0.36.1"
+version = "0.33.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18dee69613aac468922cf28a32025eb7d7ed6985b61f73245848e58f37876c98"
+checksum = "5c4fbe202b6578d3d56428fa185cdf114a05e49da05f477b3c7f0fbb221f1862"
 
 [[package]]
 name = "equivalent"
@@ -2346,15 +2308,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d817e038c30374a4bcb22f94d0a8a0e216958d4c3dcde369b1439fec4bdda6e6"
 dependencies = [
  "cc",
-]
-
-[[package]]
-name = "euclid"
-version = "0.22.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1a05365e3b1c6d1650318537c7460c6923f1abdd272ad6842baa2b509957a06"
-dependencies = [
- "num-traits",
 ]
 
 [[package]]
@@ -2403,12 +2356,6 @@ checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
 dependencies = [
  "simd-adler32",
 ]
-
-[[package]]
-name = "fearless_simd"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97b65636e5b9ef369943878ac74335ba1c55c1cb6adbf1e2c293c624248d693"
 
 [[package]]
 name = "ferrous-opencc"
@@ -2498,15 +2445,6 @@ name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
-
-[[package]]
-name = "font-types"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e64eb721ca85a34323425f4041adc5d82704d3782d5f8f03793bc012419dce23"
-dependencies = [
- "bytemuck",
-]
 
 [[package]]
 name = "foreign-types"
@@ -2938,22 +2876,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "glifo"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed4a1bb24121291d27230c1b1b44e07d6a9b28cefdb32fe1581dfb84e14f940a"
-dependencies = [
- "bytemuck",
- "foldhash 0.2.0",
- "hashbrown 0.17.1",
- "log",
- "peniko",
- "skrifa",
- "smallvec",
- "vello_common",
-]
-
-[[package]]
 name = "glob"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2977,9 +2899,9 @@ dependencies = [
 
 [[package]]
 name = "glow"
-version = "0.17.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29038e1c483364cc6bb3cf78feee1816002e127c331a1eec55a4d202b9e1adb5"
+checksum = "c5e5ea60d70410161c8bf5da3fdfeaa1c72ed2c15f8bbb9d19fe3a4fad085f08"
 dependencies = [
  "js-sys",
  "slotmap",
@@ -3117,15 +3039,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "guillotiere"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b17e70c989c36bad147b27a58d148c0741c51448aa5653436547323e524d0ab"
-dependencies = [
- "euclid",
-]
-
-[[package]]
 name = "h2"
 version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3157,18 +3070,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "harfrust"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c03d949a14aa089bbb282f7dd76a498a7f684428e4257202efc119ec010376f9"
-dependencies = [
- "bitflags 2.13.1",
- "bytemuck",
- "read-fonts",
- "smallvec",
-]
-
-[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3197,9 +3098,6 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
-dependencies = [
- "foldhash 0.2.0",
-]
 
 [[package]]
 name = "heck"
@@ -3224,6 +3122,12 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hexf-parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfa686283ad6dd069f105e5ab091b04c62850d3e4cf5d67debad1933f55023df"
 
 [[package]]
 name = "hkdf"
@@ -3646,15 +3550,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "itertools"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b4baf93f58d4425749ca49a51c50ebab072c5df6994d08fed93541c331481dc"
-dependencies = [
- "either",
-]
-
-[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3888,18 +3783,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
 
 [[package]]
-name = "kurbo"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b60dfc32f652b926df6192e55525b16d186c69d47876c3ead4da5cc9f8450e2"
-dependencies = [
- "arrayvec",
- "euclid",
- "polycool",
- "smallvec",
-]
-
-[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3981,12 +3864,6 @@ dependencies = [
  "plain",
  "redox_syscall 0.9.3",
 ]
-
-[[package]]
-name = "linebender_resource_handle"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4a5ff6bcca6c4867b1c4fd4ef63e4db7436ef363e0ad7531d1558856bae64f4"
 
 [[package]]
 name = "linux-keyutils"
@@ -4310,39 +4187,27 @@ dependencies = [
 
 [[package]]
 name = "naga"
-version = "30.0.1"
+version = "27.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a616d2fb8c89516ac2723a581f69d6c18576046bed761bd6b305e5618e6ae130"
+checksum = "066cf25f0e8b11ee0df221219010f213ad429855f57c494f995590c861a9a7d8"
 dependencies = [
  "arrayvec",
- "bit-set 0.10.0",
+ "bit-set",
  "bitflags 2.13.1",
  "cfg-if",
  "cfg_aliases",
  "codespan-reporting",
  "half",
- "hashbrown 0.17.1",
+ "hashbrown 0.16.1",
+ "hexf-parse",
  "indexmap 2.14.0",
  "libm",
  "log",
- "naga-types",
  "num-traits",
  "once_cell",
  "rustc-hash 1.1.0",
  "thiserror 2.0.20",
  "unicode-ident",
-]
-
-[[package]]
-name = "naga-types"
-version = "30.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "590afbf58a6f4f62873cd5cff4468061844bafa1cdf399cc954537c22d768d49"
-dependencies = [
- "hashbrown 0.17.1",
- "indexmap 2.14.0",
- "rustc-hash 1.1.0",
- "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -5402,19 +5267,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "peniko"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "839c8299360d2e998bdb106dc0a6cd71dcc5f4df51df1b620361bf50e283cca6"
-dependencies = [
- "bytemuck",
- "color",
- "kurbo",
- "linebender_resource_handle",
- "smallvec",
-]
-
-[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5584,15 +5436,6 @@ dependencies = [
  "pin-project-lite",
  "rustix 1.1.4",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "polycool"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50596ddc09eb5ad5f75cacd40209568e66df71baf86e1499a0e99c4cff12a5a6"
-dependencies = [
- "arrayvec",
 ]
 
 [[package]]
@@ -6010,17 +5853,6 @@ dependencies = [
  "rustls-pki-types",
  "time",
  "yasna",
-]
-
-[[package]]
-name = "read-fonts"
-version = "0.41.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "046a7d674daf459825b32f5062056d6882db0d2f5a479fbd76ccfc870ac18709"
-dependencies = [
- "bytemuck",
- "font-types",
- "once_cell",
 ]
 
 [[package]]
@@ -6639,12 +6471,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "self_cell"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab42ca02749e120097e328d91d415325bdf43b1c72c4c8badf37375fe40a813"
-
-[[package]]
 name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6981,16 +6807,6 @@ name = "siphasher"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
-
-[[package]]
-name = "skrifa"
-version = "0.44.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819ab7d62b1d3e72d9d9dea5650bac30424f9111364bb94928dbf5ecad1baa68"
-dependencies = [
- "bytemuck",
- "read-fonts",
-]
 
 [[package]]
 name = "slab"
@@ -8614,12 +8430,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
-name = "unicode-general-category"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b993bddc193ae5bd0d623b49ec06ac3e9312875fdae725a975c51db1cc1677f"
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8781,33 +8591,6 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
-name = "vello_common"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2e9aed918117e8152c9eddfd8362d73c465c23f26c44786aa331707b8a64fa2"
-dependencies = [
- "bytemuck",
- "fearless_simd",
- "guillotiere",
- "log",
- "peniko",
- "smallvec",
- "thiserror 2.0.20",
-]
-
-[[package]]
-name = "vello_cpu"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac7349e1f55f6b801c7c277958df4ea53e7f20f21e8014910ad888b2ecda93ea"
-dependencies = [
- "bytemuck",
- "glifo",
- "hashbrown 0.17.1",
- "vello_common",
-]
 
 [[package]]
 name = "version-compare"
@@ -9122,6 +8905,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "webbrowser"
+version = "1.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62c35be770821a214dbc362fc26908c853e776c0004294d0b10b8a6bad582f94"
+dependencies = [
+ "jni 0.22.4",
+ "log",
+ "ndk-context",
+ "objc2 0.6.4",
+ "objc2-app-kit 0.3.2",
+ "objc2-foundation 0.3.2",
+ "url",
+ "web-sys",
+]
+
+[[package]]
 name = "webkit2gtk"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9236,27 +9035,22 @@ checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 
 [[package]]
 name = "wgpu"
-version = "30.0.1"
+version = "27.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "527ccdf43dd5b2e8676eed9984ce00e2bbb0a1b85b70c1969dcb6cd2eb55ab9e"
+checksum = "bfe68bac7cde125de7a731c3400723cadaaf1703795ad3f4805f187459cd7a77"
 dependencies = [
  "arrayvec",
  "bitflags 2.13.1",
- "bytemuck",
  "cfg-if",
  "cfg_aliases",
  "document-features",
- "hashbrown 0.17.1",
- "js-sys",
+ "hashbrown 0.16.1",
  "log",
  "portable-atomic",
  "profiling",
  "raw-window-handle",
  "smallvec",
  "static_assertions",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
  "wgpu-core",
  "wgpu-hal",
  "wgpu-types",
@@ -9264,22 +9058,21 @@ dependencies = [
 
 [[package]]
 name = "wgpu-core"
-version = "30.0.1"
+version = "27.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14c018fce9b6270aa203c2fdd56f3cce996713534bd757e4ea58c8560b121f14"
+checksum = "27a75de515543b1897b26119f93731b385a19aea165a1ec5f0e3acecc229cae7"
 dependencies = [
  "arrayvec",
- "bit-set 0.10.0",
- "bit-vec 0.9.1",
+ "bit-set",
+ "bit-vec",
  "bitflags 2.13.1",
  "bytemuck",
  "cfg_aliases",
  "document-features",
- "hashbrown 0.17.1",
+ "hashbrown 0.16.1",
  "indexmap 2.14.0",
  "log",
  "naga",
- "naga-types",
  "once_cell",
  "parking_lot",
  "portable-atomic",
@@ -9290,66 +9083,49 @@ dependencies = [
  "thiserror 2.0.20",
  "wgpu-core-deps-windows-linux-android",
  "wgpu-hal",
- "wgpu-naga-bridge",
  "wgpu-types",
 ]
 
 [[package]]
 name = "wgpu-core-deps-windows-linux-android"
-version = "30.0.1"
+version = "27.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7586165fd5f6d881cb9ce4bb71f40d6caab2c0f1837e3fc1d9788a197fb6004f"
+checksum = "71197027d61a71748e4120f05a9242b2ad142e3c01f8c1b47707945a879a03c3"
 dependencies = [
  "wgpu-hal",
 ]
 
 [[package]]
 name = "wgpu-hal"
-version = "30.0.1"
+version = "27.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6b7fb58561a792bc237628ba0792e332de418fefe145f13b5ed8201e6d52f58"
+checksum = "5b21cb61c57ee198bc4aff71aeadff4cbb80b927beb912506af9c780d64313ce"
 dependencies = [
  "bitflags 2.13.1",
  "cfg-if",
  "cfg_aliases",
- "hashbrown 0.17.1",
  "libloading 0.8.9",
  "log",
  "naga",
- "naga-types",
  "portable-atomic",
  "portable-atomic-util",
  "raw-window-handle",
  "renderdoc-sys",
- "static_assertions",
  "thiserror 2.0.20",
- "wgpu-naga-bridge",
- "wgpu-types",
-]
-
-[[package]]
-name = "wgpu-naga-bridge"
-version = "30.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2f62e73117bb7a62bfd9c5a5841438a823f6566c6442a808ee269d2d055c081"
-dependencies = [
- "naga",
  "wgpu-types",
 ]
 
 [[package]]
 name = "wgpu-types"
-version = "30.0.1"
+version = "27.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99dad6f1fbdbbdb4c278a6508b059d44688f5cebddf78d005a46a31340269286"
+checksum = "afdcf84c395990db737f2dd91628706cb31e86d72e53482320d368e52b5da5eb"
 dependencies = [
  "bitflags 2.13.1",
  "bytemuck",
  "js-sys",
  "log",
- "naga-types",
- "raw-window-handle",
- "static_assertions",
+ "thiserror 2.0.20",
  "web-sys",
 ]
 
@@ -9461,23 +9237,11 @@ version = "0.61.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
 dependencies = [
- "windows-collections 0.2.0",
+ "windows-collections",
  "windows-core 0.61.2",
- "windows-future 0.2.1",
+ "windows-future",
  "windows-link 0.1.3",
- "windows-numerics 0.2.0",
-]
-
-[[package]]
-name = "windows"
-version = "0.62.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
-dependencies = [
- "windows-collections 0.3.2",
- "windows-core 0.62.2",
- "windows-future 0.3.2",
- "windows-numerics 0.3.1",
+ "windows-numerics",
 ]
 
 [[package]]
@@ -9487,15 +9251,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
 dependencies = [
  "windows-core 0.61.2",
-]
-
-[[package]]
-name = "windows-collections"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
-dependencies = [
- "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -9555,18 +9310,7 @@ checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
 dependencies = [
  "windows-core 0.61.2",
  "windows-link 0.1.3",
- "windows-threading 0.1.0",
-]
-
-[[package]]
-name = "windows-future"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
-dependencies = [
- "windows-core 0.62.2",
- "windows-link 0.2.1",
- "windows-threading 0.2.1",
+ "windows-threading",
 ]
 
 [[package]]
@@ -9633,16 +9377,6 @@ checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
  "windows-core 0.61.2",
  "windows-link 0.1.3",
-]
-
-[[package]]
-name = "windows-numerics"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
-dependencies = [
- "windows-core 0.62.2",
- "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -9844,15 +9578,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
 dependencies = [
  "windows-link 0.1.3",
-]
-
-[[package]]
-name = "windows-threading"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
-dependencies = [
- "windows-link 0.2.1",
 ]
 
 [[package]]

--- a/openless-all/app/src-tauri/Cargo.lock
+++ b/openless-all/app/src-tauri/Cargo.lock
@@ -3,6 +3,135 @@
 version = 4
 
 [[package]]
+name = "ab_glyph"
+version = "0.2.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01c0457472c38ea5bd1c3b5ada5e368271cb550be7a4ca4a0b4634e9913f6cc2"
+dependencies = [
+ "ab_glyph_rasterizer",
+ "owned_ttf_parser",
+]
+
+[[package]]
+name = "ab_glyph_rasterizer"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "366ffbaa4442f4684d91e2cd7c5ea7c4ed8add41959a31447066e279e432b618"
+
+[[package]]
+name = "accesskit"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3b7f7f85a7e5f68090000ed7622545829afd484d210358702ae4cb97dd0c320"
+dependencies = [
+ "uuid",
+]
+
+[[package]]
+name = "accesskit_atspi_common"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e8c61bee90b42a772d39d06a740207dc71a4e780004ace1db8d99fb1baaa954"
+dependencies = [
+ "accesskit",
+ "accesskit_consumer 0.36.0",
+ "atspi-common",
+ "phf",
+ "serde",
+ "zvariant 5.15.0",
+]
+
+[[package]]
+name = "accesskit_consumer"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53cf47daed85312e763fbf85ceca136e0d7abc68e0a7e12abe11f48172bc3b10"
+dependencies = [
+ "accesskit",
+ "hashbrown 0.16.1",
+]
+
+[[package]]
+name = "accesskit_consumer"
+version = "0.36.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25e0d7e25d06f4dc21d1774d67146e9e80d6789216cbd4d1e88185b0095dba60"
+dependencies = [
+ "accesskit",
+ "hashbrown 0.16.1",
+]
+
+[[package]]
+name = "accesskit_consumer"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d10a236f96f87d70732e44520046785431ef01d5bcd6b041317bfadd2f88245"
+dependencies = [
+ "accesskit",
+ "hashbrown 0.16.1",
+]
+
+[[package]]
+name = "accesskit_macos"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce02dc63b43f0c9296af9ac946312a2dc8814427d7a64d2d600971dac55b6076"
+dependencies = [
+ "accesskit",
+ "accesskit_consumer 0.38.0",
+ "hashbrown 0.16.1",
+ "objc2 0.5.2",
+ "objc2-app-kit 0.2.2",
+ "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "accesskit_unix"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b016ca8db0ea0ea2ceff29a9d6240391492d960716aa471967c00e8cc8cb197c"
+dependencies = [
+ "accesskit",
+ "accesskit_atspi_common",
+ "async-channel",
+ "async-executor",
+ "async-task",
+ "atspi",
+ "futures-lite",
+ "futures-util",
+ "serde",
+ "zbus 5.19.0",
+]
+
+[[package]]
+name = "accesskit_windows"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eff7009f1a532e917d66970a1e80c965140c6cfbbabbdde3d64e5431e6c78e21"
+dependencies = [
+ "accesskit",
+ "accesskit_consumer 0.35.0",
+ "hashbrown 0.16.1",
+ "static_assertions",
+ "windows 0.62.2",
+ "windows-core 0.62.2",
+]
+
+[[package]]
+name = "accesskit_winit"
+version = "0.32.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fe9a94394896352cc4660ca2288bd4ef883d83238853c038b44070c8f134313"
+dependencies = [
+ "accesskit",
+ "accesskit_macos",
+ "accesskit_unix",
+ "accesskit_windows",
+ "raw-window-handle",
+ "winit",
+]
+
+[[package]]
 name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -35,9 +164,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.4"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+checksum = "c982642fa9e8606056828ee9a8505737230110bb1099153c79efe865c59d12ba"
 dependencies = [
  "memchr",
 ]
@@ -50,9 +179,9 @@ checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
 
 [[package]]
 name = "alloc-stdlib"
-version = "0.2.2"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
+checksum = "0e76a019e91224d279006ff972f1e984179a6e9feb050adba6ce8274aef23195"
 dependencies = [
  "alloc-no-stdlib",
 ]
@@ -64,7 +193,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed7572b7ba83a31e20d1b48970ee402d2e3e0537dcfe0a3ff4d6eb7508617d43"
 dependencies = [
  "alsa-sys",
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "cfg-if",
  "libc",
 ]
@@ -80,10 +209,35 @@ dependencies = [
 ]
 
 [[package]]
-name = "android_system_properties"
-version = "0.1.5"
+name = "android-activity"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+checksum = "0f2a1bb052857d5dd49572219344a7332b31b76405648eabac5bc68978251bcd"
+dependencies = [
+ "android-properties",
+ "bitflags 2.13.1",
+ "cc",
+ "jni 0.22.4",
+ "libc",
+ "log",
+ "ndk 0.9.0",
+ "ndk-context",
+ "ndk-sys 0.6.0+11769913",
+ "num_enum",
+ "thiserror 2.0.20",
+]
+
+[[package]]
+name = "android-properties"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7eb209b1518d6bb87b283c20095f5228ecda460da70b44f0802523dea6da04"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae221649c9976a6f6c56ae1facf410f3ddb33cc661c4b7b61020a912d4237fbc"
 dependencies = [
  "libc",
 ]
@@ -140,9 +294,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.103"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "arbitrary"
@@ -175,10 +329,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrayref"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
+
+[[package]]
 name = "arrayvec"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
+
+[[package]]
+name = "as-raw-xcb-connection"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175571dd1d178ced59193a6fc02dde1b972eb0bc56c892cde9beeceac5bf0f6b"
 
 [[package]]
 name = "async-broadcast"
@@ -231,7 +397,7 @@ dependencies = [
  "futures-lite",
  "parking",
  "polling",
- "rustix",
+ "rustix 1.1.4",
  "slab",
  "windows-sys 0.61.2",
 ]
@@ -275,7 +441,7 @@ dependencies = [
  "cfg-if",
  "event-listener",
  "futures-lite",
- "rustix",
+ "rustix 1.1.4",
 ]
 
 [[package]]
@@ -286,7 +452,7 @@ checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -301,7 +467,7 @@ dependencies = [
  "cfg-if",
  "futures-core",
  "futures-io",
- "rustix",
+ "rustix 1.1.4",
  "signal-hook-registry",
  "slab",
  "windows-sys 0.61.2",
@@ -315,13 +481,13 @@ checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
-version = "0.1.89"
+version = "0.1.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+checksum = "82f6aeea286b8eb4dd3431a1be1b59d290ace00f5bfd8e2a159bc2a05e2c1667"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -352,6 +518,43 @@ name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "atspi"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c77886257be21c9cd89a4ae7e64860c6f0eefca799bb79127913052bd0eefb3d"
+dependencies = [
+ "atspi-common",
+ "atspi-proxies",
+]
+
+[[package]]
+name = "atspi-common"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20c5617155740c98003016429ad13fe43ce7a77b007479350a9f8bf95a29f63d"
+dependencies = [
+ "enumflags2",
+ "serde",
+ "static_assertions",
+ "zbus 5.19.0",
+ "zbus-lockstep",
+ "zbus-lockstep-macros",
+ "zbus_names 4.3.4",
+ "zvariant 5.15.0",
+]
+
+[[package]]
+name = "atspi-proxies"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2230e48787ed3eb4088996eab66a32ca20c0b67bbd4fd6cdfe79f04f1f04c9fc"
+dependencies = [
+ "atspi-common",
+ "serde",
+ "zbus 5.19.0",
+]
 
 [[package]]
 name = "auto-launch"
@@ -448,12 +651,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
+
+[[package]]
 name = "bindgen"
 version = "0.71.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f58bf3d7db68cfbac37cfc485a8d711e87e064c3d0fe0435b92f7a407f9d6b3"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "cexpr",
  "clang-sys",
  "itertools 0.13.0",
@@ -462,9 +671,9 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "rustc-hash",
+ "rustc-hash 2.1.3",
  "shlex 1.3.0",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -473,16 +682,16 @@ version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "cexpr",
  "clang-sys",
  "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "regex",
- "rustc-hash",
+ "rustc-hash 2.1.3",
  "shlex 1.3.0",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -491,7 +700,16 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
 dependencies = [
- "bit-vec",
+ "bit-vec 0.8.0",
+]
+
+[[package]]
+name = "bit-set"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2f926cc3060f09db9ebc5b52823d85268d24bb917e472c0c4bea35780a7d"
+dependencies = [
+ "bit-vec 0.9.1",
 ]
 
 [[package]]
@@ -501,6 +719,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
+name = "bit-vec"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b71798fca2c1fe1086445a7258a4bc81e6e49dcd24c8d0dd9a1e57395b603f51"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -508,9 +732,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.13.0"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 dependencies = [
  "serde_core",
 ]
@@ -559,9 +783,9 @@ dependencies = [
 
 [[package]]
 name = "blocking"
-version = "1.6.2"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
+checksum = "a70e4329df6cb94385eed412ec92375c3cdd8a6e502493d1229b6414e4036dfa"
 dependencies = [
  "async-channel",
  "async-task",
@@ -572,9 +796,9 @@ dependencies = [
 
 [[package]]
 name = "brotli"
-version = "8.0.3"
+version = "8.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8119e4516436f5708bbc474a9d395bf12f1b5395e93a92a56e647ac3388c8610"
+checksum = "5cc91aac060a7a1e25823bdccbfb6af1875b88f17c6daac97894eed8207166b3"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -583,9 +807,9 @@ dependencies = [
 
 [[package]]
 name = "brotli-decompressor"
-version = "5.0.1"
+version = "5.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5962523e1b92ce1b5e793d9169b9943eece10d39f62550bc04bb605d75b94924"
+checksum = "3a32acac15fe1967bc3986b2a6347dffc965602354ea6f450ad07e8bfd253583"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -608,9 +832,9 @@ checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytecheck"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0caa33a2c0edca0419d15ac723dff03f1956f7978329b1e3b5fdaaaed9d3ca8b"
+checksum = "26333eeac754f0ad8a6bcd0eb0ac012156302e4e16b852b72ee399aea4f12c29"
 dependencies = [
  "bytecheck_derive",
  "ptr_meta",
@@ -620,20 +844,34 @@ dependencies = [
 
 [[package]]
 name = "bytecheck_derive"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89385e82b5d1821d2219e0b095efa2cc1f246cbf99080f3be46a1a85c0d392d9"
+checksum = "46d07918caa9eeaaf06b7873925c53a61daac173539b4f7715090745e44e4e69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "bytemuck"
-version = "1.25.0"
+version = "1.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+checksum = "95832e849adfb21180ccb6826a99da14e5d266ae5c2e668e1602cf234f153797"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0e56a716f1e132ff6bf4bdac1c944a3fcdc1cae65f70a4a2a1ac3b401d2d1f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
 
 [[package]]
 name = "byteorder"
@@ -649,9 +887,9 @@ checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "bytes"
-version = "1.11.1"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 dependencies = [
  "serde",
 ]
@@ -691,7 +929,7 @@ version = "0.18.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ca26ef0159422fb77631dc9d17b102f253b876fe1586b03b803e63a309b4ee2"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "cairo-sys-rs",
  "glib",
  "libc",
@@ -711,10 +949,61 @@ dependencies = [
 ]
 
 [[package]]
-name = "camino"
-version = "1.2.2"
+name = "calloop"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e629a66d692cb9ff1a1c664e41771b3dcaf961985a9774c0eb0bd1b51cf60a48"
+checksum = "b99da2f8558ca23c71f4fd15dc57c906239752dd27ff3c00a1d56b685b7cbfec"
+dependencies = [
+ "bitflags 2.13.1",
+ "log",
+ "polling",
+ "rustix 0.38.44",
+ "slab",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "calloop"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dbf9978365bac10f54d1d4b04f7ce4427e51f71d61f2fe15e3fed5166474df7"
+dependencies = [
+ "bitflags 2.13.1",
+ "polling",
+ "rustix 1.1.4",
+ "slab",
+ "tracing",
+]
+
+[[package]]
+name = "calloop-wayland-source"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95a66a987056935f7efce4ab5668920b5d0dac4a7c99991a67395f13702ddd20"
+dependencies = [
+ "calloop 0.13.0",
+ "rustix 0.38.44",
+ "wayland-backend",
+ "wayland-client",
+]
+
+[[package]]
+name = "calloop-wayland-source"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "138efcf0940a02ebf0cc8d1eff41a1682a46b431630f4c52450d6265876021fa"
+dependencies = [
+ "calloop 0.14.4",
+ "rustix 1.1.4",
+ "wayland-backend",
+ "wayland-client",
+]
+
+[[package]]
+name = "camino"
+version = "1.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb1307f12aa967b5a58416e87b3653360e0fd614a016b6e970db08fecbb1b80d"
 dependencies = [
  "serde_core",
 ]
@@ -739,7 +1028,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -772,9 +1061,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.63"
+version = "1.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
+checksum = "0ad534f4357a5264cce5019c989cf66a4f0dc4e0d1b1d15f8aacec0ff7360273"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -826,9 +1115,18 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cfg_aliases"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
+
+[[package]]
+name = "cgl"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ced0551234e87afee12411d535648dd89d2e7f34c78b753395567aff3d447ff"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "chacha20"
@@ -867,9 +1165,9 @@ dependencies = [
 
 [[package]]
 name = "clang-sys"
-version = "1.8.1"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+checksum = "157a8ba7b480713b56f4c09fd13fc3e0a22a5dfab8097ba61cbc5feef950788a"
 dependencies = [
  "glob",
  "libc",
@@ -940,7 +1238,7 @@ version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad36507aeb7e16159dfe68db81ccc27571c3ccd4b76fb2fb72fc59e7a4b1b64c"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "block",
  "cocoa-foundation",
  "core-foundation 0.10.1",
@@ -956,11 +1254,29 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81411967c50ee9a1fc11365f8c585f863a22a9697c89239c452292c40ba79b0d"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "block",
  "core-foundation 0.10.1",
- "core-graphics-types",
+ "core-graphics-types 0.2.0",
  "objc",
+]
+
+[[package]]
+name = "codespan-reporting"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af491d569909a7e4dee0ad7db7f5341fef5c614d5b8ec8cf765732aba3cff681"
+dependencies = [
+ "unicode-width",
+]
+
+[[package]]
+name = "color"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ec7c5eb7a16992b1904d76c517d170ab353b0e0b3d5a0c81a8a0cd1037893cf"
+dependencies = [
+ "bytemuck",
 ]
 
 [[package]]
@@ -1024,9 +1340,9 @@ checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
 
 [[package]]
 name = "cookie"
-version = "0.18.1"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
+checksum = "1a373e3602691c3cdea496d2f0ee5935151e6168fe87739483c463db1b2f2f87"
 dependencies = [
  "time",
  "version_check",
@@ -1060,13 +1376,26 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "core-graphics"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c07782be35f9e1140080c6b96f0d44b739e2278479f64e02fdab4e32dfd8b081"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation 0.9.4",
+ "core-graphics-types 0.1.3",
+ "foreign-types 0.5.0",
+ "libc",
+]
+
+[[package]]
+name = "core-graphics"
 version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa95a34622365fa5bbf40b20b75dba8dfa8c94c734aea8ac9a5ca38af14316f1"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "core-foundation 0.10.1",
- "core-graphics-types",
+ "core-graphics-types 0.2.0",
  "foreign-types 0.5.0",
  "libc",
 ]
@@ -1077,10 +1406,21 @@ version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "064badf302c3194842cf2c5d61f56cc88e54a759313879cdf03abdd27d0c3b97"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "core-foundation 0.10.1",
- "core-graphics-types",
+ "core-graphics-types 0.2.0",
  "foreign-types 0.5.0",
+ "libc",
+]
+
+[[package]]
+name = "core-graphics-types"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45390e6114f68f718cc7a830514a96f903cccd70d02a8f6d9f643ac4ba45afaf"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation 0.9.4",
  "libc",
 ]
 
@@ -1090,7 +1430,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d44a101f213f6c4cdc1853d4b78aef6db6bdfa3468798cc1d9912f4735013eb"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "core-foundation 0.10.1",
  "libc",
 ]
@@ -1173,18 +1513,18 @@ checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
 
 [[package]]
 name = "crc32fast"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+checksum = "8498c871161e1742aaa9d52551b2d6ebdd4c3d45a3be423e3728f33b955be550"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.15"
+version = "0.5.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+checksum = "d85363c37faeca707aef026efa9f3b34d077bce547e48f770770625c6013679e"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -1210,9 +1550,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.21"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
 name = "crunchy"
@@ -1250,7 +1590,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331"
 dependencies = [
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1268,6 +1608,12 @@ name = "ctor-proc-macro"
 version = "0.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52560adf09603e58c9a7ee1fe1dcb95a16927b17c127f0ac02d6e768a0e25bc1"
+
+[[package]]
+name = "cursor-icon"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f27ae1dd37df86211c42e150270f82743308803d90a6f6e6651cd730d5e1732f"
 
 [[package]]
 name = "darling"
@@ -1300,7 +1646,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1313,7 +1659,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1324,7 +1670,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core 0.20.11",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1335,7 +1681,7 @@ checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core 0.23.0",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1355,15 +1701,15 @@ checksum = "0c87e182de0887fd5361989c677c4e8f5000cd9491d6d563161a8f3a5519fc7f"
 
 [[package]]
 name = "data-encoding"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+checksum = "4583a4551df46e2792f82ceeac45e850d2e2d5debba0b91f102385cda5b11f06"
 
 [[package]]
 name = "dbus"
-version = "0.9.11"
+version = "0.9.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b942602992bb7acfd1f51c49811c58a610ef9181b6e66f3e519d79b540a3bf73"
+checksum = "3ab69f03cc8c4340c9c8e315114e1658e6775a9b16a04357973aa21cec22b32e"
 dependencies = [
  "libc",
  "libdbus-sys",
@@ -1395,12 +1741,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac6b926516df9c60bfa16e107b21086399f8285a44ca9711344b9e553c5146e2"
 
 [[package]]
+name = "defmt"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2953bfe4f93bbd20cc71198842756f77d161884c99ebbabc41d80231ded88d1"
+dependencies = [
+ "bitflags 1.3.2",
+ "defmt-macros",
+]
+
+[[package]]
+name = "defmt-macros"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bad9c72e7ca2137e0dc3813245a0d282fd6daad32fd800af018306a9169b5fe8"
+dependencies = [
+ "defmt-parser",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "defmt-parser"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
+dependencies = [
+ "thiserror 2.0.20",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
- "powerfmt",
  "serde_core",
 ]
 
@@ -1412,7 +1788,7 @@ checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1433,7 +1809,7 @@ dependencies = [
  "darling 0.20.11",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1443,7 +1819,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
 dependencies = [
  "derive_builder_core",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1464,7 +1840,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1520,12 +1896,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "dispatch"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd0c93bb4b0c6d9b77f4435b0ae98c24d17f1c45b2ff844c6151a07256ca923b"
+
+[[package]]
 name = "dispatch2"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "block2 0.6.2",
  "libc",
  "objc2 0.6.4",
@@ -1533,13 +1915,22 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
+checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.3",
+]
+
+[[package]]
+name = "dlib"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab8ecd87370524b461f8557c119c405552c396ed91fc0a8eec68679eab26f94a"
+dependencies = [
+ "libloading 0.8.9",
 ]
 
 [[package]]
@@ -1562,7 +1953,16 @@ checksum = "0fbbb781877580993a8707ec48672673ec7b81eeba04cfd2310bd28c08e47c8f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
 ]
 
 [[package]]
@@ -1571,7 +1971,7 @@ version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521e380c0c8afb8d9a1e83a1822ee03556fc3e3e7dbc1fd30be14e37f9cb3f89"
 dependencies = [
- "bit-set",
+ "bit-set 0.8.0",
  "cssparser",
  "foldhash 0.2.0",
  "html5ever",
@@ -1638,21 +2038,149 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
-name = "either"
-version = "1.16.0"
+name = "ecolor"
+version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+checksum = "fc883f505d446814c0226bef4b64564b9adb9966fc00c88c57ce6d827dd152d6"
+dependencies = [
+ "bytemuck",
+ "emath",
+]
+
+[[package]]
+name = "eframe"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2afc0cbcdb6896b7bfb1dbbebaf7b9af9635ff38fd01e89bdd0174c1717b1857"
+dependencies = [
+ "ahash",
+ "bytemuck",
+ "document-features",
+ "egui",
+ "egui-wgpu",
+ "egui-winit",
+ "egui_glow",
+ "glow",
+ "glutin",
+ "glutin-winit",
+ "image",
+ "js-sys",
+ "log",
+ "objc2 0.6.4",
+ "objc2-app-kit 0.3.2",
+ "objc2-foundation 0.3.2",
+ "parking_lot",
+ "percent-encoding",
+ "profiling",
+ "raw-window-handle",
+ "static_assertions",
+ "wasm-bindgen",
+ "web-sys",
+ "web-time",
+ "windows-sys 0.61.2",
+ "winit",
+]
+
+[[package]]
+name = "egui"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c977ac91dfaa651633fd9722e4ce9ccb32cda4c748b89a5cb57e504036e37c13"
+dependencies = [
+ "accesskit",
+ "ahash",
+ "bitflags 2.13.1",
+ "emath",
+ "epaint",
+ "itertools 0.15.0",
+ "log",
+ "nohash-hasher",
+ "profiling",
+ "smallvec",
+ "unicode-segmentation",
+ "web-sys",
+]
+
+[[package]]
+name = "egui-wgpu"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fc362cc6bc8c1d7169c9cb0e7741ff1e03063681373d6e55cc3b25fd21213f3"
+dependencies = [
+ "ahash",
+ "bytemuck",
+ "document-features",
+ "egui",
+ "epaint",
+ "log",
+ "profiling",
+ "thiserror 2.0.20",
+ "type-map",
+ "web-time",
+ "wgpu",
+ "winit",
+]
+
+[[package]]
+name = "egui-winit"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9327fc8edef2c57db9bcbcacc82c8a4b1e8cc64cd41a67db4419dcf643d88c83"
+dependencies = [
+ "accesskit_winit",
+ "arboard",
+ "bytemuck",
+ "egui",
+ "log",
+ "objc2 0.6.4",
+ "objc2-foundation 0.3.2",
+ "objc2-ui-kit 0.3.2",
+ "profiling",
+ "raw-window-handle",
+ "smithay-clipboard",
+ "web-time",
+ "winit",
+]
+
+[[package]]
+name = "egui_glow"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69b65e45f8d8d7c6d848b3ec41f642b54ad828033f1511d4b4c9adc09040166a"
+dependencies = [
+ "bytemuck",
+ "egui",
+ "glow",
+ "log",
+ "profiling",
+ "winit",
+]
+
+[[package]]
+name = "either"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "252afb9ae5eaa683babdc6a068b3f5726eb19e05070c731f9b2a23a7c3e8ed34"
+
+[[package]]
+name = "emath"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce03cf1604f74515830012c29991beb0b58f69e4e43f5afe22fa7afed65ccd5"
+dependencies = [
+ "bytemuck",
+]
 
 [[package]]
 name = "embed-resource"
-version = "3.0.9"
+version = "3.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c31a88c8d26de40ed18fe748c547845aa39de1db3afd958f8cb91579f3644bcb"
+checksum = "fbfdaacccebec3b28e4866b8973543c7647797db5ada1bdab552e48fe665fbbd"
 dependencies = [
  "cc",
  "memchr",
  "rustc_version",
- "toml 1.1.2+spec-1.1.0",
+ "toml 1.1.4+spec-1.1.0",
  "vswhom",
  "winreg 0.55.0",
 ]
@@ -1721,14 +2249,14 @@ checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "env_filter"
-version = "1.0.1"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32e90c2accc4b07a8456ea0debdc2e7587bdd890680d71173a15d4ae604f6eef"
+checksum = "900d271a03799a1ee8d1ca9b19893b48ca674a9284fefcfb85f05e74ed314217"
 dependencies = [
  "log",
  "regex",
@@ -1736,9 +2264,9 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.11.10"
+version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0621c04f2196ac3f488dd583365b9c09be011a4ab8b9f37248ffcc8f6198b56a"
+checksum = "de671bd27a75a797dc9ae289ba1e77276e75e2026408aab65185384e2d5cd3f6"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1746,6 +2274,37 @@ dependencies = [
  "jiff",
  "log",
 ]
+
+[[package]]
+name = "epaint"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11863a6b2b7823010c1090ddf4706947bdda46766742def0673195cbf7ff4a73"
+dependencies = [
+ "ahash",
+ "bytemuck",
+ "ecolor",
+ "emath",
+ "epaint_default_fonts",
+ "font-types",
+ "harfrust",
+ "log",
+ "nohash-hasher",
+ "parking_lot",
+ "profiling",
+ "self_cell",
+ "skrifa",
+ "smallvec",
+ "unicode-general-category",
+ "unicode-segmentation",
+ "vello_cpu",
+]
+
+[[package]]
+name = "epaint_default_fonts"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18dee69613aac468922cf28a32025eb7d7ed6985b61f73245848e58f37876c98"
 
 [[package]]
 name = "equivalent"
@@ -1776,9 +2335,9 @@ dependencies = [
 
 [[package]]
 name = "error-code"
-version = "3.3.2"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
+checksum = "0b5343afd4a8365a643ac588dab4cf234a190c7f6c88c9f6dd6ffe00837661b7"
 
 [[package]]
 name = "esaxx-rs"
@@ -1790,12 +2349,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "event-listener"
-version = "5.4.1"
+name = "euclid"
+version = "0.22.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+checksum = "f1a05365e3b1c6d1650318537c7460c6923f1abdd272ad6842baa2b509957a06"
 dependencies = [
- "concurrent-queue",
+ "num-traits",
+]
+
+[[package]]
+name = "event-listener"
+version = "5.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2"
+dependencies = [
  "parking",
  "pin-project-lite",
 ]
@@ -1818,9 +2385,9 @@ checksum = "af9673d8203fcb076b19dfd17e38b3d4ae9f44959416ea532ce72415a6020365"
 
 [[package]]
 name = "fastrand"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "fax"
@@ -1838,6 +2405,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fearless_simd"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97b65636e5b9ef369943878ac74335ba1c55c1cb6adbf1e2c293c624248d693"
+
+[[package]]
 name = "ferrous-opencc"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1852,7 +2425,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -1888,9 +2461,9 @@ dependencies = [
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.9"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+checksum = "d45db016d36b838f563236e9193d0ee6ce38f3f68b6c94e914b4929c96bbb890"
 
 [[package]]
 name = "fixedbitset"
@@ -1927,6 +2500,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
+name = "font-types"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e64eb721ca85a34323425f4041adc5d82704d3782d5f8f03793bc012419dce23"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
 name = "foreign-types"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1947,13 +2529,13 @@ dependencies = [
 
 [[package]]
 name = "foreign-types-macros"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
+checksum = "ea5190182e6915eb873ddbc16e23b711b6eb1f9c00a0d0a3a91b5f6228475225"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1989,11 +2571,11 @@ dependencies = [
  "reqwest 0.12.28",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-stream",
  "tokio-util",
- "ureq 3.3.0",
+ "ureq 3.4.0",
  "urlencoding",
  "zip 2.4.2",
 ]
@@ -2012,24 +2594,24 @@ checksum = "7ab85b9b05e3978cc9a9cf8fea7f01b494e1a09ed3037e16ba39edc7a29eb61a"
 
 [[package]]
 name = "futures-channel"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+checksum = "b1f9e3d69d39e4862ffed03ed071a76f9a13ba1d9109d355b0f0aa6b15e393c4"
 dependencies = [
  "futures-core",
 ]
 
 [[package]]
 name = "futures-core"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+checksum = "92d699e522242e69e3003b94ecc1f960f3a5e015aa7c5d7486e65ad01dd94f5e"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+checksum = "031b47cf1a3c6cc8bc2fc76cd437f521619387907d469316e7c0bc278f1f5432"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -2038,9 +2620,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+checksum = "53c0fa8157de1303bfffdaa1cc2a673bfffb60102f76b0ef4441659124373fed"
 
 [[package]]
 name = "futures-lite"
@@ -2057,32 +2639,32 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+checksum = "9fb9654ba8355388abeb8dcb4fc62f511300867002afc858860463bdd9fe0c44"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+checksum = "1944426bf7d03f1d14f708785e4b33efd750b36d48a157b836b3efc15ede8e1d"
 
 [[package]]
 name = "futures-task"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+checksum = "cd417de3d1d015fc3bfd2b1ea46dfc7bab72ef86f1cc7cc9c78e728b34a6d1fd"
 
 [[package]]
 name = "futures-util"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+checksum = "0d50a92467f8ba5dd6e3ee5d4bd04d73ab2e4e1c44474a0674821dfce14b79bc"
 dependencies = [
  "futures-core",
  "futures-io",
@@ -2209,7 +2791,7 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
 dependencies = [
- "rustix",
+ "rustix 1.1.4",
  "windows-link 0.2.1",
 ]
 
@@ -2242,17 +2824,15 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
  "r-efi 6.0.0",
  "rand_core 0.10.1",
- "wasip2",
- "wasip3",
  "wasm-bindgen",
 ]
 
@@ -2264,7 +2844,7 @@ checksum = "6cf442baaabe4213ce7d1239afc26c039180b6456da2cededa316ae2c8a77a77"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2300,12 +2880,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "gl_generator"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a95dfc23a2b4a9a2f5ab41d194f8bfda3cabec42af4e39f08c339eb2a0c124d"
+dependencies = [
+ "khronos_api",
+ "log",
+ "xml-rs",
+]
+
+[[package]]
 name = "glib"
 version = "0.18.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "233daaf6e83ae6a12a52055f568f9d7cf4671dabb78ff9560ab6da230ce00ee5"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "futures-channel",
  "futures-core",
  "futures-executor",
@@ -2333,7 +2924,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2347,10 +2938,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "glob"
-version = "0.3.3"
+name = "glifo"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+checksum = "ed4a1bb24121291d27230c1b1b44e07d6a9b28cefdb32fe1581dfb84e14f940a"
+dependencies = [
+ "bytemuck",
+ "foldhash 0.2.0",
+ "hashbrown 0.17.1",
+ "log",
+ "peniko",
+ "skrifa",
+ "smallvec",
+ "vello_common",
+]
+
+[[package]]
+name = "glob"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
 
 [[package]]
 name = "global-hotkey"
@@ -2363,9 +2970,87 @@ dependencies = [
  "objc2 0.6.4",
  "objc2-app-kit 0.3.2",
  "once_cell",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "windows-sys 0.59.0",
  "x11-dl",
+]
+
+[[package]]
+name = "glow"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29038e1c483364cc6bb3cf78feee1816002e127c331a1eec55a4d202b9e1adb5"
+dependencies = [
+ "js-sys",
+ "slotmap",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "glutin"
+version = "0.32.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12124de845cacfebedff80e877bb37b5b75c34c5a4c89e47e1cdd67fb6041325"
+dependencies = [
+ "bitflags 2.13.1",
+ "cfg_aliases",
+ "cgl",
+ "dispatch2",
+ "glutin_egl_sys",
+ "glutin_glx_sys",
+ "glutin_wgl_sys",
+ "libloading 0.8.9",
+ "objc2 0.6.4",
+ "objc2-app-kit 0.3.2",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.2",
+ "once_cell",
+ "raw-window-handle",
+ "wayland-sys",
+ "windows-sys 0.52.0",
+ "x11-dl",
+]
+
+[[package]]
+name = "glutin-winit"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85edca7075f8fc728f28cb8fbb111a96c3b89e930574369e3e9c27eb75d3788f"
+dependencies = [
+ "cfg_aliases",
+ "glutin",
+ "raw-window-handle",
+ "winit",
+]
+
+[[package]]
+name = "glutin_egl_sys"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c4680ba6195f424febdc3ba46e7a42a0e58743f2edb115297b86d7f8ecc02d2"
+dependencies = [
+ "gl_generator",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "glutin_glx_sys"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7bb2938045a88b612499fbcba375a77198e01306f52272e692f8c1f3751185"
+dependencies = [
+ "gl_generator",
+ "x11-dl",
+]
+
+[[package]]
+name = "glutin_wgl_sys"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c4ee00b289aba7a9e5306d57c2d05499b2e5dc427f84ac708bd2c090212cf3e"
+dependencies = [
+ "gl_generator",
 ]
 
 [[package]]
@@ -2428,14 +3113,23 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "guillotiere"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b17e70c989c36bad147b27a58d148c0741c51448aa5653436547323e524d0ab"
+dependencies = [
+ "euclid",
 ]
 
 [[package]]
 name = "h2"
-version = "0.4.14"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+checksum = "839c0e8a181239723652be9062bb56ca5bf5f64011f73b623f6f4fc59086a228"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2458,7 +3152,20 @@ checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
 dependencies = [
  "cfg-if",
  "crunchy",
+ "num-traits",
  "zerocopy",
+]
+
+[[package]]
+name = "harfrust"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c03d949a14aa089bbb282f7dd76a498a7f684428e4257202efc119ec010376f9"
+dependencies = [
+ "bitflags 2.13.1",
+ "bytemuck",
+ "read-fonts",
+ "smallvec",
 ]
 
 [[package]]
@@ -2478,9 +3185,21 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "foldhash 0.2.0",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "heck"
@@ -2542,9 +3261,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.2"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
+checksum = "918d3568bebf352712bc2ef3d46a8bcf1a75b373be6539de198e9105cbbf9ce0"
 dependencies = [
  "bytes",
  "itoa",
@@ -2552,9 +3271,9 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+checksum = "ca2a8f2913ee65f60facd6a5905613afaa448497a0230cc41ce022d93290bc2c"
 dependencies = [
  "bytes",
  "http",
@@ -2562,9 +3281,9 @@ dependencies = [
 
 [[package]]
 name = "http-body-util"
-version = "0.1.3"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+checksum = "23169fe34a5fbcdd3f3862e78fb9b6fccd5f02a6dc6f732547005d45631ce71c"
 dependencies = [
  "bytes",
  "futures-core",
@@ -2587,9 +3306,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "1.10.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
+checksum = "d22053281f852e11534f5198498373cbb59295120a20771d90f7ed1897490a72"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2620,7 +3339,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots 1.0.7",
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]
@@ -2700,9 +3419,9 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+checksum = "fa68d21081c4a05d5a901a1c62add574c77048b6a1c67be3b50ce0b60d4ca513"
 dependencies = [
  "displaydoc",
  "potential_utf",
@@ -2714,9 +3433,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+checksum = "d56e28588da92eee5c3201a6eff33fabdd49b62269c8938d4ff050ce4d900deb"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -2727,9 +3446,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+checksum = "12f9cf5f235641ed274641dd81c3f28d870e276763d0797aeeab72317b1c646f"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -2741,16 +3460,17 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+checksum = "1563da1ed3e0b3bf3d74c9b85917ac9c56464d2f57242270c09c9e752f8021a0"
 
 [[package]]
 name = "icu_properties"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+checksum = "7e7ca276ad3145661a65914e6daf131ca5120cd3dcee8f8f3214b8875184a148"
 dependencies = [
+ "displaydoc",
  "icu_collections",
  "icu_locale_core",
  "icu_properties_data",
@@ -2761,15 +3481,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+checksum = "e590f038c1464a96894fd6d10127e90a8be4509f56ff7ecef851b15cee0b7caa"
 
 [[package]]
 name = "icu_provider"
-version = "2.2.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+checksum = "d27bbb9d3abbefac45d55f647c9de1d44aafcd1186eb91879afef17c396c3e73"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -2779,12 +3499,6 @@ dependencies = [
  "zerotrie",
  "zerovec",
 ]
-
-[[package]]
-name = "id-arena"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
 name = "ident_case"
@@ -2884,9 +3598,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.12.0"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+checksum = "6a756c3fac73139e83f14c2d742155dd2b78d3ee56597b419a0579b7bdd6dd78"
 
 [[package]]
 name = "is-docker"
@@ -2932,6 +3646,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b4baf93f58d4425749ca49a51c50ebab072c5df6994d08fed93541c331481dc"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2962,26 +3685,55 @@ dependencies = [
 
 [[package]]
 name = "jiff"
-version = "0.2.28"
+version = "0.2.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4603d3033e49e2b0e31229fcab20a5d40089c607d975cd9c80551dc69eed9102"
+checksum = "668b7183bd07af9a4885f5c35b0cc5c83c4607a913c16b7e17291832910d2dcc"
 dependencies = [
+ "defmt",
+ "jiff-core",
  "jiff-static",
+ "jiff-tzdb-platform",
  "log",
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "jiff-core"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7feca88439efe53da3754500c1851dedf3cb36c524dd5cf8225cc0794de95d09"
+dependencies = [
+ "defmt",
 ]
 
 [[package]]
 name = "jiff-static"
-version = "0.2.28"
+version = "0.2.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "782d32378dddf207193ac91cefb848ad41abb58195c95168e1291227a0832b47"
+checksum = "3a69dcb3a21cfb32ce1cd056169337ca284af0766dd766e7878819b251a49204"
 dependencies = [
+ "jiff-core",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "jiff-tzdb"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "142bd39932ad231f10513df9ab62661fead8719872150b7ad02a2df79f4e141e"
+
+[[package]]
+name = "jiff-tzdb-platform"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8"
+dependencies = [
+ "jiff-tzdb",
 ]
 
 [[package]]
@@ -3012,7 +3764,7 @@ dependencies = [
  "jni-sys 0.4.1",
  "log",
  "simd_cesu8",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "walkdir",
  "windows-link 0.2.1",
 ]
@@ -3027,7 +3779,7 @@ dependencies = [
  "quote",
  "rustc_version",
  "simd_cesu8",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3055,24 +3807,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "jobserver"
-version = "0.1.34"
+version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
 dependencies = [
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "libc",
 ]
 
 [[package]]
 name = "js-sys"
-version = "0.3.100"
+version = "0.3.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2025f20d7a4fa7785846e7b63d10a76d3f1cee98ee5cb79ea59703f95e42162"
+checksum = "0e0c1080212aad755ea003d18543e8768dd432c48819efd73a7bf1e39b7a5a3a"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -3107,7 +3859,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b750dcadc39a09dbadd74e118f6dd6598df77fa01df0cfcdc52c28dece74528a"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "serde",
  "unicode-segmentation",
 ]
@@ -3130,16 +3882,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "khronos_api"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
+
+[[package]]
+name = "kurbo"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b60dfc32f652b926df6192e55525b16d186c69d47876c3ead4da5cc9f8450e2"
+dependencies = [
+ "arrayvec",
+ "euclid",
+ "polycool",
+ "smallvec",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-
-[[package]]
-name = "leb128fmt"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libappindicator"
@@ -3167,9 +3931,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.186"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libdbus-sys"
@@ -3201,13 +3965,28 @@ dependencies = [
 ]
 
 [[package]]
-name = "libredox"
-version = "0.1.17"
+name = "libm"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
+name = "libredox"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d0a00925a9f930d679b6789b721e3a7f9ed110f41b86d2497caa780c3a070a"
 dependencies = [
+ "bitflags 2.13.1",
  "libc",
+ "plain",
+ "redox_syscall 0.9.3",
 ]
+
+[[package]]
+name = "linebender_resource_handle"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4a5ff6bcca6c4867b1c4fd4ef63e4db7436ef363e0ad7531d1558856bae64f4"
 
 [[package]]
 name = "linux-keyutils"
@@ -3215,9 +3994,15 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83270a18e9f90d0707c41e9f35efada77b64c0e6f3f1810e71c8368a864d5590"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "libc",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
@@ -3227,9 +4012,15 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+checksum = "47d9d19d1d6efa0109d2f65ff4c85cddd50bd572e5a00127ab10987290bcefae"
+
+[[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
 name = "local-ip-address"
@@ -3253,9 +4044,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.32"
+version = "0.4.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
+checksum = "f9f8bd3e56ce4dfc153cf470fffbfa98c7620958b312ca5c3a4b8d5181fd13c6"
 
 [[package]]
 name = "lru-slab"
@@ -3356,9 +4147,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.2"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "memmap2"
@@ -3418,9 +4209,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
+checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
 dependencies = [
  "libc",
  "wasi",
@@ -3446,7 +4237,7 @@ checksum = "e4db6d5580af57bf992f59068d4ea26fd518574ff48d7639b255a36f9de6e7e9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3461,9 +4252,9 @@ dependencies = [
 
 [[package]]
 name = "muda"
-version = "0.19.2"
+version = "0.19.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47a2e3dff89cd322c66647942668faee0a2b1f88ea6cbb4d374b4a8d7e92528c"
+checksum = "1dd04e60bc0b07438a6771710ee1698f98f6ebbc7f89b61264af1563b8aeb878"
 dependencies = [
  "crossbeam-channel",
  "dpi",
@@ -3476,7 +4267,7 @@ dependencies = [
  "once_cell",
  "png 0.18.1",
  "serde",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "windows-sys 0.61.2",
 ]
 
@@ -3514,7 +4305,44 @@ checksum = "4568f25ccbd45ab5d5603dc34318c1ec56b117531781260002151b8530a9f931"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "naga"
+version = "30.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a616d2fb8c89516ac2723a581f69d6c18576046bed761bd6b305e5618e6ae130"
+dependencies = [
+ "arrayvec",
+ "bit-set 0.10.0",
+ "bitflags 2.13.1",
+ "cfg-if",
+ "cfg_aliases",
+ "codespan-reporting",
+ "half",
+ "hashbrown 0.17.1",
+ "indexmap 2.14.0",
+ "libm",
+ "log",
+ "naga-types",
+ "num-traits",
+ "once_cell",
+ "rustc-hash 1.1.0",
+ "thiserror 2.0.20",
+ "unicode-ident",
+]
+
+[[package]]
+name = "naga-types"
+version = "30.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "590afbf58a6f4f62873cd5cff4468061844bafa1cdf399cc954537c22d768d49"
+dependencies = [
+ "hashbrown 0.17.1",
+ "indexmap 2.14.0",
+ "rustc-hash 1.1.0",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -3540,7 +4368,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2076a31b7010b17a38c01907c45b945e8f11495ee4dd588309718901b1f7a5b7"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "jni-sys 0.3.1",
  "log",
  "ndk-sys 0.5.0+25.2.9519653",
@@ -3554,7 +4382,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3f42e7bbe13d351b6bead8286a43aac9534b82bd3cc43e47037f012ebfd62d4"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "jni-sys 0.3.1",
  "log",
  "ndk-sys 0.6.0+11769913",
@@ -3593,7 +4421,7 @@ version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22f9786d56d972959e1408b6a93be6af13b9c1392036c5c1fafa08a1b0c6ee87"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "byteorder",
  "derive_builder",
  "getset",
@@ -3613,7 +4441,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3628,12 +4456,18 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "cfg-if",
  "cfg_aliases",
  "libc",
  "memoffset",
 ]
+
+[[package]]
+name = "nohash-hasher"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
 
 [[package]]
 name = "nom"
@@ -3679,9 +4513,9 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.4.6"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
 dependencies = [
  "num-integer",
  "num-traits",
@@ -3710,25 +4544,24 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "num-integer"
-version = "0.1.46"
+version = "0.1.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+checksum = "7ce2d95d4b3734dc35aa2f45e1aa22cd416814592a4f9d9205e11affd5b8e10b"
 dependencies = [
  "num-traits",
 ]
 
 [[package]]
 name = "num-iter"
-version = "0.1.45"
+version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+checksum = "c92800bd69a1eac91786bcfe9da64a897eb72911b8dc3095decbd07429e8048b"
 dependencies = [
- "autocfg",
  "num-integer",
  "num-traits",
 ]
@@ -3751,6 +4584,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -3772,7 +4606,7 @@ dependencies = [
  "proc-macro-crate 3.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3845,7 +4679,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4e89ad9e3d7d297152b17d39ed92cd50ca8063a89a9fa569046d41568891eff"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "block2 0.5.1",
  "libc",
  "objc2 0.5.2",
@@ -3861,7 +4695,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "block2 0.6.2",
  "objc2 0.6.4",
  "objc2-core-foundation",
@@ -3871,13 +4705,37 @@ dependencies = [
 
 [[package]]
 name = "objc2-cloud-kit"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74dd3b56391c7a0596a295029734d3c1c5e7e510a4cb30245f8221ccea96b009"
+dependencies = [
+ "bitflags 2.13.1",
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-core-location 0.2.2",
+ "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "objc2-cloud-kit"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73ad74d880bb43877038da939b7427bba67e9dd42004a18b809ba7d87cee241c"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "objc2 0.6.4",
  "objc2-foundation 0.3.2",
+]
+
+[[package]]
+name = "objc2-contacts"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5ff520e9c33812fd374d8deecef01d4a840e7b41862d849513de77e44aa4889"
+dependencies = [
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
 ]
 
 [[package]]
@@ -3886,7 +4744,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "617fbf49e071c178c0b24c080767db52958f716d9eabdf0890523aeae54773ef"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
@@ -3908,7 +4766,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "dispatch2",
  "objc2 0.6.4",
 ]
@@ -3919,7 +4777,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "dispatch2",
  "objc2 0.6.4",
  "objc2-core-foundation",
@@ -3950,6 +4808,18 @@ dependencies = [
 
 [[package]]
 name = "objc2-core-location"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "000cfee34e683244f284252ee206a27953279d370e309649dc3ee317b37e5781"
+dependencies = [
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-contacts",
+ "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "objc2-core-location"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca347214e24bc973fc025fd0d36ebb179ff30536ed1f80252706db19ee452009"
@@ -3964,7 +4834,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cde0dfb48d25d2b4862161a4d5fcc0e3c24367869ad306b0c9ec0073bfed92d"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "objc2 0.6.4",
  "objc2-core-foundation",
  "objc2-core-graphics",
@@ -3991,8 +4861,9 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ee638a5da3799329310ad4cfa62fbf045d5f56e3ef5ba4149e7452dcf89d5a8"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "block2 0.5.1",
+ "dispatch",
  "libc",
  "objc2 0.5.2",
 ]
@@ -4003,7 +4874,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "block2 0.6.2",
  "libc",
  "objc2 0.6.4",
@@ -4016,9 +4887,21 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "objc2 0.6.4",
  "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-link-presentation"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1a1ae721c5e35be65f01a03b6d2ac13a54cb4fa70d8a5da293d7b0020261398"
+dependencies = [
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-app-kit 0.2.2",
+ "objc2-foundation 0.2.2",
 ]
 
 [[package]]
@@ -4027,7 +4910,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd0cba1276f6023976a406a14ffa85e1fdd19df6b0f737b063b95f6c8c7aadd6"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
@@ -4039,7 +4922,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f112d1746737b0da274ef79a23aac283376f335f4095a083a267a082f21db0c0"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "objc2 0.6.4",
  "objc2-app-kit 0.3.2",
  "objc2-foundation 0.3.2",
@@ -4051,7 +4934,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e42bee7bff906b14b167da2bac5efe6b6a07e6f7c0a21a7308d40c960242dc7a"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
@@ -4064,10 +4947,41 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "objc2 0.6.4",
  "objc2-core-foundation",
  "objc2-foundation 0.3.2",
+]
+
+[[package]]
+name = "objc2-symbols"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a684efe3dec1b305badae1a28f6555f6ddd3bb2c2267896782858d5a78404dc"
+dependencies = [
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "objc2-ui-kit"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8bb46798b20cd6b91cbd113524c490f1686f4c4e8f49502431415f3512e2b6f"
+dependencies = [
+ "bitflags 2.13.1",
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-cloud-kit 0.2.2",
+ "objc2-core-data 0.2.2",
+ "objc2-core-image 0.2.2",
+ "objc2-core-location 0.2.2",
+ "objc2-foundation 0.2.2",
+ "objc2-link-presentation",
+ "objc2-quartz-core 0.2.2",
+ "objc2-symbols",
+ "objc2-uniform-type-identifiers",
+ "objc2-user-notifications 0.2.2",
 ]
 
 [[package]]
@@ -4076,19 +4990,43 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d87d638e33c06f577498cbcc50491496a3ed4246998a7fbba7ccb98b1e7eab22"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "block2 0.6.2",
  "objc2 0.6.4",
- "objc2-cloud-kit",
+ "objc2-cloud-kit 0.3.2",
  "objc2-core-data 0.3.2",
  "objc2-core-foundation",
  "objc2-core-graphics",
  "objc2-core-image 0.3.2",
- "objc2-core-location",
+ "objc2-core-location 0.3.2",
  "objc2-core-text",
  "objc2-foundation 0.3.2",
  "objc2-quartz-core 0.3.2",
- "objc2-user-notifications",
+ "objc2-user-notifications 0.3.2",
+]
+
+[[package]]
+name = "objc2-uniform-type-identifiers"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44fa5f9748dbfe1ca6c0b79ad20725a11eca7c2218bceb4b005cb1be26273bfe"
+dependencies = [
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "objc2-user-notifications"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76cfcbf642358e8689af64cee815d139339f3ed8ad05103ed5eaf73db8d84cb3"
+dependencies = [
+ "bitflags 2.13.1",
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-core-location 0.2.2",
+ "objc2-foundation 0.2.2",
 ]
 
 [[package]]
@@ -4107,7 +5045,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2e5aaab980c433cf470df9d7af96a7b46a9d892d521a2cbbb2f8a4c16751e7f"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "block2 0.6.2",
  "objc2 0.6.4",
  "objc2-app-kit 0.3.2",
@@ -4165,7 +5103,7 @@ version = "6.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc3cbf698f9438986c11a880c90a6d04b9de27575afd28bbf45b154b6c709e2"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "libc",
  "once_cell",
  "onig_sys",
@@ -4183,14 +5121,13 @@ dependencies = [
 
 [[package]]
 name = "open"
-version = "5.3.5"
+version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fbaa89d2ddc8473c78a3adf69eea8cffa28c483b8e02a971ef31527cd0fc92c"
+checksum = "f9cfef937e9c486488c7e3d949ae31c0f1d06bdacd75b99c086cb35356e30408"
 dependencies = [
  "dunce",
  "is-wsl",
  "libc",
- "pathdiff",
 ]
 
 [[package]]
@@ -4211,6 +5148,8 @@ dependencies = [
  "coreaudio-sys",
  "cpal",
  "dbus",
+ "eframe",
+ "egui",
  "enigo",
  "env_logger",
  "ferrous-opencc",
@@ -4269,17 +5208,18 @@ dependencies = [
  "whisper-rs",
  "window-vibrancy 0.7.1",
  "windows 0.58.0",
+ "winit",
  "winreg 0.52.0",
  "zip 2.4.2",
 ]
 
 [[package]]
 name = "openssl"
-version = "0.10.80"
+version = "0.10.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
+checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "cfg-if",
  "foreign-types 0.3.2",
  "libc",
@@ -4295,7 +5235,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4306,9 +5246,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.116"
+version = "0.9.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f28a22dc7140cda5f096e5e7724a6962ca81a7f8bfd2979f9b18c11af56318c4"
+checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
 dependencies = [
  "cc",
  "libc",
@@ -4321,6 +5261,16 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "orbclient"
+version = "0.3.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5df339f526ea9a60e371768d50efc2f2508c7203290731565d1f7a6f71d21747"
+dependencies = [
+ "libc",
+ "libredox",
+]
 
 [[package]]
 name = "ordered-stream"
@@ -4353,7 +5303,16 @@ dependencies = [
  "objc2-osa-kit",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
+]
+
+[[package]]
+name = "owned_ttf_parser"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36820e9051aca1014ddc75770aab4d68bc1e9e632f0f5627c4086bc216fb583b"
+dependencies = [
+ "ttf-parser",
 ]
 
 [[package]]
@@ -4405,7 +5364,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "smallvec",
  "windows-link 0.2.1",
 ]
@@ -4421,12 +5380,6 @@ name = "pastey"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
-
-[[package]]
-name = "pathdiff"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
 name = "pbkdf2"
@@ -4446,6 +5399,19 @@ checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
 dependencies = [
  "base64 0.22.1",
  "serde_core",
+]
+
+[[package]]
+name = "peniko"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "839c8299360d2e998bdb106dc0a6cd71dcc5f4df51df1b620361bf50e283cca6"
+dependencies = [
+ "bytemuck",
+ "color",
+ "kurbo",
+ "linebender_resource_handle",
+ "smallvec",
 ]
 
 [[package]]
@@ -4506,7 +5472,7 @@ dependencies = [
  "phf_shared",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4516,6 +5482,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
 dependencies = [
  "siphasher",
+]
+
+[[package]]
+name = "pin-project"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4537,9 +5523,15 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+checksum = "f6b464fbc74e149a392436b17d523f769e057cb6877f6a5c4618bc6f11800548"
+
+[[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plist"
@@ -4573,7 +5565,7 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "crc32fast",
  "fdeflate",
  "flate2",
@@ -4590,15 +5582,24 @@ dependencies = [
  "concurrent-queue",
  "hermit-abi",
  "pin-project-lite",
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
 [[package]]
-name = "portable-atomic"
-version = "1.13.1"
+name = "polycool"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+checksum = "50596ddc09eb5ad5f75cacd40209568e66df71baf86e1499a0e99c4cff12a5a6"
+dependencies = [
+ "arrayvec",
+]
+
+[[package]]
+name = "portable-atomic"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05c8b63e8d9609db387f0324918f81d68fe27748f084ef092fb35954d0539a85"
 
 [[package]]
 name = "portable-atomic-util"
@@ -4611,9 +5612,9 @@ dependencies = [
 
 [[package]]
 name = "potential_utf"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+checksum = "d83eb9bc6d8e5cf568e7a1101d60ee05e81ed50ea106026f3d18deeb046d7661"
 dependencies = [
  "zerovec",
 ]
@@ -4646,7 +5647,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4684,7 +5685,7 @@ version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit 0.25.12+spec-1.1.0",
+ "toml_edit 0.25.13+spec-1.1.0",
 ]
 
 [[package]]
@@ -4713,38 +5714,44 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.106"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
-name = "ptr_meta"
-version = "0.3.1"
+name = "profiling"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b9a0cf95a1196af61d4f1cbdab967179516d9a4a4312af1f31948f8f6224a79"
+checksum = "3d595e54a326bc53c1c197b32d295e14b169e3cfeaa8dc82b529f947fba6bcf5"
+
+[[package]]
+name = "ptr_meta"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743da816b98c921cdbe8628ef7381b76f25ecf4da599fc80aca90eae7ef70cc0"
 dependencies = [
  "ptr_meta_derive",
 ]
 
 [[package]]
 name = "ptr_meta_derive"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7347867d0a7e1208d93b46767be83e2b8f978c3dad35f775ac8d8847551d6fe1"
+checksum = "1c8d9ca532f185d5d4db7a7c9d51420b452168ea1c2b913953281bd6fe1fcbd0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "pxfm"
-version = "0.1.29"
+version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
+checksum = "d55d956fa96f5ec02be2e13af0e20391a5aa83d6a074e3ad368959d0fab299ea"
 
 [[package]]
 name = "quick-error"
@@ -4763,19 +5770,19 @@ dependencies = [
 
 [[package]]
 name = "quinn"
-version = "0.11.9"
+version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
 dependencies = [
  "bytes",
  "cfg_aliases",
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash",
+ "rustc-hash 2.1.3",
  "rustls",
  "socket2",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
  "web-time",
@@ -4783,21 +5790,21 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.16"
+version = "0.11.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
+checksum = "04759210543be93709136e28212294a659ef5001836ff4eab4d663e4529bba83"
 dependencies = [
  "bytes",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "lru-slab",
  "rand 0.10.2",
  "rand_pcg",
  "ring",
- "rustc-hash",
+ "rustc-hash 2.1.3",
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tinyvec",
  "tracing",
  "web-time",
@@ -4805,23 +5812,23 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.14"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
 dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]
@@ -4841,7 +5848,7 @@ dependencies = [
  "serde_json",
  "symphonia",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tokenizers",
  "tokio",
  "tower-http 0.5.2",
@@ -4863,18 +5870,18 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rancor"
-version = "0.1.1"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a063ea72381527c2a0561da9c80000ef822bdd7c3241b1cc1b12100e3df081ee"
+checksum = "9b534442d0fcdb55d66f373d9cac6d33b6293a2335bc2136dbd06ce0e87d2572"
 dependencies = [
  "ptr_meta",
 ]
 
 [[package]]
 name = "rand"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -4898,7 +5905,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
  "chacha20",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "rand_core 0.10.1",
 ]
 
@@ -5006,6 +6013,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "read-fonts"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "046a7d674daf459825b32f5062056d6882db0d2f5a479fbd76ccfc870ac18709"
+dependencies = [
+ "bytemuck",
+ "font-types",
+ "once_cell",
+]
+
+[[package]]
 name = "realfft"
 version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5016,11 +6034,29 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
+name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d678d17679829e73d371e96880897e98fee2ded7acc0a50bdf8af2affa4b2fe5"
+dependencies = [
+ "bitflags 2.13.1",
 ]
 
 [[package]]
@@ -5042,34 +6078,34 @@ checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
  "getrandom 0.2.17",
  "libredox",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
 name = "ref-cast"
-version = "1.0.25"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+checksum = "7e440fb4e4b4147295338efb76001ab9e4efc0e5839df2c47fc5ac2381d365c3"
 dependencies = [
  "ref-cast-impl",
 ]
 
 [[package]]
 name = "ref-cast-impl"
-version = "1.0.25"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+checksum = "92ecd8964f8453721699a1ed72037b0db49ce2f5a5138486ee89bed6f67cdf3a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "regex"
-version = "1.12.4"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -5079,9 +6115,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.14"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+checksum = "ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -5096,12 +6132,18 @@ checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "rend"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cadadef317c2f20755a64d7fdc48f9e7178ee6b0e1f7fce33fa60f1d68a276e6"
+checksum = "663ba70707f96e871406fe10d68128412e619b06d1d47cb91c3a4c6501176240"
 dependencies = [
  "bytecheck",
 ]
+
+[[package]]
+name = "renderdoc-sys"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832"
 
 [[package]]
 name = "reqwest"
@@ -5148,7 +6190,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams 0.4.2",
  "web-sys",
- "webpki-roots 1.0.7",
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]
@@ -5230,9 +6272,9 @@ dependencies = [
 
 [[package]]
 name = "rkyv"
-version = "0.8.17"
+version = "0.8.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "815cc8a37159a463064825246cadb07961e25cd9885908606f6d08a98d8f8874"
+checksum = "d9776093b7ca170454ab1406954f7b7d97a57c51dc6c0642957fb2ef25c2d399"
 dependencies = [
  "bytecheck",
  "bytes",
@@ -5249,13 +6291,13 @@ dependencies = [
 
 [[package]]
 name = "rkyv_derive"
-version = "0.8.17"
+version = "0.8.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0ed1a78a1b19d184b0daa629dd9a024573173ec7d485b287cb369fb3607cc1c"
+checksum = "1c25ef604ac7dd839d44d64648952ea23c97866f124ff671b0ed2cf3ad9bb06e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -5272,9 +6314,15 @@ dependencies = [
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.2"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
 
 [[package]]
 name = "rustc_version"
@@ -5301,22 +6349,35 @@ dependencies = [
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags 2.13.1",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.23.40"
+version = "0.23.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
 dependencies = [
  "log",
  "once_cell",
@@ -5341,9 +6402,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.1"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
 dependencies = [
  "web-time",
  "zeroize",
@@ -5378,9 +6439,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.13"
+version = "0.103.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+checksum = "f3c3cf1d8b1e7d4927e2d154c3fcb02979afb9939629c62cd9048d4f07b60ac2"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -5389,9 +6450,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "ryu"
@@ -5456,9 +6517,9 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+checksum = "687274d293b6cdc6e73e0fee520bf2049650090d7164f87672d212a3c530cf4a"
 dependencies = [
  "dyn-clone",
  "ref-cast",
@@ -5475,14 +6536,33 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
+
+[[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sctk-adwaita"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6277f0217056f77f1d8f49f2950ac6c278c0d607c45f5ee99328d792ede24ec"
+dependencies = [
+ "ab_glyph",
+ "log",
+ "memmap2",
+ "smithay-client-toolkit 0.19.2",
+ "tiny-skia",
+]
 
 [[package]]
 name = "secret-service"
@@ -5497,7 +6577,7 @@ dependencies = [
  "hkdf",
  "num",
  "once_cell",
- "rand 0.8.6",
+ "rand 0.8.7",
  "serde",
  "sha2",
  "zbus 4.4.0",
@@ -5509,7 +6589,7 @@ version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "core-foundation 0.9.4",
  "core-foundation-sys",
  "libc",
@@ -5522,7 +6602,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -5545,7 +6625,7 @@ version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c5d9c0c92a92d33f08817311cf3f2c29a3538a8240e94a6a3c622ce652d7e00c"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "cssparser",
  "derive_more",
  "log",
@@ -5553,10 +6633,16 @@ dependencies = [
  "phf",
  "phf_codegen",
  "precomputed-hash",
- "rustc-hash",
+ "rustc-hash 2.1.3",
  "servo_arc",
  "smallvec",
 ]
+
+[[package]]
+name = "self_cell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ab42ca02749e120097e328d91d415325bdf43b1c72c4c8badf37375fe40a813"
 
 [[package]]
 name = "semver"
@@ -5570,9 +6656,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -5592,22 +6678,22 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -5618,14 +6704,14 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.150"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
  "itoa",
  "memchr",
@@ -5647,13 +6733,13 @@ dependencies = [
 
 [[package]]
 name = "serde_repr"
-version = "0.1.20"
+version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
+checksum = "8d3b1629de253c70a0508c3899572da79ca359fdab27c7920ff00406df418906"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -5688,9 +6774,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.21.0"
+version = "3.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76a5c54c7310e7b8b9577c286d7e399ddd876c3e12b3ed917a8aabc4b96e9e8c"
+checksum = "ee78f1fbe43ac4a0e47aadb3dbd357b69eb0d3793e948624cd03dd2750ab1c0a"
 dependencies = [
  "base64 0.22.1",
  "bs58",
@@ -5698,8 +6784,9 @@ dependencies = [
  "hex",
  "indexmap 1.9.3",
  "indexmap 2.14.0",
+ "jiff",
  "schemars 0.9.0",
- "schemars 1.2.1",
+ "schemars 1.2.2",
  "serde_core",
  "serde_json",
  "serde_with_macros",
@@ -5708,14 +6795,14 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.21.0"
+version = "3.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84d57bc0c8b9a17920c178daa6bb924850d54a9c97ab45194bb8c17ad66bb660"
+checksum = "8705578779c2b6bd90d84d66eb2e206b708b1a4d7b9f17641b293545bf1c7e46"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5737,7 +6824,7 @@ checksum = "772ee033c0916d670af7860b6e1ef7d658a4629a6d0b4c8c3e67f09b3765b75d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5751,9 +6838,9 @@ dependencies = [
 
 [[package]]
 name = "sha1"
-version = "0.10.6"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+checksum = "a978451301f4db1d02937a4ab3ccce137717b81826e79b7d49ffe3244a13c3b8"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
@@ -5793,9 +6880,9 @@ dependencies = [
 
 [[package]]
 name = "sherpa-onnx"
-version = "1.13.2"
+version = "1.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f70620e4fa58e4cb1acf4e0a9c2cbc7496ea8284f80e55be23d443b92e563e49"
+checksum = "352a5dbbd9623e800be27e77de514e87fcfe2120256acc4434e6ea87a56bc885"
 dependencies = [
  "serde",
  "serde_json",
@@ -5804,9 +6891,9 @@ dependencies = [
 
 [[package]]
 name = "sherpa-onnx-sys"
-version = "1.13.2"
+version = "1.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7f3fe4987367b162336027b5d1ffca6dcd627bee6a324e46f80e82dfcb4365b"
+checksum = "c1541926ecf70b3d806467a2f100d3d879eef7fd34f8b307028bb074871d7493"
 dependencies = [
  "bzip2 0.4.4",
  "tar",
@@ -5858,15 +6945,15 @@ dependencies = [
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
 
 [[package]]
 name = "simd_cesu8"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+checksum = "11031e251abf8611c80f460e19dbdeb54a66db918e49c65a7065b46ac7aec520"
 dependencies = [
  "rustc_version",
  "simdutf8",
@@ -5896,10 +6983,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
+name = "skrifa"
+version = "0.44.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819ab7d62b1d3e72d9d9dea5650bac30424f9111364bb94928dbf5ecad1baa68"
+dependencies = [
+ "bytemuck",
+ "read-fonts",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "slotmap"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdd58c3c93c3d278ca835519292445cb4b0d4dc59ccfdf7ceadaab3f8aeb4038"
+dependencies = [
+ "version_check",
+]
 
 [[package]]
 name = "smallvec"
@@ -5908,10 +7014,82 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
-name = "socket2"
-version = "0.6.4"
+name = "smithay-client-toolkit"
+version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
+checksum = "3457dea1f0eb631b4034d61d4d8c32074caa6cd1ab2d59f2327bd8461e2c0016"
+dependencies = [
+ "bitflags 2.13.1",
+ "calloop 0.13.0",
+ "calloop-wayland-source 0.3.0",
+ "cursor-icon",
+ "libc",
+ "log",
+ "memmap2",
+ "rustix 0.38.44",
+ "thiserror 1.0.69",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-csd-frame",
+ "wayland-cursor",
+ "wayland-protocols",
+ "wayland-protocols-wlr",
+ "wayland-scanner",
+ "xkeysym",
+]
+
+[[package]]
+name = "smithay-client-toolkit"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0512da38f5e2b31201a93524adb8d3136276fa4fe4aafab4e1f727a82b534cc0"
+dependencies = [
+ "bitflags 2.13.1",
+ "calloop 0.14.4",
+ "calloop-wayland-source 0.4.1",
+ "cursor-icon",
+ "libc",
+ "log",
+ "memmap2",
+ "rustix 1.1.4",
+ "thiserror 2.0.20",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-csd-frame",
+ "wayland-cursor",
+ "wayland-protocols",
+ "wayland-protocols-experimental",
+ "wayland-protocols-misc",
+ "wayland-protocols-wlr",
+ "wayland-scanner",
+ "xkeysym",
+]
+
+[[package]]
+name = "smithay-clipboard"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71704c03f739f7745053bde45fa203a46c58d25bc5c4efba1d9a60e9dba81226"
+dependencies = [
+ "libc",
+ "smithay-client-toolkit 0.20.0",
+ "wayland-backend",
+]
+
+[[package]]
+name = "smol_str"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd538fb6910ac1099850255cf94a94df6551fbdd602454387d0adb2d1ca6dead"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "socket2"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -5932,7 +7110,7 @@ dependencies = [
  "objc2-foundation 0.3.2",
  "objc2-quartz-core 0.3.2",
  "raw-window-handle",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "tracing",
  "wasm-bindgen",
  "web-sys",
@@ -6002,6 +7180,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe895eb47f22e2ddd4dabc02bce419d2e643c8e3b585c78158b349195bc24d82"
 
 [[package]]
+name = "strict-num"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6637bab7722d379c8b41ba849228d680cc12d0a45ba1fa2b48f2a30577a06731"
+
+[[package]]
 name = "string_cache"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6039,9 +7223,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "swift-rs"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4057c98e2e852d51fdcfca832aac7b571f6b351ad159f9eda5db1655f8d0c4d7"
+checksum = "e45c444e496845d3f2a351146bff59aae4975b2280238df1dfaa0c7d1846f38e"
 dependencies = [
  "base64 0.21.7",
  "serde",
@@ -6218,9 +7402,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6255,7 +7439,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -6264,7 +7448,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
@@ -6298,7 +7482,7 @@ version = "0.35.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d1c93047acf68669466a34690ac58cca7010bd1b201e1ec86f1fd0a75d3dd4a9"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "block2 0.6.2",
  "core-foundation 0.10.1",
  "core-graphics 0.25.0",
@@ -6318,7 +7502,7 @@ dependencies = [
  "objc2 0.6.4",
  "objc2-app-kit 0.3.2",
  "objc2-foundation 0.3.2",
- "objc2-ui-kit",
+ "objc2-ui-kit 0.3.2",
  "once_cell",
  "parking_lot",
  "percent-encoding",
@@ -6334,13 +7518,13 @@ dependencies = [
 
 [[package]]
 name = "tao-macros"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4e16beb8b2ac17db28eab8bca40e62dbfbb34c0fcdc6d9826b11b7b5d047dfd"
+checksum = "5f7eeb6d99155545da6150a1795945f16ac9c178deb2a5f2e74d776107bd5849"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -6362,9 +7546,9 @@ checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 
 [[package]]
 name = "tauri"
-version = "2.11.2"
+version = "2.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "437404997acf375d85f1177afa7e11bb971f274ed6a7b83a2a3e339015f4cc28"
+checksum = "667b20e2726d572dea2de7370da16e188eb06008faf9a92fab7cdc46791190b5"
 dependencies = [
  "anyhow",
  "bytes",
@@ -6385,7 +7569,7 @@ dependencies = [
  "objc2 0.6.4",
  "objc2-app-kit 0.3.2",
  "objc2-foundation 0.3.2",
- "objc2-ui-kit",
+ "objc2-ui-kit 0.3.2",
  "objc2-web-kit",
  "percent-encoding",
  "plist",
@@ -6401,7 +7585,7 @@ dependencies = [
  "tauri-runtime",
  "tauri-runtime-wry",
  "tauri-utils",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tokio",
  "tray-icon",
  "url",
@@ -6413,9 +7597,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-build"
-version = "2.6.2"
+version = "2.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4aa1f9055fc23919a54e4e125052bed16ed04aef0487086e758fe01a67b451c7"
+checksum = "bc9ce40b16101cb6ea63d3e221567affd1c3a9205f95d7bc574941a10636b632"
 dependencies = [
  "anyhow",
  "cargo_toml",
@@ -6434,9 +7618,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-codegen"
-version = "2.6.2"
+version = "2.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4a0319528a025a38c4078e7dae2c446f4e63620ddb0659a643ede1cb38f90e9"
+checksum = "08279169ff42f8fc45a1dbc9dcae888893ba95288142e5880c59b93a26d2cfc5"
 dependencies = [
  "base64 0.22.1",
  "brotli",
@@ -6450,9 +7634,9 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
- "syn 2.0.117",
+ "syn 2.0.119",
  "tauri-utils",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "time",
  "url",
  "uuid",
@@ -6461,14 +7645,14 @@ dependencies = [
 
 [[package]]
 name = "tauri-macros"
-version = "2.6.2"
+version = "2.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae6cb4e3896c21d2f6da5b31251d2faea0153bba56ed0e970f918115dbee4924"
+checksum = "e8b394794f399a421811d06966343e7933fcae92d59f5180b9388d1174497a45"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
  "tauri-codegen",
  "tauri-utils",
 ]
@@ -6478,7 +7662,7 @@ name = "tauri-nspanel"
 version = "2.0.1"
 source = "git+https://github.com/ahkohd/tauri-nspanel?branch=v2#18ffb9a201fbf6fedfaa382fd4b92315ea30ab1a"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "block",
  "cocoa",
  "core-foundation 0.10.1",
@@ -6491,9 +7675,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-plugin"
-version = "2.6.2"
+version = "2.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e126abc9e84e35cdfd01596140a73a1850cdb0df0a23acf0185776c30b469a6e"
+checksum = "74be5dd4bed9afbd145e5716b5fa2ec28cbc29c34ffa61c258c9273d896c8020"
 dependencies = [
  "anyhow",
  "glob",
@@ -6516,7 +7700,7 @@ dependencies = [
  "serde_json",
  "tauri",
  "tauri-plugin",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -6533,7 +7717,7 @@ dependencies = [
  "tauri",
  "tauri-plugin",
  "tauri-plugin-fs",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "url",
 ]
 
@@ -6556,8 +7740,8 @@ dependencies = [
  "tauri",
  "tauri-plugin",
  "tauri-utils",
- "thiserror 2.0.18",
- "toml 1.1.2+spec-1.1.0",
+ "thiserror 2.0.20",
+ "toml 1.1.4+spec-1.1.0",
  "url",
 ]
 
@@ -6578,23 +7762,24 @@ dependencies = [
  "shared_child",
  "tauri",
  "tauri-plugin",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tokio",
 ]
 
 [[package]]
 name = "tauri-plugin-single-instance"
-version = "2.4.2"
+version = "2.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c8f29386f5e9fdc699182388a33ee80a56de436d91b67459e86afef426282af"
+checksum = "b3214becf9ef5783c0ae99a3bb25adf5353a7a16ebf53e74b909e29205735c6c"
 dependencies = [
  "serde",
  "serde_json",
  "tauri",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
+ "tokio",
  "tracing",
  "windows-sys 0.60.2",
- "zbus 5.16.0",
+ "zbus 5.19.0",
 ]
 
 [[package]]
@@ -6622,7 +7807,7 @@ dependencies = [
  "tauri",
  "tauri-plugin",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "time",
  "tokio",
  "url",
@@ -6632,9 +7817,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-runtime"
-version = "2.11.2"
+version = "2.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48222d7116c8807eaa6fe2f372e023fae125084e61e6eca6d70b7961cdf129ef"
+checksum = "b0b4bc95aed361b0019067d189a1174a603d460d0f6c72606512d59fc9c12ec8"
 dependencies = [
  "cookie",
  "dpi",
@@ -6642,13 +7827,13 @@ dependencies = [
  "http",
  "jni 0.21.1",
  "objc2 0.6.4",
- "objc2-ui-kit",
+ "objc2-ui-kit 0.3.2",
  "objc2-web-kit",
  "raw-window-handle",
  "serde",
  "serde_json",
  "tauri-utils",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "url",
  "webkit2gtk",
  "webview2-com",
@@ -6657,9 +7842,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-runtime-wry"
-version = "2.11.2"
+version = "2.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b83849ee63ecb27a8e8d0fe51915ca215076914aca43f96db1179f0f415f6cd9"
+checksum = "4e6fac707727b7a2f48e4ded90976324267371073edbb415ffb73bb0458d203f"
 dependencies = [
  "gtk",
  "http",
@@ -6683,9 +7868,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-utils"
-version = "2.9.2"
+version = "2.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "092379df9a707631978e6c56b1bc2401d387f01e2d4a3c123360d167bbb9aa95"
+checksum = "3e176a18e67764923c4f1ce66f25ae4abe5f688384d5eb1a0fa6c77f3d90f887"
 dependencies = [
  "anyhow",
  "brotli",
@@ -6711,8 +7896,8 @@ dependencies = [
  "serde_json",
  "serde_with",
  "swift-rs",
- "thiserror 2.0.18",
- "toml 1.1.2+spec-1.1.0",
+ "thiserror 2.0.20",
+ "toml 1.1.4+spec-1.1.0",
  "url",
  "urlpattern",
  "uuid",
@@ -6727,7 +7912,7 @@ checksum = "cc65d45c68858bfe420dd29e834b5d15dbecf8a07a8a16cf4d532c7b1f69d4b6"
 dependencies = [
  "dunce",
  "embed-resource",
- "toml 1.1.2+spec-1.1.0",
+ "toml 1.1.4+spec-1.1.0",
 ]
 
 [[package]]
@@ -6737,20 +7922,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "once_cell",
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "tendril"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4790fc369d5a530f4b544b094e31388b9b3a37c0f4652ade4505945f5660d24"
+checksum = "5fed54709c5b3a53d09bb1c113ea4f5ceafd1e772ddcb0030a82e1d56c087b08"
 dependencies = [
  "new_debug_unreachable",
- "utf-8",
 ]
 
 [[package]]
@@ -6773,11 +7957,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.18"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
 dependencies = [
- "thiserror-impl 2.0.18",
+ "thiserror-impl 2.0.20",
 ]
 
 [[package]]
@@ -6788,18 +7972,18 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.18"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -6827,12 +8011,11 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.47"
+version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+checksum = "cdb87b95ec50ddfa440816d227a17b2ccbdda963a316a727fda0fc4334f7d134"
 dependencies = [
  "deranged",
- "itoa",
  "libc",
  "num-conv",
  "num_threads",
@@ -6844,25 +8027,50 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.27"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+checksum = "7e689342a48d2ea927c87ea50cabf8594854bf940e9310208848d680d668ed85"
 dependencies = [
  "num-conv",
  "time-core",
 ]
 
 [[package]]
-name = "tinystr"
-version = "0.8.3"
+name = "tiny-skia"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+checksum = "83d13394d44dae3207b52a326c0c85a8bf87f1541f23b0d143811088497b09ab"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "bytemuck",
+ "cfg-if",
+ "log",
+ "tiny-skia-path",
+]
+
+[[package]]
+name = "tiny-skia-path"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c9e7fc0c2e86a30b117d0462aa261b72b7a99b7ebd7deb3a14ceda95c5bdc93"
+dependencies = [
+ "arrayref",
+ "bytemuck",
+ "strict-num",
+]
+
+[[package]]
+name = "tinystr"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1e27c91459209c2986af3dcf603a5a74a4368754ce37414f59acc971167f643"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -6870,9 +8078,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -6911,7 +8119,7 @@ dependencies = [
  "serde",
  "serde_json",
  "spm_precompiled",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "unicode-normalization-alignments",
  "unicode-segmentation",
  "unicode_categories",
@@ -6919,9 +8127,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.52.3"
+version = "1.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
+checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
 dependencies = [
  "bytes",
  "libc",
@@ -6936,13 +8144,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.7.0"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -6967,9 +8175,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+checksum = "a3d06f0b082ba57c26b79407372e57cf2a1e28124f78e9479fe80322cf53420b"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -6994,13 +8202,14 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.18"
+version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+checksum = "494815d09bf52b5548659851081238f0ca39ff638363907596da739561c62c52"
 dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
+ "libc",
  "pin-project-lite",
  "tokio",
 ]
@@ -7034,9 +8243,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "1.1.2+spec-1.1.0"
+version = "1.1.4+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
+checksum = "3aace63f4bbcdfc2c965b059de67119c89c4017a70d633be6c104910f67056f5"
 dependencies = [
  "indexmap 2.14.0",
  "serde_core",
@@ -7044,7 +8253,7 @@ dependencies = [
  "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow 1.0.3",
+ "winnow 1.0.4",
 ]
 
 [[package]]
@@ -7100,30 +8309,30 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.25.12+spec-1.1.0"
+version = "0.25.13+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
+checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
 dependencies = [
  "indexmap 2.14.0",
  "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
- "winnow 1.0.3",
+ "winnow 1.0.4",
 ]
 
 [[package]]
 name = "toml_parser"
-version = "1.1.2+spec-1.1.0"
+version = "1.1.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
 dependencies = [
- "winnow 1.0.3",
+ "winnow 1.0.4",
 ]
 
 [[package]]
 name = "toml_writer"
-version = "1.1.1+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
+checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
 
 [[package]]
 name = "tower"
@@ -7147,7 +8356,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e9cd434a998747dd2c4276bc96ee2e0c7a2eadf3cae88e52be55a05fa9053f5"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "bytes",
  "http",
  "http-body",
@@ -7164,7 +8373,7 @@ version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "bytes",
  "futures-util",
  "http",
@@ -7208,7 +8417,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -7262,9 +8471,9 @@ dependencies = [
 
 [[package]]
 name = "tray-icon"
-version = "0.23.1"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15edbb0d80583e85ee8df283410038e17314df5cba30da2087a54a85216c0773"
+checksum = "045979e3f037cd18ad1cb2a419dfda133c5c29c9f3453370079f2255d46c257e"
 dependencies = [
  "crossbeam-channel",
  "dirs 6.0.0",
@@ -7278,7 +8487,7 @@ dependencies = [
  "once_cell",
  "png 0.18.1",
  "serde",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "windows-sys 0.61.2",
 ]
 
@@ -7300,6 +8509,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "ttf-parser"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
+
+[[package]]
 name = "tungstenite"
 version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7311,12 +8526,21 @@ dependencies = [
  "http",
  "httparse",
  "log",
- "rand 0.8.6",
+ "rand 0.8.7",
  "rustls",
  "rustls-pki-types",
  "sha1",
  "thiserror 1.0.69",
  "utf-8",
+]
+
+[[package]]
+name = "type-map"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb30dbbd9036155e74adad6812e9898d03ec374946234fbcebd5dfc7b9187b90"
+dependencies = [
+ "rustc-hash 2.1.3",
 ]
 
 [[package]]
@@ -7390,6 +8614,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
+name = "unicode-general-category"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b993bddc193ae5bd0d623b49ec06ac3e9312875fdae725a975c51db1cc1677f"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7415,12 +8645,6 @@ name = "unicode-width"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
-
-[[package]]
-name = "unicode-xid"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "unicode_categories"
@@ -7452,11 +8676,11 @@ dependencies = [
 
 [[package]]
 name = "ureq"
-version = "3.3.0"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
+checksum = "972d7902c8735f2695410b8aed7df6ed12a47394aa1c8d7af49f0497b731a94d"
 dependencies = [
- "base64 0.22.1",
+ "base64 0.23.1",
  "flate2",
  "log",
  "percent-encoding",
@@ -7464,16 +8688,16 @@ dependencies = [
  "rustls-pki-types",
  "ureq-proto",
  "utf8-zero",
- "webpki-roots 1.0.7",
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]
 name = "ureq-proto"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
+checksum = "da5f78b09e6941e1a0f2e30e695e4b120377b54d5e0aec11b594bb57b3971613"
 dependencies = [
- "base64 0.22.1",
+ "base64 0.23.1",
  "http",
  "httparse",
  "log",
@@ -7536,11 +8760,11 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.3"
+version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "144d6b123cef80b301b8f72a9e2ca4370ddec21950d0a103dd22c437006d2db7"
+checksum = "f053576934f05a761a402421fbbe3d425d9366f75f978806a037b3ca481abecc"
 dependencies = [
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "js-sys",
  "serde_core",
  "wasm-bindgen",
@@ -7557,6 +8781,33 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "vello_common"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2e9aed918117e8152c9eddfd8362d73c465c23f26c44786aa331707b8a64fa2"
+dependencies = [
+ "bytemuck",
+ "fearless_simd",
+ "guillotiere",
+ "log",
+ "peniko",
+ "smallvec",
+ "thiserror 2.0.20",
+]
+
+[[package]]
+name = "vello_cpu"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac7349e1f55f6b801c7c277958df4ea53e7f20f21e8014910ad888b2ecda93ea"
+dependencies = [
+ "bytemuck",
+ "glifo",
+ "hashbrown 0.17.1",
+ "vello_common",
+]
 
 [[package]]
 name = "version-compare"
@@ -7617,27 +8868,18 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.3+wasi-0.2.9"
+version = "1.0.4+wasi-0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
 dependencies = [
- "wit-bindgen 0.57.1",
-]
-
-[[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
-dependencies = [
- "wit-bindgen 0.51.0",
+ "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.123"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a254a4b10c19a76f09a27640e7ffbf9bc30bf67e16a3bf28aaefa4920fe81563"
+checksum = "1b70935747edd64d89de3efa29d73789b806c15798f8e7dca4d8ac356b50ce70"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -7648,9 +8890,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.73"
+version = "0.4.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54568702fabf5d4849ce2b90fadfa64168a097eaf4b351ce9df8b687a0086aaf"
+checksum = "6b7777d5cc23d0e91404e53ce2d5e8ec7acae3026b16233dba62cd3246457950"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -7658,9 +8900,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.123"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24a40fc75b0ec6f3746ceb10d36f53a93dcd68a93b11b6445983945d79eba0dc"
+checksum = "77775f8f3f7217702089053b94958f8f54061a3f663417df76e19cbdcca29bc1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -7668,46 +8910,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.123"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "908f34bd9b9ce3d4caf07b72dfab63d61504d156856c6bd3cd87fa350cf3985b"
+checksum = "e11d33f857dc2fb11b8bc75aee111aa9cbeb12cd9f25efd3d4c2a3dd4e235284"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.123"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7acbf7616c27b194bbb550bf77ed0c2c3e5b7fd1260a93082b95fb7f47959b92"
+checksum = "7ef64dbcc55df09c7e5a46182d181c2cfa3e925f3da937ea764728b4bbb9dcbf"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "wasm-encoder"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
-dependencies = [
- "leb128fmt",
- "wasmparser",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-dependencies = [
- "anyhow",
- "indexmap 2.14.0",
- "wasm-encoder",
- "wasmparser",
 ]
 
 [[package]]
@@ -7737,51 +8957,101 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags 2.13.0",
- "hashbrown 0.15.5",
- "indexmap 2.14.0",
- "semver",
-]
-
-[[package]]
 name = "wayland-backend"
-version = "0.3.15"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2857dd20b54e916ec7253b3d6b4d5c4d7d4ca2c33c2e11c6c76a99bd8744755d"
+checksum = "38a91b4eaddff87b1cd1074985e3713da4af2c49742d1b356b2c01670a67a078"
 dependencies = [
  "cc",
  "downcast-rs",
- "rustix",
+ "rustix 1.1.4",
+ "scoped-tls",
  "smallvec",
  "wayland-sys",
 ]
 
 [[package]]
 name = "wayland-client"
-version = "0.31.14"
+version = "0.31.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "645c7c96bb74690c3189b5c9cb4ca1627062bb23693a4fad9d8c3de958260144"
+checksum = "e3c36a0f861ad76d0901f2800b46321410d9f73f2ea88aac0650d86c32688073"
 dependencies = [
- "bitflags 2.13.0",
- "rustix",
+ "bitflags 2.13.1",
+ "rustix 1.1.4",
  "wayland-backend",
  "wayland-scanner",
 ]
 
 [[package]]
-name = "wayland-protocols"
-version = "0.32.12"
+name = "wayland-csd-frame"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "563a85523cade2429938e790815fd7319062103b9f4a2dc806e9b53b95982d8f"
+checksum = "625c5029dbd43d25e6aa9615e88b829a5cad13b2819c4ae129fdbb7c31ab4c7e"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
+ "cursor-icon",
+ "wayland-backend",
+]
+
+[[package]]
+name = "wayland-cursor"
+version = "0.31.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a52d18780be9b1314328a3de5f930b73d2200112e3849ca6cb11822793fb34d"
+dependencies = [
+ "rustix 1.1.4",
+ "wayland-client",
+ "xcursor",
+]
+
+[[package]]
+name = "wayland-protocols"
+version = "0.32.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23d0c813de3daa2ed6520af85a3bd49b0e722a3078506899aa9686fea58dc4b6"
+dependencies = [
+ "bitflags 2.13.1",
  "wayland-backend",
  "wayland-client",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols-experimental"
+version = "20250721.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40a1f863128dcaaec790d7b4b396cc9b9a7a079e878e18c47e6c2d2c5a8dcbb1"
+dependencies = [
+ "bitflags 2.13.1",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols-misc"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e9567599ef23e09b8dad6e429e5738d4509dfc46b3b21f32841a304d16b29c8"
+dependencies = [
+ "bitflags 2.13.1",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols-plasma"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b6d8cf1eb2c1c31ed1f5643c88a6e53538129d4af80030c8cabd1f9fa884d91"
+dependencies = [
+ "bitflags 2.13.1",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
  "wayland-scanner",
 ]
 
@@ -7791,7 +9061,7 @@ version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb04e52f7836d7c7976c78ca0250d61e33873c34156a2a1fc9474828ec268234"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "wayland-backend",
  "wayland-client",
  "wayland-protocols",
@@ -7813,14 +9083,17 @@ version = "0.31.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8eab23fefc9e41f8e841df4a9c707e8a8c4ed26e944ef69297184de2785e3be"
 dependencies = [
+ "dlib",
+ "log",
+ "once_cell",
  "pkg-config",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.100"
+version = "0.3.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e0871acf327f283dc6da28a1696cdc64fb355ba9f935d052021fa77f35cce69"
+checksum = "c435338968042f4f59a557f690a253676d47ce13ceb55d70100e7facf6620a30"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -7838,9 +9111,9 @@ dependencies = [
 
 [[package]]
 name = "web_atoms"
-version = "0.2.4"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7cff6eef815df1834fd250e3a2ff436044d82a9f1bc1980ca1dbdf07effc538"
+checksum = "ba8b815c1b593dc0baf78dd0f4fc8fdb2de53198fb1163738093e9a311c33fb3"
 dependencies = [
  "phf",
  "phf_codegen",
@@ -7894,9 +9167,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-root-certs"
-version = "1.0.7"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
+checksum = "b96554aa2acc8ccdb7e1c9a58a7a68dd5d13bccc69cd124cb09406db612a1c9b"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -7907,14 +9180,14 @@ version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
 dependencies = [
- "webpki-roots 1.0.7",
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.7"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -7941,7 +9214,7 @@ checksum = "67a921c1b6914c367b2b823cd4cde6f96beec77d30a939c8199bb377cf9b9b54"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -7950,7 +9223,7 @@ version = "0.38.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "381336cfffd772377d291702245447a5251a2ffa5bad679c99e61bc48bacbf9c"
 dependencies = [
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "windows 0.61.3",
  "windows-core 0.61.2",
 ]
@@ -7960,6 +9233,125 @@ name = "weezl"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
+
+[[package]]
+name = "wgpu"
+version = "30.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527ccdf43dd5b2e8676eed9984ce00e2bbb0a1b85b70c1969dcb6cd2eb55ab9e"
+dependencies = [
+ "arrayvec",
+ "bitflags 2.13.1",
+ "bytemuck",
+ "cfg-if",
+ "cfg_aliases",
+ "document-features",
+ "hashbrown 0.17.1",
+ "js-sys",
+ "log",
+ "portable-atomic",
+ "profiling",
+ "raw-window-handle",
+ "smallvec",
+ "static_assertions",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "wgpu-core",
+ "wgpu-hal",
+ "wgpu-types",
+]
+
+[[package]]
+name = "wgpu-core"
+version = "30.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14c018fce9b6270aa203c2fdd56f3cce996713534bd757e4ea58c8560b121f14"
+dependencies = [
+ "arrayvec",
+ "bit-set 0.10.0",
+ "bit-vec 0.9.1",
+ "bitflags 2.13.1",
+ "bytemuck",
+ "cfg_aliases",
+ "document-features",
+ "hashbrown 0.17.1",
+ "indexmap 2.14.0",
+ "log",
+ "naga",
+ "naga-types",
+ "once_cell",
+ "parking_lot",
+ "portable-atomic",
+ "profiling",
+ "raw-window-handle",
+ "rustc-hash 1.1.0",
+ "smallvec",
+ "thiserror 2.0.20",
+ "wgpu-core-deps-windows-linux-android",
+ "wgpu-hal",
+ "wgpu-naga-bridge",
+ "wgpu-types",
+]
+
+[[package]]
+name = "wgpu-core-deps-windows-linux-android"
+version = "30.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7586165fd5f6d881cb9ce4bb71f40d6caab2c0f1837e3fc1d9788a197fb6004f"
+dependencies = [
+ "wgpu-hal",
+]
+
+[[package]]
+name = "wgpu-hal"
+version = "30.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6b7fb58561a792bc237628ba0792e332de418fefe145f13b5ed8201e6d52f58"
+dependencies = [
+ "bitflags 2.13.1",
+ "cfg-if",
+ "cfg_aliases",
+ "hashbrown 0.17.1",
+ "libloading 0.8.9",
+ "log",
+ "naga",
+ "naga-types",
+ "portable-atomic",
+ "portable-atomic-util",
+ "raw-window-handle",
+ "renderdoc-sys",
+ "static_assertions",
+ "thiserror 2.0.20",
+ "wgpu-naga-bridge",
+ "wgpu-types",
+]
+
+[[package]]
+name = "wgpu-naga-bridge"
+version = "30.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f62e73117bb7a62bfd9c5a5841438a823f6566c6442a808ee269d2d055c081"
+dependencies = [
+ "naga",
+ "wgpu-types",
+]
+
+[[package]]
+name = "wgpu-types"
+version = "30.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99dad6f1fbdbbdb4c278a6508b059d44688f5cebddf78d005a46a31340269286"
+dependencies = [
+ "bitflags 2.13.1",
+ "bytemuck",
+ "js-sys",
+ "log",
+ "naga-types",
+ "raw-window-handle",
+ "static_assertions",
+ "web-sys",
+]
 
 [[package]]
 name = "whisper-rs"
@@ -8069,11 +9461,23 @@ version = "0.61.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
 dependencies = [
- "windows-collections",
+ "windows-collections 0.2.0",
  "windows-core 0.61.2",
- "windows-future",
+ "windows-future 0.2.1",
  "windows-link 0.1.3",
- "windows-numerics",
+ "windows-numerics 0.2.0",
+]
+
+[[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections 0.3.2",
+ "windows-core 0.62.2",
+ "windows-future 0.3.2",
+ "windows-numerics 0.3.1",
 ]
 
 [[package]]
@@ -8083,6 +9487,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
 dependencies = [
  "windows-core 0.61.2",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+dependencies = [
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -8142,7 +9555,18 @@ checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
 dependencies = [
  "windows-core 0.61.2",
  "windows-link 0.1.3",
- "windows-threading",
+ "windows-threading 0.1.0",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core 0.62.2",
+ "windows-link 0.2.1",
+ "windows-threading 0.2.1",
 ]
 
 [[package]]
@@ -8153,7 +9577,7 @@ checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -8164,7 +9588,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -8175,7 +9599,7 @@ checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -8186,7 +9610,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -8209,6 +9633,16 @@ checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
  "windows-core 0.61.2",
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core 0.62.2",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -8413,6 +9847,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link 0.2.1",
+]
+
+[[package]]
 name = "windows-version"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8602,6 +10045,58 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
+name = "winit"
+version = "0.30.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6755fa58a9f8350bd1e472d4c3fcc25f824ec358933bba33306d0b63df5978d"
+dependencies = [
+ "ahash",
+ "android-activity",
+ "atomic-waker",
+ "bitflags 2.13.1",
+ "block2 0.5.1",
+ "bytemuck",
+ "calloop 0.13.0",
+ "cfg_aliases",
+ "concurrent-queue",
+ "core-foundation 0.9.4",
+ "core-graphics 0.23.2",
+ "cursor-icon",
+ "dpi",
+ "js-sys",
+ "libc",
+ "memmap2",
+ "ndk 0.9.0",
+ "objc2 0.5.2",
+ "objc2-app-kit 0.2.2",
+ "objc2-foundation 0.2.2",
+ "objc2-ui-kit 0.2.2",
+ "orbclient",
+ "percent-encoding",
+ "pin-project",
+ "raw-window-handle",
+ "redox_syscall 0.4.1",
+ "rustix 0.38.44",
+ "sctk-adwaita",
+ "smithay-client-toolkit 0.19.2",
+ "smol_str",
+ "tracing",
+ "unicode-segmentation",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-protocols-plasma",
+ "web-sys",
+ "web-time",
+ "windows-sys 0.52.0",
+ "x11-dl",
+ "x11rb",
+ "xkbcommon-dl",
+]
+
+[[package]]
 name = "winnow"
 version = "0.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8618,9 +10113,9 @@ checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 
 [[package]]
 name = "winnow"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 dependencies = [
  "memchr",
 ]
@@ -8656,97 +10151,9 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro",
-]
-
-[[package]]
-name = "wit-bindgen"
 version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
-
-[[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-dependencies = [
- "anyhow",
- "heck 0.5.0",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck 0.5.0",
- "indexmap 2.14.0",
- "prettyplease",
- "syn 2.0.117",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags 2.13.0",
- "indexmap 2.14.0",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap 2.14.0",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser",
-]
 
 [[package]]
 name = "wl-clipboard-rs"
@@ -8757,8 +10164,8 @@ dependencies = [
  "libc",
  "log",
  "os_pipe",
- "rustix",
- "thiserror 2.0.18",
+ "rustix 1.1.4",
+ "thiserror 2.0.20",
  "tree_magic_mini",
  "wayland-backend",
  "wayland-client",
@@ -8768,9 +10175,9 @@ dependencies = [
 
 [[package]]
 name = "writeable"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+checksum = "3ad82d2a33cdc9674dc7465672f271e096168fcdbe0f799d9e6db8c5892679dc"
 
 [[package]]
 name = "wry"
@@ -8797,7 +10204,7 @@ dependencies = [
  "objc2-app-kit 0.3.2",
  "objc2-core-foundation",
  "objc2-foundation 0.3.2",
- "objc2-ui-kit",
+ "objc2-ui-kit 0.3.2",
  "objc2-web-kit",
  "once_cell",
  "percent-encoding",
@@ -8805,7 +10212,7 @@ dependencies = [
  "sha2",
  "soup3",
  "tao-macros",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "url",
  "webkit2gtk",
  "webkit2gtk-sys",
@@ -8843,8 +10250,12 @@ version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9993aa5be5a26815fe2c3eacfc1fde061fc1a1f094bf1ad2a18bf9c495dd7414"
 dependencies = [
+ "as-raw-xcb-connection",
  "gethostname",
- "rustix",
+ "libc",
+ "libloading 0.8.9",
+ "once_cell",
+ "rustix 1.1.4",
  "x11rb-protocol",
 ]
 
@@ -8861,8 +10272,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
 dependencies = [
  "libc",
- "rustix",
+ "rustix 1.1.4",
 ]
+
+[[package]]
+name = "xcursor"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "163b33ed8786455e2fa5d72f554057ce3f3182425434f756cd39c99839d88e23"
 
 [[package]]
 name = "xdg-home"
@@ -8886,10 +10303,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "xkbcommon-dl"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d039de8032a9a8856a6be89cea3e5d12fdd82306ab7c94d74e6deab2460651c5"
+dependencies = [
+ "bitflags 2.13.1",
+ "dlib",
+ "log",
+ "once_cell",
+ "xkeysym",
+]
+
+[[package]]
 name = "xkeysym"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
+
+[[package]]
+name = "xml-rs"
+version = "0.8.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e450f9b2ed1dff33c94c12589a87338689467b9c4f5d8a5710bd09a847d2c8a7"
 
 [[package]]
 name = "xz2"
@@ -8928,7 +10364,7 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
  "synstructure",
 ]
 
@@ -8950,7 +10386,7 @@ dependencies = [
  "hex",
  "nix",
  "ordered-stream",
- "rand 0.8.6",
+ "rand 0.8.7",
  "serde",
  "serde_repr",
  "sha1",
@@ -8966,9 +10402,9 @@ dependencies = [
 
 [[package]]
 name = "zbus"
-version = "5.16.0"
+version = "5.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eee682d202a77e4a9f3b2c2bdf48a7b28af5c08c34ddf66f98c93e5e39464285"
+checksum = "5db4be7c075cb421e4b7ee645541604239bd243ba7c357511f4ff3a74b555907"
 dependencies = [
  "async-broadcast",
  "async-executor",
@@ -8986,17 +10422,41 @@ dependencies = [
  "hex",
  "libc",
  "ordered-stream",
- "rustix",
+ "rustix 1.1.4",
  "serde",
  "serde_repr",
  "tracing",
  "uds_windows",
  "uuid",
  "windows-sys 0.61.2",
- "winnow 1.0.3",
- "zbus_macros 5.16.0",
- "zbus_names 4.3.2",
- "zvariant 5.12.0",
+ "winnow 1.0.4",
+ "zbus_macros 5.19.0",
+ "zbus_names 4.3.4",
+ "zvariant 5.15.0",
+]
+
+[[package]]
+name = "zbus-lockstep"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6998de05217a084b7578728a9443d04ea4cd80f2a0839b8d78770b76ccd45863"
+dependencies = [
+ "zbus_xml",
+ "zvariant 5.15.0",
+]
+
+[[package]]
+name = "zbus-lockstep-macros"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10da05367f3a7b7553c8cdf8fa91aee6b64afebe32b51c95177957efc47ca3a0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "zbus-lockstep",
+ "zbus_xml",
+ "zvariant 5.15.0",
 ]
 
 [[package]]
@@ -9008,23 +10468,23 @@ dependencies = [
  "proc-macro-crate 3.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
  "zvariant_utils 2.1.0",
 ]
 
 [[package]]
 name = "zbus_macros"
-version = "5.16.0"
+version = "5.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adf1bd45a81a103745b1757754762a26e8cd01e4532e4d6c8ec431624b80d1d6"
+checksum = "2990635d09ade6df1868f72f8cac69a876a90981e8bd3c40b1be413f8dc88f40"
 dependencies = [
  "proc-macro-crate 3.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
- "zbus_names 4.3.2",
- "zvariant 5.12.0",
- "zvariant_utils 3.4.0",
+ "syn 3.0.3",
+ "zbus_names 4.3.4",
+ "zvariant 5.15.0",
+ "zvariant_utils 4.2.0",
 ]
 
 [[package]]
@@ -9040,33 +10500,54 @@ dependencies = [
 
 [[package]]
 name = "zbus_names"
-version = "4.3.2"
+version = "4.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7074f3e50b894eac91750142016d30d0a89be8e67dbfd9704fb875825760e52d"
+checksum = "d8bf88b4a3ff53e883001e0e0115b297a9d53c31b9c1edd2bfdd853e3428624e"
 dependencies = [
  "serde",
- "winnow 1.0.3",
- "zvariant 5.12.0",
+ "winnow 1.0.4",
+ "zvariant 5.15.0",
+]
+
+[[package]]
+name = "zbus_xml"
+version = "5.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1586c021a01ca0a9216dcd874e546382e156a5cbab5fab6cb5f10087e22682a"
+dependencies = [
+ "serde",
+ "winnow 1.0.4",
+ "zbus_names 4.3.4",
+ "zvariant 5.15.0",
+]
+
+[[package]]
+name = "zcheapstr"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1afec51604565183aeb5c54c20aeab286120d4e4460f7f76e3e8bb8c0d99473"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.52"
+version = "0.8.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
+checksum = "556764e583adb45a9f8d413c2a147fa7e8d821e48e12b14fd560b607998b75eb"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.52"
+version = "0.8.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
+checksum = "f2ab42fc20575779bd240faa45f94a74256f755c0fa9e89f0ede20d91d0cdfc1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -9086,35 +10567,35 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
  "synstructure",
 ]
 
 [[package]]
 name = "zeroize"
-version = "1.8.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 dependencies = [
  "zeroize_derive",
 ]
 
 [[package]]
 name = "zeroize_derive"
-version = "1.4.3"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "zerotrie"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+checksum = "4ea269c3bd32f0a32c321907a2ae912ba6f4649bb0fc764a15627e99a7095a3f"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -9123,9 +10604,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.6"
+version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+checksum = "bb0464e17806c1d976d5cba29399c7f08e516e279e2ba493f63123b5fca67dd8"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -9134,13 +10615,13 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.3"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
+checksum = "34df6fc39dbd26ddc9c10e6a2984476e13acce22e64e4487636ef494369225da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -9165,7 +10646,7 @@ dependencies = [
  "memchr",
  "pbkdf2",
  "sha1",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "time",
  "xz2",
  "zeroize",
@@ -9187,9 +10668,9 @@ dependencies = [
 
 [[package]]
 name = "zmij"
-version = "1.0.21"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
 
 [[package]]
 name = "zopfli"
@@ -9233,9 +10714,9 @@ dependencies = [
 
 [[package]]
 name = "zune-core"
-version = "0.5.1"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
+checksum = "d56377fd46368984a170bc5aac5567e52ca5da874caa60bea39fcbca78fb658b"
 
 [[package]]
 name = "zune-jpeg"
@@ -9261,16 +10742,17 @@ dependencies = [
 
 [[package]]
 name = "zvariant"
-version = "5.12.0"
+version = "5.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a192a0bde63360d77a7523c833d4b4ce6070a927e2c53246e4c540b1a3e27be0"
+checksum = "c1d34c27cc6cdd1f458427519dd6b8612f7b7e3f7b9a0b2355d041dda9869147"
 dependencies = [
  "endi",
  "enumflags2",
  "serde",
- "winnow 1.0.3",
- "zvariant_derive 5.12.0",
- "zvariant_utils 3.4.0",
+ "winnow 1.0.4",
+ "zcheapstr",
+ "zvariant_derive 5.15.0",
+ "zvariant_utils 4.2.0",
 ]
 
 [[package]]
@@ -9282,21 +10764,21 @@ dependencies = [
  "proc-macro-crate 3.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
  "zvariant_utils 2.1.0",
 ]
 
 [[package]]
 name = "zvariant_derive"
-version = "5.12.0"
+version = "5.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90bc6cde9c01c511074be97f7ccb6c19d0da89e3f8662e812e999dcfd4638737"
+checksum = "864155e69b4352db0c7f374917bf45d1e0c8d17659c8b3dbf9795f3673f8c497"
 dependencies = [
  "proc-macro-crate 3.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
- "zvariant_utils 3.4.0",
+ "syn 3.0.3",
+ "zvariant_utils 4.2.0",
 ]
 
 [[package]]
@@ -9307,18 +10789,18 @@ checksum = "c51bcff7cc3dbb5055396bcf774748c3dab426b4b8659046963523cee4808340"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "zvariant_utils"
-version = "3.4.0"
+version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e8535915cfa75547e559d8c68e8139909a4aeee076831e4ef7fc59d8172c4d6"
+checksum = "bad0294361a320b694a328460dc73add56c306150f5cb6bfafc44446120008a3"
 dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "syn 2.0.117",
- "winnow 1.0.3",
+ "syn 3.0.3",
+ "winnow 1.0.4",
 ]

--- a/openless-all/app/src-tauri/Cargo.toml
+++ b/openless-all/app/src-tauri/Cargo.toml
@@ -10,6 +10,11 @@ rust-version = "1.88"
 name = "openless_lib"
 crate-type = ["staticlib", "cdylib", "rlib"]
 
+[[bin]]
+name = "egui_popup"
+path = "src/bin/egui_popup.rs"
+required-features = ["egui-popup-bin"]
+
 [build-dependencies]
 tauri-build = { version = "2", features = [] }
 # Compile vendored Open-Less/qwen-asr C sources for the local ASR engine on macOS.
@@ -78,6 +83,8 @@ enigo = "0.3"
 arboard = { version = "3", features = ["wayland-data-control"] }
 rcgen = "^0.13"
 local-ip-address = "^0.6"
+egui = "=0.33.3"
+eframe = { version = "=0.33.3", default-features = false, features = ["glow", "default_fonts", "accesskit"] }
 rustls = { version = "^0.23", default-features = false, features = ["ring", "std", "tls12", "logging"] }
 tokio-rustls = { version = "^0.26", default-features = false, features = ["ring", "tls12", "logging"] }
 axum = { version = "^0.7", default-features = false, features = ["ws", "http1", "tokio", "query"] }
@@ -103,12 +110,8 @@ libc = "0.2"
 [target.'cfg(target_os = "linux")'.dependencies]
 dbus = "0.9"
 gtk = "0.18"
-# egui 浮窗宿主 —— Linux 上用 egui 替代 Tauri WebView 渲染「选区润色预览 / QA 面板」弹窗。
-# 仅 Linux 编译，其它平台保持 WebView 版（避免引入 winit 对非目标平台的额外依赖）。
-# 用 eframe 默认 features（已含 wayland + x11 + glow + default_fonts），
-# Wayland 与 X11 都走原生浮窗；winit 用于 eframe 的 EventLoopBuilder 配置。
-egui = "0.36"
-eframe = { version = "0.36", default-features = false, features = ["wayland", "x11", "glow", "default_fonts", "accesskit"] }
+# Linux 为桌面端 eframe 依赖追加 Wayland/X11 后端；QA 本身在三桌面平台启用。
+eframe = { version = "=0.33.3", default-features = false, features = ["wayland", "x11"] }
 winit = { version = "0.30", features = ["wayland", "x11"] }
 [target.'cfg(all(unix, not(target_os = "macos"), not(target_os = "android")))'.dependencies.keyring]
 version = "3.6.3"
@@ -173,6 +176,9 @@ window-vibrancy = "0.7"
 [features]
 default = ["custom-protocol"]
 custom-protocol = ["tauri/custom-protocol"]
+# 独立 popup bin 仅用于本地调试；发布版通过隐藏参数复用主程序。
+# required-features 防止 Android/iOS 的 cargo check 自动构建桌面 egui bin。
+egui-popup-bin = []
 
 [profile.release]
 # 之前没有 [profile.release] —— 发布版走 Cargo 默认（无 LTO、不 strip、

--- a/openless-all/app/src-tauri/Cargo.toml
+++ b/openless-all/app/src-tauri/Cargo.toml
@@ -103,6 +103,13 @@ libc = "0.2"
 [target.'cfg(target_os = "linux")'.dependencies]
 dbus = "0.9"
 gtk = "0.18"
+# egui 浮窗宿主 —— Linux 上用 egui 替代 Tauri WebView 渲染「选区润色预览 / QA 面板」弹窗。
+# 仅 Linux 编译，其它平台保持 WebView 版（避免引入 winit 对非目标平台的额外依赖）。
+# 用 eframe 默认 features（已含 wayland + x11 + glow + default_fonts），
+# Wayland 与 X11 都走原生浮窗；winit 用于 eframe 的 EventLoopBuilder 配置。
+egui = "0.36"
+eframe = { version = "0.36", default-features = false, features = ["wayland", "x11", "glow", "default_fonts", "accesskit"] }
+winit = { version = "0.30", features = ["wayland", "x11"] }
 [target.'cfg(all(unix, not(target_os = "macos"), not(target_os = "android")))'.dependencies.keyring]
 version = "3.6.3"
 default-features = false

--- a/openless-all/app/src-tauri/src/bin/egui_popup.rs
+++ b/openless-all/app/src-tauri/src/bin/egui_popup.rs
@@ -1,0 +1,377 @@
+//! egui 弹窗独立进程。
+//!
+//! 每个弹窗一个独立进程 + 单窗口（Linux Wayland/X11），比 eframe 多 viewport 稳定。
+//! 与主进程用 stdin/stdout JSON 行通信。
+//!
+//! 用法：
+//!   `egui_popup --preview` 选区润色预览（一次性：打开→确认/取消→退出）
+//!   `egui_popup --qa`       QA 问答面板（常驻：直到用户关窗）
+//!
+//! stdin（主进程 → 本进程）：
+//!   预览: `{"action":"set","text":"...","source":"..."}`  `{"action":"hide"}`
+//!   QA:   `{"action":"qa:state","payload":{kind,session_id,messages,selection_preview,chunk,error}}`
+//!         `{"action":"hide"}`
+//!
+//! stdout（本进程 → 主进程）：
+//!   预览: `{"action":"confirm","text":"..."}`  `{"action":"cancel"}`
+//!   QA:   `{"action":"submit","text":"..."}`  `{"action":"toggle_record"}`  `{"action":"dismiss"}`
+
+use std::io::{BufRead, Write};
+use std::sync::mpsc::{self, Receiver, Sender};
+
+use openless_lib::egui_host::fonts::install_cjk_fonts;
+use openless_lib::egui_host::{
+    qa::{apply_qa_state, QaViewState},
+    qa_event::QaStateEvent,
+};
+
+#[derive(Debug)]
+enum Msg {
+    PreviewSet { text: String, source: String },
+    QaState(QaStateEvent),
+    Hide,
+}
+
+struct PopupApp {
+    rx: Receiver<Msg>,
+    kind: String,
+    // 预览状态
+    preview_text: String,
+    preview_source: String,
+    preview_focus: bool,
+    // QA 状态
+    qa: Option<QaViewState>,
+    // 需要发送到 stdout 的操作（本帧累积，帧末 flush）
+    outgoing: Vec<String>,
+    close_requested: bool,
+}
+
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    let kind = args.get(1).map(|s| s.as_str()).unwrap_or("--preview").to_string();
+    eprintln!("[egui-popup] starting kind={kind}");
+
+    let (tx, rx): (Sender<Msg>, Receiver<Msg>) = mpsc::channel();
+    std::thread::spawn(move || {
+        let stdin = std::io::stdin();
+        for line in stdin.lock().lines() {
+            let Ok(line) = line else { break };
+            if line.trim().is_empty() {
+                continue;
+            }
+            if let Some(msg) = parse_stdin(&line) {
+                let _ = tx.send(msg);
+            }
+        }
+    });
+
+    let app = PopupApp {
+        rx,
+        kind: kind.clone(),
+        preview_text: String::new(),
+        preview_source: String::new(),
+        preview_focus: true,
+        qa: None,
+        outgoing: Vec::new(),
+        close_requested: false,
+    };
+
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        let mut options = eframe::NativeOptions {
+            viewport: egui::ViewportBuilder::default()
+                .with_title(if kind == "--qa" { "OpenLess QA" } else { "OpenLess 选区润色预览" })
+                .with_inner_size(if kind == "--qa" { [440.0, 560.0] } else { [640.0, 440.0] })
+                .with_min_inner_size([360.0, 320.0])
+                .with_decorations(false)
+                .with_always_on_top(),
+            ..Default::default()
+        };
+        #[cfg(target_os = "linux")]
+        {
+            options.event_loop_builder = Some(Box::new(|b| {
+                use winit::platform::wayland::EventLoopBuilderExtWayland as _;
+                b.with_any_thread(true);
+            }));
+        }
+        let _ = eframe::run_native(
+            "openless-egui-popup",
+            options,
+            Box::new(move |cc| {
+                install_cjk_fonts(&cc.egui_ctx);
+                cc.egui_ctx.set_visuals(egui::Visuals::light());
+                Ok(Box::new(app))
+            }),
+        );
+    }));
+    if let Err(panic) = result {
+        eprintln!("[egui-popup] panicked: {panic:?}");
+    }
+}
+
+impl eframe::App for PopupApp {
+    fn clear_color(&self, _v: &egui::Visuals) -> [f32; 4] {
+        egui::Color32::from_rgb(255, 255, 255).to_normalized_gamma_f32()
+    }
+
+    fn ui(&mut self, ui: &mut egui::Ui, _frame: &mut eframe::Frame) {
+        // 读取 stdin 消息。
+        while let Ok(msg) = self.rx.try_recv() {
+            match msg {
+                Msg::PreviewSet { text, source } => {
+                    self.preview_text = text;
+                    self.preview_source = source;
+                    self.preview_focus = true;
+                }
+                Msg::QaState(event) => {
+                    if self.qa.is_none() {
+                        self.qa = Some(QaViewState::new());
+                    }
+                    if let Some(qa) = self.qa.as_mut() {
+                        apply_qa_state(qa, &event);
+                    }
+                }
+                Msg::Hide => {
+                    self.close_requested = true;
+                    ui.ctx().send_viewport_cmd(egui::ViewportCommand::Close);
+                }
+            }
+        }
+
+        // 渲染内容。
+        if self.kind == "--qa" {
+            if self.qa.is_none() {
+                self.qa = Some(QaViewState::new());
+            }
+            let qa = self.qa.as_mut().unwrap();
+            render_qa(ui, qa, &mut self.outgoing);
+        } else {
+            render_preview(
+                ui,
+                &mut self.preview_text,
+                &mut self.preview_source,
+                &mut self.preview_focus,
+                &mut self.outgoing,
+            );
+        }
+
+        // 帧末 flush 所有待发送的 stdout 消息。
+        if !self.outgoing.is_empty() {
+            let drain: Vec<String> = std::mem::take(&mut self.outgoing);
+            flush_stdout(&drain);
+        }
+    }
+}
+
+// ───────────────────────── preview UI ─────────────────────────
+
+fn render_preview(
+    ui: &mut egui::Ui,
+    text: &mut String,
+    source: &mut String,
+    focus: &mut bool,
+    outgoing: &mut Vec<String>,
+) {
+    egui::CentralPanel::default().show(ui, |ui| {
+        // 顶栏
+        ui.horizontal(|ui| {
+            ui.label(egui::RichText::new("选区润色预览").strong().size(15.0));
+            if ui.button("✕").clicked() {
+                outgoing.push("{ \"action\": \"cancel\" }".into());
+                ui.ctx().send_viewport_cmd(egui::ViewportCommand::Close);
+            }
+        });
+        ui.separator();
+        // 可编辑区
+        let edit_height = (ui.available_height() - 100.0).max(120.0);
+        let resp = ui.add_sized(
+            [ui.available_width(), edit_height],
+            egui::TextEdit::multiline(text).hint_text("润色结果").desired_rows(8),
+        );
+        if *focus {
+            *focus = false;
+            resp.request_focus();
+        }
+        if !source.is_empty() {
+            ui.label(egui::RichText::new(format!("原文：{source}")).size(11.0));
+        }
+        // 底部按钮
+        ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+            if ui.add_enabled(!text.trim().is_empty(), egui::Button::new("确认并替换")).clicked() {
+                outgoing.push(format!("{{ \"action\": \"confirm\", \"text\": {} }}", json_escape(text)));
+                ui.ctx().send_viewport_cmd(egui::ViewportCommand::Close);
+            }
+            if ui.button("取消").clicked() {
+                outgoing.push("{ \"action\": \"cancel\" }".into());
+                ui.ctx().send_viewport_cmd(egui::ViewportCommand::Close);
+            }
+        });
+    });
+}
+
+// ───────────────────────── QA UI ─────────────────────────
+
+fn render_qa(ui: &mut egui::Ui, s: &mut QaViewState, outgoing: &mut Vec<String>) {
+    egui::CentralPanel::default().show(ui, |ui| {
+        // 顶栏
+        ui.horizontal(|ui| {
+            ui.label(egui::RichText::new("AI 问答").strong().size(15.0));
+            if ui.button("✕").clicked() {
+                outgoing.push("{ \"action\": \"dismiss\" }".into());
+                ui.ctx().send_viewport_cmd(egui::ViewportCommand::Close);
+            }
+        });
+        ui.separator();
+
+        // 消息滚动区
+        let avail = ui.available_size();
+        let body_height = (avail.y - 70.0).max(80.0);
+        egui::ScrollArea::vertical().stick_to_bottom(true).max_height(body_height).show(ui, |ui| {
+            let empty = s.messages.is_empty() && s.streaming_answer.is_empty();
+            if empty {
+                ui.centered_and_justified(|ui| {
+                    ui.label(egui::RichText::new("还没有问题，试试按住说话或输入问题。").size(13.0).color(ui.visuals().weak_text_color()));
+                });
+                return;
+            }
+            for msg in &s.messages {
+                let is_user = msg.role == "user";
+                ui.with_layout(if is_user { egui::Layout::right_to_left(egui::Align::Min) } else { egui::Layout::left_to_right(egui::Align::Min) }, |ui| {
+                    egui::Frame::new()
+                        .corner_radius(6.0)
+                        .fill(if is_user { ui.visuals().selection.bg_fill } else { ui.visuals().extreme_bg_color })
+                        .inner_margin(egui::Margin::symmetric(8, 6))
+                        .show(ui, |ui| {
+                            ui.set_max_width(ui.available_width() * 0.8);
+                            ui.label(egui::RichText::new(&msg.content).size(13.0));
+                        });
+                });
+                ui.add_space(6.0);
+            }
+            if !s.streaming_answer.is_empty() {
+                ui.label(egui::RichText::new(&s.streaming_answer).size(13.0).color(ui.visuals().weak_text_color()));
+            }
+            if matches!(s.current_kind.as_str(), "thinking" | "loading") && s.streaming_answer.is_empty() {
+                ui.label(egui::RichText::new("思考中…").size(13.0).color(ui.visuals().weak_text_color()));
+            }
+            if let Some(error) = &s.error {
+                ui.colored_label(ui.visuals().error_fg_color, error);
+            }
+        });
+
+        // 录音选区 chip
+        if s.current_kind == "recording" {
+            if let Some(preview) = &s.selection_preview {
+                ui.label(egui::RichText::new(format!("选区：{}", truncate(preview, 60))).size(11.0).color(ui.visuals().weak_text_color()));
+            }
+        }
+
+        ui.separator();
+        let recording = s.current_kind == "recording";
+        let busy = matches!(s.current_kind.as_str(), "thinking" | "loading") || recording;
+        ui.horizontal(|ui| {
+            let input = egui::TextEdit::singleline(&mut s.composer_text)
+                .hint_text("输入问题，回车发送")
+                .desired_width(ui.available_width() - 40.0);
+            let resp = ui.add(input);
+            let submit_key = resp.lost_focus() && ui.input(|i| i.key_pressed(egui::Key::Enter));
+            let mic_label = if recording { "■ 停止" } else { "🎤 说话" };
+            if ui.add_enabled(!busy || recording, egui::Button::new(mic_label)).clicked() {
+                outgoing.push("{ \"action\": \"toggle_record\" }".into());
+            }
+            let can_send = !busy && !s.composer_text.trim().is_empty();
+            if ui.add_enabled(can_send, egui::Button::new("发送")).clicked() || (submit_key && can_send) {
+                let text = s.composer_text.trim().to_string();
+                if !text.is_empty() {
+                    s.composer_text.clear();
+                    outgoing.push(format!("{{ \"action\": \"submit\", \"text\": {} }}", json_escape(&text)));
+                }
+            }
+        });
+    });
+}
+
+fn truncate(text: &str, max: usize) -> String {
+    if text.chars().count() <= max { text.to_string() } else { format!("{}…", text.chars().take(max).collect::<String>()) }
+}
+
+// ───────────────────────── stdio 辅助 ─────────────────────────
+
+fn flush_stdout(lines: &[String]) {
+    let mut out = std::io::stdout().lock();
+    for line in lines {
+        let _ = writeln!(out, "{line}");
+    }
+    let _ = out.flush();
+}
+
+fn parse_stdin(line: &str) -> Option<Msg> {
+    if line.contains("\"hide\"") {
+        return Some(Msg::Hide);
+    }
+    if line.contains("\"qa:state\"") {
+        // 提取 payload 字段解析。
+        if let Some(payload) = extract_str(line, "payload") {
+            if let Ok(event) = serde_json::from_str::<QaStateEvent>(&payload) {
+                return Some(Msg::QaState(event));
+            }
+        }
+        return None;
+    }
+    let text = extract_str(line, "text");
+    if text.is_some() {
+        return Some(Msg::PreviewSet {
+            text: text.unwrap_or_default(),
+            source: extract_str(line, "source").unwrap_or_default(),
+        });
+    }
+    None
+}
+
+fn extract_str(line: &str, key: &str) -> Option<String> {
+    let pat = format!("\"{key}\":");
+    let start = line.find(&pat)? + pat.len();
+    let mut rest = line[start..].trim_start();
+    // 处理 "payload": { ... } 这种嵌套对象：找到匹配的闭合括号。
+    if rest.starts_with('{') {
+        let mut depth = 0;
+        let mut in_str = false;
+        let mut out = String::new();
+        for ch in rest.chars() {
+            if in_str {
+                out.push(ch);
+                if ch == '"' { in_str = false; }
+                continue;
+            }
+            match ch {
+                '\\' => { out.push(ch); in_str = true; }
+                '"' => { out.push(ch); in_str = false; }
+                '{' => { depth += 1; out.push(ch); }
+                '}' => { depth -= 1; out.push(ch); if depth == 0 { break; } }
+                _ => out.push(ch),
+            }
+        }
+        return Some(out);
+    }
+    if let Some(stripped) = rest.strip_prefix('"') {
+        let end = stripped.find('"')?;
+        let raw = &stripped[..end];
+        Some(raw.replace("\\\"", "\"").replace("\\n", "\n").replace("\\\\", "\\"))
+    } else {
+        None
+    }
+}
+
+fn json_escape(s: &str) -> String {
+    let mut out = String::with_capacity(s.len() + 2);
+    out.push('"');
+    for ch in s.chars() {
+        match ch {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            '\n' => out.push_str("\\n"),
+            _ => out.push(ch),
+        }
+    }
+    out.push('"');
+    out
+}

--- a/openless-all/app/src-tauri/src/bin/egui_popup.rs
+++ b/openless-all/app/src-tauri/src/bin/egui_popup.rs
@@ -114,6 +114,9 @@ impl eframe::App for PopupApp {
     }
 
     fn ui(&mut self, ui: &mut egui::Ui, _frame: &mut eframe::Frame) {
+        // 强制持续重绘，确保按钮点击、键盘输入、流式消息都能及时响应。
+        ui.ctx().request_repaint();
+
         // 读取 stdin 消息。
         while let Ok(msg) = self.rx.try_recv() {
             match msg {

--- a/openless-all/app/src-tauri/src/bin/egui_popup.rs
+++ b/openless-all/app/src-tauri/src/bin/egui_popup.rs
@@ -116,7 +116,15 @@ impl eframe::App for PopupApp {
         egui::Color32::TRANSPARENT.to_normalized_gamma_f32()
     }
 
-    fn ui(&mut self, ui: &mut egui::Ui, _frame: &mut eframe::Frame) {
+    fn update(&mut self, ctx: &egui::Context, frame: &mut eframe::Frame) {
+        egui::CentralPanel::default()
+            .frame(egui::Frame::NONE)
+            .show(ctx, |ui| self.render(ui, frame));
+    }
+}
+
+impl PopupApp {
+    fn render(&mut self, ui: &mut egui::Ui, _frame: &mut eframe::Frame) {
         // 强制持续重绘，确保按钮点击、键盘输入、流式消息都能及时响应。
         ui.ctx().request_repaint();
 
@@ -251,19 +259,30 @@ fn render_preview(
         // 原版中原文是 textarea 后、按钮前的普通内容块，不属于 footer，
         // 最多占两行（42px）。必须预留完整高度，避免长原文压到按钮区域。
         let source_h = if source.is_empty() { 0.0 } else { 50.0 };
-        let resp = ui.add_sized(
-            [
+        let editor_rect = egui::Rect::from_min_size(
+            ui.cursor().min,
+            egui::vec2(
                 ui.available_width(),
                 (ui.available_height() - source_h).max(80.0),
-            ],
+            ),
+        );
+        ui.allocate_rect(editor_rect, egui::Sense::hover());
+        ui.painter().rect_filled(
+            editor_rect,
+            egui::CornerRadius::same(10),
+            egui::Color32::WHITE,
+        );
+        ui.painter().rect_stroke(
+            editor_rect,
+            egui::CornerRadius::same(10),
+            egui::Stroke::new(1.0, egui::Color32::from_gray(210)),
+            egui::StrokeKind::Inside,
+        );
+        let resp = ui.put(
+            editor_rect.shrink(8.0),
             egui::TextEdit::multiline(text)
                 .desired_width(f32::INFINITY)
-                .frame(
-                    egui::Frame::new()
-                        .stroke(egui::Stroke::new(1.0, egui::Color32::from_gray(210)))
-                        .corner_radius(10.0)
-                        .inner_margin(8),
-                ),
+                .frame(false),
         );
         if *focus {
             *focus = false;
@@ -413,7 +432,7 @@ fn render_qa(ui: &mut egui::Ui, s: &mut QaViewState, outgoing: &mut Vec<String>)
                 input_rect,
                 egui::TextEdit::singleline(&mut s.composer_text)
                     .hint_text("输入问题，Enter 发送")
-                    .frame(egui::Frame::NONE),
+                    .frame(false),
             );
             let submit_key = resp.lost_focus() && ui.input(|i| i.key_pressed(egui::Key::Enter));
             let mic_rect = egui::Rect::from_min_size(

--- a/openless-all/app/src-tauri/src/bin/egui_popup.rs
+++ b/openless-all/app/src-tauri/src/bin/egui_popup.rs
@@ -80,8 +80,9 @@ fn main() {
         let mut options = eframe::NativeOptions {
             viewport: egui::ViewportBuilder::default()
                 .with_title(if kind == "--qa" { "OpenLess QA" } else { "OpenLess 选区润色预览" })
-                .with_inner_size(if kind == "--qa" { [440.0, 560.0] } else { [640.0, 440.0] })
-                .with_min_inner_size([360.0, 320.0])
+                .with_inner_size(if kind == "--qa" { [480.0, 620.0] } else { [640.0, 480.0] })
+                .with_min_inner_size([420.0, 360.0])
+                .with_resizable(true)
                 .with_decorations(false)
                 .with_always_on_top(),
             ..Default::default()
@@ -174,21 +175,49 @@ fn render_preview(
     focus: &mut bool,
     outgoing: &mut Vec<String>,
 ) {
-    egui::CentralPanel::default().show(ui, |ui| {
-        // 顶栏
-        ui.horizontal(|ui| {
-            ui.label(egui::RichText::new("选区润色预览").strong().size(15.0));
-            if ui.button("✕").clicked() {
-                outgoing.push("{ \"action\": \"cancel\" }".into());
-                ui.ctx().send_viewport_cmd(egui::ViewportCommand::Close);
-            }
+    // 顶栏（固定高度）：左标题 + 右关闭。
+    egui::Panel::top("preview_titlebar")
+        .exact_size(38.0)
+        .show(ui, |ui| {
+            ui.horizontal(|ui| {
+                ui.label(egui::RichText::new("选区润色预览").strong().size(15.0));
+                // 把 ✕ 推到最右。
+                ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+                    if ui.button("✕").clicked() {
+                        outgoing.push("{ \"action\": \"cancel\" }".into());
+                        ui.ctx().send_viewport_cmd(egui::ViewportCommand::Close);
+                    }
+                });
+            });
         });
-        ui.separator();
-        // 可编辑区
-        let edit_height = (ui.available_height() - 100.0).max(120.0);
+
+    // 底部操作区（固定高度）：确认 + 取消。
+    egui::Panel::bottom("preview_footer")
+        .exact_size(44.0)
+        .show(ui, |ui| {
+            ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+                if ui
+                    .add_enabled(!text.trim().is_empty(), egui::Button::new("确认并替换"))
+                    .clicked()
+                {
+                    outgoing.push(format!("{{ \"action\": \"confirm\", \"text\": {} }}", json_escape(text)));
+                    ui.ctx().send_viewport_cmd(egui::ViewportCommand::Close);
+                }
+                if ui.button("取消").clicked() {
+                    outgoing.push("{ \"action\": \"cancel\" }".into());
+                    ui.ctx().send_viewport_cmd(egui::ViewportCommand::Close);
+                }
+            });
+        });
+
+    // 中央可编辑区。
+    egui::CentralPanel::default().show(ui, |ui| {
         let resp = ui.add_sized(
-            [ui.available_width(), edit_height],
-            egui::TextEdit::multiline(text).hint_text("润色结果").desired_rows(8),
+            [ui.available_width(), ui.available_height() - 24.0],
+            egui::TextEdit::multiline(text)
+                .hint_text("润色结果")
+                .desired_rows(8)
+                .desired_width(f32::INFINITY),
         );
         if *focus {
             *focus = false;
@@ -197,99 +226,134 @@ fn render_preview(
         if !source.is_empty() {
             ui.label(egui::RichText::new(format!("原文：{source}")).size(11.0));
         }
-        // 底部按钮
-        ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
-            if ui.add_enabled(!text.trim().is_empty(), egui::Button::new("确认并替换")).clicked() {
-                outgoing.push(format!("{{ \"action\": \"confirm\", \"text\": {} }}", json_escape(text)));
-                ui.ctx().send_viewport_cmd(egui::ViewportCommand::Close);
-            }
-            if ui.button("取消").clicked() {
-                outgoing.push("{ \"action\": \"cancel\" }".into());
-                ui.ctx().send_viewport_cmd(egui::ViewportCommand::Close);
-            }
-        });
     });
 }
 
 // ───────────────────────── QA UI ─────────────────────────
 
 fn render_qa(ui: &mut egui::Ui, s: &mut QaViewState, outgoing: &mut Vec<String>) {
-    egui::CentralPanel::default().show(ui, |ui| {
-        // 顶栏
-        ui.horizontal(|ui| {
-            ui.label(egui::RichText::new("AI 问答").strong().size(15.0));
-            if ui.button("✕").clicked() {
-                outgoing.push("{ \"action\": \"dismiss\" }".into());
-                ui.ctx().send_viewport_cmd(egui::ViewportCommand::Close);
-            }
-        });
-        ui.separator();
-
-        // 消息滚动区
-        let avail = ui.available_size();
-        let body_height = (avail.y - 70.0).max(80.0);
-        egui::ScrollArea::vertical().stick_to_bottom(true).max_height(body_height).show(ui, |ui| {
-            let empty = s.messages.is_empty() && s.streaming_answer.is_empty();
-            if empty {
-                ui.centered_and_justified(|ui| {
-                    ui.label(egui::RichText::new("还没有问题，试试按住说话或输入问题。").size(13.0).color(ui.visuals().weak_text_color()));
+    // 顶栏（固定高度）：左标题 + 右关闭。
+    egui::Panel::top("qa_titlebar")
+        .exact_size(38.0)
+        .show(ui, |ui| {
+            ui.horizontal(|ui| {
+                ui.label(egui::RichText::new("AI 问答").strong().size(15.0));
+                // 把 ✕ 推到最右。
+                ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+                    if ui.button("✕").clicked() {
+                        outgoing.push("{ \"action\": \"dismiss\" }".into());
+                        ui.ctx().send_viewport_cmd(egui::ViewportCommand::Close);
+                    }
                 });
-                return;
-            }
-            for msg in &s.messages {
-                let is_user = msg.role == "user";
-                ui.with_layout(if is_user { egui::Layout::right_to_left(egui::Align::Min) } else { egui::Layout::left_to_right(egui::Align::Min) }, |ui| {
-                    egui::Frame::new()
-                        .corner_radius(6.0)
-                        .fill(if is_user { ui.visuals().selection.bg_fill } else { ui.visuals().extreme_bg_color })
-                        .inner_margin(egui::Margin::symmetric(8, 6))
-                        .show(ui, |ui| {
-                            ui.set_max_width(ui.available_width() * 0.8);
-                            ui.label(egui::RichText::new(&msg.content).size(13.0));
-                        });
-                });
-                ui.add_space(6.0);
-            }
-            if !s.streaming_answer.is_empty() {
-                ui.label(egui::RichText::new(&s.streaming_answer).size(13.0).color(ui.visuals().weak_text_color()));
-            }
-            if matches!(s.current_kind.as_str(), "thinking" | "loading") && s.streaming_answer.is_empty() {
-                ui.label(egui::RichText::new("思考中…").size(13.0).color(ui.visuals().weak_text_color()));
-            }
-            if let Some(error) = &s.error {
-                ui.colored_label(ui.visuals().error_fg_color, error);
-            }
+            });
         });
 
-        // 录音选区 chip
-        if s.current_kind == "recording" {
-            if let Some(preview) = &s.selection_preview {
-                ui.label(egui::RichText::new(format!("选区：{}", truncate(preview, 60))).size(11.0).color(ui.visuals().weak_text_color()));
-            }
-        }
-
-        ui.separator();
-        let recording = s.current_kind == "recording";
-        let busy = matches!(s.current_kind.as_str(), "thinking" | "loading") || recording;
-        ui.horizontal(|ui| {
-            let input = egui::TextEdit::singleline(&mut s.composer_text)
-                .hint_text("输入问题，回车发送")
-                .desired_width(ui.available_width() - 40.0);
-            let resp = ui.add(input);
-            let submit_key = resp.lost_focus() && ui.input(|i| i.key_pressed(egui::Key::Enter));
-            let mic_label = if recording { "■ 停止" } else { "🎤 说话" };
-            if ui.add_enabled(!busy || recording, egui::Button::new(mic_label)).clicked() {
-                outgoing.push("{ \"action\": \"toggle_record\" }".into());
-            }
-            let can_send = !busy && !s.composer_text.trim().is_empty();
-            if ui.add_enabled(can_send, egui::Button::new("发送")).clicked() || (submit_key && can_send) {
-                let text = s.composer_text.trim().to_string();
-                if !text.is_empty() {
-                    s.composer_text.clear();
-                    outgoing.push(format!("{{ \"action\": \"submit\", \"text\": {} }}", json_escape(&text)));
+    // 底部输入区（固定高度）：输入框 + 麦克风 + 发送。
+    egui::Panel::bottom("qa_input")
+        .exact_size(50.0)
+        .show(ui, |ui| {
+            let recording = s.current_kind == "recording";
+            let busy = matches!(s.current_kind.as_str(), "thinking" | "loading") || recording;
+            // 录音选区 chip。
+            if recording {
+                if let Some(preview) = &s.selection_preview {
+                    ui.label(
+                        egui::RichText::new(format!("选区：{}", truncate(preview, 60)))
+                            .size(11.0)
+                            .color(ui.visuals().weak_text_color()),
+                    );
                 }
             }
+            ui.horizontal(|ui| {
+                let mic_label = if recording { "■ 停止" } else { "🎤 说话" };
+                let mic_w = 72.0;
+                let send_w = 48.0;
+                let input_w = (ui.available_width() - mic_w - send_w - 16.0).max(80.0);
+                let resp = ui.add(
+                    egui::TextEdit::singleline(&mut s.composer_text)
+                        .hint_text("输入问题，回车发送")
+                        .desired_width(input_w),
+                );
+                let submit_key = resp.lost_focus() && ui.input(|i| i.key_pressed(egui::Key::Enter));
+                if ui
+                    .add_enabled(!busy || recording, egui::Button::new(mic_label).min_size(egui::vec2(mic_w, 0.0)))
+                    .clicked()
+                {
+                    outgoing.push("{ \"action\": \"toggle_record\" }".into());
+                }
+                let can_send = !busy && !s.composer_text.trim().is_empty();
+                if ui
+                    .add_enabled(can_send, egui::Button::new("发送").min_size(egui::vec2(send_w, 0.0)))
+                    .clicked()
+                    || (submit_key && can_send)
+                {
+                    let text = s.composer_text.trim().to_string();
+                    if !text.is_empty() {
+                        s.composer_text.clear();
+                        outgoing.push(format!("{{ \"action\": \"submit\", \"text\": {} }}", json_escape(&text)));
+                    }
+                }
+            });
         });
+
+    // 中央消息滚动区（占满剩余空间）。
+    egui::CentralPanel::default().show(ui, |ui| {
+        egui::ScrollArea::vertical()
+            .stick_to_bottom(true)
+            .auto_shrink([false, false])
+            .show(ui, |ui| {
+                let empty = s.messages.is_empty() && s.streaming_answer.is_empty();
+                if empty {
+                    ui.centered_and_justified(|ui| {
+                        ui.label(
+                            egui::RichText::new("还没有问题，试试按住说话或输入问题。")
+                                .size(13.0)
+                                .color(ui.visuals().weak_text_color()),
+                        );
+                    });
+                    return;
+                }
+                for msg in &s.messages {
+                    let is_user = msg.role == "user";
+                    ui.with_layout(
+                        if is_user {
+                            egui::Layout::right_to_left(egui::Align::Min)
+                        } else {
+                            egui::Layout::left_to_right(egui::Align::Min)
+                        },
+                        |ui| {
+                            egui::Frame::new()
+                                .corner_radius(6.0)
+                                .fill(if is_user {
+                                    ui.visuals().selection.bg_fill
+                                } else {
+                                    ui.visuals().extreme_bg_color
+                                })
+                                .inner_margin(egui::Margin::symmetric(8, 6))
+                                .show(ui, |ui| {
+                                    ui.set_max_width(ui.available_width() * 0.8);
+                                    ui.label(egui::RichText::new(&msg.content).size(13.0));
+                                });
+                        },
+                    );
+                    ui.add_space(6.0);
+                }
+                if !s.streaming_answer.is_empty() {
+                    ui.label(
+                        egui::RichText::new(&s.streaming_answer)
+                            .size(13.0)
+                            .color(ui.visuals().weak_text_color()),
+                    );
+                }
+                if matches!(s.current_kind.as_str(), "thinking" | "loading")
+                    && s.streaming_answer.is_empty()
+                {
+                    ui.label(egui::RichText::new("思考中…").size(13.0).color(ui.visuals().weak_text_color()));
+                }
+                if let Some(error) = &s.error {
+                    ui.colored_label(ui.visuals().error_fg_color, error);
+                }
+            });
     });
 }
 

--- a/openless-all/app/src-tauri/src/bin/egui_popup.rs
+++ b/openless-all/app/src-tauri/src/bin/egui_popup.rs
@@ -1,20 +1,4 @@
-//! egui 弹窗独立进程。
-//!
-//! 每个弹窗一个独立进程 + 单窗口（Linux Wayland/X11），比 eframe 多 viewport 稳定。
-//! 与主进程用 stdin/stdout JSON 行通信。
-//!
-//! 用法：
-//!   `egui_popup --preview` 选区润色预览（一次性：打开→确认/取消→退出）
-//!   `egui_popup --qa`       QA 问答面板（常驻：直到用户关窗）
-//!
-//! stdin（主进程 → 本进程）：
-//!   预览: `{"action":"set","text":"...","source":"..."}`  `{"action":"hide"}`
-//!   QA:   `{"action":"qa:state","payload":{kind,session_id,messages,selection_preview,chunk,error}}`
-//!         `{"action":"hide"}`
-//!
-//! stdout（本进程 → 主进程）：
-//!   预览: `{"action":"confirm","text":"..."}`  `{"action":"cancel"}`
-//!   QA:   `{"action":"submit","text":"..."}`  `{"action":"toggle_record"}`  `{"action":"dismiss"}`
+// egui 弹窗独立进程；也可被 Linux 主程序内嵌复用。
 
 use std::io::{BufRead, Write};
 use std::sync::mpsc::{self, Receiver, Sender};
@@ -46,9 +30,14 @@ struct PopupApp {
     close_requested: bool,
 }
 
-fn main() {
+pub fn main() {
     let args: Vec<String> = std::env::args().collect();
-    let kind = args.get(1).map(|s| s.as_str()).unwrap_or("--preview").to_string();
+    let kind = args
+        .iter()
+        .find(|arg| arg.as_str() == "--preview" || arg.as_str() == "--qa")
+        .map(String::as_str)
+        .unwrap_or("--preview")
+        .to_string();
     eprintln!("[egui-popup] starting kind={kind}");
 
     let (tx, rx): (Sender<Msg>, Receiver<Msg>) = mpsc::channel();
@@ -79,11 +68,20 @@ fn main() {
     let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
         let mut options = eframe::NativeOptions {
             viewport: egui::ViewportBuilder::default()
-                .with_title(if kind == "--qa" { "OpenLess QA" } else { "OpenLess 选区润色预览" })
-                .with_inner_size(if kind == "--qa" { [480.0, 620.0] } else { [640.0, 480.0] })
-                .with_min_inner_size([420.0, 360.0])
-                .with_resizable(true)
+                .with_title(if kind == "--qa" {
+                    "OpenLess QA"
+                } else {
+                    "OpenLess 选区润色预览"
+                })
+                .with_inner_size(if kind == "--qa" {
+                    [420.0, 540.0]
+                } else {
+                    [640.0, 440.0]
+                })
+                .with_min_inner_size([360.0, 320.0])
+                .with_resizable(kind != "--qa")
                 .with_decorations(false)
+                .with_transparent(true)
                 .with_always_on_top(),
             ..Default::default()
         };
@@ -100,6 +98,10 @@ fn main() {
             Box::new(move |cc| {
                 install_cjk_fonts(&cc.egui_ctx);
                 cc.egui_ctx.set_visuals(egui::Visuals::light());
+                cc.egui_ctx.style_mut_of(egui::Theme::Light, |style| {
+                    style.visuals.window_corner_radius = egui::CornerRadius::same(12);
+                    style.visuals.panel_fill = egui::Color32::TRANSPARENT;
+                });
                 Ok(Box::new(app))
             }),
         );
@@ -111,7 +113,7 @@ fn main() {
 
 impl eframe::App for PopupApp {
     fn clear_color(&self, _v: &egui::Visuals) -> [f32; 4] {
-        egui::Color32::from_rgb(255, 255, 255).to_normalized_gamma_f32()
+        egui::Color32::TRANSPARENT.to_normalized_gamma_f32()
     }
 
     fn ui(&mut self, ui: &mut egui::Ui, _frame: &mut eframe::Frame) {
@@ -141,22 +143,57 @@ impl eframe::App for PopupApp {
             }
         }
 
-        // 渲染内容。
-        if self.kind == "--qa" {
-            if self.qa.is_none() {
-                self.qa = Some(QaViewState::new());
+        // Escape 是两个弹窗一致的取消/关闭快捷键；不能只依赖窗口管理器的关闭事件，
+        // 否则主进程收不到 cancel/dismiss，pending 状态会残留。
+        let escape_pressed = ui.ctx().input(|input| {
+            input.key_pressed(egui::Key::Escape)
+                || input.raw.events.iter().any(|event| {
+                    matches!(
+                        event,
+                        egui::Event::Key {
+                            key: egui::Key::Escape,
+                            pressed: true,
+                            ..
+                        }
+                    )
+                })
+        });
+        if escape_pressed {
+            if self.kind == "--qa" {
+                self.outgoing.push("{ \"action\": \"dismiss\" }".into());
+            } else {
+                self.outgoing.push("{ \"action\": \"cancel\" }".into());
             }
-            let qa = self.qa.as_mut().unwrap();
-            render_qa(ui, qa, &mut self.outgoing);
-        } else {
-            render_preview(
-                ui,
-                &mut self.preview_text,
-                &mut self.preview_source,
-                &mut self.preview_focus,
-                &mut self.outgoing,
-            );
+            self.close_requested = true;
+            ui.ctx().send_viewport_cmd(egui::ViewportCommand::Close);
         }
+
+        // 渲染内容。
+        // 所有绘制和布局共享同一个显式 Card 矩形，避免 Frame 的内容 rect 与
+        // viewport max_rect 不一致造成分隔线、footer 越过圆角边界。
+        let card = ui.max_rect().shrink(8.0);
+        ui.painter().rect_filled(
+            card,
+            egui::CornerRadius::same(24),
+            egui::Color32::from_rgb(255, 255, 255),
+        );
+        ui.scope_builder(egui::UiBuilder::new().max_rect(card), |ui| {
+            if self.kind == "--qa" {
+                if self.qa.is_none() {
+                    self.qa = Some(QaViewState::new());
+                }
+                let qa = self.qa.as_mut().unwrap();
+                render_qa(ui, qa, &mut self.outgoing);
+            } else {
+                render_preview(
+                    ui,
+                    &mut self.preview_text,
+                    &mut self.preview_source,
+                    &mut self.preview_focus,
+                    &mut self.outgoing,
+                );
+            }
+        });
 
         // 帧末 flush 所有待发送的 stdout 消息。
         if !self.outgoing.is_empty() {
@@ -175,174 +212,348 @@ fn render_preview(
     focus: &mut bool,
     outgoing: &mut Vec<String>,
 ) {
-    // 顶栏（固定高度）：左标题 + 右关闭。
-    egui::Panel::top("preview_titlebar")
-        .exact_size(38.0)
-        .show(ui, |ui| {
-            ui.horizontal(|ui| {
-                ui.label(egui::RichText::new("选区润色预览").strong().size(15.0));
-                // 把 ✕ 推到最右。
-                ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
-                    if ui.button("✕").clicked() {
-                        outgoing.push("{ \"action\": \"cancel\" }".into());
-                        ui.ctx().send_viewport_cmd(egui::ViewportCommand::Close);
-                    }
-                });
+    let rect = ui.max_rect();
+    let header = egui::Rect::from_min_max(rect.min, egui::pos2(rect.max.x, rect.min.y + 54.0));
+    let footer = egui::Rect::from_min_max(egui::pos2(rect.min.x, rect.max.y - 60.0), rect.max);
+    let body = egui::Rect::from_min_max(
+        egui::pos2(rect.min.x, header.max.y),
+        egui::pos2(rect.max.x, footer.min.y),
+    );
+    let drag = ui.interact(header, ui.id().with("preview_drag"), egui::Sense::drag());
+    if drag.drag_started() {
+        ui.ctx().send_viewport_cmd(egui::ViewportCommand::StartDrag);
+    }
+    ui.scope_builder(egui::UiBuilder::new().max_rect(header.shrink(10.0)), |ui| {
+        ui.horizontal(|ui| {
+            ui.vertical(|ui| {
+                ui.add(
+                    egui::Label::new(egui::RichText::new("选区润色预览").strong().size(16.0))
+                        .selectable(false),
+                );
+                ui.add(
+                    egui::Label::new(
+                        egui::RichText::new("可直接编辑；点击确认后才会替换原选区。")
+                            .size(11.0)
+                            .color(egui::Color32::from_gray(145)),
+                    )
+                    .selectable(false),
+                );
             });
-        });
-
-    // 底部操作区（固定高度）：确认 + 取消。
-    egui::Panel::bottom("preview_footer")
-        .exact_size(44.0)
-        .show(ui, |ui| {
-            ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
-                if ui
-                    .add_enabled(!text.trim().is_empty(), egui::Button::new("确认并替换"))
-                    .clicked()
-                {
-                    outgoing.push(format!("{{ \"action\": \"confirm\", \"text\": {} }}", json_escape(text)));
-                    ui.ctx().send_viewport_cmd(egui::ViewportCommand::Close);
-                }
-                if ui.button("取消").clicked() {
+            ui.with_layout(egui::Layout::right_to_left(egui::Align::TOP), |ui| {
+                if close_button(ui) {
                     outgoing.push("{ \"action\": \"cancel\" }".into());
                     ui.ctx().send_viewport_cmd(egui::ViewportCommand::Close);
                 }
             });
         });
-
-    // 中央可编辑区。
-    egui::CentralPanel::default().show(ui, |ui| {
+    });
+    ui.scope_builder(egui::UiBuilder::new().max_rect(body.shrink(10.0)), |ui| {
+        // 原版中原文是 textarea 后、按钮前的普通内容块，不属于 footer，
+        // 最多占两行（42px）。必须预留完整高度，避免长原文压到按钮区域。
+        let source_h = if source.is_empty() { 0.0 } else { 50.0 };
         let resp = ui.add_sized(
-            [ui.available_width(), ui.available_height() - 24.0],
+            [
+                ui.available_width(),
+                (ui.available_height() - source_h).max(80.0),
+            ],
             egui::TextEdit::multiline(text)
-                .hint_text("润色结果")
-                .desired_rows(8)
-                .desired_width(f32::INFINITY),
+                .desired_width(f32::INFINITY)
+                .frame(
+                    egui::Frame::new()
+                        .stroke(egui::Stroke::new(1.0, egui::Color32::from_gray(210)))
+                        .corner_radius(10.0)
+                        .inner_margin(8),
+                ),
         );
         if *focus {
             *focus = false;
             resp.request_focus();
         }
         if !source.is_empty() {
-            ui.label(egui::RichText::new(format!("原文：{source}")).size(11.0));
+            ui.add_space(8.0);
+            ui.add(
+                egui::Label::new(
+                    egui::RichText::new(format!("原文：{source}"))
+                        .size(11.0)
+                        .color(egui::Color32::from_gray(145)),
+                )
+                .wrap(),
+            );
         }
+    });
+    ui.scope_builder(egui::UiBuilder::new().max_rect(footer.shrink(10.0)), |ui| {
+        ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+            if ui
+                .add_enabled(
+                    !text.trim().is_empty(),
+                    egui::Button::new(
+                        egui::RichText::new("✓  确认并替换").color(egui::Color32::WHITE),
+                    )
+                    .fill(egui::Color32::from_rgb(40, 98, 235))
+                    .corner_radius(egui::CornerRadius::same(7))
+                    .min_size(egui::vec2(112.0, 34.0)),
+                )
+                .clicked()
+            {
+                outgoing.push(format!(
+                    "{{ \"action\": \"confirm\", \"text\": {} }}",
+                    json_escape(text)
+                ));
+                ui.ctx().send_viewport_cmd(egui::ViewportCommand::Close);
+            }
+            if ui
+                .add(
+                    egui::Button::new("取消")
+                        .fill(egui::Color32::WHITE)
+                        .stroke(egui::Stroke::new(1.0, egui::Color32::from_gray(205)))
+                        .corner_radius(egui::CornerRadius::same(7))
+                        .min_size(egui::vec2(52.0, 34.0)),
+                )
+                .clicked()
+            {
+                outgoing.push("{ \"action\": \"cancel\" }".into());
+                ui.ctx().send_viewport_cmd(egui::ViewportCommand::Close);
+            }
+        });
     });
 }
 
 // ───────────────────────── QA UI ─────────────────────────
 
 fn render_qa(ui: &mut egui::Ui, s: &mut QaViewState, outgoing: &mut Vec<String>) {
-    // 顶栏（固定高度）：左标题 + 右关闭。
-    egui::Panel::top("qa_titlebar")
-        .exact_size(38.0)
-        .show(ui, |ui| {
+    let rect = ui.max_rect();
+    let recording = s.current_kind == "recording";
+    let has_recording_preview = recording
+        && s.selection_preview
+            .as_deref()
+            .is_some_and(|preview| !preview.trim().is_empty());
+    let footer_height = if has_recording_preview { 132.0 } else { 106.0 };
+    let header = egui::Rect::from_min_max(rect.min, egui::pos2(rect.max.x, rect.min.y + 88.0));
+    let footer =
+        egui::Rect::from_min_max(egui::pos2(rect.min.x, rect.max.y - footer_height), rect.max);
+    let body = egui::Rect::from_min_max(
+        egui::pos2(rect.min.x, header.max.y),
+        egui::pos2(rect.max.x, footer.min.y),
+    );
+    let drag = ui.interact(header, ui.id().with("qa_drag"), egui::Sense::drag());
+    if drag.drag_started() {
+        ui.ctx().send_viewport_cmd(egui::ViewportCommand::StartDrag);
+    }
+    ui.painter().hline(
+        rect.x_range(),
+        header.max.y,
+        egui::Stroke::new(1.0, egui::Color32::from_gray(225)),
+    );
+    ui.scope_builder(
+        egui::UiBuilder::new().max_rect(header.shrink2(egui::vec2(20.0, 14.0))),
+        |ui| {
             ui.horizontal(|ui| {
-                ui.label(egui::RichText::new("AI 问答").strong().size(15.0));
-                // 把 ✕ 推到最右。
-                ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
-                    if ui.button("✕").clicked() {
+                ui.vertical(|ui| {
+                    ui.add(
+                        egui::Label::new(egui::RichText::new("划词追问").strong().size(16.0))
+                            .selectable(false),
+                    );
+                    ui.add(
+                        egui::Label::new(
+                            egui::RichText::new("随时提问")
+                                .size(14.0)
+                                .color(egui::Color32::from_gray(125)),
+                        )
+                        .selectable(false),
+                    );
+                });
+                ui.with_layout(egui::Layout::right_to_left(egui::Align::TOP), |ui| {
+                    if close_button(ui) {
                         outgoing.push("{ \"action\": \"dismiss\" }".into());
                         ui.ctx().send_viewport_cmd(egui::ViewportCommand::Close);
                     }
                 });
             });
-        });
-
-    // 底部输入区（固定高度）：输入框 + 麦克风 + 发送。
-    egui::Panel::bottom("qa_input")
-        .exact_size(50.0)
-        .show(ui, |ui| {
-            let recording = s.current_kind == "recording";
+        },
+    );
+    ui.scope_builder(
+        egui::UiBuilder::new().max_rect(footer.shrink2(egui::vec2(20.0, 9.0))),
+        |ui| {
             let busy = matches!(s.current_kind.as_str(), "thinking" | "loading") || recording;
-            // 录音选区 chip。
-            if recording {
-                if let Some(preview) = &s.selection_preview {
-                    ui.label(
-                        egui::RichText::new(format!("选区：{}", truncate(preview, 60)))
+            let inner = ui.max_rect();
+            let composer =
+                egui::Rect::from_min_max(egui::pos2(inner.min.x, inner.max.y - 78.0), inner.max);
+            if has_recording_preview {
+                let preview = s.selection_preview.as_deref().unwrap_or_default();
+                let chip = egui::Rect::from_min_max(
+                    inner.min,
+                    egui::pos2(inner.max.x, composer.min.y - 6.0),
+                );
+                ui.painter().rect_filled(
+                    chip,
+                    egui::CornerRadius::same(12),
+                    egui::Color32::from_rgb(242, 242, 244),
+                );
+                ui.put(
+                    chip.shrink2(egui::vec2(10.0, 5.0)),
+                    egui::Label::new(
+                        egui::RichText::new(format!("基于选中文本：{}", truncate(preview, 60)))
                             .size(11.0)
-                            .color(ui.visuals().weak_text_color()),
-                    );
+                            .color(egui::Color32::from_gray(120)),
+                    )
+                    .selectable(false)
+                    .truncate(),
+                );
+            }
+            ui.painter().rect_filled(
+                composer,
+                egui::CornerRadius::same(16),
+                egui::Color32::from_rgb(244, 244, 246),
+            );
+            let input_rect = egui::Rect::from_min_size(
+                composer.min + egui::vec2(10.0, 7.0),
+                egui::vec2(composer.width() - 20.0, 28.0),
+            );
+            let resp = ui.put(
+                input_rect,
+                egui::TextEdit::singleline(&mut s.composer_text)
+                    .hint_text("输入问题，Enter 发送")
+                    .frame(egui::Frame::NONE),
+            );
+            let submit_key = resp.lost_focus() && ui.input(|i| i.key_pressed(egui::Key::Enter));
+            let mic_rect = egui::Rect::from_min_size(
+                composer.min + egui::vec2(10.0, 39.0),
+                egui::vec2(32.0, 32.0),
+            );
+            if ui
+                .put(
+                    mic_rect,
+                    egui::Button::new(if recording { "■" } else { "♩" }).frame(false),
+                )
+                .clicked()
+            {
+                outgoing.push("{ \"action\": \"toggle_record\" }".into());
+            }
+            let send_rect = egui::Rect::from_min_size(
+                egui::pos2(composer.max.x - 42.0, composer.min.y + 39.0),
+                egui::vec2(32.0, 32.0),
+            );
+            let can_send = !busy && !s.composer_text.trim().is_empty();
+            if ui
+                .put(
+                    send_rect,
+                    egui::Button::new("↑")
+                        .corner_radius(egui::CornerRadius::same(16))
+                        .min_size(egui::vec2(32.0, 32.0)),
+                )
+                .clicked()
+                && can_send
+                || (submit_key && can_send)
+            {
+                let text = s.composer_text.trim().to_string();
+                if !text.is_empty() {
+                    s.composer_text.clear();
+                    outgoing.push(format!(
+                        "{{ \"action\": \"submit\", \"text\": {} }}",
+                        json_escape(&text)
+                    ));
                 }
             }
-            ui.horizontal(|ui| {
-                let mic_label = if recording { "■ 停止" } else { "🎤 说话" };
-                let mic_w = 72.0;
-                let send_w = 48.0;
-                let input_w = (ui.available_width() - mic_w - send_w - 16.0).max(80.0);
-                let resp = ui.add(
-                    egui::TextEdit::singleline(&mut s.composer_text)
-                        .hint_text("输入问题，回车发送")
-                        .desired_width(input_w),
-                );
-                let submit_key = resp.lost_focus() && ui.input(|i| i.key_pressed(egui::Key::Enter));
-                if ui
-                    .add_enabled(!busy || recording, egui::Button::new(mic_label).min_size(egui::vec2(mic_w, 0.0)))
-                    .clicked()
-                {
-                    outgoing.push("{ \"action\": \"toggle_record\" }".into());
-                }
-                let can_send = !busy && !s.composer_text.trim().is_empty();
-                if ui
-                    .add_enabled(can_send, egui::Button::new("发送").min_size(egui::vec2(send_w, 0.0)))
-                    .clicked()
-                    || (submit_key && can_send)
-                {
-                    let text = s.composer_text.trim().to_string();
-                    if !text.is_empty() {
-                        s.composer_text.clear();
-                        outgoing.push(format!("{{ \"action\": \"submit\", \"text\": {} }}", json_escape(&text)));
-                    }
-                }
-            });
-        });
-
-    // 中央消息滚动区（占满剩余空间）。
-    egui::CentralPanel::default().show(ui, |ui| {
+        },
+    );
+    ui.scope_builder(egui::UiBuilder::new().max_rect(body.shrink(20.0)), |ui| {
         egui::ScrollArea::vertical()
             .stick_to_bottom(true)
             .auto_shrink([false, false])
             .show(ui, |ui| {
+                ui.set_width(body.width() - 40.0);
                 let empty = s.messages.is_empty() && s.streaming_answer.is_empty();
                 if empty {
                     ui.centered_and_justified(|ui| {
-                        ui.label(
-                            egui::RichText::new("还没有问题，试试按住说话或输入问题。")
-                                .size(13.0)
-                                .color(ui.visuals().weak_text_color()),
-                        );
+                        ui.vertical_centered(|ui| {
+                            ui.label(egui::RichText::new("◌").size(28.0)); ui.add_space(12.0);
+                            ui.label(egui::RichText::new("有什么可以帮你？").strong().size(20.0)); ui.add_space(8.0);
+                            ui.add(egui::Label::new(egui::RichText::new("选中任意文字后开始追问，或直接在下方输入问题。回答会显示在这里，可以连续多轮。").size(13.0).color(egui::Color32::from_gray(120))).wrap());
+                        });
                     });
                     return;
                 }
                 for msg in &s.messages {
                     let is_user = msg.role == "user";
-                    ui.with_layout(
-                        if is_user {
-                            egui::Layout::right_to_left(egui::Align::Min)
-                        } else {
-                            egui::Layout::left_to_right(egui::Align::Min)
-                        },
-                        |ui| {
-                            egui::Frame::new()
-                                .corner_radius(6.0)
-                                .fill(if is_user {
-                                    ui.visuals().selection.bg_fill
-                                } else {
-                                    ui.visuals().extreme_bg_color
-                                })
-                                .inner_margin(egui::Margin::symmetric(8, 6))
-                                .show(ui, |ui| {
-                                    ui.set_max_width(ui.available_width() * 0.8);
-                                    ui.label(egui::RichText::new(&msg.content).size(13.0));
-                                });
-                        },
-                    );
+                    let message_width = body.width() - 40.0;
+                    if is_user {
+                        let (selection, question) =
+                            split_qa_user_message(&msg.content, msg.selection_text.as_deref());
+                        if !selection.is_empty() {
+                            let bubble_width = estimated_bubble_width(
+                                &format!("“{}”", truncate(&selection, 120)),
+                                message_width * 0.8,
+                            );
+                            ui.with_layout(egui::Layout::right_to_left(egui::Align::Min), |ui| {
+                                ui.allocate_ui_with_layout(
+                                    egui::vec2(bubble_width, 0.0),
+                                    egui::Layout::top_down(egui::Align::Min),
+                                    |ui| {
+                                        egui::Frame::new()
+                                            .corner_radius(egui::CornerRadius::same(20))
+                                            .fill(egui::Color32::from_rgb(242, 242, 244))
+                                            .inner_margin(egui::Margin::symmetric(12, 8))
+                                            .show(ui, |ui| {
+                                                ui.set_width((bubble_width - 24.0).max(20.0));
+                                                ui.add(
+                                                    egui::Label::new(
+                                                        egui::RichText::new(format!(
+                                                            "“{}”",
+                                                            truncate(&selection, 120)
+                                                        ))
+                                                        .italics()
+                                                        .size(12.0)
+                                                        .color(egui::Color32::from_gray(105)),
+                                                    )
+                                                    .wrap(),
+                                                );
+                                            });
+                                    },
+                                );
+                            });
+                            ui.add_space(4.0);
+                        }
+                        let bubble_width =
+                            estimated_bubble_width(&question, message_width * 0.8);
+                        ui.with_layout(egui::Layout::right_to_left(egui::Align::Min), |ui| {
+                            ui.allocate_ui_with_layout(
+                                egui::vec2(bubble_width, 0.0),
+                                egui::Layout::top_down(egui::Align::Min),
+                                |ui| {
+                                    egui::Frame::new()
+                                        .corner_radius(egui::CornerRadius::same(20))
+                                        .fill(egui::Color32::from_rgb(24, 24, 27))
+                                        .inner_margin(egui::Margin::symmetric(12, 8))
+                                        .show(ui, |ui| {
+                                            ui.set_width((bubble_width - 24.0).max(20.0));
+                                            ui.add(
+                                                egui::Label::new(
+                                                    egui::RichText::new(question)
+                                                        .size(13.0)
+                                                        .color(egui::Color32::WHITE),
+                                                )
+                                                .wrap(),
+                                            );
+                                        });
+                                },
+                            );
+                        });
+                    } else {
+                        // Markdown 会生成多个 Label。必须在独立的纵向布局中渲染，
+                        // 否则继承水平消息布局后，剩余宽度会逐行缩窄成单字竖排。
+                        ui.allocate_ui_with_layout(
+                            egui::vec2(message_width, 0.0),
+                            egui::Layout::top_down(egui::Align::Min),
+                            |ui| render_markdown(ui, &msg.content),
+                        );
+                    }
                     ui.add_space(6.0);
                 }
                 if !s.streaming_answer.is_empty() {
-                    ui.label(
-                        egui::RichText::new(&s.streaming_answer)
-                            .size(13.0)
-                            .color(ui.visuals().weak_text_color()),
+                    ui.allocate_ui_with_layout(
+                        egui::vec2(body.width() - 40.0, 0.0),
+                        egui::Layout::top_down(egui::Align::Min),
+                        |ui| render_markdown(ui, &s.streaming_answer),
                     );
                 }
                 if matches!(s.current_kind.as_str(), "thinking" | "loading")
@@ -357,8 +568,268 @@ fn render_qa(ui: &mut egui::Ui, s: &mut QaViewState, outgoing: &mut Vec<String>)
     });
 }
 
+fn estimated_bubble_width(text: &str, max_width: f32) -> f32 {
+    let longest_line = text
+        .lines()
+        .map(|line| {
+            line.chars()
+                .map(|ch| if ch.is_ascii() { 7.0 } else { 13.0 })
+                .sum::<f32>()
+        })
+        .fold(0.0_f32, f32::max);
+    (longest_line + 24.0).clamp(44.0, max_width)
+}
+
+/// 与 WebView 版 `splitQaUserMessage` 保持相同协议：安全选区信封只作为
+/// 灰色引用上下文展示，`# 我的问题` 后面的内容才是用户气泡正文。
+fn split_qa_user_message(content: &str, selection_text: Option<&str>) -> (String, String) {
+    const ENVELOPE_START: &str = "<selected_text>\n";
+    const ENVELOPE_END: &str = "\n</selected_text>\n\n# 我的问题\n";
+    const LEGACY_START: &str = "# 选区原文\n";
+    const LEGACY_END: &str = "\n\n# 我的问题\n";
+
+    let parsed = content
+        .strip_prefix(ENVELOPE_START)
+        .and_then(|rest| rest.split_once(ENVELOPE_END))
+        .or_else(|| {
+            content
+                .strip_prefix(LEGACY_START)
+                .and_then(|rest| rest.split_once(LEGACY_END))
+        });
+
+    let (parsed_selection, question) = parsed
+        .map(|(selection, question)| (selection.trim(), question.trim()))
+        .unwrap_or(("", content.trim()));
+    let selection = selection_text.unwrap_or(parsed_selection).trim();
+    (selection.to_string(), question.to_string())
+}
+
+/// 轻量 Markdown 渲染：覆盖 QA 常见的标题、列表、引用、代码块和行内强调。
+/// 不引入 WebView 或重量级 Markdown 组件，保证 Linux 单文件产物仍然自包含。
+fn render_markdown(ui: &mut egui::Ui, markdown: &str) {
+    let mut in_code = false;
+    let mut code = String::new();
+    for line in markdown.lines() {
+        let trimmed = line.trim();
+        if trimmed.starts_with("```") && trimmed.ends_with("```") && trimmed.len() > 6 {
+            render_code_block(ui, trimmed[3..trimmed.len() - 3].trim());
+            continue;
+        }
+        if trimmed.starts_with("```") {
+            if in_code {
+                render_code_block(ui, code.trim_end());
+                code.clear();
+            }
+            in_code = !in_code;
+            continue;
+        }
+        if in_code {
+            code.push_str(line);
+            code.push('\n');
+            continue;
+        }
+        if trimmed.is_empty() {
+            ui.add_space(4.0);
+            continue;
+        }
+        let (text, size, color, strong, italics) = if let Some(value) = trimmed.strip_prefix("### ")
+        {
+            (value, 14.0, ui.visuals().text_color(), true, false)
+        } else if let Some(value) = trimmed.strip_prefix("## ") {
+            (value, 15.0, ui.visuals().text_color(), true, false)
+        } else if let Some(value) = trimmed.strip_prefix("# ") {
+            (value, 16.0, ui.visuals().text_color(), true, false)
+        } else if let Some(value) = trimmed.strip_prefix("> ") {
+            (value, 13.0, ui.visuals().weak_text_color(), false, true)
+        } else if let Some(value) = trimmed
+            .strip_prefix("- ")
+            .or_else(|| trimmed.strip_prefix("* "))
+        {
+            (value, 13.0, ui.visuals().text_color(), false, false)
+        } else {
+            (trimmed, 13.0, ui.visuals().text_color(), false, false)
+        };
+        let display = if trimmed.starts_with("- ") || trimmed.starts_with("* ") {
+            format!("• {text}")
+        } else {
+            text.to_string()
+        };
+        render_inline_markdown(ui, &display, size, color, strong, italics);
+    }
+    if in_code && !code.is_empty() {
+        render_code_block(ui, code.trim_end());
+    }
+}
+
+fn render_code_block(ui: &mut egui::Ui, code: &str) {
+    egui::Frame::new()
+        .fill(egui::Color32::from_rgb(244, 244, 246))
+        .corner_radius(egui::CornerRadius::same(6))
+        .inner_margin(egui::Margin::symmetric(8, 6))
+        .show(ui, |ui| {
+            ui.add(egui::Label::new(egui::RichText::new(code).monospace().size(12.0)).wrap());
+        });
+}
+
+fn render_inline_markdown(
+    ui: &mut egui::Ui,
+    text: &str,
+    size: f32,
+    color: egui::Color32,
+    strong: bool,
+    italics: bool,
+) {
+    let mut job = egui::text::LayoutJob::default();
+    job.wrap.max_width = ui.available_width();
+    append_inline_segments(
+        &mut job,
+        text,
+        size,
+        color,
+        ui.visuals().strong_text_color(),
+        strong,
+        italics,
+    );
+    ui.add(egui::Label::new(job).wrap());
+}
+
+fn append_inline_segments(
+    job: &mut egui::text::LayoutJob,
+    text: &str,
+    size: f32,
+    color: egui::Color32,
+    strong_color: egui::Color32,
+    base_strong: bool,
+    base_italics: bool,
+) {
+    let mut rest = text;
+    while !rest.is_empty() {
+        let paired = [
+            ("**", "**", true, false, false),
+            ("__", "__", true, false, false),
+            ("`", "`", false, false, true),
+            ("*", "*", false, true, false),
+            ("_", "_", false, true, false),
+        ];
+        let mut matched = false;
+        for (open, close, strong, italics, code) in paired {
+            if let Some(after_open) = rest.strip_prefix(open) {
+                if let Some(end) = after_open.find(close) {
+                    let value = &after_open[..end];
+                    append_text_format(
+                        job,
+                        value,
+                        size,
+                        if strong || base_strong {
+                            strong_color
+                        } else {
+                            color
+                        },
+                        base_italics || italics,
+                        code,
+                    );
+                    rest = &after_open[end + close.len()..];
+                    matched = true;
+                    break;
+                }
+            }
+        }
+        if matched {
+            continue;
+        }
+
+        let next = ["**", "__", "`", "*", "_"]
+            .iter()
+            .filter_map(|marker| rest.find(marker))
+            .min()
+            .unwrap_or(rest.len());
+        if next > 0 {
+            append_text_format(
+                job,
+                &rest[..next],
+                size,
+                if base_strong { strong_color } else { color },
+                base_italics,
+                false,
+            );
+            rest = &rest[next..];
+        } else {
+            let len = rest.chars().next().map(char::len_utf8).unwrap_or(0);
+            append_text_format(
+                job,
+                &rest[..len],
+                size,
+                if base_strong { strong_color } else { color },
+                base_italics,
+                false,
+            );
+            rest = &rest[len..];
+        }
+    }
+}
+
+fn append_text_format(
+    job: &mut egui::text::LayoutJob,
+    text: &str,
+    size: f32,
+    color: egui::Color32,
+    italics: bool,
+    code: bool,
+) {
+    let format = egui::TextFormat {
+        font_id: egui::FontId::new(
+            size,
+            if code {
+                egui::FontFamily::Monospace
+            } else {
+                egui::FontFamily::Proportional
+            },
+        ),
+        color,
+        background: if code {
+            egui::Color32::from_rgb(238, 238, 240)
+        } else {
+            egui::Color32::TRANSPARENT
+        },
+        italics,
+        ..Default::default()
+    };
+    job.append(text, 0.0, format);
+}
+
+/// 不依赖字体字形的关闭按钮。某些 CJK 字体没有 `✕`，直接显示会变成方块。
+fn close_button(ui: &mut egui::Ui) -> bool {
+    let response = ui.add(
+        egui::Button::new("")
+            .frame(false)
+            .min_size(egui::vec2(28.0, 28.0)),
+    );
+    let rect = response.rect;
+    let stroke = egui::Stroke::new(1.5, ui.visuals().text_color());
+    let inset = 8.0;
+    ui.painter().line_segment(
+        [
+            rect.left_top() + egui::vec2(inset, inset),
+            rect.right_bottom() - egui::vec2(inset, inset),
+        ],
+        stroke,
+    );
+    ui.painter().line_segment(
+        [
+            rect.right_top() + egui::vec2(-inset, inset),
+            rect.left_bottom() + egui::vec2(inset, -inset),
+        ],
+        stroke,
+    );
+    response.clicked()
+}
+
 fn truncate(text: &str, max: usize) -> String {
-    if text.chars().count() <= max { text.to_string() } else { format!("{}…", text.chars().take(max).collect::<String>()) }
+    if text.chars().count() <= max {
+        text.to_string()
+    } else {
+        format!("{}…", text.chars().take(max).collect::<String>())
+    }
 }
 
 // ───────────────────────── stdio 辅助 ─────────────────────────
@@ -406,14 +877,31 @@ fn extract_str(line: &str, key: &str) -> Option<String> {
         for ch in rest.chars() {
             if in_str {
                 out.push(ch);
-                if ch == '"' { in_str = false; }
+                if ch == '"' {
+                    in_str = false;
+                }
                 continue;
             }
             match ch {
-                '\\' => { out.push(ch); in_str = true; }
-                '"' => { out.push(ch); in_str = false; }
-                '{' => { depth += 1; out.push(ch); }
-                '}' => { depth -= 1; out.push(ch); if depth == 0 { break; } }
+                '\\' => {
+                    out.push(ch);
+                    in_str = true;
+                }
+                '"' => {
+                    out.push(ch);
+                    in_str = false;
+                }
+                '{' => {
+                    depth += 1;
+                    out.push(ch);
+                }
+                '}' => {
+                    depth -= 1;
+                    out.push(ch);
+                    if depth == 0 {
+                        break;
+                    }
+                }
                 _ => out.push(ch),
             }
         }
@@ -422,7 +910,11 @@ fn extract_str(line: &str, key: &str) -> Option<String> {
     if let Some(stripped) = rest.strip_prefix('"') {
         let end = stripped.find('"')?;
         let raw = &stripped[..end];
-        Some(raw.replace("\\\"", "\"").replace("\\n", "\n").replace("\\\\", "\\"))
+        Some(
+            raw.replace("\\\"", "\"")
+                .replace("\\n", "\n")
+                .replace("\\\\", "\\"),
+        )
     } else {
         None
     }

--- a/openless-all/app/src-tauri/src/coordinator/selection_polish.rs
+++ b/openless-all/app/src-tauri/src/coordinator/selection_polish.rs
@@ -100,7 +100,8 @@ impl Drop for SelectionPolishBusyGuard<'_> {
 
 /// 面向 capsule 的短提示必须是稳定、无敏感信息的用户文案。底层 provider 错误仍写入
 /// 日志并作为调用结果返回，但不会把 endpoint / 认证等实现细节浮到用户正在输入的应用上。
-fn selection_polish_feedback_message(code: &str) -> &'static str {
+/// `pub(crate)` 供 egui 预览窗（egui_host::polish_preview）复用同一套提示文案。
+pub(crate) fn selection_polish_feedback_message(code: &str) -> &'static str {
     match code {
         "selectionPolishNoSelection" => "未选中内容",
         "selectionPolishEmptyOutput" => "未生成可替换文本",

--- a/openless-all/app/src-tauri/src/egui_host/fonts.rs
+++ b/openless-all/app/src-tauri/src/egui_host/fonts.rs
@@ -1,0 +1,73 @@
+//! CJK 字体安装（egui 默认字体不含中文字形，不装会显示成 □）。
+//! 候选优先级：OPENLESS_IME_FONT 环境变量 > 常见系统中文字体 > HOME 字体目录扫描。
+
+pub fn install_cjk_fonts(ctx: &egui::Context) {
+    const CANDIDATES: &[&str] = &[
+        // Linux
+        "/usr/share/fonts/truetype/droid/DroidSansFallbackFull.ttf",
+        "/usr/share/fonts/noto-cjk/NotoSansCJK-Regular.ttc",
+        "/usr/share/fonts/opentype/noto/NotoSansCJK-Regular.ttc",
+        "/usr/share/fonts/truetype/noto/NotoSansCJK-Regular.ttc",
+        "/usr/share/fonts/truetype/wqy/wqy-microhei.ttc",
+        "/usr/share/fonts/wenquanyi/wqy-microhei/wqy-microhei.ttc",
+        // macOS
+        "/System/Library/Fonts/PingFang.ttc",
+        "/System/Library/Fonts/Hiragino Sans GB.ttc",
+        // Windows
+        "C:\\Windows\\Fonts\\msyh.ttc",
+    ];
+
+    let mut paths: Vec<std::path::PathBuf> = Vec::new();
+    if let Ok(p) = std::env::var("OPENLESS_IME_FONT") {
+        paths.push(std::path::PathBuf::from(p));
+    }
+    paths.extend(CANDIDATES.iter().map(std::path::PathBuf::from));
+
+    if let Ok(home) = std::env::var("HOME") {
+        for sub in [".fonts", ".local/share/fonts"] {
+            if let Ok(entries) = std::fs::read_dir(std::path::PathBuf::from(&home).join(sub)) {
+                for entry in entries.flatten() {
+                    let p = entry.path();
+                    let name = p.file_name().and_then(|n| n.to_str()).unwrap_or("");
+                    if name.to_ascii_lowercase().contains("cjk")
+                        || name.to_ascii_lowercase().contains("wqy")
+                    {
+                        paths.push(p);
+                    }
+                }
+            }
+        }
+    }
+
+    let mut inserted = 0usize;
+    for path in paths {
+        if !path.exists() {
+            continue;
+        }
+        let Ok(bytes) = std::fs::read(&path) else {
+            continue;
+        };
+        let mut fonts = egui::FontDefinitions::default();
+        let name = format!("cjk-{inserted}");
+        fonts.font_data.insert(
+            name.clone(),
+            std::sync::Arc::new(egui::FontData::from_owned(bytes)),
+        );
+        for family in [egui::FontFamily::Proportional, egui::FontFamily::Monospace] {
+            if let Some(list) = fonts.families.get_mut(&family) {
+                list.insert(0, name.clone());
+            }
+        }
+        ctx.set_fonts(fonts);
+        log::info!("[egui-host] CJK 字体: {}", path.display());
+        inserted += 1;
+        if inserted >= 2 {
+            break;
+        }
+    }
+    if inserted == 0 {
+        log::warn!(
+            "[egui-host] 未找到 CJK 字体，中文将显示为 □ (OPENLESS_IME_FONT 可指定)"
+        );
+    }
+}

--- a/openless-all/app/src-tauri/src/egui_host/mod.rs
+++ b/openless-all/app/src-tauri/src/egui_host/mod.rs
@@ -1,0 +1,333 @@
+//! # egui 浮窗宿主（egui host）
+//!
+//! 在 **Linux** 上用 egui 原生窗口渲染弹窗，替代 Tauri WebView 浮窗。
+//! 采用「**每个弹窗一个独立进程、单窗口**」的方案，避免 eframe 多 viewport 在
+//! Wayland 下的局限性（root 泄漏 / child 内容闪烁）。每个弹窗的 UI 是仓库里的
+//! 独立二进制 `egui_popup`（`src/bin/egui_popup.rs`），主进程按需 spawn、用
+//! stdin/stdout JSON 行通信、不用时 kill。
+//!
+//! 当前覆盖两枚弹窗：
+//! - **选区润色预览**（`--preview`）—— 一次性进程。
+//! - **QA 问答面板**（`--qa`）—— 常驻进程，流式双向 IPC。
+//!
+//! 其它平台（macOS/Windows/Android/iOS）维持 WebView 版，本模块整体
+//! `#[cfg(target_os = "linux")]` 门控。
+//!
+//! ## 为何用独立进程而非多 viewport
+//! eframe 0.36 的 `show_viewport_deferred` + 隐藏 root 在 Wayland 下实测 root 会
+//! 泄漏成可见窗、child 内容渲染不稳定（一闪而过）。独立进程单窗口是 Wayland/X11
+//! 下最简单、最稳妥的形态：每个进程只有一个原生窗口，没有隐藏宿主、没有多
+//! viewport 生命周期，不用时杀掉进程即可。
+
+pub mod fonts;
+pub(crate) mod qa;
+pub(crate) mod qa_event;
+
+use std::io::{BufRead, BufReader, Write};
+use std::process::{Child, ChildStdin, Command, Stdio};
+use std::sync::{Mutex, OnceLock};
+
+use crate::coordinator::Coordinator;
+use qa_event::QaStateEvent;
+use tauri::Manager;
+
+/// 是否启用 egui 浮窗宿主：Linux + 未显式禁用。
+/// 环境变量 `OPENLESS_EGUI_PREVIEW=0` 可关闭（用于回退 WebView / 排查）。
+pub(crate) fn enabled() -> bool {
+    cfg!(target_os = "linux") && std::env::var("OPENLESS_EGUI_PREVIEW").as_deref() != Ok("0")
+}
+
+// ───────────────────────── 独立进程可执行路径 ─────────────────────────
+
+/// 定位 `egui_popup` 可执行文件路径。
+/// 优先用当前 exe 所在目录（开发/发布 sibling），否则回退到 PATH。
+fn popup_bin_path() -> Option<std::path::PathBuf> {
+    if let Ok(exe) = std::env::current_exe() {
+        if let Some(dir) = exe.parent() {
+            let candidate = dir.join("egui_popup");
+            if candidate.exists() {
+                return Some(candidate);
+            }
+        }
+    }
+    // 回退：target/debug 或 target/release（开发便捷）。
+    if let Ok(cwd) = std::env::current_dir() {
+        for sub in ["target/debug/egui_popup", "target/release/egui_popup"] {
+            let candidate = cwd.join(sub);
+            if candidate.exists() {
+                return Some(candidate);
+            }
+        }
+    }
+    None
+}
+
+// ───────────────────────── 预览窗（一次性进程）─────────────────────────
+
+/// 打开划词润色预览窗（专用入口）。成功返回 true；未启用/无 pending payload /
+/// 无法定位子进程，返回 false，由 lib.rs 回退到 WebView 版。
+pub(crate) fn show_preview<R: tauri::Runtime>(app: &tauri::AppHandle<R>) -> bool {
+    if !enabled() {
+        return false;
+    }
+    let Some(coordinator) = app.try_state::<Arc<Coordinator>>().map(|s| s.inner().clone()) else {
+        log::warn!("[egui-host] coordinator state unavailable");
+        return false;
+    };
+    let Some(payload) = coordinator.selection_polish_preview() else {
+        log::warn!("[egui-host] no pending preview payload");
+        return false;
+    };
+    let Some(bin) = popup_bin_path() else {
+        log::warn!("[egui-host] egui_popup binary not found; falling back to WebView");
+        return false;
+    };
+
+    let mut child = match Command::new(&bin)
+        .arg("--preview")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::inherit())
+        .spawn()
+    {
+        Ok(c) => c,
+        Err(error) => {
+            log::warn!("[egui-host] spawn egui_popup failed: {error}");
+            return false;
+        }
+    };
+
+    // 写入初始 payload。
+    if let Some(stdin) = child.stdin.as_mut() {
+        let line = format!(
+            "{{\"action\":\"set\",\"text\":{},\"source\":{}}}\n",
+            json_escape(&payload.text),
+            json_escape(&payload.source_text)
+        );
+        let _ = stdin.write_all(line.as_bytes());
+        let _ = stdin.flush();
+    }
+
+    // 后台线程读 stdout：收到 confirm/cancel 就回调 coordinator。
+    let stdout = child.stdout.take().expect("stdout piped");
+    let coordinator_for_thread = coordinator.clone();
+    std::thread::spawn(move || {
+        let reader = BufReader::new(stdout);
+        for line in reader.lines() {
+            let Ok(line) = line else { break };
+            let trimmed = line.trim();
+            if trimmed.contains("\"confirm\"") {
+                let text = extract_str(trimmed, "text").unwrap_or_default();
+                let _ = coordinator_for_thread.confirm_selection_polish_preview(text);
+                break;
+            } else if trimmed.contains("\"cancel\"") {
+                coordinator_for_thread.cancel_selection_polish_preview();
+                break;
+            }
+        }
+    });
+
+    // 等待进程结束，回收 child（避免僵尸进程）。
+    let _ = child.wait();
+    true
+}
+
+pub(crate) fn hide_preview() -> bool {
+    // 预览窗是一次性进程，用户确认/取消后会自行退出；hide 无需额外动作。
+    // 返回 true 表示「已由 egui 接管」（未启用时返回 false 让 WebView 兜底）。
+    enabled()
+}
+
+// ───────────────────────── QA 面板（常驻进程）─────────────────────────
+
+/// QA 子进程管理器（进程级单例）。
+struct QaProcess {
+    child: Mutex<Option<Child>>,
+    stdin: Mutex<Option<ChildStdin>>,
+}
+
+static QA_PROC: OnceLock<QaProcess> = OnceLock::new();
+
+fn qa_proc() -> &'static QaProcess {
+    QA_PROC.get_or_init(|| QaProcess {
+        child: Mutex::new(None),
+        stdin: Mutex::new(None),
+    })
+}
+
+/// 打开 QA 问答面板窗。成功返回 true；未启用/无法启动返回 false，回退 WebView。
+pub(crate) fn show_qa<R: tauri::Runtime>(app: &tauri::AppHandle<R>) -> bool {
+    if !enabled() {
+        return false;
+    }
+    let Some(coordinator) = app.try_state::<Arc<Coordinator>>().map(|s| s.inner().clone()) else {
+        log::warn!("[egui-host] coordinator state unavailable");
+        return false;
+    };
+    let Some(bin) = popup_bin_path() else {
+        log::warn!("[egui-host] egui_popup binary not found; falling back to WebView");
+        return false;
+    };
+
+    let proc = qa_proc();
+    // 已有进程在跑则复用（重复打开只需窗口已存在）。
+    if proc.child.lock().unwrap().is_some() {
+        return true;
+    }
+
+    let mut child = match Command::new(&bin)
+        .arg("--qa")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::inherit())
+        .spawn()
+    {
+        Ok(c) => c,
+        Err(error) => {
+            log::warn!("[egui-host] spawn egui_popup --qa failed: {error}");
+            return false;
+        }
+    };
+
+    let stdin = child.stdin.take();
+    *proc.stdin.lock().unwrap() = stdin;
+    *proc.child.lock().unwrap() = Some(child);
+
+    // 后台线程读 stdout：处理 QA 用户操作 → coordinator。
+    let mut child_to_wait = proc.child.lock().unwrap().take();
+    let stdout = child_to_wait
+        .as_mut()
+        .and_then(|c| c.stdout.take())
+        .expect("stdout piped");
+    let coordinator_for_thread = coordinator.clone();
+    std::thread::spawn(move || {
+        let reader = BufReader::new(stdout);
+        for line in reader.lines() {
+            let Ok(line) = line else { break };
+            let trimmed = line.trim();
+            if trimmed.contains("\"submit\"") {
+                let text = extract_str(trimmed, "text").unwrap_or_default();
+                let coord = coordinator_for_thread.clone();
+                tauri::async_runtime::spawn(async move {
+                    let _ = coord.qa_submit_text(text).await;
+                });
+            } else if trimmed.contains("\"toggle_record\"") {
+                let coord = coordinator_for_thread.clone();
+                tauri::async_runtime::spawn(async move {
+                    coord.qa_toggle_recording().await;
+                });
+            } else if trimmed.contains("\"dismiss\"") {
+                coordinator_for_thread.qa_window_dismiss();
+            }
+        }
+        // stdout 关闭（子进程退出）→ 清空 child。
+        *qa_proc().child.lock().unwrap() = None;
+        *qa_proc().stdin.lock().unwrap() = None;
+        // 回收子进程。
+        if let Some(mut c) = child_to_wait {
+            let _ = c.wait();
+        }
+    });
+
+    log::info!("[egui-host] qa egui_popup spawned");
+    true
+}
+
+/// 隐藏 QA 面板：向子进程发 hide（子进程自行退出），并回收。
+pub(crate) fn hide_qa() -> bool {
+    if !enabled() {
+        return false;
+    }
+    let proc = qa_proc();
+    if let Some(mut stdin) = proc.stdin.lock().unwrap().take() {
+        let _ = stdin.write_all(b"{\"action\":\"hide\"}\n");
+        let _ = stdin.flush();
+        // 等待子进程退出。
+        if let Some(mut child) = proc.child.lock().unwrap().take() {
+            let _ = child.kill(); // 兜底：若 hide 未让进程退出则强制结束。
+            let _ = child.wait();
+        }
+    }
+    true
+}
+
+/// 把后端一个 `qa:state` 事件推入 QA 子进程（由 lib.rs 的 `app.listen_any` 调用）。
+pub(crate) fn push_qa_state(event: QaStateEvent) {
+    if !enabled() {
+        return;
+    }
+    let proc = qa_proc();
+    let payload = serde_json::to_string(&event).unwrap_or_default();
+    let line = format!("{{\"action\":\"qa:state\",\"payload\":{payload}}}\n");
+    if let Some(mut stdin) = proc.stdin.lock().unwrap().as_mut() {
+        let _ = stdin.write_all(line.as_bytes());
+        let _ = stdin.flush();
+    }
+}
+
+// ───────────────────────── JSON 辅助（与 bin 一致）─────────────────────────
+
+fn extract_str(line: &str, key: &str) -> Option<String> {
+    let pat = format!("\"{key}\":");
+    let start = line.find(&pat)? + pat.len();
+    let mut rest = line[start..].trim_start();
+    if rest.starts_with('{') {
+        let mut depth = 0;
+        let mut in_str = false;
+        let mut out = String::new();
+        for ch in rest.chars() {
+            if in_str {
+                out.push(ch);
+                if ch == '"' {
+                    in_str = false;
+                }
+                continue;
+            }
+            match ch {
+                '\\' => {
+                    out.push(ch);
+                    in_str = true;
+                }
+                '"' => {
+                    out.push(ch);
+                    in_str = false;
+                }
+                '{' => {
+                    depth += 1;
+                    out.push(ch);
+                }
+                '}' => {
+                    depth -= 1;
+                    out.push(ch);
+                    if depth == 0 {
+                        break;
+                    }
+                }
+                _ => out.push(ch),
+            }
+        }
+        return Some(out);
+    }
+    if let Some(stripped) = rest.strip_prefix('"') {
+        let end = stripped.find('"')?;
+        let raw = &stripped[..end];
+        Some(raw.replace("\\\"", "\"").replace("\\n", "\n").replace("\\\\", "\\"))
+    } else {
+        None
+    }
+}
+
+fn json_escape(s: &str) -> String {
+    let mut out = String::with_capacity(s.len() + 2);
+    out.push('"');
+    for ch in s.chars() {
+        match ch {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            '\n' => out.push_str("\\n"),
+            _ => out.push(ch),
+        }
+    }
+    out.push('"');
+    out
+}

--- a/openless-all/app/src-tauri/src/egui_host/mod.rs
+++ b/openless-all/app/src-tauri/src/egui_host/mod.rs
@@ -18,14 +18,21 @@
 //! 泄漏成可见窗、child 内容渲染不稳定（一闪而过）。独立进程单窗口是 Wayland/X11
 //! 下最简单、最稳妥的形态：每个进程只有一个原生窗口，没有隐藏宿主、没有多
 //! viewport 生命周期，不用时杀掉进程即可。
+//!
+//! ## 可替换的宿主边界（HostActions）
+//! 本模块**不直接依赖** `Coordinator`。它只依赖一个 [`HostActions`] trait：
+//! 主进程把子进程吐出的动作（确认/取消/提交/录音/关闭）翻译成语义化回调。
+//! 现在这个 trait 由 Tauri 侧的 `CoordinatorAdapter` 实现（内部调 `Coordinator`）；
+//! 将来替换掉 Tauri 时，只需换一个 `HostActions` 实现，本模块与 `egui_popup`
+//! 进程、以及稳定的 JSON 协议都不动。这就是「切换期留出的空间」。
 
 pub mod fonts;
-pub(crate) mod qa;
-pub(crate) mod qa_event;
+pub mod qa;
+pub mod qa_event;
 
 use std::io::{BufRead, BufReader, Write};
 use std::process::{Child, ChildStdin, Command, Stdio};
-use std::sync::{Mutex, OnceLock};
+use std::sync::{Arc, Mutex, OnceLock};
 
 use crate::coordinator::Coordinator;
 use qa_event::QaStateEvent;
@@ -33,8 +40,40 @@ use tauri::Manager;
 
 /// 是否启用 egui 浮窗宿主：Linux + 未显式禁用。
 /// 环境变量 `OPENLESS_EGUI_PREVIEW=0` 可关闭（用于回退 WebView / 排查）。
-pub(crate) fn enabled() -> bool {
+pub fn enabled() -> bool {
     cfg!(target_os = "linux") && std::env::var("OPENLESS_EGUI_PREVIEW").as_deref() != Ok("0")
+}
+
+// ───────────────────────── 宿主动作边界（薄适配层）─────────────────────────
+
+/// 弹窗子进程吐出的、需要宿主响应的语义化动作。
+/// 这是与 Tauri 解耦的边界：将来替换宿主只需实现这个 trait。
+#[allow(dead_code)]
+pub trait HostActions: Send + Sync + 'static {
+    /// 用户确认了划词润色预览（可能编辑过 `text`）。
+    fn confirm_selection_polish_preview(&self, text: String) -> Result<(), String>;
+    /// 用户取消了划词润色预览。
+    fn cancel_selection_polish_preview(&self);
+    /// 用户关闭了 QA 面板。
+    fn qa_window_dismiss(&self);
+    /// 用户提交了一个问题（异步）。
+    fn qa_submit_text(&self, text: String);
+    /// 用户切换了录音状态（异步）。
+    fn qa_toggle_recording(&self);
+}
+
+/// 读取 QA 弹窗当前 selection 预览 payload（同步，供 show_preview 取初始内容）。
+#[allow(dead_code)]
+pub trait HostPoller {
+    fn selection_polish_preview(&self) -> Option<SelectionPreviewPayload>;
+}
+
+/// 划词润色预览的初始 payload（与 coordinator 侧结构对齐的轻量定义）。
+#[derive(Clone)]
+#[allow(dead_code)]
+pub struct SelectionPreviewPayload {
+    pub text: String,
+    pub source_text: String,
 }
 
 // ───────────────────────── 独立进程可执行路径 ─────────────────────────
@@ -70,11 +109,11 @@ pub(crate) fn show_preview<R: tauri::Runtime>(app: &tauri::AppHandle<R>) -> bool
     if !enabled() {
         return false;
     }
-    let Some(coordinator) = app.try_state::<Arc<Coordinator>>().map(|s| s.inner().clone()) else {
-        log::warn!("[egui-host] coordinator state unavailable");
+    let Some(host) = app.try_state::<Arc<dyn EguiHost>>().map(|s| s.inner().clone()) else {
+        log::warn!("[egui-host] egui host state unavailable");
         return false;
     };
-    let Some(payload) = coordinator.selection_polish_preview() else {
+    let Some(payload) = host.selection_polish_preview() else {
         log::warn!("[egui-host] no pending preview payload");
         return false;
     };
@@ -108,9 +147,9 @@ pub(crate) fn show_preview<R: tauri::Runtime>(app: &tauri::AppHandle<R>) -> bool
         let _ = stdin.flush();
     }
 
-    // 后台线程读 stdout：收到 confirm/cancel 就回调 coordinator。
+    // 后台线程读 stdout：收到 confirm/cancel 就回调宿主动作。
     let stdout = child.stdout.take().expect("stdout piped");
-    let coordinator_for_thread = coordinator.clone();
+    let host_for_thread = host.clone();
     std::thread::spawn(move || {
         let reader = BufReader::new(stdout);
         for line in reader.lines() {
@@ -118,10 +157,10 @@ pub(crate) fn show_preview<R: tauri::Runtime>(app: &tauri::AppHandle<R>) -> bool
             let trimmed = line.trim();
             if trimmed.contains("\"confirm\"") {
                 let text = extract_str(trimmed, "text").unwrap_or_default();
-                let _ = coordinator_for_thread.confirm_selection_polish_preview(text);
+                let _ = host_for_thread.confirm_selection_polish_preview(text);
                 break;
             } else if trimmed.contains("\"cancel\"") {
-                coordinator_for_thread.cancel_selection_polish_preview();
+                host_for_thread.cancel_selection_polish_preview();
                 break;
             }
         }
@@ -134,25 +173,30 @@ pub(crate) fn show_preview<R: tauri::Runtime>(app: &tauri::AppHandle<R>) -> bool
 
 pub(crate) fn hide_preview() -> bool {
     // 预览窗是一次性进程，用户确认/取消后会自行退出；hide 无需额外动作。
-    // 返回 true 表示「已由 egui 接管」（未启用时返回 false 让 WebView 兜底）。
     enabled()
 }
 
 // ───────────────────────── QA 面板（常驻进程）─────────────────────────
 
-/// QA 子进程管理器（进程级单例）。
-struct QaProcess {
+/// QA 子进程生命周期（进程级单例）。
+struct QaProc {
     child: Mutex<Option<Child>>,
     stdin: Mutex<Option<ChildStdin>>,
 }
 
-static QA_PROC: OnceLock<QaProcess> = OnceLock::new();
+impl QaProc {
+    fn new() -> Self {
+        Self {
+            child: Mutex::new(None),
+            stdin: Mutex::new(None),
+        }
+    }
+}
 
-fn qa_proc() -> &'static QaProcess {
-    QA_PROC.get_or_init(|| QaProcess {
-        child: Mutex::new(None),
-        stdin: Mutex::new(None),
-    })
+/// 用 `OnceLock` 存 QA 进程单例。
+static QA_PROC: OnceLock<QaProc> = OnceLock::new();
+fn qa_proc() -> &'static QaProc {
+    QA_PROC.get_or_init(QaProc::new)
 }
 
 /// 打开 QA 问答面板窗。成功返回 true；未启用/无法启动返回 false，回退 WebView。
@@ -160,8 +204,8 @@ pub(crate) fn show_qa<R: tauri::Runtime>(app: &tauri::AppHandle<R>) -> bool {
     if !enabled() {
         return false;
     }
-    let Some(coordinator) = app.try_state::<Arc<Coordinator>>().map(|s| s.inner().clone()) else {
-        log::warn!("[egui-host] coordinator state unavailable");
+    let Some(host) = app.try_state::<Arc<dyn EguiHost>>().map(|s| s.inner().clone()) else {
+        log::warn!("[egui-host] egui host state unavailable");
         return false;
     };
     let Some(bin) = popup_bin_path() else {
@@ -193,13 +237,12 @@ pub(crate) fn show_qa<R: tauri::Runtime>(app: &tauri::AppHandle<R>) -> bool {
     *proc.stdin.lock().unwrap() = stdin;
     *proc.child.lock().unwrap() = Some(child);
 
-    // 后台线程读 stdout：处理 QA 用户操作 → coordinator。
-    let mut child_to_wait = proc.child.lock().unwrap().take();
-    let stdout = child_to_wait
-        .as_mut()
-        .and_then(|c| c.stdout.take())
-        .expect("stdout piped");
-    let coordinator_for_thread = coordinator.clone();
+    // 后台线程读 stdout：把 QA 用户操作分发给 HostActions。
+    let stdout = {
+        let mut guard = proc.child.lock().unwrap();
+        guard.as_mut().and_then(|c| c.stdout.take()).expect("stdout piped")
+    };
+    let host_for_thread = host.clone();
     std::thread::spawn(move || {
         let reader = BufReader::new(stdout);
         for line in reader.lines() {
@@ -207,26 +250,19 @@ pub(crate) fn show_qa<R: tauri::Runtime>(app: &tauri::AppHandle<R>) -> bool {
             let trimmed = line.trim();
             if trimmed.contains("\"submit\"") {
                 let text = extract_str(trimmed, "text").unwrap_or_default();
-                let coord = coordinator_for_thread.clone();
-                tauri::async_runtime::spawn(async move {
-                    let _ = coord.qa_submit_text(text).await;
-                });
+                host_for_thread.qa_submit_text(text);
             } else if trimmed.contains("\"toggle_record\"") {
-                let coord = coordinator_for_thread.clone();
-                tauri::async_runtime::spawn(async move {
-                    coord.qa_toggle_recording().await;
-                });
+                host_for_thread.qa_toggle_recording();
             } else if trimmed.contains("\"dismiss\"") {
-                coordinator_for_thread.qa_window_dismiss();
+                host_for_thread.qa_window_dismiss();
+                break;
             }
         }
-        // stdout 关闭（子进程退出）→ 清空 child。
-        *qa_proc().child.lock().unwrap() = None;
-        *qa_proc().stdin.lock().unwrap() = None;
-        // 回收子进程。
-        if let Some(mut c) = child_to_wait {
+        // stdout 关闭（子进程退出）→ 清空 child（回收，避免僵尸进程）。
+        if let Some(mut c) = qa_proc().child.lock().unwrap().take() {
             let _ = c.wait();
         }
+        *qa_proc().stdin.lock().unwrap() = None;
     });
 
     log::info!("[egui-host] qa egui_popup spawned");
@@ -242,11 +278,10 @@ pub(crate) fn hide_qa() -> bool {
     if let Some(mut stdin) = proc.stdin.lock().unwrap().take() {
         let _ = stdin.write_all(b"{\"action\":\"hide\"}\n");
         let _ = stdin.flush();
-        // 等待子进程退出。
-        if let Some(mut child) = proc.child.lock().unwrap().take() {
-            let _ = child.kill(); // 兜底：若 hide 未让进程退出则强制结束。
-            let _ = child.wait();
-        }
+    }
+    if let Some(mut child) = proc.child.lock().unwrap().take() {
+        let _ = child.kill();
+        let _ = child.wait();
     }
     true
 }
@@ -262,6 +297,60 @@ pub(crate) fn push_qa_state(event: QaStateEvent) {
     if let Some(mut stdin) = proc.stdin.lock().unwrap().as_mut() {
         let _ = stdin.write_all(line.as_bytes());
         let _ = stdin.flush();
+    }
+}
+
+// ───────────────────────── Coordinator 适配层（临时接线）─────────────────────────
+
+/// 宿主要实现的动作 + 数据拉取。组合 trait，方便用单个 trait 对象走 state。
+#[allow(dead_code)]
+pub trait EguiHost: HostActions + HostPoller {}
+
+/// 把 [`HostActions`] 桥接到 Tauri 侧的 [`Coordinator`] 实现。
+/// 将来替换 Tauri 时，仅替换此适配层，`egui_host` 与 `egui_popup` 均不动。
+#[allow(dead_code)]
+pub struct CoordinatorHostAdapter {
+    coordinator: Arc<Coordinator>,
+}
+
+impl CoordinatorHostAdapter {
+    pub fn new(coordinator: Arc<Coordinator>) -> Self {
+        Self { coordinator }
+    }
+}
+
+impl EguiHost for CoordinatorHostAdapter {}
+
+impl HostPoller for CoordinatorHostAdapter {
+    fn selection_polish_preview(&self) -> Option<SelectionPreviewPayload> {
+        self.coordinator.selection_polish_preview().map(|p| SelectionPreviewPayload {
+            text: p.text,
+            source_text: p.source_text,
+        })
+    }
+}
+
+impl HostActions for CoordinatorHostAdapter {
+    fn confirm_selection_polish_preview(&self, text: String) -> Result<(), String> {
+        self.coordinator.confirm_selection_polish_preview(text)
+    }
+    fn cancel_selection_polish_preview(&self) {
+        self.coordinator.cancel_selection_polish_preview();
+    }
+    fn qa_window_dismiss(&self) {
+        self.coordinator.qa_window_dismiss();
+    }
+    fn qa_submit_text(&self, text: String) {
+        let coord = self.coordinator.clone();
+        tauri::async_runtime::spawn(async move {
+            let _ = coord.qa_submit_text(text).await;
+        });
+    }
+    fn qa_toggle_recording(&self) {
+        let coord = self.coordinator.clone();
+        tauri::async_runtime::spawn(async move {
+            coord.qa_toggle_recording().await;
+        });
     }
 }
 

--- a/openless-all/app/src-tauri/src/egui_host/mod.rs
+++ b/openless-all/app/src-tauri/src/egui_host/mod.rs
@@ -1,6 +1,6 @@
 //! # egui 浮窗宿主（egui host）
 //!
-//! 在 **Linux** 上用 egui 原生窗口渲染弹窗，替代 Tauri WebView 浮窗。
+//! 在桌面端用 egui 原生窗口渲染 QA；选区润色预览仅在 Linux 替代 WebView。
 //! 采用「**每个弹窗一个独立进程、单窗口**」的方案，避免 eframe 多 viewport 在
 //! Wayland 下的局限性（root 泄漏 / child 内容闪烁）。每个弹窗的 UI 是仓库里的
 //! 独立二进制 `egui_popup`（`src/bin/egui_popup.rs`），主进程按需 spawn、用
@@ -10,8 +10,7 @@
 //! - **选区润色预览**（`--preview`）—— 一次性进程。
 //! - **QA 问答面板**（`--qa`）—— 常驻进程，流式双向 IPC。
 //!
-//! 其它平台（macOS/Windows/Android/iOS）维持 WebView 版，本模块整体
-//! `#[cfg(target_os = "linux")]` 门控。
+//! QA 覆盖 Linux/macOS/Windows；润色预览在 macOS/Windows 维持 WebView 版。
 //!
 //! ## 为何用独立进程而非多 viewport
 //! eframe 0.36 的 `show_viewport_deferred` + 隐藏 root 在 Wayland 下实测 root 会
@@ -27,6 +26,11 @@
 //! 进程、以及稳定的 JSON 协议都不动。这就是「切换期留出的空间」。
 
 pub mod fonts;
+// 与独立 bin 共用同一份 popup 实现；主程序可通过隐藏参数直接进入该入口，
+// 从而把 Linux 产物打包成单个 ELF 文件。
+pub mod popup {
+    include!("../bin/egui_popup.rs");
+}
 pub mod qa;
 pub mod qa_event;
 
@@ -38,9 +42,13 @@ use crate::coordinator::Coordinator;
 use qa_event::QaStateEvent;
 use tauri::Manager;
 
-/// 是否启用 egui 浮窗宿主：Linux + 未显式禁用。
-/// 环境变量 `OPENLESS_EGUI_PREVIEW=0` 可关闭（用于回退 WebView / 排查）。
+/// 是否启用跨平台 egui QA。环境变量可用于紧急回退 WebView。
 pub fn enabled() -> bool {
+    std::env::var("OPENLESS_EGUI_QA").as_deref() != Ok("0")
+}
+
+/// 选区润色 egui 预览严格限制在 Linux。
+fn preview_enabled() -> bool {
     cfg!(target_os = "linux") && std::env::var("OPENLESS_EGUI_PREVIEW").as_deref() != Ok("0")
 }
 
@@ -78,16 +86,10 @@ pub struct SelectionPreviewPayload {
 
 // ───────────────────────── 独立进程可执行路径 ─────────────────────────
 
-/// 定位 `egui_popup` 可执行文件路径。
-/// 优先用当前 exe 所在目录（开发/发布 sibling），否则回退到 PATH。
+/// 定位 popup 执行入口。桌面端通过隐藏参数重新执行当前主程序，保持单文件发布。
 fn popup_bin_path() -> Option<std::path::PathBuf> {
     if let Ok(exe) = std::env::current_exe() {
-        if let Some(dir) = exe.parent() {
-            let candidate = dir.join("egui_popup");
-            if candidate.exists() {
-                return Some(candidate);
-            }
-        }
+        return Some(exe);
     }
     // 回退：target/debug 或 target/release（开发便捷）。
     if let Ok(cwd) = std::env::current_dir() {
@@ -106,10 +108,13 @@ fn popup_bin_path() -> Option<std::path::PathBuf> {
 /// 打开划词润色预览窗（专用入口）。成功返回 true；未启用/无 pending payload /
 /// 无法定位子进程，返回 false，由 lib.rs 回退到 WebView 版。
 pub(crate) fn show_preview<R: tauri::Runtime>(app: &tauri::AppHandle<R>) -> bool {
-    if !enabled() {
+    if !preview_enabled() {
         return false;
     }
-    let Some(host) = app.try_state::<Arc<dyn EguiHost>>().map(|s| s.inner().clone()) else {
+    let Some(host) = app
+        .try_state::<Arc<dyn EguiHost>>()
+        .map(|s| s.inner().clone())
+    else {
         log::warn!("[egui-host] egui host state unavailable");
         return false;
     };
@@ -123,6 +128,7 @@ pub(crate) fn show_preview<R: tauri::Runtime>(app: &tauri::AppHandle<R>) -> bool
     };
 
     let mut child = match Command::new(&bin)
+        .arg("--openless-egui-popup")
         .arg("--preview")
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
@@ -173,7 +179,7 @@ pub(crate) fn show_preview<R: tauri::Runtime>(app: &tauri::AppHandle<R>) -> bool
 
 pub(crate) fn hide_preview() -> bool {
     // 预览窗是一次性进程，用户确认/取消后会自行退出；hide 无需额外动作。
-    enabled()
+    preview_enabled()
 }
 
 // ───────────────────────── QA 面板（常驻进程）─────────────────────────
@@ -204,7 +210,10 @@ pub(crate) fn show_qa<R: tauri::Runtime>(app: &tauri::AppHandle<R>) -> bool {
     if !enabled() {
         return false;
     }
-    let Some(host) = app.try_state::<Arc<dyn EguiHost>>().map(|s| s.inner().clone()) else {
+    let Some(host) = app
+        .try_state::<Arc<dyn EguiHost>>()
+        .map(|s| s.inner().clone())
+    else {
         log::warn!("[egui-host] egui host state unavailable");
         return false;
     };
@@ -220,6 +229,7 @@ pub(crate) fn show_qa<R: tauri::Runtime>(app: &tauri::AppHandle<R>) -> bool {
     }
 
     let mut child = match Command::new(&bin)
+        .arg("--openless-egui-popup")
         .arg("--qa")
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
@@ -240,7 +250,10 @@ pub(crate) fn show_qa<R: tauri::Runtime>(app: &tauri::AppHandle<R>) -> bool {
     // 后台线程读 stdout：把 QA 用户操作分发给 HostActions。
     let stdout = {
         let mut guard = proc.child.lock().unwrap();
-        guard.as_mut().and_then(|c| c.stdout.take()).expect("stdout piped")
+        guard
+            .as_mut()
+            .and_then(|c| c.stdout.take())
+            .expect("stdout piped")
     };
     let host_for_thread = host.clone();
     std::thread::spawn(move || {
@@ -323,10 +336,12 @@ impl EguiHost for CoordinatorHostAdapter {}
 
 impl HostPoller for CoordinatorHostAdapter {
     fn selection_polish_preview(&self) -> Option<SelectionPreviewPayload> {
-        self.coordinator.selection_polish_preview().map(|p| SelectionPreviewPayload {
-            text: p.text,
-            source_text: p.source_text,
-        })
+        self.coordinator
+            .selection_polish_preview()
+            .map(|p| SelectionPreviewPayload {
+                text: p.text,
+                source_text: p.source_text,
+            })
     }
 }
 
@@ -400,7 +415,11 @@ fn extract_str(line: &str, key: &str) -> Option<String> {
     if let Some(stripped) = rest.strip_prefix('"') {
         let end = stripped.find('"')?;
         let raw = &stripped[..end];
-        Some(raw.replace("\\\"", "\"").replace("\\n", "\n").replace("\\\\", "\\"))
+        Some(
+            raw.replace("\\\"", "\"")
+                .replace("\\n", "\n")
+                .replace("\\\\", "\\"),
+        )
     } else {
         None
     }

--- a/openless-all/app/src-tauri/src/egui_host/qa.rs
+++ b/openless-all/app/src-tauri/src/egui_host/qa.rs
@@ -1,0 +1,129 @@
+//! QA 问答面板 —— 浮窗宿主第二个 `HostWindow` 实现（多 viewport 版）。
+//!
+//! UI 对齐原 WebView 版（QaPanel）：标题 + 欢迎语 + 关闭、消息滚动列表（用户右气泡 /
+//! 助手左气泡 + 选区引用 + 流式答案 + thinking/error 行）、底部录音选区 chip +
+//! 输入组（打字 Enter 提交 + 麦克风开/停录音）。
+//!
+//! 状态由后端 `qa:state` 事件驱动：lib.rs 里 `app.listen("qa:state", ...)` 解析后经
+//! [`QaHostSink::push_qa_state`] 推入宿主线程（`Arc<Mutex<QaViewState>>`）。用户操作
+//! 直接同步回调 `Coordinator` 既有方法（`qa_submit_text` / `qa_toggle_recording` /
+//! `qa_window_dismiss`）。事件去重/会话 token 判定复用前端 `acceptQaSessionEvent` 逻辑。
+
+use crate::egui_host::qa_event::QaStateEvent;
+
+/// QA 会话状态（由后端 `qa:state` 事件驱动更新）。
+pub struct QaViewState {
+    /// 会话 token（丢弃关闭/重开后迟到的旧轮事件）。
+    pub session_id: Option<String>,
+    /// 最近一个 kind。
+    pub current_kind: String,
+    /// 后端权威的多轮历史（user → assistant 交替）。
+    pub messages: Vec<crate::types::QaChatMessage>,
+    /// recording 状态时的选区预览（前 60 字）。
+    pub selection_preview: Option<String>,
+    /// error 状态提示。
+    pub error: Option<String>,
+    /// 流式答案 buffer（answer_delta 累积，answer 事件来时清空）。
+    pub streaming_answer: String,
+    /// 输入框文本。
+    pub composer_text: String,
+    /// 是否已进入「应显示」状态（独立于窗口映射；对 IME/状态机无意义，仅作标记）。
+    pub shown: bool,
+}
+
+impl QaViewState {
+    pub fn new() -> Self {
+        Self {
+            session_id: None,
+            current_kind: "idle".to_string(),
+            messages: Vec::new(),
+            selection_preview: None,
+            error: None,
+            streaming_answer: String::new(),
+            composer_text: String::new(),
+            shown: false,
+        }
+    }
+
+    pub(crate) fn mark_shown(&mut self) {
+        self.shown = true;
+    }
+
+    /// 判定一个 `qa:state` 载荷是否应接收（等价前端 `acceptQaSessionEvent`）。
+    fn accept(&mut self, kind: &str, session_id: Option<&str>) -> bool {
+        let Some(sid) = session_id else {
+            return true;
+        };
+        // idle 一律视为新会话 token：open_qa_panel 的 idle 总是携带新生成的 session_id。
+        let starts_turn = matches!(kind, "recording" | "loading" | "thinking" | "idle");
+        if let Some(current) = self.session_id.as_deref() {
+            if !starts_turn && current != sid {
+                return false;
+            }
+        }
+        if !self.session_id.is_some() || starts_turn {
+            self.session_id = Some(sid.to_string());
+        }
+        true
+    }
+}
+
+/// 把后端一个 `qa:state` 事件应用到 QA 视图状态。由 lib.rs 的监听器经
+/// [`QaHostSink`] 推送。
+pub fn apply_qa_state(s: &mut QaViewState, payload: &QaStateEvent) {
+    let kind = payload.kind.as_deref().unwrap_or("idle");
+    if !s.accept(kind, payload.session_id.as_deref()) {
+        return;
+    }
+    if let Some(messages) = &payload.messages {
+        s.messages = messages.clone();
+    }
+    s.current_kind = kind.to_string();
+    match kind {
+        "idle" => {
+            s.selection_preview = None;
+            s.error = None;
+            s.streaming_answer.clear();
+        }
+        "recording" => {
+            s.selection_preview = payload.selection_preview.clone();
+            s.error = None;
+            s.streaming_answer.clear();
+        }
+        "loading" | "thinking" => {
+            if payload.selection_preview.is_some() {
+                s.selection_preview = payload.selection_preview.clone();
+            }
+            s.error = None;
+            s.streaming_answer.clear();
+        }
+        "answer_delta" => {
+            if let Some(chunk) = &payload.chunk {
+                s.streaming_answer.push_str(chunk);
+            }
+        }
+        "answer" => {
+            s.error = None;
+            s.streaming_answer.clear();
+        }
+        "error" => {
+            s.error = Some(
+                payload
+                    .error
+                    .clone()
+                    .unwrap_or_else(|| "问答出错，请重试".to_string()),
+            );
+            s.streaming_answer.clear();
+        }
+        _ => {}
+    }
+}
+
+fn truncate(text: &str, max: usize) -> String {
+    if text.chars().count() <= max {
+        text.to_string()
+    } else {
+        let cut: String = text.chars().take(max).collect();
+        format!("{cut}…")
+    }
+}

--- a/openless-all/app/src-tauri/src/egui_host/qa_event.rs
+++ b/openless-all/app/src-tauri/src/egui_host/qa_event.rs
@@ -1,0 +1,25 @@
+//! QA 事件载荷 —— 对应后端 `qa:state` 事件（`coordinator/qa_session.rs` emit 的 JSON）。
+//!
+//! 顶层字段为 snake_case（`session_id` / `selection_preview` / `chunk`），`messages`
+//! 数组元素 `QaChatMessage` 序列化为 camelCase（`selectionText`）。字段全部可缺省，
+//! 便于用 `serde_json::from_value` 容错解析（后端不同 kind 只带部分字段）。
+//!
+//! 寄生在 `egui_host` 内避免污染 `types.rs` 的公开契约；`apply_qa_state` 依赖它。
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+pub struct QaStateEvent {
+    #[serde(default)]
+    pub kind: Option<String>,
+    #[serde(default)]
+    pub session_id: Option<String>,
+    #[serde(default)]
+    pub messages: Option<Vec<crate::types::QaChatMessage>>,
+    #[serde(default)]
+    pub selection_preview: Option<String>,
+    #[serde(default)]
+    pub error: Option<String>,
+    #[serde(default)]
+    pub chunk: Option<String>,
+}

--- a/openless-all/app/src-tauri/src/lib.rs
+++ b/openless-all/app/src-tauri/src/lib.rs
@@ -491,6 +491,9 @@ fn run_desktop() {
     ));
     #[cfg(not(target_os = "windows"))]
     let coordinator = Arc::new(coordinator::Coordinator::new());
+    let egui_host: std::sync::Arc<dyn crate::egui_host::EguiHost> = std::sync::Arc::new(
+        crate::egui_host::CoordinatorHostAdapter::new(coordinator.clone()),
+    );
     #[cfg(target_os = "windows")]
     if let Err(error) = coordinator.sync_active_asr_provider_from_preferences() {
         log::warn!("[startup] sync active ASR provider from preferences failed: {error}");
@@ -549,6 +552,7 @@ fn run_desktop() {
             None,
         ))
         .manage(coordinator.clone())
+        .manage(egui_host.clone())
         .manage(local_asr_download_manager.clone())
         .manage(sherpa_download_manager.clone())
         .manage(foundry_local_runtime.clone())
@@ -818,6 +822,16 @@ fn run_desktop() {
                         }
                     }
                 });
+
+                // 临时验证钩子：OPENLESS_EGUI_TEST_QA=1 时启动即打开 QA 弹窗并注入演示状态。
+                // 验收后删除。
+                if std::env::var("OPENLESS_EGUI_TEST_QA").ok().as_deref() == Some("1") {
+                    if crate::egui_host::show_qa(app.handle()) {
+                        log::info!("[egui-host][test] qa egui_popup spawned via test hook");
+                    } else {
+                        log::warn!("[egui-host][test] qa show_qa returned false");
+                    }
+                }
             }
 
             Ok(())

--- a/openless-all/app/src-tauri/src/lib.rs
+++ b/openless-all/app/src-tauri/src/lib.rs
@@ -34,6 +34,10 @@ mod correction;
 // Linux 退化为纯轮询兜底。仅桌面端。详见 issue #470。
 #[cfg(not(mobile))]
 mod device_watch;
+// Linux 上把「选区润色预览 / QA 面板」弹窗改用 egui 渲染（替代 Tauri WebView 浮窗）。
+// 模块内部用 cfg(target_os = "linux") 门控，其它平台保持 WebView 版。
+#[cfg(target_os = "linux")]
+pub mod egui_host;
 mod endpoint_security;
 mod external_url;
 #[cfg(not(mobile))]
@@ -129,8 +133,8 @@ use tauri::menu::{
 #[cfg(not(mobile))]
 use tauri::tray::{MouseButton, TrayIconBuilder, TrayIconEvent};
 use tauri::{
-    AppHandle, Emitter, LogicalPosition, LogicalSize, Manager, PhysicalPosition, PhysicalSize,
-    RunEvent, Runtime,
+    AppHandle, Emitter, Listener, LogicalPosition, LogicalSize, Manager, PhysicalPosition,
+    PhysicalSize, RunEvent, Runtime,
 };
 // 桌面专用：移动端 WebviewWindowBuilder 没有 decorations/shadow 等方法，懒创建只在桌面用。
 #[cfg(not(any(target_os = "android", target_os = "ios")))]
@@ -795,6 +799,25 @@ fn run_desktop() {
             if let Some(intent) = cli::parse_cli_intent(&first_run_args) {
                 log::info!("[startup] first-run CLI intent={intent:?}, dispatching");
                 dispatch_cli_intent(app.handle(), intent);
+            }
+
+            // Linux + egui 浮窗：后端把 `qa:state` 发给 "qa" webview window。egui 版
+            // 没有该 window，但仍要收到状态事件驱动 QA 面板渲染——这里在宿主侧订阅
+            // 全局事件并转发到 egui host。事件只在 Linux 生效，其它平台用 WebView 版。
+            #[cfg(target_os = "linux")]
+            if crate::egui_host::enabled() {
+                // 用 listen_any：后端 emit_to("qa", ...) 只发给 "qa" window，
+                // 普通 listen（target=App）收不到；listen_any 能收到任意 target。
+                let _ = app.listen_any("qa:state", |event| {
+                    let payload = event.payload();
+                    match serde_json::from_str::<crate::egui_host::qa_event::QaStateEvent>(payload)
+                    {
+                        Ok(parsed) => crate::egui_host::push_qa_state(parsed),
+                        Err(error) => {
+                            log::warn!("[egui-host] parse qa:state failed: {error}");
+                        }
+                    }
+                });
             }
 
             Ok(())
@@ -2294,6 +2317,13 @@ pub(crate) fn show_qa_window<R: tauri::Runtime>(app: &AppHandle<R>, content_kind
         return;
     }
 
+    // Linux：优先走 egui 原生浮窗；未启用（禁用/失败）回退 WebView 版。
+    // egui 侧通过 lib.rs 的 app.listen("qa:state") 接收后续状态事件。
+    #[cfg(target_os = "linux")]
+    if crate::egui_host::show_qa(app) {
+        return;
+    }
+
     let Some(window) = ensure_qa_window(app) else {
         log::info!("[qa] show 跳过：qa 窗口不存在 (content_kind={content_kind})");
         return;
@@ -2596,6 +2626,12 @@ pub(crate) fn hide_qa_window<R: tauri::Runtime>(app: &AppHandle<R>) {
         return;
     }
 
+    // Linux：egui 浮窗的隐藏走宿主；WebView 版不存在时静默。
+    #[cfg(target_os = "linux")]
+    if crate::egui_host::hide_qa() {
+        return;
+    }
+
     #[cfg(not(any(target_os = "android", target_os = "ios")))]
     hide_chat_window_animated(app, "qa", &QA_PANEL_EPOCH);
 }
@@ -2629,6 +2665,12 @@ fn ensure_selection_polish_preview_window<R: tauri::Runtime>(
 
 #[cfg(not(any(target_os = "android", target_os = "ios")))]
 pub(crate) fn show_selection_polish_preview<R: tauri::Runtime>(app: &AppHandle<R>) {
+    // Linux：优先走 egui 原生浮窗；未启用（禁用/失败）回退 WebView 版。
+    #[cfg(target_os = "linux")]
+    if crate::egui_host::show_preview(app) {
+        return;
+    }
+
     let Some(window) = ensure_selection_polish_preview_window(app) else {
         return;
     };
@@ -2650,6 +2692,12 @@ pub(crate) fn show_selection_polish_preview<R: tauri::Runtime>(app: &AppHandle<R
 pub(crate) fn show_selection_polish_preview<R: tauri::Runtime>(_app: &AppHandle<R>) {}
 
 pub(crate) fn hide_selection_polish_preview<R: tauri::Runtime>(app: &AppHandle<R>) {
+    // Linux：egui 浮窗的隐藏走宿主；WebView 版不存在时静默。
+    #[cfg(target_os = "linux")]
+    if crate::egui_host::hide_preview() {
+        return;
+    }
+
     if let Some(window) = app.get_webview_window("selection-polish-preview") {
         let _ = window.hide();
     }

--- a/openless-all/app/src-tauri/src/lib.rs
+++ b/openless-all/app/src-tauri/src/lib.rs
@@ -14,11 +14,14 @@
 //! - coordinator: dictation state machine glue
 //! - commands: Tauri IPC surface
 
+// 让被内嵌复用的 popup 源码在 lib crate 中也能使用 `openless_lib::...` 路径。
+extern crate self as openless_lib;
+
 mod android;
-#[cfg(test)]
-mod build_target;
 mod asr;
 mod audio_mute;
+#[cfg(test)]
+mod build_target;
 mod cli;
 mod coding_agent;
 #[cfg(not(mobile))]
@@ -34,9 +37,8 @@ mod correction;
 // Linux 退化为纯轮询兜底。仅桌面端。详见 issue #470。
 #[cfg(not(mobile))]
 mod device_watch;
-// Linux 上把「选区润色预览 / QA 面板」弹窗改用 egui 渲染（替代 Tauri WebView 浮窗）。
-// 模块内部用 cfg(target_os = "linux") 门控，其它平台保持 WebView 版。
-#[cfg(target_os = "linux")]
+// 桌面端 QA 面板统一使用 egui；选区润色预览仅 Linux 使用 egui。
+#[cfg(not(mobile))]
 pub mod egui_host;
 mod endpoint_security;
 mod external_url;
@@ -805,10 +807,10 @@ fn run_desktop() {
                 dispatch_cli_intent(app.handle(), intent);
             }
 
-            // Linux + egui 浮窗：后端把 `qa:state` 发给 "qa" webview window。egui 版
+            // 桌面端 egui 浮窗：后端把 `qa:state` 发给 "qa" webview window。egui 版
             // 没有该 window，但仍要收到状态事件驱动 QA 面板渲染——这里在宿主侧订阅
-            // 全局事件并转发到 egui host。事件只在 Linux 生效，其它平台用 WebView 版。
-            #[cfg(target_os = "linux")]
+            // 全局事件并转发到 egui host。
+            #[cfg(not(mobile))]
             if crate::egui_host::enabled() {
                 // 用 listen_any：后端 emit_to("qa", ...) 只发给 "qa" window，
                 // 普通 listen（target=App）收不到；listen_any 能收到任意 target。
@@ -2331,9 +2333,9 @@ pub(crate) fn show_qa_window<R: tauri::Runtime>(app: &AppHandle<R>, content_kind
         return;
     }
 
-    // Linux：优先走 egui 原生浮窗；未启用（禁用/失败）回退 WebView 版。
+    // 桌面端统一优先走 egui 原生 QA；启动失败时回退 WebView 版。
     // egui 侧通过 lib.rs 的 app.listen("qa:state") 接收后续状态事件。
-    #[cfg(target_os = "linux")]
+    #[cfg(not(any(target_os = "android", target_os = "ios")))]
     if crate::egui_host::show_qa(app) {
         return;
     }
@@ -2640,8 +2642,8 @@ pub(crate) fn hide_qa_window<R: tauri::Runtime>(app: &AppHandle<R>) {
         return;
     }
 
-    // Linux：egui 浮窗的隐藏走宿主；WebView 版不存在时静默。
-    #[cfg(target_os = "linux")]
+    // 桌面端 egui QA 的隐藏走宿主；WebView 回退窗不存在时静默。
+    #[cfg(not(any(target_os = "android", target_os = "ios")))]
     if crate::egui_host::hide_qa() {
         return;
     }

--- a/openless-all/app/src-tauri/src/main.rs
+++ b/openless-all/app/src-tauri/src/main.rs
@@ -2,6 +2,12 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
 fn main() {
+    #[cfg(not(any(target_os = "android", target_os = "ios")))]
+    if std::env::args().nth(1).as_deref() == Some("--openless-egui-popup") {
+        openless_lib::egui_host::popup::main();
+        return;
+    }
+
     // Work around WebKitGTK compositing bugs on Linux Wayland:
     // - WEBKIT_DISABLE_COMPOSITING_MODE=1 fixes "whole window unresponsive
     //   to clicks until maximize/restore" (tauri#9394)


### PR DESCRIPTION
## Summary

- replace the desktop selection QA WebView popup with a native egui popup on Linux, Windows, and macOS
- keep the egui selection-polish preview Linux-only while Windows and macOS retain the existing WebView path
- embed popup mode in the main executable and communicate through JSON lines over stdin/stdout
- restore the original QA layout behavior, selected-text envelope presentation, right-aligned user messages, Markdown rendering, wrapping, rounded corners, dragging, and Escape dismissal
- keep the recording composer and selection context inside fixed window bounds

## Validation

- cargo check --bin openless --bin egui_popup
- cargo build --release --bin openless
- manually tested the Linux QA and selection-polish popup flows

## Platform note

The current development environment only has the Linux Rust target installed. Linux was compiled and manually exercised; Windows and macOS routing is implemented but was not cross-compiled locally.