### PR TITLE
fix(model-store): 接受 HF tree API 返回的裸 LFS oid，修复本地模型下载失败

### DIFF
--- a/openless-all/app/crates/openless-core/src/model_store.rs
+++ b/openless-all/app/crates/openless-core/src/model_store.rs
@@ -2485,10 +2485,10 @@ fn parse_hf_tree_page_for_entry(
     Ok(files)
 }
 
+/// The Hugging Face tree API returns `lfs.oid` as a bare SHA-256 hex digest;
+/// the `sha256:`-prefixed form (as in Git LFS pointer files) is accepted too.
 fn parse_lfs_sha256(oid: &str) -> Result<String, BackendError> {
-    let digest = oid
-        .strip_prefix("sha256:")
-        .ok_or_else(|| invalid("unsupported Hugging Face LFS oid"))?;
+    let digest = oid.strip_prefix("sha256:").unwrap_or(oid);
     if digest.len() != 64 || !digest.bytes().all(|byte| byte.is_ascii_hexdigit()) {
         return Err(invalid("invalid Hugging Face LFS sha256 oid"));
     }

--- a/openless-all/app/crates/openless-core/src/model_store.rs
+++ b/openless-all/app/crates/openless-core/src/model_store.rs
@@ -2941,6 +2941,31 @@ mod tests {
     }
 
     #[test]
+    fn hf_tree_accepts_bare_lfs_oid_from_live_api() {
+        // Shape returned by huggingface.co and hf-mirror.com for Qwen/Qwen3-ASR-0.6B
+        // (2026-09-13): `lfs.oid` is the bare hex digest, without a `sha256:` prefix.
+        let entries = vec![serde_json::json!({
+            "type": "file",
+            "oid": "3d4b2a1f0e9c8b7a6d5e4f3a2b1c0d9e8f7a6b5c",
+            "size": 1876091704u64,
+            "path": "model.safetensors",
+            "lfs": {
+                "oid": "79d6cbd4c98c7bbffe9db2edac07f56cd6637d0d5944b27f6c2b8353840323ea",
+                "size": 1876091704u64,
+                "pointerSize": 135
+            }
+        })];
+        let files = parse_hf_tree_page("Qwen/Qwen3-ASR-0.6B", "qwen3-asr-0.6b", &entries).unwrap();
+        assert_eq!(files.len(), 1);
+        assert_eq!(files[0].path, "model.safetensors");
+        assert_eq!(files[0].size_bytes, 1_876_091_704);
+        assert_eq!(
+            files[0].sha256.as_deref(),
+            Some("79d6cbd4c98c7bbffe9db2edac07f56cd6637d0d5944b27f6c2b8353840323ea")
+        );
+    }
+
+    #[test]
     fn hf_link_pagination_accepts_same_origin_and_rejects_redirected_origin() {
         let current = "https://huggingface.co/api/models/org/model/tree/main?limit=1000";
         assert_eq!(


### PR DESCRIPTION
## 摘要

2.0 beta 下载本地模型（如 Qwen3-ASR 0.6B）时直接失败，界面报 `unsupported Hugging Face LFS oid`。原因是 `parse_lfs_sha256` 只接受 `sha256:<hex>` 形式，而 huggingface.co 与 hf-mirror.com 的 `/api/models/{repo}/tree/main` 接口返回的 `lfs.oid` 是不带前缀的 64 位十六进制。该解析在 #1019 引入；原有单测的 fixture 用的是带前缀的写法，所以没有暴露问题。

## 修复 / 新增 / 改进

- `parse_lfs_sha256`：`sha256:` 前缀改为可选，仍校验 64 位十六进制并转小写。
- 新增单测 `hf_tree_accepts_bare_lfs_oid_from_live_api`，fixture 取自 2026-09-13 两个接口对 `Qwen/Qwen3-ASR-0.6B` 的真实返回。原有带前缀的单测保留不动。

## 兼容

- 不包含：下载、校验流程的其它改动。
- 对现有用户 / 本地环境 / 构建流程的影响：只放宽 oid 格式，下载后的 sha256 校验不变。

## 测试计划

- [x] 先提交失败的单测（8cefc18）：修复前报 `unsupported Hugging Face LFS oid`，与界面报错一致。
- [x] 命令：`cargo test -p openless-core`
- [x] 结果：全部通过（lib 797 过，1 个原本就 ignore；集成测试全过）
- [x] 实机：macOS 26 / Apple M5，本分支 `tauri dev`，默认 huggingface 源：
  - 修复前：点下载即报 `unsupported Hugging Face LFS oid`
  - 修复后：Qwen3-ASR 0.6B 下载完成（7 个文件，`.openless-model-ready` 已写），`model.safetensors` 的 sha256 与 HF 公布的 `79d6cbd4…3ea` 一致
  - 随后「Load & Test」走 MLX Metal 后端：加载 2.0s，内置音频识别为 "Hello. This is a test of the Vox Troll speech-to-text system."（期望 "Voxtrail"），进程未退出——#1006 在 M5 上也一并确认
- 说明：`cargo fmt -p openless-core --check` 在 `api.rs` 上有 diff，beta 上本来就有，本 PR 未改动该文件。
