### PR TITLE
fix(polish): 润色流式请求让取消检测和网络等待赛跑，不再悬挂到 budget 结束

### DIFF
--- a/openless-all/app/src-tauri/src/polish.rs
+++ b/openless-all/app/src-tauri/src/polish.rs
@@ -924,7 +924,19 @@ impl OpenAICompatibleLLMProvider {
         }
         let request = request.json(&body);
 
-        let response = send_with_transient_retry(request).await?;
+        // 建连 / 请求写出阶段也可能挂住（服务端只 accept 不响应）。若只在下面 SSE
+        // 循环里查 should_cancel，一个字都没收到时永远等不到那个检查点——跟转写阶段
+        // 修复前（PR #798）同一类问题。让它和取消轮询赛跑，命中取消就直接放弃这次请求。
+        let response = tokio::select! {
+            _ = wait_until_cancelled(&should_cancel) => {
+                log::info!("[llm] polish stream cancelled by caller before response arrived");
+                return Err(LLMError::InvalidResponse {
+                    status: 200,
+                    body: "empty polish stream".to_string(),
+                });
+            }
+            result = send_with_transient_retry(request) => result?,
+        };
 
         let status = response.status();
         if !status.is_success() {
@@ -947,15 +959,6 @@ impl OpenAICompatibleLLMProvider {
         let stream_started = std::time::Instant::now();
         let mut first_content_at: Option<Duration> = None;
         loop {
-            if should_cancel() {
-                log::info!(
-                    "[llm] polish stream cancelled by caller after {} deltas ({} chars); breaking SSE loop",
-                    delta_count,
-                    full_text.chars().count()
-                );
-                cancelled = true;
-                break;
-            }
             // 首字之前用「还剩多少首字预算」，首字之后用「两个 chunk 之间能空多久」。
             // 注意首字预算是从请求发出起算的**总量**，不随 chunk 到达而重置——推理模型
             // 思考期的 reasoning_content 是一串正常 chunk，若让它续命，用户干等就没有上限。
@@ -965,27 +968,42 @@ impl OpenAICompatibleLLMProvider {
                     .saturating_sub(stream_started.elapsed()),
                 Some(_) => timeouts.idle,
             };
-            let chunk_opt = match tokio::time::timeout(budget, response.chunk()).await {
-                Ok(result) => result.map_err(llm_error_from_reqwest)?,
-                Err(_) => {
-                    // 已经交给 on_delta 的字此刻就在用户屏幕上；上层 dictation 的 Failed
-                    // 分支拿 typed_text 当 final_text，屏幕 / history / 剪贴板保持一致。
-                    match first_content_at {
-                        None => log::error!(
-                            "[llm] polish stream timed out waiting for first content delta (budget {:?}); \
-                             模型可能仍在思考——加长首字预算或换非推理模型",
-                            timeouts.first_token
-                        ),
-                        Some(first) => log::error!(
-                            "[llm] polish stream stalled {:?} after {} chars (first delta at {:?}); \
-                             已落屏的字保留",
-                            timeouts.idle,
-                            full_text.chars().count(),
-                            first
-                        ),
-                    }
-                    return Err(LLMError::Timeout);
+            // 取消检查不再只在循环顶部查一次：卡在单次 chunk() 等待里时，旧写法要等这次
+            // await 自然到点（budget 最长数十秒）才会看到取消旗；现在跟取消轮询赛跑，最多
+            // ~75ms 就能感知到并中断连接（reqwest 的 Response 一旦被 drop，底层 TCP 连接
+            // 随之中断——跟转写阶段 wait_for_processing_cancel 依赖的是同一条保证）。
+            let chunk_opt = tokio::select! {
+                _ = wait_until_cancelled(&should_cancel) => {
+                    log::info!(
+                        "[llm] polish stream cancelled by caller after {} deltas ({} chars); breaking SSE loop",
+                        delta_count,
+                        full_text.chars().count()
+                    );
+                    cancelled = true;
+                    break;
                 }
+                timed = tokio::time::timeout(budget, response.chunk()) => match timed {
+                    Ok(result) => result.map_err(llm_error_from_reqwest)?,
+                    Err(_) => {
+                        // 已经交给 on_delta 的字此刻就在用户屏幕上；上层 dictation 的 Failed
+                        // 分支拿 typed_text 当 final_text，屏幕 / history / 剪贴板保持一致。
+                        match first_content_at {
+                            None => log::error!(
+                                "[llm] polish stream timed out waiting for first content delta (budget {:?}); \
+                                 模型可能仍在思考——加长首字预算或换非推理模型",
+                                timeouts.first_token
+                            ),
+                            Some(first) => log::error!(
+                                "[llm] polish stream stalled {:?} after {} chars (first delta at {:?}); \
+                                 已落屏的字保留",
+                                timeouts.idle,
+                                full_text.chars().count(),
+                                first
+                            ),
+                        }
+                        return Err(LLMError::Timeout);
+                    }
+                },
             };
             let Some(chunk) = chunk_opt else { break };
             append_utf8_sse_chunk(&mut buffer, &mut utf8_pending, &chunk)?;
@@ -1500,6 +1518,20 @@ pub(crate) fn http_client_builder(base_url: &str, timeout_secs: u64) -> reqwest:
         builder.no_proxy()
     } else {
         builder
+    }
+}
+
+/// 轮询 `should_cancel`，用于跟网络 I/O 的 future 通过 `tokio::select!` 赛跑，让取消
+/// 不必等当前这一次网络 await 自然结束才被看到。轮询间隔跟 `coordinator::dictation::
+/// wait_for_processing_cancel`（转写阶段取消轮询，PR #798 引入）保持一致——75ms 对
+/// 用户不可感知，且不依赖任何唤醒信号，没有「取消边沿在注册 waiter 之前触发就被错过」
+/// 的竞态。
+async fn wait_until_cancelled<C: Fn() -> bool>(should_cancel: &C) {
+    loop {
+        if should_cancel() {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(75)).await;
     }
 }
 
@@ -2337,7 +2369,7 @@ mod tests {
             "https://user:pass@example.com/v1/chat/completions?token=query-secret#client-fragment"
         );
     }
-    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
     use std::sync::Mutex as StdMutex;
     use std::thread;
 
@@ -2891,6 +2923,56 @@ mod tests {
             *seen.lock().unwrap(),
             "开头",
             "卡死之前已经流出去的字必须留在屏幕上"
+        );
+        drop(server);
+    }
+
+    /// 服务端 accept 了连接、收到了请求，但一个字节都不回——这正是本机日志复现的真实
+    /// 故障（润色阶段配置 deepseek-v4-flash 时，取消要等 32~53s 才生效，胶囊卡死到只能
+    /// 强制重启 App）。取消信号必须在 ~75ms 轮询周期内生效，不能悬挂到 first_token 预算
+    /// （这里刻意设得很长）自然到点才被看到。
+    #[tokio::test]
+    async fn cancellation_before_response_arrives_does_not_wait_out_the_budget() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            read_http_request(&mut stream);
+            // 故意什么都不回——连接保持打开，模拟服务端只 accept 不响应。
+            thread::sleep(std::time::Duration::from_secs(5));
+            let _ = stream;
+        });
+
+        let cancelled = std::sync::Arc::new(AtomicBool::new(false));
+        let cancelled_setter = cancelled.clone();
+        tokio::spawn(async move {
+            tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+            cancelled_setter.store(true, Ordering::SeqCst);
+        });
+
+        let timeouts = StreamingTimeouts {
+            first_token: std::time::Duration::from_secs(30),
+            idle: std::time::Duration::from_secs(30),
+        };
+        let started = std::time::Instant::now();
+        let err = streaming_test_provider(addr)
+            .chat_completion_messages_streaming(
+                test_messages(),
+                timeouts,
+                |_| {},
+                move || cancelled.load(Ordering::SeqCst),
+            )
+            .await
+            .expect_err("取消之后必须尽快返回错误，不能悬挂到 budget 结束");
+        let elapsed = started.elapsed();
+
+        assert!(
+            elapsed < std::time::Duration::from_secs(2),
+            "取消应在一个轮询周期内生效，而不是等 30s 的首字预算，实际耗时 {elapsed:?}"
+        );
+        assert!(
+            matches!(err, LLMError::InvalidResponse { status: 200, .. }),
+            "got {err:?}"
         );
         drop(server);
     }

