### PR TITLE
fix(windows-ime): 避免 TSF 预检导致文本重复插入

### DIFF
--- a/openless-all/app/scripts/windows-package-msvc.test.mjs
+++ b/openless-all/app/scripts/windows-package-msvc.test.mjs
@@ -11,6 +11,7 @@ const launcherPath = join(scriptsDir, "windows-package-msvc.cmd");
 const ciWorkflowPath = join(repoRoot, ".github", "workflows", "release-tauri.yml");
 const imeBuildPath = join(scriptsDir, "windows-ime-build.ps1");
 const imeInstallSmokePath = join(scriptsDir, "windows-ime-install-smoke.ps1");
+const realAsrInsertionSmokePath = join(scriptsDir, "windows-real-asr-insertion-smoke.ps1");
 const imeRegisterPath = join(scriptsDir, "windows-ime-register.ps1");
 const imeUnregisterPath = join(scriptsDir, "windows-ime-unregister.ps1");
 const imeSolutionPath = join(appRoot, "windows-ime", "OpenLessIme.sln");
@@ -26,6 +27,7 @@ const launcher = readFileSync(launcherPath, "utf8");
 const ciWorkflow = readFileSync(ciWorkflowPath, "utf8");
 const imeBuild = readFileSync(imeBuildPath, "utf8");
 const imeInstallSmoke = readFileSync(imeInstallSmokePath, "utf8");
+const realAsrInsertionSmoke = readFileSync(realAsrInsertionSmokePath, "utf8");
 const imeRegister = readFileSync(imeRegisterPath, "utf8");
 const imeUnregister = readFileSync(imeUnregisterPath, "utf8");
 const imeSolution = readFileSync(imeSolutionPath, "utf8");
