### PR TITLE
fix(less-computer): 升级 @shadcn/react 到 0.2.1，修复聊天框不自动滚到底

### DIFF
--- a/openless-all/app/package-lock.json
+++ b/openless-all/app/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.0.0-Beta.1",
       "dependencies": {
         "@base-ui/react": "^1.6.0",
-        "@shadcn/react": "^0.2.0",
+        "@shadcn/react": "^0.2.1",
         "@tailwindcss/vite": "^4.3.2",
         "@tauri-apps/api": "^2.1.1",
         "@tauri-apps/plugin-dialog": "^2.7.2",
@@ -1778,9 +1778,9 @@
       "license": "MIT"
     },
     "node_modules/@shadcn/react": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@shadcn/react/-/react-0.2.0.tgz",
-      "integrity": "sha512-g/LMtyL0eiHCHkOCelhYf32RC5nTMdtUNag1ZQRhSDCW+jnHxDY1Dajk7P6zJosOg8z2N4wzfKOY5sh54QTDYA==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@shadcn/react/-/react-0.2.1.tgz",
+      "integrity": "sha512-5krgi3dRMKb5jH6a+qPzVJUy/54s0kKE4Rw4LjDfLqOdVQTWKUgxWf1kW8r912I0jX/Lzxqc+pgjkjWxUIK5BQ==",
       "license": "MIT",
       "peerDependencies": {
         "@types/react": ">=19",

--- a/openless-all/app/package.json
+++ b/openless-all/app/package.json
@@ -36,7 +36,7 @@
   },
   "dependencies": {
     "@base-ui/react": "^1.6.0",
-    "@shadcn/react": "^0.2.0",
+    "@shadcn/react": "^0.2.1",
     "@tailwindcss/vite": "^4.3.2",
     "@tauri-apps/api": "^2.1.1",
     "@tauri-apps/plugin-dialog": "^2.7.2",


### PR DESCRIPTION
## 摘要

Fixes #1010。

Less Computer 聊天框在 agent 连续输出时会停止跟随到底部，之后每条新输出都要手动拖滚动条。根因在依赖 `@shadcn/react@0.2.0` 的 MessageScroller：自动滚动后约 180ms 会复核一次滚动状态，如果这次复核恰好落在「新内容已提交、ResizeObserver 还没触发」的间隙，就会把「跟随底部」误判成「用户滚走了」，此后不再跟随。上游已在 shadcn-ui/ui#11106 修复（"no longer releases follow-output … when content growth outruns the frame-coalesced resize handler"），随 0.2.1 发布。本 PR 只把依赖升到 0.2.1。

## 修复 / 新增 / 改进

- `@shadcn/react` 0.2.0 → 0.2.1（`package.json` 下限与 `package-lock.json` 同步）。0.2.1 还包含上游 #11085（ResizeObserver 循环报错）和 #11100（新锚点在流式期间保持在阅读线）。

## 兼容

- 不包含：任何业务代码改动；首次冷加载时「指令与长回复在同一帧到达」会停在指令处，这是库的锚点设计（#11100），0.2.0/0.2.1 表现一致，不在本 PR 范围。
- 对现有用户 / 本地环境 / 构建流程的影响：0.2.1 在原 `^0.2.0` 范围内，导出接口与 peer 依赖不变；QaPanel 用的同一个组件也会一并受益。

## 测试计划

- [x] 命令：`npm ci && npm run build`
- [x] 结果：通过（lockfile integrity 与 registry 发布值一致）
- [x] 命令：前端测试 83 项中除 `check-hotkey-injection.mjs`、`pin-persistence-security-contract.test.mjs`（需编译 Rust 主 crate，本机缺完整 Xcode 的 Metal 工具链）外的 81 项
- [x] 结果：81 过 0 挂
- [x] 复现与对照：浏览器预览（`?window=less-computer`，420×540）里用临时钩子注入 Less Computer 事件（工具行 / 文本 delta 交替，间隔扫过 150–210ms，模拟 Claude Code 后端的工具停顿），headless Chromium 与 WebKit 各跑多轮，看最后一条输出是否在视口内：
  - 0.2.0：12/12 轮在第 8–22 步后停止跟随，最新输出落在视口下方
  - 0.2.1：16/16 轮全程跟随到底
  - 同一分支换回 0.2.0 对照，问题复现，确认差异来自依赖版本
- [ ] 未验证：真机 Tauri 窗口（本机无法编译主 crate）。欢迎 @AndrewY-unique 在 beta 构建上确认。