--- a/openless-all/app/src-tauri/src/polish.rs
+++ b/openless-all/app/src-tauri/src/polish.rs
@@ -930,9 +930,11 @@ impl OpenAICompatibleLLMProvider {
         let response = tokio::select! {
             _ = wait_until_cancelled(&should_cancel) => {
                 log::info!("[llm] polish stream cancelled by caller before response arrived");
+                // status 用 0 而不是 200：这条路径上一个 HTTP 响应字节都没收到，
+                // 编一个 200 会让日志读起来像「服务端回了 200 但内容为空」，把排查带偏。
                 return Err(LLMError::InvalidResponse {
-                    status: 200,
-                    body: "empty polish stream".to_string(),
+                    status: 0,
+                    body: "polish stream cancelled before response arrived".to_string(),
                 });
             }
             result = send_with_transient_retry(request) => result?,
@@ -2927,10 +2929,9 @@ mod tests {
         drop(server);
     }
 
-    /// 服务端 accept 了连接、收到了请求，但一个字节都不回——这正是本机日志复现的真实
-    /// 故障（润色阶段配置 deepseek-v4-flash 时，取消要等 32~53s 才生效，胶囊卡死到只能
-    /// 强制重启 App）。取消信号必须在 ~75ms 轮询周期内生效，不能悬挂到 first_token 预算
-    /// （这里刻意设得很长）自然到点才被看到。
+    /// 覆盖**建连/请求写出**阶段的取消：服务端 accept 了连接、收到了请求，但连状态行都
+    /// 不回，`send_with_transient_retry` 因此一直不 resolve。这一路锁的是 `send` 之前那个
+    /// `select!`。真实故障（0 deltas 后卡住）走的是下面 `cancellation_mid_stream_*` 那条。
     #[tokio::test]
     async fn cancellation_before_response_arrives_does_not_wait_out_the_budget() {
         let listener = TcpListener::bind("127.0.0.1:0").unwrap();
@@ -2970,6 +2971,63 @@ mod tests {
             elapsed < std::time::Duration::from_secs(2),
             "取消应在一个轮询周期内生效，而不是等 30s 的首字预算，实际耗时 {elapsed:?}"
         );
+        assert!(
+            matches!(err, LLMError::InvalidResponse { status: 0, .. }),
+            "got {err:?}"
+        );
+        drop(server);
+    }
+
+    /// 覆盖 **SSE 循环内**的取消，也就是 issue #1000 日志里真正发生的那条路径：日志打出了
+    /// `cancelled by caller after 0 deltas ... breaking SSE loop`，说明 response 头已经到达、
+    /// 代码已经进了循环，卡住的是 `response.chunk()` 那一次 await。
+    ///
+    /// 这里服务端立刻回 200 header（客户端由此进入 SSE 循环），随后长时间不发任何 delta。
+    /// 若把循环里的 `select!` 还原成「只在循环顶部查一次 should_cancel」，本用例会一直等到
+    /// 30s 首字预算耗尽才返回 `Timeout`，两条断言都会失败——它锁住的正是本次修复的核心。
+    #[tokio::test]
+    async fn cancellation_mid_stream_does_not_wait_out_the_budget() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            read_http_request(&mut stream);
+            // header 立刻回，body 迟迟不来：模拟「连接活着、模型一个字都不吐」。
+            let never = content_event("永远来不了");
+            write_chunked_sse_response_with_delays(
+                &mut stream,
+                &[(never.as_slice(), std::time::Duration::from_secs(5))],
+            );
+        });
+
+        let cancelled = std::sync::Arc::new(AtomicBool::new(false));
+        let cancelled_setter = cancelled.clone();
+        tokio::spawn(async move {
+            tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+            cancelled_setter.store(true, Ordering::SeqCst);
+        });
+
+        let timeouts = StreamingTimeouts {
+            first_token: std::time::Duration::from_secs(30),
+            idle: std::time::Duration::from_secs(30),
+        };
+        let started = std::time::Instant::now();
+        let err = streaming_test_provider(addr)
+            .chat_completion_messages_streaming(
+                test_messages(),
+                timeouts,
+                |_| {},
+                move || cancelled.load(Ordering::SeqCst),
+            )
+            .await
+            .expect_err("一个 delta 都没收到就取消，最终应落到空流错误");
+        let elapsed = started.elapsed();
+
+        assert!(
+            elapsed < std::time::Duration::from_secs(2),
+            "SSE 循环内的取消应在一个轮询周期内生效，而不是等满首字预算，实际耗时 {elapsed:?}"
+        );
+        // 走的是「break 出循环 → full_text 为空」这条既有路径，status 200 是真实收到的。
         assert!(
             matches!(err, LLMError::InvalidResponse { status: 200, .. }),
             "got {err:?}"

--- a/openless-all/app/src-tauri/src/polish.rs
+++ b/openless-all/app/src-tauri/src/polish.rs
@@ -924,14 +924,14 @@ impl OpenAICompatibleLLMProvider {
         }
         let request = request.json(&body);
 
-        // 建连 / 请求写出阶段也可能挂住（服务端只 accept 不响应）。若只在下面 SSE
-        // 循环里查 should_cancel，一个字都没收到时永远等不到那个检查点——跟转写阶段
-        // 修复前（PR #798）同一类问题。让它和取消轮询赛跑，命中取消就直接放弃这次请求。
+        // 服务端只 accept 不响应时，SSE 循环里的检查点根本够不着。`biased` 让取消分支
+        // 先于网络分支被 poll。
         let response = tokio::select! {
+            biased;
             _ = wait_until_cancelled(&should_cancel) => {
                 log::info!("[llm] polish stream cancelled by caller before response arrived");
-                // status 用 0 而不是 200：这条路径上一个 HTTP 响应字节都没收到，
-                // 编一个 200 会让日志读起来像「服务端回了 200 但内容为空」，把排查带偏。
+                // status 0 = 一个 HTTP 响应字节都没收到；编个 200 会让日志读起来像
+                // 「服务端回了 200 空 body」。
                 return Err(LLMError::InvalidResponse {
                     status: 0,
                     body: "polish stream cancelled before response arrived".to_string(),
@@ -942,7 +942,22 @@ impl OpenAICompatibleLLMProvider {
 
         let status = response.status();
         if !status.is_success() {
-            let body_text = response.text().await.map_err(llm_error_from_reqwest)?;
+            // 错误 body 也要能被取消打断：服务端回了非 2xx 头之后挂住时，这里会一路等到
+            // client 硬顶（POLISH_CLIENT_HARD_CAP_SECS，900s），期间取消完全不生效。
+            let body_text = tokio::select! {
+                biased;
+                _ = wait_until_cancelled(&should_cancel) => {
+                    log::info!(
+                        "[llm] polish stream cancelled by caller while reading HTTP {} error body",
+                        status.as_u16()
+                    );
+                    return Err(LLMError::InvalidResponse {
+                        status: status.as_u16(),
+                        body: "cancelled while reading error body".to_string(),
+                    });
+                }
+                text = response.text() => text.map_err(llm_error_from_reqwest)?,
+            };
             let preview_end = BODY_PREVIEW_LIMIT.min(body_text.len());
             let preview = safe_str_slice(&body_text, preview_end);
             log::error!("[llm] streaming HTTP {} body={}", status.as_u16(), preview);
@@ -972,9 +987,10 @@ impl OpenAICompatibleLLMProvider {
             };
             // 取消检查不再只在循环顶部查一次：卡在单次 chunk() 等待里时，旧写法要等这次
             // await 自然到点（budget 最长数十秒）才会看到取消旗；现在跟取消轮询赛跑，最多
-            // ~75ms 就能感知到并中断连接（reqwest 的 Response 一旦被 drop，底层 TCP 连接
-            // 随之中断——跟转写阶段 wait_for_processing_cancel 依赖的是同一条保证）。
+            // ~75ms 就能放弃这次响应体的等待（Response 被 drop 即取消该请求；HTTP/2 与
+            // 连接池下未必关闭整条 TCP，但这一次请求确定不再占着调用方）。
             let chunk_opt = tokio::select! {
+                biased;
                 _ = wait_until_cancelled(&should_cancel) => {
                     log::info!(
                         "[llm] polish stream cancelled by caller after {} deltas ({} chars); breaking SSE loop",
@@ -1523,11 +1539,9 @@ pub(crate) fn http_client_builder(base_url: &str, timeout_secs: u64) -> reqwest:
     }
 }
 
-/// 轮询 `should_cancel`，用于跟网络 I/O 的 future 通过 `tokio::select!` 赛跑，让取消
-/// 不必等当前这一次网络 await 自然结束才被看到。轮询间隔跟 `coordinator::dictation::
-/// wait_for_processing_cancel`（转写阶段取消轮询，PR #798 引入）保持一致——75ms 对
-/// 用户不可感知，且不依赖任何唤醒信号，没有「取消边沿在注册 waiter 之前触发就被错过」
-/// 的竞态。
+/// 轮询 `should_cancel`，跟网络 I/O 的 future 用 `tokio::select!` 赛跑。75ms 间隔与
+/// `coordinator::dictation::wait_for_processing_cancel`（PR #798）一致：对用户不可感知，
+/// 又不依赖唤醒信号，没有「取消边沿早于 waiter 注册就被漏掉」的竞态。
 async fn wait_until_cancelled<C: Fn() -> bool>(should_cancel: &C) {
     loop {
         if should_cancel() {
@@ -2929,9 +2943,8 @@ mod tests {
         drop(server);
     }
 
-    /// 覆盖**建连/请求写出**阶段的取消：服务端 accept 了连接、收到了请求，但连状态行都
-    /// 不回，`send_with_transient_retry` 因此一直不 resolve。这一路锁的是 `send` 之前那个
-    /// `select!`。真实故障（0 deltas 后卡住）走的是下面 `cancellation_mid_stream_*` 那条。
+    /// 覆盖**建连阶段**的取消：服务端连状态行都不回，`send_with_transient_retry` 一直不
+    /// resolve。锁的是 `send` 之前那个 `select!`。
     #[tokio::test]
     async fn cancellation_before_response_arrives_does_not_wait_out_the_budget() {
         let listener = TcpListener::bind("127.0.0.1:0").unwrap();
@@ -2978,13 +2991,9 @@ mod tests {
         drop(server);
     }
 
-    /// 覆盖 **SSE 循环内**的取消，也就是 issue #1000 日志里真正发生的那条路径：日志打出了
-    /// `cancelled by caller after 0 deltas ... breaking SSE loop`，说明 response 头已经到达、
-    /// 代码已经进了循环，卡住的是 `response.chunk()` 那一次 await。
-    ///
-    /// 这里服务端立刻回 200 header（客户端由此进入 SSE 循环），随后长时间不发任何 delta。
-    /// 若把循环里的 `select!` 还原成「只在循环顶部查一次 should_cancel」，本用例会一直等到
-    /// 30s 首字预算耗尽才返回 `Timeout`，两条断言都会失败——它锁住的正是本次修复的核心。
+    /// 覆盖 **SSE 循环内**的取消——issue #1000 日志里 `after 0 deltas ... breaking SSE loop`
+    /// 那条真实路径：200 头已到达、卡住的是 `response.chunk()`。把循环里的 `select!` 还原成
+    /// 「只在循环顶部查一次」，本用例会等满 30s 首字预算才返回 `Timeout` 而失败。
     #[tokio::test]
     async fn cancellation_mid_stream_does_not_wait_out_the_budget() {
         let listener = TcpListener::bind("127.0.0.1:0").unwrap();
@@ -3030,6 +3039,58 @@ mod tests {
         // 走的是「break 出循环 → full_text 为空」这条既有路径，status 200 是真实收到的。
         assert!(
             matches!(err, LLMError::InvalidResponse { status: 200, .. }),
+            "got {err:?}"
+        );
+        drop(server);
+    }
+
+    /// 覆盖**非 2xx 错误 body 的读取**：服务端回了 500 头就不再发 body，`response.text()`
+    /// 会一路等到 client 硬顶（`POLISH_CLIENT_HARD_CAP_SECS`，900s）。这条路径在两个 SSE
+    /// 相关的 `select!` 之外，必须单独跟取消赛跑。
+    #[tokio::test]
+    async fn cancellation_while_reading_error_body_does_not_hang() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            read_http_request(&mut stream);
+            // 声明了 1KB body 却一个字节都不发，读 body 因此永远等不到头。
+            stream
+                .write_all(b"HTTP/1.1 500 Internal Server Error\r\nContent-Length: 1024\r\n\r\n")
+                .unwrap();
+            stream.flush().unwrap();
+            thread::sleep(std::time::Duration::from_secs(5));
+        });
+
+        let cancelled = std::sync::Arc::new(AtomicBool::new(false));
+        let cancelled_setter = cancelled.clone();
+        tokio::spawn(async move {
+            tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+            cancelled_setter.store(true, Ordering::SeqCst);
+        });
+
+        let timeouts = StreamingTimeouts {
+            first_token: std::time::Duration::from_secs(30),
+            idle: std::time::Duration::from_secs(30),
+        };
+        let started = std::time::Instant::now();
+        let err = streaming_test_provider(addr)
+            .chat_completion_messages_streaming(
+                test_messages(),
+                timeouts,
+                |_| {},
+                move || cancelled.load(Ordering::SeqCst),
+            )
+            .await
+            .expect_err("非 2xx 必然返回错误");
+        let elapsed = started.elapsed();
+
+        assert!(
+            elapsed < std::time::Duration::from_secs(2),
+            "读错误 body 时的取消应在一个轮询周期内生效，实际耗时 {elapsed:?}"
+        );
+        assert!(
+            matches!(err, LLMError::InvalidResponse { status: 500, .. }),
             "got {err:?}"
         );
         drop(server);


### PR DESCRIPTION
## 摘要

Fixes #1000。

润色阶段模型迟迟不返回时，取消要等 32~53s 才生效，期间胶囊卡死、快捷键无响应，只能强制重启 App。根因是 `chat_completion_messages_streaming` 里等待网络的 await 都不参与取消检测，`should_cancel` 只在 SSE 循环顶部被轮询一次。同类问题在转写阶段已由 #798 修过，没有推广到润色阶段。

本 PR 用同款 `tokio::select!` 赛跑补齐该函数里的三处网络等待，取消粒度从「最长等一个 budget」收窄到 ~75ms。

## 修复 / 新增 / 改进

- 新增 `wait_until_cancelled`（75ms 轮询，与 `wait_for_processing_cancel` 同间隔），分别与三处网络等待赛跑：建连 `send_with_transient_retry`、SSE 逐帧 `response.chunk()`、非 2xx 错误体 `response.text()`。
- 第三处是外部 review 才发现的遗漏：`polish_client` 用 `POLISH_CLIENT_HARD_CAP_SECS`（900s）作总超时，服务端只要回一个 500 头就挂住不发 body，取消完全不生效，最坏卡死 15 分钟——比原路径的 30s 首字预算严重一个数量级。
- 三处 `select!` 均加 `biased`，让取消分支先于网络分支被 poll，消掉「budget 归零与取消同时就绪时随机选分支」的竞态。
- 建连阶段取消返回的 status 由 200 改为 0：该路径上一个 HTTP 响应字节都没收到，报 200 会把日志排查带偏。
- 三个回归测试各锁一处等待点，均做过反向验证（移除对应赛跑后该用例失败）：`cancellation_mid_stream_*` 对应 issue 日志里 `after 0 deltas ... breaking SSE loop` 的真实路径；`cancellation_while_reading_error_body_*` 在移除赛跑后实测耗时 5.01s。
- 未改动：`dictation.rs` 状态机、`already_streamed` 语义、各项超时预算数值。
- 未改动：`chat_completion_history_streaming` 与 Codex OAuth 流式路径存在同款写法，不在本次复现路径内，留作单独跟进。

## 兼容

- 不包含：不改超时预算数值（首字 30s+ / 空闲 20s / 硬顶 900s），不改 `already_streamed` 语义与 `dictation.rs` 状态机。
- 对现有用户 / 本地环境 / 构建流程的影响：无。只缩短「点了取消后还要等多久」，未取消路径的行为不变。
- 改动量：生产代码净增 48 行（含注释），测试净增 153 行。

## 测试计划

- [x] 命令：`cargo test --manifest-path src-tauri/Cargo.toml --lib`（macOS/aarch64）
- [x] 结果：`1227 passed; 0 failed`
- [x] 反向验证：逐个移除三处赛跑后重跑，对应用例分别失败（SSE 循环那处取消被忽略并返回 `Ok`；错误体那处耗时 5.01s）
- [ ] 证据路径：本地终端输出，未落盘到仓库