@@ -107,6 +109,9 @@ assert.match(imeEditSession, /SetEvent/, "IME edit session should signal async c
 assert.match(imeEditSession, /Collapse\(edit_cookie, TF_ANCHOR_END\)/, "IME should collapse the committed range to its end after insertion");
 assert.match(imeEditSession, /SetSelection\(edit_cookie, 1, &selection\)/, "IME should move the caret to the end of inserted text");
 assert.match(imeEditSession, /TF_AE_END/, "IME should make the end of the committed text the active selection end");
+const insertAtSelectionCalls = imeEditSession.match(/\bInsertTextAtSelection\s*\(/g) ?? [];
+assert.equal(insertAtSelectionCalls.length, 1, "IME should submit the dictated text to the host exactly once");
+assert.doesNotMatch(imeEditSession, /TF_IAS_QUERYONLY/, "IME should not preflight the full text through host text stores before committing it");
 
 assert.match(wixFragment, /DirectoryRef Id="INSTALLDIR"/, "WiX fragment should install into the app directory");
 assert.match(wixFragment, /Component Id="OpenLessImeDllX64Component"/, "WiX fragment should define the x64 TSF DLL component");
@@ -145,6 +150,7 @@ assert.match(imeInstallSmoke, /Join-ProcessArguments/, "install smoke should quo
 assert.match(imeInstallSmoke, /\$commandLine = Join-ProcessArguments \$ArgumentList/, "install smoke should build a single quoted command line");
 assert.match(imeInstallSmoke, /Start-Process -FilePath \$FilePath -ArgumentList \$commandLine/, "install smoke should pass a single quoted command line to Start-Process");
 assert.match(imeInstallSmoke, /OpenLessImeSubmit/, "install smoke should preserve TSF backend context");
+assert.match(realAsrInsertionSmoke, /\$targetTextForComparison -cne \$finalTextForComparison/, "real insertion smoke should reject duplicate or partial text in initially empty targets");
 assert.match(imeInstallSmoke, /Software\\Classes\\CLSID\\\{6B9F3F4F-5EE7-42D6-9C61-9F80B03A5D7D\}\\InprocServer32/, "install smoke should check x64 COM registration");
 assert.match(imeInstallSmoke, /Software\\WOW6432Node\\Classes\\CLSID\\\{6B9F3F4F-5EE7-42D6-9C61-9F80B03A5D7D\}\\InprocServer32/, "install smoke should check x86 COM registration");
 assert.match(imeInstallSmoke, /LanguageProfile\\0x00000804\\\{9B5F5E04-23F6-47DA-9A26-D221F6C3F02E\}/, "install smoke should check the TSF language profile");

--- a/openless-all/app/scripts/windows-real-asr-insertion-smoke.ps1
+++ b/openless-all/app/scripts/windows-real-asr-insertion-smoke.ps1
@@ -1016,7 +1016,13 @@ try {
   if ([string]::IsNullOrWhiteSpace($targetText)) {
     throw "$Target readback is empty."
   }
-  if (-not $targetText.Contains($latest.finalText)) {
+  $targetTextForComparison = $targetText.Replace("`r`n", "`n")
+  $finalTextForComparison = ([string]$latest.finalText).Replace("`r`n", "`n")
+  $targetStartsEmpty = $Target -in @("notepad", "browser", "win32edit")
+  if ($targetStartsEmpty -and $targetTextForComparison -cne $finalTextForComparison) {
+    throw "$Target readback does not exactly match latest finalText in an initially empty target; duplicate or partial insertion detected (expected length=$($finalTextForComparison.Length), actual length=$($targetTextForComparison.Length))."
+  }
+  if (-not $targetStartsEmpty -and -not $targetText.Contains($latest.finalText)) {
     if ($targetText.Contains($clipboardSentinel)) {
       throw "$Target readback contains the pre-dictation clipboard sentinel instead of latest finalText."
     }

--- a/openless-all/app/windows-ime/src/edit_session.cpp
+++ b/openless-all/app/windows-ime/src/edit_session.cpp
@@ -101,38 +101,30 @@ HRESULT OpenLessEditSession::InsertText(TfEditCookie edit_cookie) {
     return hr;
   }
 
-  ITfRange* query_range = nullptr;
+  if (cancellation_ && cancellation_->load()) {
+    insert_at_selection->Release();
+    return HRESULT_FROM_WIN32(ERROR_CANCELLED);
+  }
+
+  // Commit in a single call. Some Chromium-backed text stores surface a
+  // full-text QUERYONLY preflight as an edit and then duplicate the real commit.
+  ITfRange* committed_range = nullptr;
   hr = insert_at_selection->InsertTextAtSelection(
-      edit_cookie, TF_IAS_QUERYONLY, text_.c_str(),
-      static_cast<LONG>(text_.size()), &query_range);
-  if (query_range != nullptr) {
-    query_range->Release();
-    query_range = nullptr;
-  }
-
-  if (SUCCEEDED(hr) && cancellation_ && cancellation_->load()) {
-    hr = HRESULT_FROM_WIN32(ERROR_CANCELLED);
-  }
-
-  if (SUCCEEDED(hr)) {
-    ITfRange* committed_range = nullptr;
-    hr = insert_at_selection->InsertTextAtSelection(
-        edit_cookie, 0, text_.c_str(), static_cast<LONG>(text_.size()),
-        &committed_range);
-    if (committed_range != nullptr) {
-      if (SUCCEEDED(hr)) {
-        const HRESULT collapse_hr =
-            committed_range->Collapse(edit_cookie, TF_ANCHOR_END);
-        if (SUCCEEDED(collapse_hr)) {
-          TF_SELECTION selection = {};
-          selection.range = committed_range;
-          selection.style.ase = TF_AE_END;
-          selection.style.fInterimChar = FALSE;
-          (void)context_->SetSelection(edit_cookie, 1, &selection);
-        }
+      edit_cookie, 0, text_.c_str(), static_cast<LONG>(text_.size()),
+      &committed_range);
+  if (committed_range != nullptr) {
+    if (SUCCEEDED(hr)) {
+      const HRESULT collapse_hr =
+          committed_range->Collapse(edit_cookie, TF_ANCHOR_END);
+      if (SUCCEEDED(collapse_hr)) {
+        TF_SELECTION selection = {};
+        selection.range = committed_range;
+        selection.style.ase = TF_AE_END;
+        selection.style.fInterimChar = FALSE;
+        (void)context_->SetSelection(edit_cookie, 1, &selection);
       }
-      committed_range->Release();
     }
+    committed_range->Release();
   }
 
   insert_at_selection->Release();


### PR DESCRIPTION
## 摘要

Related to #1014，但不自动关闭它：#1014 当前描述的是 `PreviewConfirm` / `Ctrl+V` 选区替换路径；本 PR 修复的是产生同类“完整文本嵌套重复”症状的 Windows 语音听写 TSF 路径。

Windows TSF edit session 现在只把最终文本提交给宿主一次，避免 Chromium / Electron 富文本宿主在 `TF_IAS_QUERYONLY` 预检与正式提交之间发生选区重算后，将同一全文嵌套插入两遍。

## 复现与根因

受影响会话具备以下特征：

- OpenLess 历史记录中的 `finalText` 正常且只有一份；
- 目标输入框中出现一份完整文本，同时另一份完整文本被嵌入原文本中间；
- 会话只有一次热键开始/结束、一次 ASR 和一次 LLM 请求；
- `streaming_eligible=false`，且没有进入 clipboard / SendInput fallback；
- 目标是 Chromium 内核的富文本输入框。

`OpenLessEditSession::InsertText` 原先会把同一份全文传给宿主两次：

1. `InsertTextAtSelection(..., TF_IAS_QUERYONLY, full_text, ...)`
2. `InsertTextAtSelection(..., 0, full_text, ...)`

按照 Microsoft TSF 合同，`TF_IAS_QUERYONLY` 不应修改 context；但受影响宿主会在这两次调用之间暴露或重算编辑状态，最终表现为全文嵌套重复。这里不需要预检调用：带读写 edit cookie 的正式调用本身会返回 HRESULT 和 committed range。

参考：<https://learn.microsoft.com/windows/win32/api/msctf/nf-msctf-itfinsertatselection-inserttextatselection>

## 修复 / 新增 / 改进

- 移除带完整文本的 `TF_IAS_QUERYONLY` 预检，改为一次正式 `InsertTextAtSelection` 调用；
- 保留提交前取消检查、committed range、Word 光标折叠与 `SetSelection` 行为；
- 增加契约测试，强制 edit session 只能出现一次 `InsertTextAtSelection`，且不得重新引入全文 `QUERYONLY`；
- 加强真实插入 smoke：对初始为空的 Notepad、browser、Win32 Edit 目标要求回读文本与 `finalText` 完全相等。旧的 `Contains` 断言会让嵌套重复误通过，因为内层仍包含一份完整 `finalText`。

## 兼容

- 不包含：`PreviewConfirm` 的 Ctrl+C 校验路径、clipboard fallback、SendInput fallback、ASR/LLM 逻辑；
- 对现有用户 / 本地环境 / 构建流程的影响：仅改变 Windows TSF IME 的最终提交方式；异步 Word edit session 和提交后光标定位保持不变；
- Microsoft 文档允许不带 `TF_IAS_QUERYONLY` 直接执行读写插入，并通过 `ppRange` 返回已插入范围。

## 测试计划

- [x] 命令：`node scripts/windows-package-msvc.test.mjs`
  - 修复前：失败，`2 !== 1`，证明同一 edit session 存在两次宿主调用；
  - 修复后：通过。
- [x] 命令：`node scripts/windows-ime-lifecycle-contract.test.mjs`
  - 结果：通过。
- [x] 命令：`windows-ime-build.ps1 -Configuration Release -Platform x64`
  - 结果：成功，0 errors。
- [x] 命令：`windows-ime-build.ps1 -Configuration Release -Platform Win32`
  - 结果：成功，0 errors。
- [x] 命令：`npm test`
  - 结果：production build 成功；发现并通过 61 个测试。
- [x] 命令：PowerShell parser + `git diff --check`
  - 结果：通过。
- [ ] 安装态受影响宿主复测
  - 尚未替换用户当前系统注册的 OpenLess IME DLL，避免在提交 PR 时干扰正在运行的输入法环境。

证据路径：

- `openless-all/app/windows-ime/src/edit_session.cpp`
- `openless-all/app/scripts/windows-package-msvc.test.mjs`
- `openless-all/app/scripts/windows-real-asr-insertion-smoke.ps1`